### PR TITLE
Terminate the program timers properly.

### DIFF
--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -54,9 +54,16 @@ CLI::CLI(const CLI& other) : desc(other.desc),
 
 CLI::~CLI()
 {
-  // Terminate the program timer.
-  Timer::Stop("total_time");
-
+  // Terminate the program timers.
+  std::map<std::string, timeval>::iterator it;
+  for (it = timer.GetAllTimers().begin(); it != timer.GetAllTimers().end();
+       ++it)
+  {
+    std::string i = (*it).first;
+    if(timer.GetState(i) == 1)
+      Timer::Stop(i);
+  }
+  
   // Did the user ask for verbose output?  If so we need to print everything.
   // But only if the user did not ask for help or info.
   if (HasParam("verbose") && !HasParam("help") && !HasParam("info"))

--- a/src/mlpack/core/util/timers.cpp
+++ b/src/mlpack/core/util/timers.cpp
@@ -62,6 +62,11 @@ timeval Timers::GetTimer(const std::string& timerName)
   return timers[timerName];
 }
 
+bool Timers::GetState(std::string timerName)
+{
+  return timerState[timerName];
+}
+
 void Timers::PrintTimer(const std::string& timerName)
 {
   timeval& t = timers[timerName];

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -137,6 +137,13 @@ class Timers
    */
   void StopTimer(const std::string& timerName);
 
+  /**
+   * Returns state of the given timer.
+   * 
+   * @param timerName The name of the timer in question.
+   */
+  bool GetState(std::string timerName);
+  
  private:
   //! A map of all the timers that are being tracked.
   std::map<std::string, timeval> timers;


### PR DESCRIPTION
CLI Destructor terminate the program timers properly even if the 'Timer::Stop' wasn't called.