### PR TITLE
Implemented multi-dimensional scaling

### DIFF
--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -23,6 +23,7 @@ set(DIRS
   neighbor_search
   nmf
 #  lmf
+  manifold
   pca
   perceptron
   quic_svd

--- a/src/mlpack/methods/manifold/CMakeLists.txt
+++ b/src/mlpack/methods/manifold/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Define the files we need to compile
+# Anything not in this list will not be compiled into MLPACK.
+set(SOURCES
+  mds.hpp
+  mds.cpp
+)
+
+# Add directory name to sources.
+set(DIR_SRCS)
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+# Append sources (with directory name) to list of all MLPACK sources (used at
+# the parent scope).
+set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)
+
+add_executable(mds
+  mds_main.cpp
+)
+target_link_libraries(mds
+  mlpack
+)
+install(TARGETS mds RUNTIME DESTINATION bin)

--- a/src/mlpack/methods/manifold/mds.cpp
+++ b/src/mlpack/methods/manifold/mds.cpp
@@ -1,0 +1,87 @@
+#include "mds.hpp"
+
+using namespace std;
+using namespace mlpack;
+using namespace mlpack::manifold;
+using namespace arma;
+
+//Currently all the computations are done considering "metric" MDS, although MDS type variable has been included
+//to change to non-metric later. Default is metric.
+
+//create MDS object and compute MDS by calling dissimilarity() and reduce()
+MDS::MDS(const arma::mat& data,
+		 size_t dimensionality,
+		 std::string dis/*= "euclidean"*/,
+		 std::string type/*="metric"*/){
+	
+	arma::mat d;
+	if(!dis.compare("euclidean")){
+		d=dissimilarity(data);
+		reduce(d, dimensionality);	
+	}
+}
+
+
+/*this will take dissimilarity matrix and compute MDS by reducing the data into specified reduced dimensions.
+ * The implementation here is done based on this paper:
+ * http://www.math.uwaterloo.ca/~aghodsib/courses/f06stat890/readings/tutorial_stat890.pdf
+ * and the test examples can be taken from here:
+ * https://homepages.uni-tuebingen.de/florian.wickelmaier/pubs/Wickelmaier2003SQRU.pdf
+ */
+const arma::mat& MDS::reduce(const arma::mat& dissimalarity_mat,
+							 size_t dimensionality,
+							 std::string dis/*= "euclidean"*/,
+							 std::string type/*="metric"*/){
+	
+
+	arma::mat XX,H,I,one,eigvec;
+	arma::vec eigval;
+	double n=dissimalarity_mat.n_rows;
+	I=eye<mat>(n,n);
+	one=ones<mat>(n,n);
+	H=I-1/n*one;
+	XX=-0.5*H*square(dissimalarity_mat)*H;
+	eig_sym(eigval,eigvec,XX);
+	
+	if(dimensionality<eigvec.n_rows){
+		eigval.shed_rows(0,eigval.n_elem-dimensionality-1);
+		eigvec.shed_cols(0,eigvec.n_cols-dimensionality-1);
+	}
+	
+	//If dissimilarity matrix is somethinig else than euclidean,
+	// an extra step for making negative eigenvalues to 0 might be neeeded as mentioned in pg6 of this paper.
+	//http://www.lcayton.com/resexam.pdf
+
+	if(!dis.compare("euclidean")){
+		XX=eigvec*sqrt(diagmat(eigval));
+		transformed_data=XX;
+	}
+	return transformed_data;
+
+}
+
+
+//This calls the suitable distance function e.g euclidean_dissim here in case of euclidean distance.
+//Currently support for euclidean dissimilarity is given which can be extended later for other dissimilarity functions.
+
+arma::mat MDS::dissimilarity(const arma::mat& data, std::string dis/*="euclidean"*/){
+	arma::mat d;
+	if(!dis.compare("euclidean"))
+		d=euclidean_dissim(data);
+	return d;
+}
+
+/*This calculates the euclidean dissimilarity between X and Y vectors using 
+ *X.X+Y.Y-2*X.Y
+ *This along with other armadillo functions gives the fastest implementation for calculating nxn euclidean 
+ *dissimilarity matrix with only one matrix product required in the whole implementation 
+ */
+
+arma::mat MDS::euclidean_dissim(arma::mat data){
+	arma::mat d;
+	arma::vec v=sum(square(data),1);
+	d=repmat(v,1,data.n_rows);
+	d=d+trans(d)-2*data*trans(data);
+	return sqrt(d);
+}
+

--- a/src/mlpack/methods/manifold/mds.cpp
+++ b/src/mlpack/methods/manifold/mds.cpp
@@ -1,3 +1,10 @@
+/**
+ * @file mds.cpp
+ * @author Dhawal Arora
+ * Defines the functions for the MDS class to perform Multi-Dimensional Scaling on the
+ * specified data set.
+ */
+
 #include "mds.hpp"
 
 using namespace std;

--- a/src/mlpack/methods/manifold/mds.cpp
+++ b/src/mlpack/methods/manifold/mds.cpp
@@ -17,9 +17,9 @@ using namespace arma;
 
 //create MDS object and compute MDS by calling dissimilarity() and reduce()
 MDS::MDS(const arma::mat& data,
-		 size_t dimensionality,
-		 std::string dis/*= "euclidean"*/,
-		 std::string type/*="metric"*/){
+	 size_t dimensionality,
+	 std::string dis/*= "euclidean"*/,
+	 std::string type/*="metric"*/){
 	
 	arma::mat d;
 	if(!dis.compare("euclidean")){
@@ -36,9 +36,9 @@ MDS::MDS(const arma::mat& data,
  * https://homepages.uni-tuebingen.de/florian.wickelmaier/pubs/Wickelmaier2003SQRU.pdf
  */
 const arma::mat& MDS::reduce(const arma::mat& dissimalarity_mat,
-							 size_t dimensionality,
-							 std::string dis/*= "euclidean"*/,
-							 std::string type/*="metric"*/){
+			     size_t dimensionality,
+       			     std::string dis/*= "euclidean"*/,
+			     std::string type/*="metric"*/){
 	
 
 	arma::mat XX,H,I,one,eigvec;

--- a/src/mlpack/methods/manifold/mds.hpp
+++ b/src/mlpack/methods/manifold/mds.hpp
@@ -1,6 +1,6 @@
 /**
  * @file mds.hpp
- *
+ * @author Dhawal Arora
  * Defines the MDS class to perform Multi-Dimensional Scaling on the
  * specified data set.
  */

--- a/src/mlpack/methods/manifold/mds.hpp
+++ b/src/mlpack/methods/manifold/mds.hpp
@@ -40,9 +40,9 @@ public:
  */
 
 	MDS(const arma::mat& data,
-		size_t dimensionality,
-		std::string dis= "euclidean",
-		std::string type="metric");
+	    size_t dimensionality,
+	    std::string dis= "euclidean",
+	    std::string type="metric");
 
 /**
  * This function calculates the dissimilarity matrix, provided the input dataset. Dissimilarity is the measure of
@@ -67,9 +67,9 @@ public:
  */
 
 	const arma::mat& reduce(const arma::mat& dissimalarity_mat,
-							size_t dimensionality,
-							std::string dis= "euclidean", 
-							std::string type="metric");
+				size_t dimensionality,
+				std::string dis= "euclidean", 
+				std::string type="metric");
 
 	//const arma::mat& reduce(std::string type="metric", size_t dimensionality);
 

--- a/src/mlpack/methods/manifold/mds.hpp
+++ b/src/mlpack/methods/manifold/mds.hpp
@@ -1,0 +1,96 @@
+/**
+ * @file mds.hpp
+ *
+ * Defines the MDS class to perform Multi-Dimensional Scaling on the
+ * specified data set.
+ */
+#ifndef __MLPACK_METHODS_MANIFOLD_MDS_HPP
+#define __MLPACK_METHODS_MANIFOLD_MDS_HPP
+
+#include <mlpack/core.hpp>
+namespace mlpack{
+namespace manifold{
+/**
+ *This class implements Multi-Dimensional Scaling.MDS is a classical approach that maps the original high dimensional
+ *space to a lower dimensional space, but does so in an attempt to preserve pairwise dis-
+ *tances between all the data points in both the dimensions. Further information on MDS can be found through research 
+ *papers on the internet.Some other libraries also have robust implemenation of MDS. 
+ */
+
+class MDS{
+
+public: 
+
+/**
+ *This creates an MDS object without specifying any parameters. Further computations for MDS then are done using
+ *other functions provided in the class separtely.
+ */
+ 	MDS(){}
+
+/**
+ * This creates an MDS object and simultaneously solves the MDS by calling dissimalirity() and reduce() function of this class.
+ * class. The final reduced vectors are stored in transformed_data matrix.
+ *
+ *@param data It is the coordinate matrix nxm where n is the number of objects and m is
+ *			  the initial dimensionality of the data.
+ *@param dimensionality It is the number of dimensions in which the data has to be reduced.
+ *@param dis It is a string which specifies the type of dissimilarity matrix to be computed for the dataset.
+ *		     The default is the euclidean matrix where Xij is the euclidean distance between vector Xi and Xj.
+ *@param type It specifies type of MDS. It is either mertic or non-metric.
+ */
+
+	MDS(const arma::mat& data,
+		size_t dimensionality,
+		std::string dis= "euclidean",
+		std::string type="metric");
+
+/**
+ * This function calculates the dissimilarity matrix, provided the input dataset. Dissimilarity is the measure of
+ * distance between two data points.The default dissimilarity distance is the euclidean distance. This returns the 
+ * euclidean matrix where Xij is the euclidean distance between vector Xi and  Xj. 
+ *
+ * @param data It is the coordinate matrix nxm where n is the number of objects and m is
+ *			   the initial dimensionality of the data.
+ * @param dis  It is a string which specifies the type of dissimilarity matrix to be computed for the dataset.
+ */
+	arma::mat dissimilarity(const arma::mat& data, std::string dis="euclidean");
+
+/**
+ * This function performs the MDS algorithm and returns dxm matrix where d is the number of datapoints
+ * and m is the reduced dimension.
+ *
+ *@param dissimilarity_mat It is the dissimilarity matrix.
+ *@param dimensionality It is the number of dimensions in which the data has to be reduced.
+ *@param dis It is a string which specifies the type of dissimilarity matrix to be computed for the dataset.
+ *		     The default is the euclidean matrix where Xij is the euclidean distance between vector Xi and Xj.
+ *@param type It specifies type of MDS. It is either mertic or non-metric.
+ */
+
+	const arma::mat& reduce(const arma::mat& dissimalarity_mat,
+							size_t dimensionality,
+							std::string dis= "euclidean", 
+							std::string type="metric");
+
+	//const arma::mat& reduce(std::string type="metric", size_t dimensionality);
+
+	//It calculates the euclidean dissimilarity matrix.
+	arma::mat euclidean_dissim(arma::mat data);
+
+
+	//This returns the final reduced matrix of dimension dxm where d is the number of data points 
+	//and m is the reduced dimension.
+	const arma::mat& transformedData() const { return transformed_data; }
+
+	//arma::mat& transformedData() { return transformed_data; }
+
+
+private:
+	arma::mat transformed_data;
+	//arma::mat dissimalarity_matrix;
+	//std::string dis_type;
+};//class MDS
+
+};//namespace manifold
+};//namespace mlpack
+
+#endif	

--- a/src/mlpack/methods/manifold/mds_main.cpp
+++ b/src/mlpack/methods/manifold/mds_main.cpp
@@ -1,3 +1,9 @@
+/**
+ * @file mds_main.cpp
+ * @author Dhawal Arora
+ * This will form the executable for Multi-Dimensional Scaling
+ * 
+ */
 #include <mlpack/core.hpp>
 #include "mds.hpp"
 using namespace std;

--- a/src/mlpack/methods/manifold/mds_main.cpp
+++ b/src/mlpack/methods/manifold/mds_main.cpp
@@ -1,0 +1,53 @@
+#include <mlpack/core.hpp>
+#include "mds.hpp"
+using namespace std;
+using namespace mlpack;
+using namespace mlpack::manifold;
+using namespace arma;
+
+// Document program.
+PROGRAM_INFO("Multi Dimensional Scaling", "Multidimensional Scaling is a classical approach that maps the original high dimensional
+ space to a lower dimensional space, but does so in an attempt to preserve pairwise dis-
+ tances between all the data points in both the dimensions.");
+
+// Parameters for program.
+PARAM_STRING_REQ("input", "Input dataset to perform MDS on.", "i");
+PARAM_STRING_REQ("output", "File to save modified dataset to.", "o");
+PARAM_INT("dimensionality", "Desired dimensionality of output dataset." , "d", 2);
+
+
+int main(int argc,char **argv){
+	// Parse commandline.
+  	CLI::ParseCommandLine(argc, argv);
+	
+	// Load input dataset.
+	string inputFile = CLI::GetParam<string>("input");
+  	arma::mat dataset;
+  	
+  	Timer::Start("Load dataset");
+  	data::Load(inputFile, dataset);
+  	dataset=trans(dataset);
+  	Timer::Stop("Load dataset");
+
+  	size_t dimensions = CLI::GetParam<int>("dimensionality")
+
+    if (dimensions >= dataset.n_rows){
+      	Log::Warn << "For cases of dimensionality greater than the number of observations,"
+      	"the result for dimensionality same as number of observations will be computed" << std::endl;
+    }
+  	
+  	//Perform MDS
+    Timer::Start("Perform MDS");
+    MDS m(dataset,dimensions,"euclidean","metric");
+    dataset=m.transformedData();
+    Timer::Stop("Perform MDS");
+
+    Timer::Start("Save output");
+    // Now save the results.
+  	string outputFile = CLI::GetParam<string>("output");
+  	data::Save(outputFile, dataset);
+  	Timer::Stop("Save output");
+
+
+	return 0;
+}

--- a/src/mlpack/methods/manifold/mds_main.cpp
+++ b/src/mlpack/methods/manifold/mds_main.cpp
@@ -12,9 +12,10 @@ using namespace mlpack::manifold;
 using namespace arma;
 
 // Document program.
-PROGRAM_INFO("Multi Dimensional Scaling", "Multidimensional Scaling is a classical approach that maps the original high dimensional
- space to a lower dimensional space, but does so in an attempt to preserve pairwise dis-
- tances between all the data points in both the dimensions.");
+PROGRAM_INFO("Multi Dimensional Scaling", "Multidimensional Scaling is a classical approach"
+ 	     "that maps the original high dimensional space to a lower dimensional space,"
+             "but does so in an attempt to preserve pairwise distances"
+             "between all the data points in both the dimensions.");
 
 // Parameters for program.
 PARAM_STRING_REQ("input", "Input dataset to perform MDS on.", "i");
@@ -23,26 +24,27 @@ PARAM_INT("dimensionality", "Desired dimensionality of output dataset." , "d", 2
 
 
 int main(int argc,char **argv){
-	// Parse commandline.
-  	CLI::ParseCommandLine(argc, argv);
+    
+    // Parse commandline.
+    CLI::ParseCommandLine(argc, argv);
 	
-	// Load input dataset.
-	string inputFile = CLI::GetParam<string>("input");
-  	arma::mat dataset;
+    // Load input dataset.
+    string inputFile = CLI::GetParam<string>("input");
+    arma::mat dataset;
   	
-  	Timer::Start("Load dataset");
-  	data::Load(inputFile, dataset);
-  	dataset=trans(dataset);
-  	Timer::Stop("Load dataset");
+    Timer::Start("Load dataset");
+    data::Load(inputFile, dataset);
+    dataset=trans(dataset);
+    Timer::Stop("Load dataset");
 
-  	size_t dimensions = CLI::GetParam<int>("dimensionality")
+    size_t dimensions = CLI::GetParam<int>("dimensionality");
 
     if (dimensions >= dataset.n_rows){
       	Log::Warn << "For cases of dimensionality greater than the number of observations,"
       	"the result for dimensionality same as number of observations will be computed" << std::endl;
     }
   	
-  	//Perform MDS
+    //Perform MDS
     Timer::Start("Perform MDS");
     MDS m(dataset,dimensions,"euclidean","metric");
     dataset=m.transformedData();
@@ -50,10 +52,11 @@ int main(int argc,char **argv){
 
     Timer::Start("Save output");
     // Now save the results.
-  	string outputFile = CLI::GetParam<string>("output");
-  	data::Save(outputFile, dataset);
-  	Timer::Stop("Save output");
+    string outputFile = CLI::GetParam<string>("output");
+    dataset=trans(dataset);
+    data::Save(outputFile, dataset);
+    Timer::Stop("Save output");
 
 
-	return 0;
+    return 0;
 }

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(mlpack_test
   math_test.cpp
   matrix_completion_test.cpp
   metric_test.cpp
+  mds_test.cpp
   nbc_test.cpp
   nca_test.cpp
   nmf_test.cpp

--- a/src/mlpack/tests/mds_test.cpp
+++ b/src/mlpack/tests/mds_test.cpp
@@ -1,4 +1,5 @@
 /**@file mds_test.cpp
+ *@author Dhawal Arora
  *
  *Test file for MDS class
  */

--- a/src/mlpack/tests/mds_test.cpp
+++ b/src/mlpack/tests/mds_test.cpp
@@ -31,13 +31,13 @@ BOOST_AUTO_TEST_CASE(DimensionalityReductionTestMatlab){
 	
 	//Matlab's reduced dimensions. Have to be put manually.
 	mat matlab("15.1721 17.4301;"
-			   "-24.8743 2.7574;"
-			   "9.7022 -20.1875");
+		   "-24.8743 2.7574;"
+		   "9.7022 -20.1875");
 	
 	//Raw input data, this is not the dissimilarity matrix
 	mat data("20 30 40;"
-			 "1 3 13;"
-			 "5 44 8");
+		 "1 3 13;"
+		 "5 44 8");
 
 	BOOST_REQUIRE_EQUAL(matlab.n_rows,data.n_rows);
 	
@@ -75,12 +75,12 @@ BOOST_AUTO_TEST_CASE(DetermineKruskalStress){
 	double num, den,k_stress;
 	arma::mat B,dis1,dis2;
 	mat matlab("15.1721 17.4301;"
-			   "-24.8743 2.7574;"
-			   "9.7022 -20.1875");
+	           "-24.8743 2.7574;"
+		   "9.7022 -20.1875");
 	
 	mat data("20 30 40;"
-			 "1 3 13;"
-			 "5 44 8");
+	         "1 3 13;"
+		 "5 44 8");
 	//Dissimilarity of the input data
 	B=m.dissimilarity(data);
 	dis1=B;

--- a/src/mlpack/tests/mds_test.cpp
+++ b/src/mlpack/tests/mds_test.cpp
@@ -1,0 +1,112 @@
+/**@file mds_test.cpp
+ *
+ *Test file for MDS class
+ */
+
+#include <mlpack/core.hpp>
+#include <mlpack/methods/manifold/mds.hpp>
+
+//#define BOOST_TEST_DYN_LINK
+//#define BOOST_TEST_MODULE MDStest
+
+#include <boost/test/unit_test.hpp>
+#include "old_boost_test_definitions.hpp"
+
+
+BOOST_AUTO_TEST_SUITE(MDStest);
+
+using namespace std;
+using namespace mlpack;
+using namespace mlpack::manifold;
+using namespace arma;
+
+//To match the MDS result with matlab's implementation. 
+
+BOOST_AUTO_TEST_CASE(DimensionalityReductionTestMatlab){
+	
+	MDS m;
+	arma::mat B;
+	bool a_isnegative,b_isnegative;
+	
+	//Matlab's reduced dimensions. Have to be put manually.
+	mat matlab("15.1721 17.4301;"
+			   "-24.8743 2.7574;"
+			   "9.7022 -20.1875");
+	
+	//Raw input data, this is not the dissimilarity matrix
+	mat data("20 30 40;"
+			 "1 3 13;"
+			 "5 44 8");
+
+	BOOST_REQUIRE_EQUAL(matlab.n_rows,data.n_rows);
+	
+	//Calculating the euclidean dissimilarity(default)
+	B=m.dissimilarity(data);
+	//Reducing the dimensions performing MDS
+	B=m.reduce(B,2);
+	//Flippping the eigenvectors in descending order of eigenvalues to match matlab's similar output.
+	B=fliplr(B);
+	
+	BOOST_REQUIRE_EQUAL(matlab.n_cols,B.n_cols);
+
+	//If vectors are in opposite directions as compared to matlab, reverse them.
+	for(size_t i=0;i<B.n_cols;i++){
+		a_isnegative=matlab(0,i)<0;
+		b_isnegative=B(0,i)<0;
+		if(a_isnegative!=b_isnegative)
+			B.col(i)*=-1;	
+	}
+
+
+	for (size_t row = 0; row < B.n_rows; row++)
+		for (size_t col = 0; col < B.n_cols; col++)
+			BOOST_CHECK_CLOSE(B(row, col), matlab(row, col), 0.001);
+
+}
+
+/* Information about the Kruskal's stress can be found online. This will compare the dissimilarity matrix of the raw 
+ * input data and the dissimilarity matrix formed after reducing the dimensions. They should approximately be equal 
+ * to solve the purpose of MDS. This data is interpreted in the form of stress. 
+ */
+BOOST_AUTO_TEST_CASE(DetermineKruskalStress){
+	
+	MDS m;
+	double num, den,k_stress;
+	arma::mat B,dis1,dis2;
+	mat matlab("15.1721 17.4301;"
+			   "-24.8743 2.7574;"
+			   "9.7022 -20.1875");
+	
+	mat data("20 30 40;"
+			 "1 3 13;"
+			 "5 44 8");
+	//Dissimilarity of the input data
+	B=m.dissimilarity(data);
+	dis1=B;
+	
+	//Dissimilarity after reduced dimensions
+	B=m.reduce(B,2);
+	dis2=m.dissimilarity(B);
+	
+	//Calculating Kruskal's stress.
+	num=accu(square(dis2-dis1));
+	den=accu(square(dis1));
+	k_stress=std::sqrt(num/den);
+
+	/*This shows the goodness of fit defined by kruskal.
+	 *Stress  Goodness of fit
+	 *0.200       poor
+	 *0.100       fair
+	 *0.050       good
+	 *0.025       excellent
+	 *0.000       perfect
+	 */
+	
+	BOOST_REQUIRE_MESSAGE(k_stress<0.025,"The goodness of fit is : good to fair"<<k_stress);
+	BOOST_TEST_MESSAGE("The goodness of fit is : excellent, kruskal's stress: "<< k_stress);
+
+
+
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Hi, 
I have created the implementation for metric MDS with euclidean dissimilarity. Scope for non metric and other dissimiliarity functions has been provided for now which could be extended later. The papers used for this have been mentioned in the comments documentaton too.

For testing it separately, i calculated the dissimilarity of input dataset and applied MDS to get the lower-dimensional datapoints. Then again calulated the dissimilarity matrix with reduced dataset. Both the dissimilarity matrices are approximately coming the same. So i guess the MDS code is working fine.I tested the working by calling these functions separately and have not run the code for executable(mds_main) though.

Also tried testing in comparison to scikit. But i guess scikit is using a different implementation internally for MDS since their answers for reduced data come different everytime.

So later, a few changes can be incorporated if needed:
1. Implementing non-metric
2. Implmenting bunch of other distance metrics than euclidean, since with euclidean MDS is approximately equal to PCA.
3. Returning the stress value and using other loss functions(like kruskal's).
4. Computing the r-squares etc for reliability testing, as mentioned on this page http://en.wikipedia.org/wiki/Multidimensional_scaling 

Please see or test for any changes. 
Thanks.
