### PR TITLE
Rename mlpack_allknn/mlpack_allkfn to mlpack_knn/mlpack_kfn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,8 @@ if (UNIX)
           ${CMAKE_BINARY_DIR}/bin
         DEPENDS
           mlpack_adaboost
+          mlpack_kfn
+          mlpack_knn
           mlpack_allkfn
           mlpack_allknn
           mlpack_allkrann

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This will build all library components as well as 'mlpack_test'.
 You can specify individual components which you want to build, if you do not
 want to build everything in the library:
 
-    $ make mlpack_pca mlpack_allknn mlpack_allkfn
+    $ make mlpack_pca mlpack_knn mlpack_kfn
 
 If the build fails and you cannot figure out why, register an account on Github
 and submit an issue; the mlpack developers will quickly help you figure it out:
@@ -142,7 +142,7 @@ You can now run the executables by name; you can link against mlpack with
 and the mlpack headers are found in
     `/usr/local/include/mlpack/`.
 
-If running the programs (i.e. `$ mlpack_allknn -h`) gives an error of the form
+If running the programs (i.e. `$ mlpack_knn -h`) gives an error of the form
 
     error while loading shared libraries: libmlpack.so.2: cannot open shared object file: No such file or directory
 
@@ -164,7 +164,7 @@ them from there, or you can install the library and (depending on system
 settings) they should be added to your PATH and you can call them directly.  The
 documentation below assumes the executables are in your PATH.
 
-Consider the 'mlpack_allknn' program, which finds the k nearest neighbors in a
+Consider the 'mlpack_knn' program, which finds the k nearest neighbors in a
 reference dataset of all the points in a query set.  That is, we have a query
 and a reference dataset. For each point in the query dataset, we wish to know
 the k points in the reference dataset which are closest to the given query
@@ -177,15 +177,15 @@ nearest points to that point.
 Each mlpack program has extensive help documentation which details what the
 method does, what each of the parameters are, and how to use them:
 
-    $ mlpack_allknn --help
+    $ mlpack_knn --help
 
-Running `mlpack_allknn` on one dataset (that is, the query and reference
+Running `mlpack_knn` on one dataset (that is, the query and reference
 datasets are the same) and finding the 5 nearest neighbors is very simple:
 
-    $ mlpack_allknn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 5 -v
+    $ mlpack_knn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 5 -v
 
 The `-v (--verbose)` flag is optional; it gives informational output.  It is not
-unique to `mlpack_allknn` but is available in all mlpack programs.  Verbose
+unique to `mlpack_knn` but is available in all mlpack programs.  Verbose
 output also gives timing output at the end of the program, which can be very
 useful.
 

--- a/doc/tutorials/README.md
+++ b/doc/tutorials/README.md
@@ -4,7 +4,7 @@
 Tutorials for mlpack can be found [here : mlpack tutorials](http://www.mlpack.org/tutorial.html).
 
 ### Method-specific tutorials
-* [NeighborSearch tutorial (mlpack_allknn / mlpack_allkfn)](http://www.mlpack.org/doxygen.php?doc=nstutorial.html)
+* [NeighborSearch tutorial (mlpack_knn / mlpack_kfn)](http://www.mlpack.org/doxygen.php?doc=nstutorial.html)
 * [RangeSearch tutorial (mlpack_range_search)](http://www.mlpack.org/doxygen.php?doc=rstutorial.html)
 * [LinearRegression tutorial (mlpack_linear_regression)](http://www.mlpack.org/doxygen.php?doc=lrtutorial.html)
 * [Density Estimation Trees tutorial (mlpack_det)](http://www.mlpack.org/doxygen.php?doc=dettutorial.html)

--- a/doc/tutorials/neighbor_search/neighbor_search.txt
+++ b/doc/tutorials/neighbor_search/neighbor_search.txt
@@ -50,7 +50,7 @@ A list of all the sections this tutorial contains.
 @section cli_nstut Command-Line 'allknn'
 
 The simplest way to perform nearest-neighbors search in \b mlpack is to use the
-\c mlpack_allknn executable.  This program will perform nearest-neighbors search
+\c mlpack_knn executable.  This program will perform nearest-neighbors search
 and place the resultant neighbors into one file and the resultant distances into
 another.  The output files are organized such that the first row corresponds to
 the nearest neighbors of the first query point, with the first column
@@ -61,13 +61,13 @@ Below are several examples of simple usage (and the resultant output).  The
 individual option can be found by typing
 
 @code
-$ mlpack_allknn --help
+$ mlpack_knn --help
 @endcode
 
 @subsection cli_ex1_nstut One dataset, 5 nearest neighbors
 
 @code
-$ mlpack_allknn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 5 -v
+$ mlpack_knn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 5 -v
 [INFO ] Loading 'dataset.csv' as CSV data.  Size is 3 x 1000.
 [INFO ] Loaded reference data from 'dataset.csv' (3 x 1000).
 [INFO ] Building reference tree...
@@ -144,7 +144,7 @@ distance of 7.664920518084e-02.  The third nearest neighbor to point 5 is point
 @subsection cli_ex2_nstut Query and reference dataset, 10 nearest neighbors
 
 @code
-$ mlpack_allknn -q query_dataset.csv -r reference_dataset.csv \
+$ mlpack_knn -q query_dataset.csv -r reference_dataset.csv \
 > -n neighbors_out.csv -d distances_out.csv -k 10 -v
 [INFO ] Loading 'reference_dataset.csv' as CSV data.  Size is 3 x 1000.
 [INFO ] Loaded reference data from 'reference_dataset.csv' (3 x 1000).

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -51,8 +51,8 @@
  * A full list of executables is given below:
  *
  * - mlpack_adaboost
- * - mlpack_allkfn
- * - mlpack_allknn
+ * - mlpack_kfn
+ * - mlpack_knn
  * - mlpack_allkrann
  * - mlpack_cf
  * - mlpack_decision_stump

--- a/src/mlpack/methods/neighbor_search/CMakeLists.txt
+++ b/src/mlpack/methods/neighbor_search/CMakeLists.txt
@@ -48,12 +48,22 @@ install(TARGETS mlpack_knn mlpack_kfn RUNTIME DESTINATION bin)
 # -- mlpack_knn/mlpack_kfn compatibility start --
 # make a copy of mlpack_knn/mlpack_kfn both on Windows and *unix for compatibility
 # should be removed in future release
-get_filename_component(knn_ext $<TARGET_FILE:mlpack_knn> EXT)
+get_property(knn_loc TARGET mlpack_knn PROPERTY LOCATION)
+get_filename_component(knn_ext ${knn_loc} EXT)
 
 add_custom_command(TARGET mlpack_knn POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mlpack_knn> $<TARGET_FILE_DIR:mlpack_knn>/mlpack_allknn${knn_ext}
 )
 
+get_property(kfn_loc TARGET mlpack_kfn PROPERTY LOCATION)
+get_filename_component(kfn_ext ${kfn_loc} EXT)
+
+add_custom_command(TARGET mlpack_kfn POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mlpack_kfn> $<TARGET_FILE_DIR:mlpack_kfn>/mlpack_allkfn${kfn_ext}
+)
+
 MESSAGE( STATUS "knn_ext:" ${knn_ext} )
-MESSAGE( STATUS "mlpack_knn:" $<TARGET_FILE:mlpack_knn> )
+MESSAGE( STATUS "mlpack_knn:" ${knn_loc} )
+MESSAGE( STATUS "kfn_ext:" ${kfn_ext} )
+MESSAGE( STATUS "mlpack_kfn:" ${kfn_loc} )
 # -- mlpack_knn/mlpack_kfn compatibility end --

--- a/src/mlpack/methods/neighbor_search/CMakeLists.txt
+++ b/src/mlpack/methods/neighbor_search/CMakeLists.txt
@@ -48,19 +48,12 @@ install(TARGETS mlpack_knn mlpack_kfn RUNTIME DESTINATION bin)
 # -- mlpack_knn/mlpack_kfn compatibility start --
 # make a copy of mlpack_knn/mlpack_kfn both on Windows and *unix for compatibility
 # should be removed in future release
-add_executable(mlpack_allknn
-  allknn_main.cpp
-)
-target_link_libraries(mlpack_allknn
-  mlpack
+get_filename_component(knn_ext $<TARGET_FILE:mlpack_knn> EXT)
+
+add_custom_command(TARGET mlpack_knn POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mlpack_knn> $<TARGET_FILE_DIR:mlpack_knn>/mlpack_allknn${knn_ext}
 )
 
-add_executable(mlpack_allkfn
-  allkfn_main.cpp
-)
-target_link_libraries(mlpack_allkfn
-  mlpack
-)
-
-install(TARGETS mlpack_allknn mlpack_allkfn RUNTIME DESTINATION bin)
+MESSAGE( STATUS "knn_ext:" ${knn_ext} )
+MESSAGE( STATUS "mlpack_knn:" $<TARGET_FILE:mlpack_knn> )
 # -- mlpack_knn/mlpack_kfn compatibility end --

--- a/src/mlpack/methods/neighbor_search/CMakeLists.txt
+++ b/src/mlpack/methods/neighbor_search/CMakeLists.txt
@@ -29,6 +29,25 @@ endforeach()
 # the parent scope).
 set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)
 
+add_executable(mlpack_knn
+  allknn_main.cpp
+)
+target_link_libraries(mlpack_knn
+  mlpack
+)
+
+add_executable(mlpack_kfn
+  allkfn_main.cpp
+)
+target_link_libraries(mlpack_kfn
+  mlpack
+)
+
+install(TARGETS mlpack_knn mlpack_kfn RUNTIME DESTINATION bin)
+
+# -- mlpack_knn/mlpack_kfn compatibility start --
+# make a copy of mlpack_knn/mlpack_kfn both on Windows and *unix for compatibility
+# should be removed in future release
 add_executable(mlpack_allknn
   allknn_main.cpp
 )
@@ -44,3 +63,4 @@ target_link_libraries(mlpack_allkfn
 )
 
 install(TARGETS mlpack_allknn mlpack_allkfn RUNTIME DESTINATION bin)
+# -- mlpack_knn/mlpack_kfn compatibility end --


### PR DESCRIPTION
fixes #532

Make a copy of mlpack_knn/mlpack_kfn both on Windows and *unix.
Update documentation which references 'allknn' or 'allkfn').