### PR TITLE
Fixes bfd.h: config.h must be included before this header

### DIFF
--- a/src/mlpack/core/util/backtrace.cpp
+++ b/src/mlpack/core/util/backtrace.cpp
@@ -19,7 +19,25 @@
   #include <signal.h>
   #include <unistd.h>
   #include <cxxabi.h>
-  #include <bfd.h>
+  #ifndef PACKAGE
+    #define PACKAGE
+    #ifndef PACKAGE_VERSION
+      #define PACKAGE_VERSION
+      #include <bfd.h>
+      #undef PACKAGE_VERSION
+    #else
+      #include <bfd.h>
+    #endif
+    #undef PACKAGE
+  #else
+    #ifndef PACKAGE_VERSION
+      #define PACKAGE_VERSION
+      #include <bfd.h>
+      #undef PACKAGE_VERSION
+    #else
+      #include <bfd.h>
+    #endif
+  #endif
   #include <dlfcn.h>
 #endif
 


### PR DESCRIPTION
Refers to #574