### PR TITLE
fix bug--ann constructor hide the name of network

### DIFF
--- a/src/mlpack/methods/ann/cnn_impl.hpp
+++ b/src/mlpack/methods/ann/cnn_impl.hpp
@@ -46,8 +46,8 @@ CNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 
   // Train the model.
   Timer::Start("cnn_optimization");
@@ -83,8 +83,8 @@ CNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 
   Train(predictors, responses);
 }
@@ -112,8 +112,8 @@ CNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 }
 
 template<typename LayerTypes,

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -46,8 +46,8 @@ FFN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 
   // Train the model.
   Timer::Start("ffn_optimization");
@@ -83,8 +83,8 @@ FFN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 
   Train(predictors, responses);
 }
@@ -112,8 +112,8 @@ FFN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 }
 
 template<typename LayerTypes,

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -48,8 +48,8 @@ RNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 
   // Train the model.
   Timer::Start("rnn_optimization");
@@ -87,8 +87,8 @@ RNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 
   Train(predictors, responses);
 }
@@ -118,8 +118,8 @@ RNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
                 OutputLayerType>::value,
                 "The type of outputLayer must be OutputLayerType.");
 
-  initializeRule.Initialize(parameter, NetworkSize(network), 1);
-  NetworkWeights(parameter, network);
+  initializeRule.Initialize(parameter, NetworkSize(this->network), 1);
+  NetworkWeights(parameter, this->network);
 }
 
 template<typename LayerTypes,


### PR DESCRIPTION
The name of network conflict with the data member--"netowrk", this bug related to issues #531