### PR TITLE
removing global dependency on cli deleter

### DIFF
--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -13,7 +13,7 @@
 
 #include "cli.hpp"
 #include "log.hpp"
-
+#include "cli_deleter.hpp" // To make sure we can delete the singleton.
 #include "option.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -18,7 +18,7 @@
 #include <boost/program_options.hpp>
 
 #include "timers.hpp"
-#include "cli_deleter.hpp" // To make sure we can delete the singleton.
+
 #include "version.hpp"
 
 /**


### PR DESCRIPTION
This change removes the need to include cli.cpp from my project if I am not using it. 