### PR TITLE
MinGW: use lowercase windows.h

### DIFF
--- a/src/mlpack/tests/cli_test.cpp
+++ b/src/mlpack/tests/cli_test.cpp
@@ -14,7 +14,7 @@
 
 // For Sleep().
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
 #endif
 
 #include <mlpack/core.hpp>


### PR DESCRIPTION
Fixes the build for MinGW-w64 as it uses lowercase headers, unchanged for case-insensitive native windows platforms.