### PR TITLE
don't hardcore Evaluate for the lovasz theta objective function

### DIFF
--- a/src/mlpack/core/optimizers/lrsdp/lrsdp_function.cpp
+++ b/src/mlpack/core/optimizers/lrsdp/lrsdp_function.cpp
@@ -34,7 +34,13 @@ LRSDPFunction::LRSDPFunction(const size_t numSparseConstraints,
 
 double LRSDPFunction::Evaluate(const arma::mat& coordinates) const
 {
-  return -accu(coordinates * trans(coordinates));
+  const arma::mat rrt = coordinates * trans(coordinates);
+  double objective = 0.;
+  if (hasSparseObjective())
+    objective += trace(SparseC() * rrt);
+  if (hasDenseObjective())
+    objective += trace(DenseC() * rrt);
+  return objective;
 }
 
 void LRSDPFunction::Gradient(const arma::mat& /* coordinates */,


### PR DESCRIPTION
this function is actually not very useful, since the augmented lagrangian's implementation is what the L-BFGS uses. however, it does confuse debug output. 