### PR TITLE
Fix bug #358 (CosineTreeTest/CosineNodeCosineSplit test sometimes fails, only on i386)

### DIFF
--- a/src/mlpack/tests/cosine_tree_test.cpp
+++ b/src/mlpack/tests/cosine_tree_test.cpp
@@ -51,6 +51,8 @@ BOOST_AUTO_TEST_CASE(CosineNodeCosineSplit)
   // Initialize constants required for the test.
   const size_t numRows = 500;
   const size_t numCols = 1000;
+  // Calculation accuracy
+  const double precision = 1e-15;
 
   // Make a random dataset and the root object.
   arma::mat data = arma::randu(numRows, numCols);
@@ -105,14 +107,58 @@ BOOST_AUTO_TEST_CASE(CosineNodeCosineSplit)
 
       // Check if the columns assigned to the children agree with the splitting
       // condition.
-      double cosineMax = arma::max(cosines % (cosines < 1));
+      // Due to miscalculations cosineMax calculated at CosineNodeSplit
+      // may differ from cosineMax below
+      double cosineMax = arma::max(cosines % (cosines < 1.0 + precision));
       double cosineMin = arma::min(cosines);
+      // If max(cosines) is close to 1.0 cosineMax and cosineMax2 may
+      // differ significantly
+      double cosineMax2 = arma::max(cosines % (cosines < 1.0 - precision));
 
-      for (i = 0; i < leftIndices.size(); i++)
-        BOOST_CHECK_LT(cosineMax - cosines(i), cosines(i) - cosineMin);
 
-      for (j = 0, k = i; j < rightIndices.size(); j++, k++)
-        BOOST_CHECK_GT(cosineMax - cosines(k), cosines(k) - cosineMin);
+      if(std::fabs(cosineMax - cosineMax2) < precision)
+      {
+        // Check with some precision
+	    for (i = 0; i < leftIndices.size(); i++)
+          BOOST_CHECK_LT(cosineMax - cosines(i), cosines(i) - cosineMin + precision);
+
+        for (j = 0, k = i; j < rightIndices.size(); j++, k++)
+          BOOST_CHECK_GT(cosineMax - cosines(k), cosines(k) - cosineMin - precision);
+	  }
+	  else
+	  {
+        size_t numMax1Errors = 0;
+        size_t numMax2Errors = 0;
+
+        // Find errors for cosineMax
+        for (i = 0; i < leftIndices.size(); i++)
+          if(cosineMax - cosines(i) >= cosines(i) - cosineMin + precision)
+            numMax1Errors++;
+
+        for (j = 0, k = i; j < rightIndices.size(); j++, k++)
+          if(cosineMax - cosines(k) <= cosines(k) - cosineMin - precision)
+            numMax1Errors++;
+
+        // Find errors for cosineMax
+        for (i = 0; i < leftIndices.size(); i++)
+          if(cosineMax2 - cosines(i) >= cosines(i) - cosineMin + precision)
+            numMax2Errors++;
+
+        for (j = 0, k = i; j < rightIndices.size(); j++, k++)
+          if(cosineMax2 - cosines(k) <= cosines(k) - cosineMin - precision)
+            numMax2Errors++;
+
+        if(numMax1Errors > 0 && numMax2Errors > 0)
+        {
+          // cosineMax and cosineMax2 do not match
+          // we should report the problem
+	      for (i = 0; i < leftIndices.size(); i++)
+            BOOST_CHECK_LT(cosineMax - cosines(i), cosines(i) - cosineMin);
+
+          for (j = 0, k = i; j < rightIndices.size(); j++, k++)
+            BOOST_CHECK_GT(cosineMax - cosines(k), cosines(k) - cosineMin);
+        }
+      }
     }
   }
 }

--- a/src/mlpack/tests/cosine_tree_test.cpp
+++ b/src/mlpack/tests/cosine_tree_test.cpp
@@ -119,14 +119,14 @@ BOOST_AUTO_TEST_CASE(CosineNodeCosineSplit)
       if(std::fabs(cosineMax - cosineMax2) < precision)
       {
         // Check with some precision
-	    for (i = 0; i < leftIndices.size(); i++)
-          BOOST_CHECK_LT(cosineMax - cosines(i), cosines(i) - cosineMin + precision);
+        for (i = 0; i < leftIndices.size(); i++)
+          BOOST_REQUIRE_LT(cosineMax - cosines(i), cosines(i) - cosineMin + precision);
 
         for (j = 0, k = i; j < rightIndices.size(); j++, k++)
-          BOOST_CHECK_GT(cosineMax - cosines(k), cosines(k) - cosineMin - precision);
-	  }
-	  else
-	  {
+          BOOST_REQUIRE_GT(cosineMax - cosines(k), cosines(k) - cosineMin - precision);
+      }
+      else
+      {
         size_t numMax1Errors = 0;
         size_t numMax2Errors = 0;
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(CosineNodeCosineSplit)
           if(cosineMax - cosines(k) <= cosines(k) - cosineMin - precision)
             numMax1Errors++;
 
-        // Find errors for cosineMax
+        // Find errors for cosineMax2
         for (i = 0; i < leftIndices.size(); i++)
           if(cosineMax2 - cosines(i) >= cosines(i) - cosineMin + precision)
             numMax2Errors++;
@@ -148,16 +148,8 @@ BOOST_AUTO_TEST_CASE(CosineNodeCosineSplit)
           if(cosineMax2 - cosines(k) <= cosines(k) - cosineMin - precision)
             numMax2Errors++;
 
-        if(numMax1Errors > 0 && numMax2Errors > 0)
-        {
-          // cosineMax and cosineMax2 do not match
-          // we should report the problem
-	      for (i = 0; i < leftIndices.size(); i++)
-            BOOST_CHECK_LT(cosineMax - cosines(i), cosines(i) - cosineMin);
-
-          for (j = 0, k = i; j < rightIndices.size(); j++, k++)
-            BOOST_CHECK_GT(cosineMax - cosines(k), cosines(k) - cosineMin);
-        }
+        //  One of the maximum cosine values should be correct
+        BOOST_REQUIRE_EQUAL(std::min(numMax1Errors,numMax2Errors),0);
       }
     }
   }


### PR DESCRIPTION
I think I solved the problem.

This problem happens due to miscalculations.
The cosines and cosineMax are computed two times (in CosineTree::CosineNodeSplit and in the test).
And the first cosineMax may differ significantly from the second one.

For example, look at the debug output below
`THIS IS TREE 0xbcbe978`
`cosineMax = 0.99999999999999988898`
`cosineMin = 0.73421824357373099978`
`cosines`
`0.75763372746624790821 0.75999261009165319791 0.75479082605226166525` `0.75788044353107164586 0.99999999999999988898 0.73421824357373099978 `
`THIS IS TEST 0xbcbe978`
`TreeDepth = 11`
`cosineMax = 0.75999261009165330893`
`cosineMin = 0.73421824357373111081`
`cosines`
`1 0.75763372746624801923 0.75999261009165330893 0.75479082605226177627` `0.7578804435310718679 0.73421824357373111081 `

All sets differ by a calculational accuracy of double (about 1e-16 around 1.0).
And the first cosineMax differs significantly from the second one because the second one equals 1 exactly (`cosineMax = arma::max(cosines % (cosines < 1));`).

I suggest to compare doubles with some precision. I correct the test. This should fix the problem.