### PR TITLE
move matrix_completion_impl.hpp to matrix_completion.cpp

### DIFF
--- a/src/mlpack/methods/matrix_completion/CMakeLists.txt
+++ b/src/mlpack/methods/matrix_completion/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Anything not in this list will not be compiled into MLPACK.
 set(SOURCES
   matrix_completion.hpp
-  matrix_completion_impl.hpp
+  matrix_completion.cpp
 )
 
 # Add directory name to sources.

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -4,8 +4,8 @@
  *
  * Implementation of MatrixCompletion class.
  */
-#ifndef __MLPACK_METHODS_MATRIX_COMPLETION_MATRIX_COMPLETION_IMPL_HPP
-#define __MLPACK_METHODS_MATRIX_COMPLETION_MATRIX_COMPLETION_IMPL_HPP
+
+#include "matrix_completion.hpp"
 
 namespace mlpack {
 namespace matrix_completion {
@@ -107,5 +107,3 @@ size_t MatrixCompletion::DefaultRank(const size_t m,
 
 } // namespace matrix_completion
 } // namespace mlpack
-
-#endif

--- a/src/mlpack/methods/matrix_completion/matrix_completion.hpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.hpp
@@ -136,7 +136,4 @@ class MatrixCompletion
 } // namespace matrix_completion
 } // namespace mlpack
 
-// Include implementation.
-#include "matrix_completion_impl.hpp"
-
 #endif


### PR DESCRIPTION
avoid a possible multiple definitions issue at link time