### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR during files generation.

### DIFF
--- a/CMake/CreateArmaConfigInfo.cmake
+++ b/CMake/CreateArmaConfigInfo.cmake
@@ -3,12 +3,12 @@
 # assumes ${ARMADILLO_INCLUDE_DIR} is set.  In addition, we must be careful to
 # avoid overwriting arma_config.hpp with the exact same information, because
 # this may trigger a new complete rebuild, which is undesired.
-if(EXISTS "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
-  file(READ "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp"
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp"
       OLD_FILE_CONTENTS)
-else(EXISTS "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
+else(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
   set(OLD_FILE_CONTENTS "")
-endif(EXISTS "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
+endif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
 
 # If we are using Armadillo 5+, ARMA_64BIT_WORD is implicitly enabled.
 set(ARMA_HAS_64BIT_WORD 0) # This may be unnecessary.
@@ -74,8 +74,8 @@ ${ARMA_64BIT_WORD_DEFINE}
 if(NOT "${OLD_FILE_CONTENTS}" STREQUAL "${NEW_FILE_CONTENTS}")
   # We have a reason to write the new file.
   message(STATUS "Regenerating arma_config.hpp.")
-  file(REMOVE "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
-  file(WRITE "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp"
+  file(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
+  file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp"
       "${NEW_FILE_CONTENTS}")
 endif(NOT "${OLD_FILE_CONTENTS}" STREQUAL "${NEW_FILE_CONTENTS}")
 

--- a/CMake/CreateGitVersionHeader.cmake
+++ b/CMake/CreateGitVersionHeader.cmake
@@ -9,21 +9,21 @@ execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Get the current version, if it exists.
-if(EXISTS ${CMAKE_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
-  file(READ ${CMAKE_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp
       _OLD_GITVERSION_CONTENTS)
   string(REGEX REPLACE ".*return \"mlpack git-([0-9a-f]+)\".*" "\\1"
       OLD_GIT_REVISION ${_OLD_GITVERSION_CONTENTS})
-else(EXISTS ${CMAKE_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
+else(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
   set(OLD_GIT_REVISION "notfound")
-endif(EXISTS ${CMAKE_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
+endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
 
 if("${OLD_GIT_REVISION}" STREQUAL "${NEW_GIT_REVISION}")
   message(STATUS "gitversion.hpp is already up to date.")
 else("${OLD_GIT_REVISION}" STREQUAL "${NEW_GIT_REVISION}")
   # Remove the old version.
-  file(REMOVE ${CMAKE_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
-  file(WRITE ${CMAKE_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp
+  file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp)
+  file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/gitversion.hpp
       "return \"mlpack git-${NEW_GIT_REVISION}\";\n")
   message(STATUS "Updated gitversion.hpp.")
 endif("${OLD_GIT_REVISION}" STREQUAL "${NEW_GIT_REVISION}")


### PR DESCRIPTION
I tried to use mlpack as a submodule of my project. Building such setup failed since some files were generated outside of mlpack source tree.