### PR TITLE
add move constructor and move assignment for ann modules

### DIFF
--- a/src/mlpack/methods/ann/layer/base_layer.hpp
+++ b/src/mlpack/methods/ann/layer/base_layer.hpp
@@ -50,6 +50,20 @@ class BaseLayer
   {
     // Nothing to do here.
   }
+  
+  BaseLayer(BaseLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  BaseLayer& operator=(BaseLayer &&layer) noexcept
+  {
+    delta.swap(layer.delta);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+
+    return *this;
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/bias_layer.hpp
+++ b/src/mlpack/methods/ann/layer/bias_layer.hpp
@@ -62,6 +62,29 @@ class BiasLayer
   {
     weightInitRule.Initialize(weights, outSize, 1);
   }
+  
+  BiasLayer(BiasLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  BiasLayer& operator=(BiasLayer &&layer) noexcept
+  {
+    optimizer = layer.optimizer;
+    layer.optimizer = nullptr;
+    ownsOptimizer = layer.ownsOptimizer;
+    layer.ownsOptimizer = false;
+
+    outSize = layer.outSize;
+    bias = layer.bias;
+    weights.swap(layer.weights);
+    delta.swap(layer.delta);
+    gradient.swap(layer.gradient);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+
+    return *this;
+  }
 
   /**
    * Delete the bias layer object and its optimizer.
@@ -191,7 +214,7 @@ class BiasLayer
 
  private:
   //! Locally-stored number of output units.
-  const size_t outSize;
+  size_t outSize;
 
   //! Locally-stored bias value.
   double bias;

--- a/src/mlpack/methods/ann/layer/conv_layer.hpp
+++ b/src/mlpack/methods/ann/layer/conv_layer.hpp
@@ -88,6 +88,35 @@ class ConvLayer
     weightInitRule.Initialize(weights, wfilter, hfilter, inMaps * outMaps);
   }
 
+  ConvLayer(ConvLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  ConvLayer& operator=(ConvLayer &&layer) noexcept
+  {
+    optimizer = layer.optimizer;
+    ownsOptimizer = layer.ownsOptimizer;
+    layer.optimizer = nullptr;
+    layer.ownsOptimizer = false;
+
+    wfilter = layer.wfilter;
+    hfilter = layer.hfilter;
+    inMaps = layer.inMaps;
+    outMaps = layer.outMaps;
+    xStride = layer.xStride;
+    yStride = layer.yStride;
+    wPad = layer.wPad;
+    hPad = layer.hPad;
+    weights.swap(layer.weights);
+    delta.swap(layer.delta);
+    gradient.swap(layer.gradient);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+
+    return *this;
+  }
+
   /**
    * Delete the convolution layer object and its optimizer.
    */
@@ -282,28 +311,28 @@ class ConvLayer
   }
 
   //! Locally-stored filter/kernel width.
-  const size_t wfilter;
+  size_t wfilter;
 
   //! Locally-stored filter/kernel height.
-  const size_t hfilter;
+  size_t hfilter;
 
   //! Locally-stored number of input maps.
-  const size_t inMaps;
+  size_t inMaps;
 
   //! Locally-stored number of output maps.
-  const size_t outMaps;
+  size_t outMaps;
 
   //! Locally-stored stride of the filter in x-direction.
-  const size_t xStride;
+  size_t xStride;
 
   //! Locally-stored stride of the filter in y-direction.
-  const size_t yStride;
+  size_t yStride;
 
   //! Locally-stored padding width.
-  const size_t wPad;
+  size_t wPad;
 
   //! Locally-stored padding height.
-  const size_t hPad;
+  size_t hPad;
 
   //! Locally-stored weight object.
   OutputDataType weights;
@@ -359,7 +388,7 @@ class LayerTraits<ConvLayer<OptimizerType,
   static const bool IsConnection = true;
 };
 
-} // namespace ann
-} // namespace mlpack
+}; // namespace ann
+}; // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/dropout_layer.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_layer.hpp
@@ -66,6 +66,25 @@ class DropoutLayer
     // Nothing to do here.
   }
 
+  DropoutLayer(DropoutLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  DropoutLayer& operator=(DropoutLayer &&layer) noexcept
+  {
+    delta.swap(layer.delta);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(outputParameter);
+    mask.swap(layer.mask);
+    ratio = layer.ratio;
+    scale = layer.scale;
+    deterministic = layer.deterministic;
+    rescale = layer.rescale;
+
+    return *this;
+  }
+
   /**
    * Ordinary feed forward pass of the dropout layer.
    *
@@ -231,7 +250,7 @@ template <
 >
 using DropoutLayer2D = DropoutLayer<InputDataType, OutputDataType>;
 
-} // namespace ann
-} // namespace mlpack
+}; // namespace ann
+}; // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/linear_layer.hpp
+++ b/src/mlpack/methods/ann/layer/linear_layer.hpp
@@ -58,6 +58,29 @@ class LinearLayer
   {
     weightInitRule.Initialize(weights, outSize, inSize);
   }
+  
+  LinearLayer(LinearLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  LinearLayer& operator=(LinearLayer &&layer) noexcept
+  {
+    ownsOptimizer = layer.ownsOptimizer;
+    layer.ownsOptimizer = false;
+    optimizer = layer.optimizer;
+    layer.optimizer = nullptr;
+
+    inSize = layer.inSize;
+    outSize = layer.outSize;
+    weights.swap(layer.weights);
+    delta.swap(layer.delta);
+    gradient.swap(layer.gradient);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+
+    return *this;
+  }
 
   /**
    * Delete the linear layer object and its optimizer.
@@ -262,10 +285,10 @@ class LinearLayer
   }
 
   //! Locally-stored number of input units.
-  const size_t inSize;
+  size_t inSize;
 
   //! Locally-stored number of output units.
-  const size_t outSize;
+  size_t outSize;
 
   //! Locally-stored weight object.
   OutputDataType weights;

--- a/src/mlpack/methods/ann/layer/lstm_layer.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_layer.hpp
@@ -83,6 +83,45 @@ class LSTMLayer
     }
   }
 
+  LSTMLayer(LSTMLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  LSTMLayer& operator=(LSTMLayer &&layer) noexcept
+  {
+    optimizer = layer.optimizer;
+    ownsOptimizer = layer.ownsOptimizer;
+    layer.optimizer = nullptr;
+    layer.ownsOptimizer = false;
+
+    outSize = layer.outSize;
+    peepholes = layer.peepholes;
+    seqLen = layer.seqLen;
+    offset = layer.offset;
+    delta.swap(layer.delta);
+    gradient.swap(layer.gradient);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+    inGate.swap(layer.inGate);
+    inGateAct.swap(layer.inGateAct);
+    inGateError.swap(layer.inGateError);
+    outGate.swap(layer.outGate);
+    outGateAct.swap(layer.outGateAct);
+    outGateError.swap(layer.outGateError);
+    forgetGate.swap(layer.forgetGate);
+    forgetGateAct.swap(layer.forgetGateAct);
+    forgetGateError.swap(layer.forgetGateError);
+    state.swap(layer.state);
+    stateError.swap(layer.stateError);
+    cellAct.swap(layer.cellAct);
+    peepholeWeights.swap(layer.peepholeWeights);
+    peepholeDerivatives.swap(layer.peepholeDerivatives);
+    peepholeGradient.swap(layer.peepholeGradient);
+
+    return *this;
+  }
+
   /**
    * Delete the LSTMLayer object and its optimizer.
    */
@@ -309,10 +348,10 @@ class LSTMLayer
 
  private:
   //! Locally-stored number of output units.
-  const size_t outSize;
+  size_t outSize;
 
   //! Locally-stored peephole indication flag.
-  const bool peepholes;
+  bool peepholes;
 
   //! Locally-stored length of the the input sequence.
   size_t seqLen;
@@ -419,7 +458,7 @@ class LayerTraits<LSTMLayer<OptimizerType,
   static const bool IsConnection = false;
 };
 
-} // namespace ann
-} // namespace mlpack
+}; // namespace ann
+}; // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/pooling_layer.hpp
+++ b/src/mlpack/methods/ann/layer/pooling_layer.hpp
@@ -45,6 +45,22 @@ class PoolingLayer
     // Nothing to do here.
   }
 
+  PoolingLayer(PoolingLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  PoolingLayer& operator=(PoolingLayer &&layer) noexcept
+  {
+    kSize = layer.kSize;
+    delta.swap(layer.delta);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+    pooling = std::move(layer.pooling);
+
+    return *this;
+  }
+
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
    * f(x) by propagating the activity forward through f.
@@ -235,7 +251,7 @@ class LayerTraits<PoolingLayer<PoolingRule, InputDataType, OutputDataType> >
 };
 
 
-} // namespace ann
-} // namespace mlpack
+}; // namespace ann
+}; // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/recurrent_layer.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_layer.hpp
@@ -82,6 +82,30 @@ class RecurrentLayer
     weightInitRule.Initialize(weights, outSize, inSize);
   }
 
+  RecurrentLayer(RecurrentLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  RecurrentLayer& operator=(RecurrentLayer &&layer) noexcept
+  {
+    optimizer = layer.optimizer;
+    ownsOptimizer = layer.ownsOptimizer;
+    layer.optimizer = nullptr;
+    layer.ownsOptimizer = false;
+
+    inSize = layer.inSize;
+    outSize = layer.outSize;
+    weights.swap(layer.weights);
+    delta.swap(layer.delta);
+    gradient.swap(layer.gradient);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+    recurrentParameter.swap(layer.recurrentParameter);
+
+    return *this;
+  }
+
   /**
    * Delete the RecurrentLayer object and its optimizer.
    */
@@ -183,10 +207,10 @@ class RecurrentLayer
 
  private:
   //! Locally-stored number of input units.
-  const size_t inSize;
+  size_t inSize;
 
   //! Locally-stored number of output units.
-  const size_t outSize;
+  size_t outSize;
 
   //! Locally-stored weight object.
   OutputDataType weights;
@@ -234,7 +258,7 @@ class LayerTraits<RecurrentLayer<
   static const bool IsConnection = true;
 };
 
-} // namespace ann
-} // namespace mlpack
+}; // namespace ann
+}; // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/softmax_layer.hpp
+++ b/src/mlpack/methods/ann/layer/softmax_layer.hpp
@@ -36,6 +36,20 @@ class SoftmaxLayer
     // Nothing to do here.
   }
 
+  SoftmaxLayer(SoftmaxLayer &&layer) noexcept
+  {
+    *this = std::move(layer);
+  }
+
+  SoftmaxLayer& operator=(SoftmaxLayer &&layer) noexcept
+  {
+    delta.swap(layer.delta);
+    inputParameter.swap(layer.inputParameter);
+    outputParameter.swap(layer.outputParameter);
+
+    return *this;
+  }
+
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
    * f(x) by propagating the activity forward through f.
@@ -94,7 +108,7 @@ class SoftmaxLayer
   OutputDataType outputParameter;
 }; // class SoftmaxLayer
 
-} // namespace ann
-} // namespace mlpack
+}; // namespace ann
+}; // namespace mlpack
 
 #endif


### PR DESCRIPTION
Implement move constructor and move assignment for ann modues.

By now only implement for linear_layer.hpp, base_layer.hpp and bias_layer.hpp, will implement for another classes step by step