### PR TITLE
Add covariance factorization caching to gaussian distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build*
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 build*
-*.swp

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -48,7 +48,9 @@ class RegressionDistribution
       rf(regression::LinearRegression(predictors, responses))
   {
     err = GaussianDistribution(1);
-    err.Covariance() = rf.ComputeError(predictors, responses);
+    arma::mat cov(1, 1);
+    cov(0, 0) = rf.ComputeError(predictors, responses);
+    err.Covariance(std::move(cov));
   }
 
   /**

--- a/src/mlpack/methods/gmm/gmm_convert_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_convert_main.cpp
@@ -47,12 +47,14 @@ int main(int argc, char* argv[])
   for (size_t i = 0; i < gaussians; ++i)
   {
     stringstream o;
+    arma::mat covariance;
     o << i;
     string meanName = "mean" + o.str();
     string covName = "covariance" + o.str();
 
     load.LoadParameter(gmm.Component(i).Mean(), meanName);
-    load.LoadParameter(gmm.Component(i).Covariance(), covName);
+    load.LoadParameter(covariance, covName);
+    gmm.Component(i).Covariance(std::move(covariance));
   }
 
   gmm.Save(CLI::GetParam<string>("output_file"));

--- a/src/mlpack/methods/hmm/hmm_util_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_util_impl.hpp
@@ -115,8 +115,10 @@ void ConvertHMM(HMM<distribution::GaussianDistribution>& hmm,
     sr.LoadParameter(hmm.Emission()[i].Mean(), s.str());
 
     s.str("");
+    arma::mat covariance;
     s << "hmm_emission_covariance_" << i;
-    sr.LoadParameter(hmm.Emission()[i].Covariance(), s.str());
+    sr.LoadParameter(covariance, s.str());
+    hmm.Emission()[i].Covariance(std::move(covariance));
   }
 
   hmm.Dimensionality() = hmm.Emission()[0].Mean().n_elem;
@@ -168,7 +170,9 @@ void ConvertHMM(HMM<gmm::GMM<> >& hmm, const util::SaveRestoreUtility& sr)
 
       s.str("");
       s << "hmm_emission_" << i << "_gaussian_" << g << "_covariance";
-      sr.LoadParameter(hmm.Emission()[i].Component(g).Covariance(), s.str());
+      arma::mat covariance;
+      sr.LoadParameter(covariance, s.str());
+      hmm.Emission()[i].Component(g).Covariance(std::move(covariance));
     }
 
     s.str("");

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -187,16 +187,23 @@ BOOST_AUTO_TEST_CASE(GaussianUnivariateProbabilityTest)
       1e-5);
 
   // A few more cases...
-  g.Covariance().fill(2.0);
+  arma::mat covariance;
+  covariance.set_size(g.Covariance().n_rows, g.Covariance().n_cols);
+
+  covariance.fill(2.0);
+  g.Covariance(std::move(covariance));
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("0.0")), 0.282094791773878, 1e-5);
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("1.0")), 0.219695644733861, 1e-5);
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("-1.0")), 0.219695644733861,
       1e-5);
 
   g.Mean().fill(1.0);
-  g.Covariance().fill(1.0);
+  covariance.fill(1.0);
+  g.Covariance(std::move(covariance));
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("1.0")), 0.398942280401433, 1e-5);
-  g.Covariance().fill(2.0);
+
+  covariance.fill(2.0);
+  g.Covariance(std::move(covariance));
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("-1.0")), 0.103776874355149,
       1e-5);
 }
@@ -215,7 +222,9 @@ BOOST_AUTO_TEST_CASE(GaussianMultivariateProbabilityTest)
 
   BOOST_REQUIRE_CLOSE(g.Probability(x), 0.159154943091895, 1e-5);
 
-  g.Covariance() = "2 0; 0 2";
+  arma::mat covariance;
+  covariance = "2 0; 0 2";
+  g.Covariance(std::move(covariance));
 
   BOOST_REQUIRE_CLOSE(g.Probability(x), 0.0795774715459477, 1e-5);
 
@@ -230,7 +239,8 @@ BOOST_AUTO_TEST_CASE(GaussianMultivariateProbabilityTest)
   BOOST_REQUIRE_CLOSE(g.Probability(-x), 0.0795774715459477, 1e-5);
 
   g.Mean() = "1 1";
-  g.Covariance() = "2 1.5; 1 4";
+  covariance = "2 1.5; 1 4";
+  g.Covariance(std::move(covariance));
 
   BOOST_REQUIRE_CLOSE(g.Probability(x), 0.0624257046546403, 1e-5);
   g.Mean() *= -1;
@@ -245,11 +255,13 @@ BOOST_AUTO_TEST_CASE(GaussianMultivariateProbabilityTest)
   // Higher-dimensional case.
   x = "0 1 2 3 4";
   g.Mean() = "5 6 3 3 2";
-  g.Covariance() = "6 1 1 0 2;"
-                   "0 7 1 0 1;"
-                   "1 1 4 1 1;"
-                   "1 0 1 7 0;"
-                   "2 0 1 1 6";
+
+  covariance = "6 1 1 0 2;"
+               "0 7 1 0 1;"
+               "1 1 4 1 1;"
+               "1 0 1 7 0;"
+               "2 0 1 1 6";
+  g.Covariance(std::move(covariance));
 
   BOOST_REQUIRE_CLOSE(g.Probability(x), 1.02531207499358e-6, 1e-5);
   BOOST_REQUIRE_CLOSE(g.Probability(-x), 1.06784794079363e-8, 1e-5);

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -190,9 +190,8 @@ BOOST_AUTO_TEST_CASE(GaussianUnivariateProbabilityTest)
 
   // A few more cases...
   arma::mat covariance;
-  covariance.set_size(g.Covariance().n_rows, g.Covariance().n_cols);
 
-  covariance.fill(2.0);
+  covariance = 2.0;
   g.Covariance(std::move(covariance));
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("0.0")), 0.282094791773878, 1e-5);
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("1.0")), 0.219695644733861, 1e-5);
@@ -200,11 +199,11 @@ BOOST_AUTO_TEST_CASE(GaussianUnivariateProbabilityTest)
       1e-5);
 
   g.Mean().fill(1.0);
-  covariance.fill(1.0);
+  covariance = 1.0;
   g.Covariance(std::move(covariance));
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("1.0")), 0.398942280401433, 1e-5);
 
-  covariance.fill(2.0);
+  covariance = 2.0;
   g.Covariance(std::move(covariance));
   BOOST_REQUIRE_CLOSE(g.Probability(arma::vec("-1.0")), 0.103776874355149,
       1e-5);
@@ -282,7 +281,11 @@ BOOST_AUTO_TEST_CASE(GaussianMultipointMultivariateProbabilityTest)
 {
   // Same case as before.
   arma::vec mean = "5 6 3 3 2";
-  arma::mat cov = "6 1 1 0 2; 0 7 1 0 1; 1 1 4 1 1; 1 0 1 7 0; 2 0 1 1 6";
+  arma::mat cov("6 1 1 1 2;"
+                "1 7 1 0 0;"
+                "1 1 4 1 1;"
+                "1 0 1 7 0;"
+                "2 0 1 0 6");
 
   arma::mat points = "0 3 2 2 3 4;"
                      "1 2 2 1 0 0;"
@@ -292,16 +295,16 @@ BOOST_AUTO_TEST_CASE(GaussianMultipointMultivariateProbabilityTest)
 
   arma::vec phis;
   GaussianDistribution g(mean, cov);
-  g.Probability(points, phis);
+  g.LogProbability(points, phis);
 
   BOOST_REQUIRE_EQUAL(phis.n_elem, 6);
 
-  BOOST_REQUIRE_CLOSE(phis(0), 1.02531207499358e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(phis(1), 1.82353695848039e-7, 1e-5);
-  BOOST_REQUIRE_CLOSE(phis(2), 1.29759261892949e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(phis(3), 1.33218060268258e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(phis(4), 1.12120427975708e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(phis(5), 4.57951032485297e-7, 1e-5);
+  BOOST_REQUIRE_CLOSE(phis(0), -13.432076798791542, 1e-5);
+  BOOST_REQUIRE_CLOSE(phis(1), -15.814880322345738, 1e-5);
+  BOOST_REQUIRE_CLOSE(phis(2), -13.754462857772776, 1e-5);
+  BOOST_REQUIRE_CLOSE(phis(3), -13.283283233107898, 1e-5);
+  BOOST_REQUIRE_CLOSE(phis(4), -13.800326511545279, 1e-5);
+  BOOST_REQUIRE_CLOSE(phis(5), -14.900192463287908, 1e-5);
 }
 
 /**

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -140,6 +140,8 @@ BOOST_AUTO_TEST_CASE(GaussianDistributionDistributionConstructor)
 
   mean.randu();
   covariance.randu();
+  covariance *= covariance.t();
+  covariance += arma::eye<arma::mat>(3, 3);
 
   GaussianDistribution d(mean, covariance);
 

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -159,20 +159,20 @@ BOOST_AUTO_TEST_CASE(GaussianDistributionDistributionConstructor)
 BOOST_AUTO_TEST_CASE(GaussianDistributionProbabilityTest)
 {
   arma::vec mean("5 6 3 3 2");
-  arma::mat cov("6 1 1 0 2;"
-                "0 7 1 0 1;"
+  arma::mat cov("6 1 1 1 2;"
+                "1 7 1 0 0;"
                 "1 1 4 1 1;"
                 "1 0 1 7 0;"
-                "2 0 1 1 6");
+                "2 0 1 0 6");
 
   GaussianDistribution d(mean, cov);
 
-  BOOST_REQUIRE_CLOSE(d.Probability("0 1 2 3 4"), 1.02531207499358e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(d.Probability("3 2 3 7 8"), 1.82353695848039e-7, 1e-5);
-  BOOST_REQUIRE_CLOSE(d.Probability("2 2 0 8 1"), 1.29759261892949e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(d.Probability("2 1 5 0 1"), 1.33218060268258e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(d.Probability("3 0 5 1 0"), 1.12120427975708e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(d.Probability("4 0 6 1 0"), 4.57951032485297e-7, 1e-5);
+  BOOST_REQUIRE_CLOSE(d.LogProbability("0 1 2 3 4"), -13.432076798791542, 1e-5);
+  BOOST_REQUIRE_CLOSE(d.LogProbability("3 2 3 7 8"), -15.814880322345738, 1e-5);
+  BOOST_REQUIRE_CLOSE(d.LogProbability("2 2 0 8 1"), -13.754462857772776, 1e-5);
+  BOOST_REQUIRE_CLOSE(d.LogProbability("2 1 5 0 1"), -13.283283233107898, 1e-5);
+  BOOST_REQUIRE_CLOSE(d.LogProbability("3 0 5 1 0"), -13.800326511545279, 1e-5);
+  BOOST_REQUIRE_CLOSE(d.LogProbability("4 0 6 1 0"), -14.900192463287908, 1e-5);
 }
 
 /**
@@ -244,33 +244,33 @@ BOOST_AUTO_TEST_CASE(GaussianMultivariateProbabilityTest)
   covariance = "2 1.5; 1 4";
   g.Covariance(std::move(covariance));
 
-  BOOST_REQUIRE_CLOSE(g.Probability(x), 0.0624257046546403, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(x), 0.060154914192541771, 1e-5);
   g.Mean() *= -1;
-  BOOST_REQUIRE_CLOSE(g.Probability(-x), 0.0624257046546403, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(-x), 0.060154914192541771, 1e-5);
 
   g.Mean() = "1 1";
   x = "-1 4";
 
-  BOOST_REQUIRE_CLOSE(g.Probability(x), 0.00144014867515135, 1e-5);
-  BOOST_REQUIRE_CLOSE(g.Probability(-x), 0.00133352162064845, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(x), 0.0022506270186086271, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(-x), 0.0016912950996661141, 1e-5);
 
   // Higher-dimensional case.
   x = "0 1 2 3 4";
   g.Mean() = "5 6 3 3 2";
 
-  covariance = "6 1 1 0 2;"
-               "0 7 1 0 1;"
+  covariance = "6 1 1 1 2;"
+               "1 7 1 0 0;"
                "1 1 4 1 1;"
                "1 0 1 7 0;"
-               "2 0 1 1 6";
+               "2 0 1 0 6";
   g.Covariance(std::move(covariance));
 
-  BOOST_REQUIRE_CLOSE(g.Probability(x), 1.02531207499358e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(g.Probability(-x), 1.06784794079363e-8, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(x), 1.4673143531128877e-06, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(-x), 7.7404143494891786e-09, 1e-8);
 
   g.Mean() *= -1;
-  BOOST_REQUIRE_CLOSE(g.Probability(-x), 1.02531207499358e-6, 1e-5);
-  BOOST_REQUIRE_CLOSE(g.Probability(x), 1.06784794079363e-8, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(-x), 1.4673143531128877e-06, 1e-5);
+  BOOST_REQUIRE_CLOSE(g.Probability(x), 7.7404143494891786e-09, 1e-8);
 
 }
 

--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -493,6 +493,8 @@ BOOST_AUTO_TEST_CASE(GMMLoadSaveTest)
     arma::mat covariance = arma::randu<arma::mat>(
         gmm.Component(i).Covariance().n_rows,
         gmm.Component(i).Covariance().n_cols);
+    covariance *= covariance.t();
+    covariance += arma::eye<arma::mat>(covariance.n_rows, covariance.n_cols);
     gmm.Component(i).Covariance(std::move(covariance));
   }
 

--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -490,7 +490,10 @@ BOOST_AUTO_TEST_CASE(GMMLoadSaveTest)
   for (size_t i = 0; i < gmm.Gaussians(); ++i)
   {
     gmm.Component(i).Mean().randu();
-    gmm.Component(i).Covariance().randu();
+    arma::mat covariance = arma::randu<arma::mat>(
+        gmm.Component(i).Covariance().n_rows,
+        gmm.Component(i).Covariance().n_cols);
+    gmm.Component(i).Covariance(std::move(covariance));
   }
 
   gmm.Save("test-gmm-save.xml");

--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -992,7 +992,10 @@ BOOST_AUTO_TEST_CASE(GMMHMMLoadSaveTest)
     for (size_t i = 0; i < hmm.Emission()[j].Gaussians(); ++i)
     {
       hmm.Emission()[j].Component(i).Mean().randu();
-      hmm.Emission()[j].Component(i).Covariance().randu();
+      arma::mat covariance = arma::randu<arma::mat>(
+          hmm.Emission()[j].Component(i).Covariance().n_rows,
+          hmm.Emission()[j].Component(i).Covariance().n_cols);
+      hmm.Emission()[j].Component(i).Covariance(std::move(covariance));
     }
   }
 
@@ -1048,7 +1051,10 @@ BOOST_AUTO_TEST_CASE(GaussianHMMLoadSaveTest)
   for(size_t j = 0; j < hmm.Emission().size(); ++j)
   {
     hmm.Emission()[j].Mean().randu();
-    hmm.Emission()[j].Covariance().randu();
+    arma::mat covariance = arma::randu<arma::mat>(
+        hmm.Emission()[j].Covariance().n_rows,
+        hmm.Emission()[j].Covariance().n_cols);
+    hmm.Emission()[j].Covariance(std::move(covariance));
   }
 
   util::SaveRestoreUtility sr;

--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -995,6 +995,8 @@ BOOST_AUTO_TEST_CASE(GMMHMMLoadSaveTest)
       arma::mat covariance = arma::randu<arma::mat>(
           hmm.Emission()[j].Component(i).Covariance().n_rows,
           hmm.Emission()[j].Component(i).Covariance().n_cols);
+      covariance *= covariance.t();
+      covariance += arma::eye<arma::mat>(covariance.n_rows, covariance.n_cols);
       hmm.Emission()[j].Component(i).Covariance(std::move(covariance));
     }
   }
@@ -1054,6 +1056,8 @@ BOOST_AUTO_TEST_CASE(GaussianHMMLoadSaveTest)
     arma::mat covariance = arma::randu<arma::mat>(
         hmm.Emission()[j].Covariance().n_rows,
         hmm.Emission()[j].Covariance().n_cols);
+    covariance *= covariance.t();
+    covariance += arma::eye<arma::mat>(covariance.n_rows, covariance.n_cols);
     hmm.Emission()[j].Covariance(std::move(covariance));
   }
 


### PR DESCRIPTION
These series of commits adds caching of various factorizations and inverses of the covariance matrix for the gaussian distribution. Note that the previous version did not do error checking for positive definite (or even symmetric matrices) on construction-- this is no longer the case (via a cholesky decomposition attempt which fails if the assumption is violated).

In addition, various test cases had to be fixed to make this work. Previous test cases did not even use symmetric covariance matrices in some cases (who knows what the results were actually computing)!