### PR TITLE
Fix confusion in error message

### DIFF
--- a/src/mlpack/methods/logistic_regression/logistic_regression_main.cpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_main.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
 
   // If no output file is given, the user should know that the model will not be
   // saved, but only if a model is being trained.
-  if (outputFile.empty() && !trainingFile.empty())
+  if (outputModelFile.empty() && !trainingFile.empty())
     Log::Warn << "--output_model not given; trained model will not be saved."
         << endl;
 


### PR DESCRIPTION
The error message was "missing output_model",
while the variable used for detecting it was "outputFile",
which refers to the testing output, rather than the model output.