### PR TITLE
Issue 344 - Better boost test output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(DEBUG "Compile with debugging information" ON)
 option(PROFILE "Compile with profiling information" ON)
 option(ARMA_EXTRA_DEBUG "Compile with extra Armadillo debugging symbols." OFF)
 option(MATLAB_BINDINGS "Compile MATLAB bindings if MATLAB is found." OFF)
+option(TEST_VERBOSE "Running test cases with verbose ouput" OFF)
 
 # This is as of yet unused.
 #option(PGO "Use profile-guided optimization if not a debug build" ON)
@@ -54,6 +55,11 @@ if(CMAKE_COMPILER_IS_GNUCC AND PROFILE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pg")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
 endif(CMAKE_COMPILER_IS_GNUCC AND PROFILE)
+
+# If the user asked for running test cases with verbose output, turn that on.
+if(TEST_VERBOSE)
+  add_definitions(-DTEST_VERBOSE)
+endif(TEST_VERBOSE)
 
 # If the user asked for extra Armadillo debugging output, turn that on.
 if(ARMA_EXTRA_DEBUG)

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -77,7 +77,7 @@ add_dependencies(mlpack mlpack_headers)
 
 # For 'make test'.
 add_custom_target(test
-  ${CMAKE_BINARY_DIR}/bin/mlpack_test
+  ${CMAKE_BINARY_DIR}/bin/mlpack_test "--log_level=test_suite" # Set UTF runtime param
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/ # This is where test files are put.
   COMMENT "Running MLPACK test"
   DEPENDS mlpack_test)

--- a/src/mlpack/tests/mlpack_test.cpp
+++ b/src/mlpack/tests/mlpack_test.cpp
@@ -1,10 +1,13 @@
 /**
  * @file mlpack_test.cpp
  *
- * Simple file defining the name of the overall test for MLPACK.  Each
- * individual test is contained in its own file.
+ * Simple file defining the name of the overall test for MLPACK, and set up
+ * global test fixture for each test. Each individual test is contained in
+ * its own file.
  */
 #define BOOST_TEST_MODULE MLPACKTest
+
+#include <mlpack/core/util/log.hpp>
 
 #include <boost/version.hpp>
 
@@ -15,3 +18,30 @@
 
 #include <boost/test/unit_test.hpp>
 #include "old_boost_test_definitions.hpp"
+
+/**
+ * Provide a global fixture for each test.
+ *
+ * A global fixture is expected to be implemented as a class where the class
+ * constructor serves as a setup method and class destructor serves as teardown
+ * method. 
+ * 
+ * By default, Log::objects should have their output redirected, otherwise
+ * the UTF test output would be drown out by Log::Debug and Log::Warn messages.
+ *
+ * For more detailed test output, set cmake flag TEST_VERBOSE=ON.
+ */
+struct GlobalFixture {
+  GlobalFixture()
+  {
+#ifndef TEST_VERBOSE
+#ifdef DEBUG
+    mlpack::Log::Debug.ignoreInput = true;
+#endif
+    mlpack::Log::Info.ignoreInput = true;
+    mlpack::Log::Warn.ignoreInput = true;
+#endif
+  }
+};
+
+BOOST_GLOBAL_FIXTURE(GlobalFixture);


### PR DESCRIPTION
This branch makes UTF to give running test output like this
```
Running 460 test cases...
Entering test suite "MLPACKTest"
Entering test suite "AdaBoostTest"
Entering test case "HammingLossBoundIris"
Leaving test case "HammingLossBoundIris"; testing time: 874945mks
Entering test case "WeakLearnerErrorIris"
Leaving test case "WeakLearnerErrorIris"; testing time: 886266mks
Entering test case "HammingLossBoundVertebralColumn"
Leaving test case "HammingLossBoundVertebralColumn"; testing time: 8275244mks
Entering test case "WeakLearnerErrorVertebralColumn"
Leaving test case "WeakLearnerErrorVertebralColumn"; testing time: 8266254mks
Entering test case "HammingLossBoundNonLinearSepData"
Leaving test case "HammingLossBoundNonLinearSepData"; testing time: 2507713mks
Entering test case "WeakLearnerErrorNonLinearSepData"
Leaving test case "WeakLearnerErrorNonLinearSepData"; testing time: 2491369mks
```

This is done by setting boost UTF runtime parameter [log_level](http://www.boost.org/doc/libs/1_43_0/libs/test/doc/html/utf/user-guide/runtime-config/reference.html). 
Since Log::objects output would drown UTF test output, we need to ignore those output. In order to minimize the change to other modules, I wrote a global fixture to set up the environment .