### PR TITLE
Add exception for starting & stopping given timer

### DIFF
--- a/doc/guide/timer.hpp
+++ b/doc/guide/timer.hpp
@@ -30,7 +30,8 @@ timeval Timer::Get(const char* name);
 Each timer is given a name, and is referenced by that name.  You can call \c
 Timer::Start() and \c Timer::Stop() multiple times for a particular timer name,
 and the result will be the sum of the runs of the timer.  Note that \c
-Timer::Stop() must be called before \c Timer::Start() is called again.
+Timer::Stop() must be called before \c Timer::Start() is called again,
+otherwise runtime_error exception will occur.
 
 A "total_time" timer is run by default for each MLPACK program.
 

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -147,6 +147,7 @@
  *   - Janzen Brewer <jahabrewer@gmail.com>
  *   - Trung Dinh <dinhanhtrung@gmail.com>
  *   - Tham Ngap Wei <thamngapwei@gmail.com>
+ *   - Grzegorz Krajewski <krajekg@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core/util/timers.cpp
+++ b/src/mlpack/core/util/timers.cpp
@@ -33,6 +33,17 @@ inline void timersub(const timeval* tvp, const timeval* uvp, timeval* vvp)
  */
 void Timer::Start(const std::string& name)
 {
+    if((timerState[name] == 1) && (name != "total_time"))
+  {
+    std::ostringstream error;
+    error << "Timer::Start(): timer '" << name
+	      << "' has already been " << "started";
+	
+    throw std::runtime_error(error.str());
+  }
+  
+  timerState[name] = true;
+  
   CLI::GetSingleton().timer.StartTimer(name);
 }
 
@@ -41,6 +52,17 @@ void Timer::Start(const std::string& name)
  */
 void Timer::Stop(const std::string& name)
 {
+    if((timerState[name] == 0) && (name != "total_time"))
+  {
+    std::ostringstream error;
+    error << "Timer::Stop(): timer '" << name
+	<< "' has already been " << "stopped";
+	
+    throw std::runtime_error(error.str());
+  }
+  
+  timerState[name] = false;
+  
   CLI::GetSingleton().timer.StopTimer(name);
 }
 

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -68,7 +68,7 @@ class Timer
    * both runs -- that is, MLPACK timers are additive for each time they are
    * run, and do not reset.
    *
-   * @note Undefined behavior will occur if a timer is started twice.
+   * @note Runtime error exception will occur if a timer is started twice.
    *
    * @param name Name of timer to be started.
    */
@@ -77,7 +77,7 @@ class Timer
   /**
    * Stop the given timer.
    *
-   * @note Undefined behavior will occur if a timer is started twice.
+   * @note Runtime error exception will occur if a timer is stopped twice.
    *
    * @param name Name of timer to be stopped.
    */
@@ -89,6 +89,9 @@ class Timer
    * @param name Name of timer to return value of.
    */
   static timeval Get(const std::string& name);
+    
+ private:
+  static std::map<std::string, bool> timerState;
 };
 
 class Timers

--- a/src/mlpack/tests/cli_test.cpp
+++ b/src/mlpack/tests/cli_test.cpp
@@ -269,4 +269,18 @@ BOOST_AUTO_TEST_CASE(MultiRunTimerTest)
   BOOST_REQUIRE_GE(Timer::Get("test_timer").tv_usec, 40000);
 }
 
+BOOST_AUTO_TEST_CASE(TwiceStartTimerTest)
+{
+  Timer::Start("test_timer");
+  
+  BOOST_REQUIRE_THROW(Timer::Start("test_timer"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(TwiceStopTimerTest)
+{
+  Timer::Stop("test_timer");
+  
+  BOOST_REQUIRE_THROW(Timer::Stop("test_timer"), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Runtime error exception will occur if a <b>Timer::Start</b> or <b>Timer::Stop</b> will be called twice.