### PR TITLE
Fix build failure with clang (MacOS)

### DIFF
--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
@@ -43,7 +43,7 @@ template<typename MetricType,
          typename StatisticType = EmptyStatistic,
          typename MatType = arma::mat,
          template<typename BoundMetricType> class BoundType = bound::HRectBound,
-         template<typename BoundType, typename MatType> class SplitType =
+         template<typename TBoundType, typename TMatType> class SplitType =
              MidpointSplit>
 class BinarySpaceTree
 {

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
@@ -23,7 +23,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const MatType& data,
@@ -49,7 +49,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const MatType& data,
@@ -81,7 +81,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const MatType& data,
@@ -119,7 +119,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(MatType&& data, const size_t maxLeafSize) :
     left(NULL),
@@ -143,7 +143,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     MatType&& data,
@@ -175,7 +175,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     MatType&& data,
@@ -201,7 +201,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     BinarySpaceTree* parent,
@@ -228,7 +228,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     BinarySpaceTree* parent,
@@ -260,7 +260,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     BinarySpaceTree* parent,
@@ -302,7 +302,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const BinarySpaceTree& other) :
@@ -360,7 +360,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename Archive>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
@@ -382,7 +382,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
   ~BinarySpaceTree()
 {
@@ -400,7 +400,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline bool BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                             SplitType>::IsLeaf() const
 {
@@ -414,7 +414,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::NumChildren() const
 {
@@ -434,7 +434,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline double BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::FurthestPointDistance() const
 {
@@ -456,7 +456,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline double BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::FurthestDescendantDistance() const
 {
@@ -468,7 +468,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline double BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::MinimumBoundDistance() const
 {
@@ -482,7 +482,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                        SplitType>&
     BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
@@ -501,7 +501,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::NumPoints() const
 {
@@ -518,7 +518,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::NumDescendants() const
 {
@@ -532,7 +532,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::Descendant(const size_t index) const
 {
@@ -546,7 +546,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 inline size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                               SplitType>::Point(const size_t index) const
 {
@@ -557,7 +557,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
     SplitNode(const size_t maxLeafSize,
               SplitType<BoundType<MetricType>, MatType>& splitter)
@@ -611,7 +611,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 SplitNode(std::vector<size_t>& oldFromNew,
           const size_t maxLeafSize,
@@ -668,7 +668,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
     BinarySpaceTree() :
     left(NULL),
@@ -691,7 +691,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename Archive>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
     Serialize(Archive& ar, const unsigned int /* version */)
@@ -770,7 +770,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 std::string BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                             SplitType>::
     ToString() const

--- a/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
@@ -32,7 +32,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 class BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                       SplitType>::BreadthFirstDualTreeTraverser

--- a/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser_impl.hpp
@@ -19,7 +19,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BreadthFirstDualTreeTraverser<RuleType>::BreadthFirstDualTreeTraverser(
@@ -46,7 +46,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BreadthFirstDualTreeTraverser<RuleType>::Traverse(
@@ -85,7 +85,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 BreadthFirstDualTreeTraverser<RuleType>::Traverse(

--- a/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser.hpp
@@ -21,7 +21,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 class BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                       SplitType>::DualTreeTraverser

--- a/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser_impl.hpp
@@ -19,7 +19,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 DualTreeTraverser<RuleType>::DualTreeTraverser(RuleType& rule) :
@@ -34,7 +34,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 DualTreeTraverser<RuleType>::Traverse(

--- a/src/mlpack/core/tree/binary_space_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/single_tree_traverser.hpp
@@ -20,7 +20,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 class BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                       SplitType>::SingleTreeTraverser

--- a/src/mlpack/core/tree/binary_space_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/single_tree_traverser_impl.hpp
@@ -21,7 +21,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 SingleTreeTraverser<RuleType>::SingleTreeTraverser(RuleType& rule) :
@@ -33,7 +33,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 template<typename RuleType>
 void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
 SingleTreeTraverser<RuleType>::Traverse(

--- a/src/mlpack/core/tree/binary_space_tree/traits.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/traits.hpp
@@ -22,7 +22,7 @@ template<typename MetricType,
          typename StatisticType,
          typename MatType,
          template<typename BoundMetricType> class BoundType,
-         template<typename BoundType, typename MatType> class SplitType>
+         template<typename TBoundType, typename TMatType> class SplitType>
 class TreeTraits<BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
                                  SplitType>>
 {

--- a/src/mlpack/methods/emst/dtb.hpp
+++ b/src/mlpack/methods/emst/dtb.hpp
@@ -71,7 +71,7 @@ namespace emst /** Euclidean Minimum Spanning Trees. */ {
 template<
     typename MetricType = metric::EuclideanDistance,
     typename MatType = arma::mat,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType = tree::KDTree
 >
 class DualTreeBoruvka

--- a/src/mlpack/methods/emst/dtb_impl.hpp
+++ b/src/mlpack/methods/emst/dtb_impl.hpp
@@ -43,7 +43,7 @@ TreeType* BuildTree(
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 DualTreeBoruvka<MetricType, MatType, TreeType>::DualTreeBoruvka(
     const MatType& dataset,
@@ -69,7 +69,7 @@ DualTreeBoruvka<MetricType, MatType, TreeType>::DualTreeBoruvka(
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 DualTreeBoruvka<MetricType, MatType, TreeType>::DualTreeBoruvka(
     Tree* tree,
@@ -93,7 +93,7 @@ DualTreeBoruvka<MetricType, MatType, TreeType>::DualTreeBoruvka(
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 DualTreeBoruvka<MetricType, MatType, TreeType>::~DualTreeBoruvka()
 {
@@ -108,7 +108,7 @@ DualTreeBoruvka<MetricType, MatType, TreeType>::~DualTreeBoruvka()
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 void DualTreeBoruvka<MetricType, MatType, TreeType>::ComputeMST(
     arma::mat& results)
@@ -161,7 +161,7 @@ void DualTreeBoruvka<MetricType, MatType, TreeType>::ComputeMST(
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 void DualTreeBoruvka<MetricType, MatType, TreeType>::AddEdge(
     const size_t e1,
@@ -183,7 +183,7 @@ void DualTreeBoruvka<MetricType, MatType, TreeType>::AddEdge(
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 void DualTreeBoruvka<MetricType, MatType, TreeType>::AddAllEdges()
 {
@@ -209,7 +209,7 @@ void DualTreeBoruvka<MetricType, MatType, TreeType>::AddAllEdges()
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 void DualTreeBoruvka<MetricType, MatType, TreeType>::EmitResults(
     arma::mat& results)
@@ -264,7 +264,7 @@ void DualTreeBoruvka<MetricType, MatType, TreeType>::EmitResults(
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 void DualTreeBoruvka<MetricType, MatType, TreeType>::CleanupHelper(Tree* tree)
 {
@@ -303,7 +303,7 @@ void DualTreeBoruvka<MetricType, MatType, TreeType>::CleanupHelper(Tree* tree)
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 void DualTreeBoruvka<MetricType, MatType, TreeType>::Cleanup()
 {
@@ -318,7 +318,7 @@ void DualTreeBoruvka<MetricType, MatType, TreeType>::Cleanup()
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType>
 std::string DualTreeBoruvka<MetricType, MatType, TreeType>::ToString() const
 {

--- a/src/mlpack/methods/fastmks/fastmks.hpp
+++ b/src/mlpack/methods/fastmks/fastmks.hpp
@@ -50,7 +50,7 @@ namespace fastmks /** Fast max-kernel search. */ {
 template<
     typename KernelType,
     typename MatType = arma::mat,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType = tree::StandardCoverTree
 >
 class FastMKS

--- a/src/mlpack/methods/fastmks/fastmks_impl.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_impl.hpp
@@ -21,7 +21,7 @@ namespace fastmks {
 // No instantiated kernel.
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 FastMKS<KernelType, MatType, TreeType>::FastMKS(
     const MatType& referenceSet,
@@ -44,7 +44,7 @@ FastMKS<KernelType, MatType, TreeType>::FastMKS(
 // Instantiated kernel.
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 FastMKS<KernelType, MatType, TreeType>::FastMKS(const MatType& referenceSet,
                                                 KernelType& kernel,
@@ -69,7 +69,7 @@ FastMKS<KernelType, MatType, TreeType>::FastMKS(const MatType& referenceSet,
 // One dataset, pre-built tree.
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 FastMKS<KernelType, MatType, TreeType>::FastMKS(Tree* referenceTree,
                                                 const bool singleMode) :
@@ -85,7 +85,7 @@ FastMKS<KernelType, MatType, TreeType>::FastMKS(Tree* referenceTree,
 
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 FastMKS<KernelType, MatType, TreeType>::~FastMKS()
 {
@@ -96,7 +96,7 @@ FastMKS<KernelType, MatType, TreeType>::~FastMKS()
 
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void FastMKS<KernelType, MatType, TreeType>::Search(
     const MatType& querySet,
@@ -175,7 +175,7 @@ void FastMKS<KernelType, MatType, TreeType>::Search(
 
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void FastMKS<KernelType, MatType, TreeType>::Search(
     Tree* queryTree,
@@ -212,7 +212,7 @@ void FastMKS<KernelType, MatType, TreeType>::Search(
 
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void FastMKS<KernelType, MatType, TreeType>::Search(
     const size_t k,
@@ -297,7 +297,7 @@ void FastMKS<KernelType, MatType, TreeType>::Search(
  */
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void FastMKS<KernelType, MatType, TreeType>::InsertNeighbor(
     arma::Mat<size_t>& indices,
@@ -327,7 +327,7 @@ void FastMKS<KernelType, MatType, TreeType>::InsertNeighbor(
 // Return string of object.
 template<typename KernelType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 std::string FastMKS<KernelType, MatType, TreeType>::ToString() const
 {

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans.hpp
@@ -29,7 +29,7 @@ namespace kmeans {
 template<
     typename MetricType,
     typename MatType,
-    template<typename MetricType, typename StatisticType, typename MatType>
+    template<typename TMetricType, typename StatisticType, typename TMatType>
         class TreeType = tree::KDTree>
 class DualTreeKMeans
 {

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
@@ -46,7 +46,7 @@ TreeType* BuildTree(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 DualTreeKMeans<MetricType, MatType, TreeType>::DualTreeKMeans(
     const MatType& dataset,
@@ -75,7 +75,7 @@ DualTreeKMeans<MetricType, MatType, TreeType>::DualTreeKMeans(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 DualTreeKMeans<MetricType, MatType, TreeType>::~DualTreeKMeans()
 {
@@ -86,7 +86,7 @@ DualTreeKMeans<MetricType, MatType, TreeType>::~DualTreeKMeans()
 // Run a single iteration.
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 double DualTreeKMeans<MetricType, MatType, TreeType>::Iterate(
     const arma::mat& centroids,
@@ -206,7 +206,7 @@ double DualTreeKMeans<MetricType, MatType, TreeType>::Iterate(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void DualTreeKMeans<MetricType, MatType, TreeType>::UpdateTree(
     Tree& node,
@@ -470,7 +470,7 @@ visited[node.Descendant(i)] << ".\n";
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void DualTreeKMeans<MetricType, MatType, TreeType>::ExtractCentroids(
     Tree& node,
@@ -562,7 +562,7 @@ assignments[node.Point(i)] << " with ub " << upperBounds[node.Point(i)] <<
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void DualTreeKMeans<MetricType, MatType, TreeType>::CoalesceTree(
     Tree& node,
@@ -610,7 +610,7 @@ void DualTreeKMeans<MetricType, MatType, TreeType>::CoalesceTree(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void DualTreeKMeans<MetricType, MatType, TreeType>::DecoalesceTree(Tree& node)
 {

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -50,7 +50,7 @@ namespace neighbor /** Neighbor-search routines.  These include
 template<typename SortPolicy = NearestNeighborSort,
          typename MetricType = mlpack::metric::EuclideanDistance,
          typename MatType = arma::mat,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType = tree::KDTree,
          template<typename RuleType> class TraversalType =
              TreeType<MetricType,

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -43,7 +43,7 @@ TreeType* BuildTree(
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
@@ -68,7 +68,7 @@ NeighborSearch(const MatType& referenceSetIn,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
@@ -91,7 +91,7 @@ NeighborSearch(Tree* referenceTree,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
@@ -108,7 +108,7 @@ NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
@@ -269,7 +269,7 @@ Search(const MatType& querySet,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
@@ -331,7 +331,7 @@ Search(Tree* queryTree,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
@@ -429,7 +429,7 @@ Search(const size_t k,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType,
          template<typename> class TraversalType>
 std::string NeighborSearch<SortPolicy, MetricType, MatType, TreeType,

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -28,7 +28,7 @@ namespace range /** Range-search routines. */ {
  */
 template<typename MetricType = metric::EuclideanDistance,
          typename MatType = arma::mat,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType = tree::KDTree>
 class RangeSearch
 {

--- a/src/mlpack/methods/range_search/range_search_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_impl.hpp
@@ -41,7 +41,7 @@ TreeType* BuildTree(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
     const MatType& referenceSetIn,
@@ -61,7 +61,7 @@ RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
     Tree* referenceTree,
@@ -79,7 +79,7 @@ RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 RangeSearch<MetricType, MatType, TreeType>::~RangeSearch()
 {
@@ -89,7 +89,7 @@ RangeSearch<MetricType, MatType, TreeType>::~RangeSearch()
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RangeSearch<MetricType, MatType, TreeType>::Search(
     const MatType& querySet,
@@ -245,7 +245,7 @@ void RangeSearch<MetricType, MatType, TreeType>::Search(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RangeSearch<MetricType, MatType, TreeType>::Search(
     Tree* queryTree,
@@ -308,7 +308,7 @@ void RangeSearch<MetricType, MatType, TreeType>::Search(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RangeSearch<MetricType, MatType, TreeType>::Search(
     const math::Range& range,
@@ -395,7 +395,7 @@ void RangeSearch<MetricType, MatType, TreeType>::Search(
 
 template<typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 std::string RangeSearch<MetricType, MatType, TreeType>::ToString() const
 {

--- a/src/mlpack/methods/rann/ra_search.hpp
+++ b/src/mlpack/methods/rann/ra_search.hpp
@@ -56,7 +56,7 @@ namespace neighbor {
 template<typename SortPolicy = NearestNeighborSort,
          typename MetricType = metric::EuclideanDistance,
          typename MatType = arma::mat,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType = tree::KDTree>
 class RASearch
 {

--- a/src/mlpack/methods/rann/ra_search_impl.hpp
+++ b/src/mlpack/methods/rann/ra_search_impl.hpp
@@ -47,7 +47,7 @@ TreeType* BuildTree(
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 RASearch<SortPolicy, MetricType, MatType, TreeType>::
 RASearch(const MatType& referenceSetIn,
@@ -79,7 +79,7 @@ RASearch(const MatType& referenceSetIn,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 RASearch<SortPolicy, MetricType, MatType, TreeType>::
 RASearch(Tree* referenceTree,
@@ -111,7 +111,7 @@ RASearch(Tree* referenceTree,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 RASearch<SortPolicy, MetricType, MatType, TreeType>::
 ~RASearch()
@@ -127,7 +127,7 @@ RASearch<SortPolicy, MetricType, MatType, TreeType>::
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RASearch<SortPolicy, MetricType, MatType, TreeType>::
 Search(const MatType& querySet,
@@ -304,7 +304,7 @@ Search(const MatType& querySet,
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RASearch<SortPolicy, MetricType, MatType, TreeType>::Search(
     Tree* queryTree,
@@ -364,7 +364,7 @@ void RASearch<SortPolicy, MetricType, MatType, TreeType>::Search(
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RASearch<SortPolicy, MetricType, MatType, TreeType>::Search(
     const size_t k,
@@ -455,7 +455,7 @@ void RASearch<SortPolicy, MetricType, MatType, TreeType>::Search(
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 void RASearch<SortPolicy, MetricType, MatType, TreeType>::ResetQueryTree(
     Tree* queryNode) const
@@ -471,7 +471,7 @@ void RASearch<SortPolicy, MetricType, MatType, TreeType>::ResetQueryTree(
 template<typename SortPolicy,
          typename MetricType,
          typename MatType,
-         template<typename MetricType, typename StatisticType, typename MatType>
+         template<typename TMetricType, typename StatisticType, typename TMatType>
              class TreeType>
 std::string RASearch<SortPolicy, MetricType, MatType, TreeType>::ToString()
     const

--- a/src/mlpack/tests/layer_traits_test.cpp
+++ b/src/mlpack/tests/layer_traits_test.cpp
@@ -55,13 +55,13 @@ BOOST_AUTO_TEST_CASE(BiasLayerTraitsTest)
 // Test the MulticlassClassificationLayer traits.
 BOOST_AUTO_TEST_CASE(MulticlassClassificationLayerTraitsTest)
 {
-  bool b = LayerTraits<MulticlassClassificationLayer>::IsBinary;
+  bool b = LayerTraits<MulticlassClassificationLayer<> >::IsBinary;
   BOOST_REQUIRE_EQUAL(b, false);
 
-  b = LayerTraits<MulticlassClassificationLayer>::IsOutputLayer;
+  b = LayerTraits<MulticlassClassificationLayer<> >::IsOutputLayer;
   BOOST_REQUIRE_EQUAL(b, true);
 
-  b = LayerTraits<MulticlassClassificationLayer>::IsBiasLayer;
+  b = LayerTraits<MulticlassClassificationLayer<> >::IsBiasLayer;
   BOOST_REQUIRE_EQUAL(b, false);
 }
 


### PR DESCRIPTION
Template declaration duplication, which is fine with `gcc` but raises error with `clang`.
For example:
```
mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp:231:28:
error: declaration of 'BoundType' shadows template parameter
template<typename BoundType, typename MatType> class SplitType>
```