### PR TITLE
kmeans: small fix with inf variance

### DIFF
--- a/src/mlpack/methods/kmeans/max_variance_new_cluster_impl.hpp
+++ b/src/mlpack/methods/kmeans/max_variance_new_cluster_impl.hpp
@@ -65,7 +65,10 @@ size_t MaxVarianceNewCluster::EmptyCluster(const MatType& data,
   // Modify the variances, as necessary.
   variances[emptyCluster] = 0;
   // One has already been subtracted from clusterCounts[maxVarCluster].
-  variances[maxVarCluster] = (1.0 / (clusterCounts[maxVarCluster])) *
+  if (clusterCounts[maxVarCluster] <= 1)
+    variances[maxVarCluster] = 0;
+  else
+    variances[maxVarCluster] = (1.0 / clusterCounts[maxVarCluster]) *
       ((clusterCounts[maxVarCluster] + 1) * variances[maxVarCluster] - maxDistance);
 
   // Output some debugging information.


### PR DESCRIPTION
Hi there!

There seems to be no check on the cluster size when it's decreased, yet it's used afterwards to update the variance. So, if the cluster size reaches zero, the variance is infinity. As a result, the cluster gets chosen in the next iteration and causes access to `furthestPoint == data.n_cols`, which is rather sad.
I simply added the same condition as in `Precalculate`.