### PR TITLE
moving cliDeleter instance to log.cpp

### DIFF
--- a/src/mlpack/core/util/cli_deleter.hpp
+++ b/src/mlpack/core/util/cli_deleter.hpp
@@ -24,8 +24,7 @@ class CLIDeleter
   ~CLIDeleter();
 };
 
-//! Declare the deleter.
-static CLIDeleter cliDeleter;
+
 
 } // namespace io
 } // namespace mlpack

--- a/src/mlpack/core/util/log.cpp
+++ b/src/mlpack/core/util/log.cpp
@@ -8,7 +8,7 @@
   #include <cstddef>
   #include <cxxabi.h>
 #endif
-
+#include "cli.hpp"
 #include "log.hpp"
 
 #ifdef BACKTRACE_FOUND
@@ -47,7 +47,8 @@ PrefixedOutStream Log::Warn = PrefixedOutStream(std::cout,
     BASH_YELLOW "[WARN ] " BASH_CLEAR, false, false);
 PrefixedOutStream Log::Fatal = PrefixedOutStream(std::cerr,
     BASH_RED "[FATAL] " BASH_CLEAR, false, true /* fatal */);
-
+//! Declare the deleter.
+static mlpack::util::CLIDeleter cliDeleter;
 std::ostream& Log::cout = std::cout;
 
 // Only do anything for Assert() if in debugging mode.


### PR DESCRIPTION
The sequence of deletion has to be different to the reverse of sequence of creation. Hence cliDeleter is necessary.