### PR TITLE
Allow to build dlls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ enable_cxx11()
 
 # First, define all the compilation options.
 # We default to debugging mode for developers.
+option(BUILD_SHARED_LIBS "shared/static libs" ON)
 option(DEBUG "Compile with debugging information" ON)
 option(PROFILE "Compile with profiling information" ON)
 option(ARMA_EXTRA_DEBUG "Compile with extra Armadillo debugging symbols." OFF)
@@ -19,6 +20,10 @@ option(TEST_VERBOSE "Run test cases with verbose output." OFF)
 
 # Include modules in the CMake directory.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
+
+if (NOT BUILD_SHARED_LIBS)
+  add_definitions (-DMLPACK_STATIC)
+endif ()
 
 # This is as of yet unused.
 #option(PGO "Use profile-guided optimization if not a debug build" ON)

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -15,15 +15,8 @@ foreach(dir ${DIRS})
     add_subdirectory(${dir})
 endforeach()
 
-# MLPACK_SRCS is set in the subdirectories.
-# We don't use a DLL (shared) on Windows because it's a nightmare.  We can't
-# easily generate the .def file and we won't put __declspec(dllexport) next to
-# every function signature.
-if (WIN32)
-  add_library(mlpack ${MLPACK_SRCS})
-else ()
-  add_library(mlpack SHARED ${MLPACK_SRCS})
-endif ()
+add_library(mlpack ${MLPACK_SRCS})
+
 target_link_libraries(mlpack
   ${ARMADILLO_LIBRARIES}
   ${Boost_LIBRARIES}

--- a/src/mlpack/core/data/dataset_info.hpp
+++ b/src/mlpack/core/data/dataset_info.hpp
@@ -35,7 +35,7 @@ enum Datatype : bool /* bool is all the precision we need for two types */
  * Datatype::categorical) as well as mappings from strings to unsigned integers
  * and vice versa.
  */
-class DatasetInfo
+class MLPACK_API DatasetInfo
 {
  public:
   /**

--- a/src/mlpack/core/dists/discrete_distribution.hpp
+++ b/src/mlpack/core/dists/discrete_distribution.hpp
@@ -35,7 +35,7 @@ namespace distribution /** Probability distributions. */ {
  * into size_t before comparisons.
  * @endnote
  */
-class DiscreteDistribution
+class MLPACK_API DiscreteDistribution
 {
  public:
   /**

--- a/src/mlpack/core/dists/gaussian_distribution.cpp
+++ b/src/mlpack/core/dists/gaussian_distribution.cpp
@@ -201,3 +201,28 @@ void GaussianDistribution::Train(const arma::mat& observations,
 
   FactorCovariance();
 }
+
+
+/**
+* Calculates the multivariate Gaussian log probability density function for each
+* data point (column) in the given matrix
+*/
+void GaussianDistribution::LogProbability(const arma::mat& x,
+                                          arma::vec& logProbabilities) const
+{
+  // Column i of 'diffs' is the difference between x.col(i) and the mean.
+  arma::mat diffs = x - (mean * arma::ones<arma::rowvec>(x.n_cols));
+
+  // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1 *
+  // diffs).  We just don't need any of the other elements.  We can calculate
+  // the right hand part of the equation (instead of the left side) so that
+  // later we are referencing columns, not rows -- that is faster.
+  const arma::mat rhs = -0.5 * invCov * diffs;
+  arma::vec logExponents(diffs.n_cols); // We will now fill this.
+  for (size_t i = 0; i < diffs.n_cols; i++)
+    logExponents(i) = accu(diffs.unsafe_col(i) % rhs.unsafe_col(i));
+
+  const size_t k = x.n_rows;
+
+  logProbabilities = -0.5 * k * log2pi - 0.5 * logDetCov + logExponents;
+}

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -16,7 +16,7 @@ namespace distribution {
 /**
  * A single multivariate Gaussian distribution.
  */
-class GaussianDistribution
+class MLPACK_API GaussianDistribution
 {
  private:
   //! Mean of the distribution.
@@ -90,6 +90,13 @@ class GaussianDistribution
     probabilities = arma::exp(logProbabilities);
   }
 
+  /**
+  * Calculates the multivariate Gaussian log probability density function for each
+  * data point (column) in the given matrix
+  *
+  * @param x List of observations.
+  * @param probabilities Output log probabilities for each input observation.
+  */
   void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const;
 
   /**
@@ -161,33 +168,6 @@ class GaussianDistribution
    */
   void FactorCovariance();
 };
-
-/**
-* Calculates the multivariate Gaussian log probability density function for each
-* data point (column) in the given matrix
-*
-* @param x List of observations.
-* @param probabilities Output log probabilities for each input observation.
-*/
-inline void GaussianDistribution::LogProbability(const arma::mat& x,
-                                                 arma::vec& logProbabilities) const
-{
-  // Column i of 'diffs' is the difference between x.col(i) and the mean.
-  arma::mat diffs = x - (mean * arma::ones<arma::rowvec>(x.n_cols));
-
-  // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1 *
-  // diffs).  We just don't need any of the other elements.  We can calculate
-  // the right hand part of the equation (instead of the left side) so that
-  // later we are referencing columns, not rows -- that is faster.
-  const arma::mat rhs = -0.5 * invCov * diffs;
-  arma::vec logExponents(diffs.n_cols); // We will now fill this.
-  for (size_t i = 0; i < diffs.n_cols; i++)
-    logExponents(i) = accu(diffs.unsafe_col(i) % rhs.unsafe_col(i));
-
-  const size_t k = x.n_rows;
-
-  logProbabilities = -0.5 * k * log2pi - 0.5 * logDetCov + logExponents;
-}
 
 
 } // namespace distribution

--- a/src/mlpack/core/dists/laplace_distribution.hpp
+++ b/src/mlpack/core/dists/laplace_distribution.hpp
@@ -41,7 +41,7 @@ namespace distribution {
  * in the paper above becomes simplified, and the PDF takes roughly the same
  * form as the univariate case.
  */
-class LaplaceDistribution
+class MLPACK_API LaplaceDistribution
 {
  public:
   /**

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -22,7 +22,7 @@ namespace distribution {
  * The hmm observations should have the dependent variable in the first row,
  * with the independent variables in the other rows.
  */
-class RegressionDistribution
+class MLPACK_API RegressionDistribution
 {
  private:
   //! Regression function for representing conditional mean.

--- a/src/mlpack/core/kernels/cosine_distance.hpp
+++ b/src/mlpack/core/kernels/cosine_distance.hpp
@@ -22,7 +22,7 @@ namespace kernel {
  *
  * and this class assumes the standard L2 inner product.
  */
-class CosineDistance
+class MLPACK_API CosineDistance
 {
  public:
   /**

--- a/src/mlpack/core/kernels/epanechnikov_kernel.hpp
+++ b/src/mlpack/core/kernels/epanechnikov_kernel.hpp
@@ -21,7 +21,7 @@ namespace kernel {
  *
  * where @f$ b @f$ is the bandwidth the of the kernel (defaults to 1.0).
  */
-class EpanechnikovKernel
+class MLPACK_API EpanechnikovKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/example_kernel.hpp
+++ b/src/mlpack/core/kernels/example_kernel.hpp
@@ -69,7 +69,7 @@ namespace kernel {
  * is necessary.
  * @endnote
  */
-class ExampleKernel
+class MLPACK_API ExampleKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/gaussian_kernel.hpp
+++ b/src/mlpack/core/kernels/gaussian_kernel.hpp
@@ -25,7 +25,7 @@ namespace kernel {
  *
  * The implementation is all in the header file because it is so simple.
  */
-class GaussianKernel
+class MLPACK_API GaussianKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/hyperbolic_tangent_kernel.hpp
+++ b/src/mlpack/core/kernels/hyperbolic_tangent_kernel.hpp
@@ -20,7 +20,7 @@ namespace kernel {
  * K(x, y) = \tanh(s <x, y> + t)
  * @f]
  */
-class HyperbolicTangentKernel
+class MLPACK_API HyperbolicTangentKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/laplacian_kernel.hpp
+++ b/src/mlpack/core/kernels/laplacian_kernel.hpp
@@ -22,7 +22,7 @@ namespace kernel {
  *
  * The implementation is all in the header file because it is so simple.
  */
-class LaplacianKernel
+class MLPACK_API LaplacianKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/linear_kernel.hpp
+++ b/src/mlpack/core/kernels/linear_kernel.hpp
@@ -24,7 +24,7 @@ namespace kernel {
  *
  * This kernel has no parameters and therefore the evaluation can be static.
  */
-class LinearKernel
+class MLPACK_API LinearKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/polynomial_kernel.hpp
+++ b/src/mlpack/core/kernels/polynomial_kernel.hpp
@@ -20,7 +20,7 @@ namespace kernel {
  * K(x, y) = (x^T * y + offset) ^ {degree}.
  * @f]
  */
-class PolynomialKernel
+class MLPACK_API PolynomialKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/pspectrum_string_kernel.hpp
+++ b/src/mlpack/core/kernels/pspectrum_string_kernel.hpp
@@ -56,7 +56,7 @@ namespace kernel {
  * tree.  This kernel was originally written for the FastMKS method; so, at the
  * very least, it will work with that.
  */
-class PSpectrumStringKernel
+class MLPACK_API PSpectrumStringKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/spherical_kernel.hpp
+++ b/src/mlpack/core/kernels/spherical_kernel.hpp
@@ -15,7 +15,7 @@ namespace kernel {
  * The spherical kernel, which is 1 when the distance between the two argument
  * points is less than or equal to the bandwidth, or 0 otherwise.
  */
-class SphericalKernel
+class MLPACK_API SphericalKernel
 {
  public:
   /**

--- a/src/mlpack/core/kernels/triangular_kernel.hpp
+++ b/src/mlpack/core/kernels/triangular_kernel.hpp
@@ -22,7 +22,7 @@ namespace kernel {
  *
  * where \f$ b \f$ is the bandwidth of the kernel.
  */
-class TriangularKernel
+class MLPACK_API TriangularKernel
 {
  public:
   /**

--- a/src/mlpack/core/math/columns_to_blocks.hpp
+++ b/src/mlpack/core/math/columns_to_blocks.hpp
@@ -98,7 +98,7 @@ namespace math {
  * set the buffer size and value.  See the Scale(), MinRange(), MaxRange(),
  * BufSize(), and BufValue() methods for more details.
  */
-class ColumnsToBlocks
+class MLPACK_API ColumnsToBlocks
 {
  public:
   /**

--- a/src/mlpack/core/math/lin_alg.hpp
+++ b/src/mlpack/core/math/lin_alg.hpp
@@ -20,6 +20,7 @@ namespace math {
  * is ignored in the power operation and then re-added.  Useful for
  * eigenvalues.
  */
+MLPACK_API
 void VectorPower(arma::vec& vec, const double power);
 
 /**
@@ -29,6 +30,7 @@ void VectorPower(arma::vec& vec, const double power);
  * @param x Input matrix
  * @param xCentered Matrix to write centered output into
  */
+MLPACK_API
 void Center(const arma::mat& x, arma::mat& xCentered);
 
 /**
@@ -36,6 +38,7 @@ void Center(const arma::mat& x, arma::mat& xCentered);
  * matrix. Whitening means the covariance matrix of the result is the identity
  * matrix.
  */
+MLPACK_API
 void WhitenUsingSVD(const arma::mat& x,
                     arma::mat& xWhitened,
                     arma::mat& whiteningMatrix);
@@ -44,6 +47,7 @@ void WhitenUsingSVD(const arma::mat& x,
  * Whitens a matrix using the eigendecomposition of the covariance matrix.
  * Whitening means the covariance matrix of the result is the identity matrix.
  */
+MLPACK_API
 void WhitenUsingEig(const arma::mat& x,
                     arma::mat& xWhitened,
                     arma::mat& whiteningMatrix);
@@ -51,18 +55,21 @@ void WhitenUsingEig(const arma::mat& x,
 /**
  * Overwrites a dimension-N vector to a random vector on the unit sphere in R^N.
  */
+MLPACK_API
 void RandVector(arma::vec& v);
 
 /**
  * Orthogonalize x and return the result in W, using eigendecomposition.
  * We will be using the formula \f$ W = x (x^T x)^{-0.5} \f$.
  */
+MLPACK_API
 void Orthogonalize(const arma::mat& x, arma::mat& W);
 
 /**
  * Orthogonalize x in-place.  This could be sped up by a custom
  * implementation.
  */
+MLPACK_API
 void Orthogonalize(arma::mat& x);
 
 /**
@@ -72,6 +79,7 @@ void Orthogonalize(arma::mat& x);
  * @param rowsToRemove Vector containing indices of rows to be removed.
  * @param output Matrix to copy non-removed rows into.
  */
+MLPACK_API
 void RemoveRows(const arma::mat& input,
                 const std::vector<size_t>& rowsToRemove,
                 arma::mat& output);
@@ -85,8 +93,10 @@ void RemoveRows(const arma::mat& input,
  * @param input A symmetric matrix
  * @param output
  */
+MLPACK_API
 void Svec(const arma::mat& input, arma::vec& output);
 
+MLPACK_API
 void Svec(const arma::sp_mat& input, arma::sp_vec& output);
 
 /**
@@ -95,6 +105,7 @@ void Svec(const arma::sp_mat& input, arma::sp_vec& output);
  * @param input
  * @param output A symmetric matrix
  */
+MLPACK_API
 void Smat(const arma::vec& input, arma::mat& output);
 
 /**
@@ -117,6 +128,7 @@ inline size_t SvecIndex(size_t i, size_t j, size_t n);
  * @param A
  * @param op
  */
+MLPACK_API
 void SymKronId(const arma::mat& A, arma::mat& op);
 
 } // namespace math

--- a/src/mlpack/core/math/random.cpp
+++ b/src/mlpack/core/math/random.cpp
@@ -5,15 +5,17 @@
  */
 #include <random>
 
+#include <mlpack/prereqs.hpp>
+
 namespace mlpack {
 namespace math {
 
 // Global random object.
-std::mt19937 randGen;
+MLPACK_API std::mt19937 randGen;
 // Global uniform distribution.
-std::uniform_real_distribution<> randUniformDist(0.0, 1.0);
+MLPACK_API std::uniform_real_distribution<> randUniformDist(0.0, 1.0);
 // Global normal distribution.
-std::normal_distribution<> randNormalDist(0.0, 1.0);
+MLPACK_API std::normal_distribution<> randNormalDist(0.0, 1.0);
 
 } // namespace math
 } // namespace mlpack

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -13,11 +13,11 @@ namespace mlpack {
 namespace math /** Miscellaneous math routines. */ {
 
 // Global random object.
-extern std::mt19937 randGen;
+MLPACK_API extern std::mt19937 randGen;
 // Global uniform distribution.
-extern std::uniform_real_distribution<> randUniformDist;
+MLPACK_API extern std::uniform_real_distribution<> randUniformDist;
 // Global normal distribution.
-extern std::normal_distribution<> randNormalDist;
+MLPACK_API extern std::normal_distribution<> randNormalDist;
 
 /**
  * Set the random seed used by the random functions (Random() and RandInt()).
@@ -41,6 +41,7 @@ inline void RandomSeed(const size_t seed)
 /**
  * Generates a uniform random number between 0 and 1.
  */
+
 inline double Random()
 {
   return randUniformDist(randGen);
@@ -49,6 +50,7 @@ inline double Random()
 /**
  * Generates a uniform random number in the specified range.
  */
+
 inline double Random(const double lo, const double hi)
 {
   return lo + (hi - lo) * randUniformDist(randGen);
@@ -57,6 +59,7 @@ inline double Random(const double lo, const double hi)
 /**
  * Generates a uniform random integer.
  */
+
 inline int RandInt(const int hiExclusive)
 {
   return (int) std::floor((double) hiExclusive * randUniformDist(randGen));
@@ -65,6 +68,7 @@ inline int RandInt(const int hiExclusive)
 /**
  * Generates a uniform random integer.
  */
+
 inline int RandInt(const int lo, const int hiExclusive)
 {
   return lo + (int) std::floor((double) (hiExclusive - lo)
@@ -74,6 +78,7 @@ inline int RandInt(const int lo, const int hiExclusive)
 /**
  * Generates a normally distributed random number with mean 0 and variance 1.
  */
+
 inline double RandNormal()
 {
   return randNormalDist(randGen);
@@ -86,6 +91,7 @@ inline double RandNormal()
  * @param mean Mean of distribution.
  * @param variance Variance of distribution.
  */
+
 inline double RandNormal(const double mean, const double variance)
 {
   return variance * randNormalDist(randGen) + mean;

--- a/src/mlpack/core/math/random_basis.hpp
+++ b/src/mlpack/core/math/random_basis.hpp
@@ -19,6 +19,7 @@ namespace math {
  * @param basis Matrix to store basis in.
  * @param d Desired number of dimensions in the basis.
  */
+MLPACK_API
 void RandomBasis(arma::mat& basis, const size_t d);
 
 } // namespace math

--- a/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_test_functions.hpp
+++ b/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_test_functions.hpp
@@ -20,7 +20,7 @@ namespace optimization {
  * The minimum that satisfies the constraint is x = [1, 4], with an objective
  * value of 70.
  */
-class AugLagrangianTestFunction
+class MLPACK_API AugLagrangianTestFunction
 {
  public:
   AugLagrangianTestFunction();
@@ -53,7 +53,7 @@ class AugLagrangianTestFunction
  * The minimum that satisfies the two constraints is given as
  *   x = [0.12288, -1.1078, 0.015100], with an objective value of about 29.634.
  */
-class GockenbachFunction
+class MLPACK_API GockenbachFunction
 {
  public:
   GockenbachFunction();
@@ -97,7 +97,7 @@ class GockenbachFunction
  * coordinates given to the Evaluate(), Gradient(), EvaluateConstraint(), and
  * GradientConstraint() functions.
  */
-class LovaszThetaSDP
+class MLPACK_API LovaszThetaSDP
 {
  public:
   LovaszThetaSDP();

--- a/src/mlpack/core/optimizers/lbfgs/test_functions.hpp
+++ b/src/mlpack/core/optimizers/lbfgs/test_functions.hpp
@@ -45,7 +45,7 @@ namespace test {
  * "An automatic method for finding the greatest or least value of a function."
  *   H.H. Rosenbrock.  1960.  Comput. J. 3., 175-184.
  */
-class RosenbrockFunction
+class MLPACK_API RosenbrockFunction
 {
  public:
   RosenbrockFunction(); // initialize initial point
@@ -75,7 +75,7 @@ class RosenbrockFunction
  * "A comparative study of nonlinear programming codes."
  *   A.R. Colville.  1968.  Rep. 320-2949, IBM N.Y. Scientific Center.
  */
-class WoodFunction
+class MLPACK_API WoodFunction
 {
  public:
   WoodFunction(); // initialize initial point
@@ -105,7 +105,7 @@ class WoodFunction
  * "An analysis of the behavior of a glass of genetic adaptive systems."
  *   K.A. De Jong.  Ph.D. thesis, University of Michigan, 1975.
  */
-class GeneralizedRosenbrockFunction
+class MLPACK_API GeneralizedRosenbrockFunction
 {
  public:
   /***
@@ -136,7 +136,7 @@ class GeneralizedRosenbrockFunction
  * four dimensions.  In this function we are actually optimizing a 2x4 matrix of
  * coordinates, not a vector.
  */
-class RosenbrockWoodFunction
+class MLPACK_API RosenbrockWoodFunction
 {
  public:
   RosenbrockWoodFunction(); // initialize initial point

--- a/src/mlpack/core/optimizers/sgd/sgd.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd.hpp
@@ -67,8 +67,9 @@ namespace optimization {
  * @tparam DecomposableFunctionType Decomposable objective function type to be
  *     minimized.
  */
+
 template<typename DecomposableFunctionType>
-class SGD
+class MLPACK_API SGD
 {
  public:
   /**

--- a/src/mlpack/core/optimizers/sgd/test_function.hpp
+++ b/src/mlpack/core/optimizers/sgd/test_function.hpp
@@ -17,7 +17,7 @@ namespace test {
 //! functions.  The gradient is not very steep far away from the optimum, so a
 //! larger step size may be required to optimize it in a reasonable number of
 //! iterations.
-class SGDTestFunction
+class MLPACK_API SGDTestFunction
 {
  public:
   //! Nothing to do for the constructor.

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
@@ -21,7 +21,7 @@ class CosineTree;
 typedef boost::heap::priority_queue<CosineTree*,
     boost::heap::compare<CompareCosineNode> > CosineNodeQueue;
 
-class CosineTree
+class MLPACK_API CosineTree
 {
  public:
   /**

--- a/src/mlpack/core/util/backtrace.hpp
+++ b/src/mlpack/core/util/backtrace.hpp
@@ -45,7 +45,7 @@ namespace mlpack {
  *
  * @see PrefixedOutStream, Log
  */
-class Backtrace
+class MLPACK_API Backtrace
 {
  public:   
   /**

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -513,7 +513,7 @@ struct ParamData
  * collisions are still possible, and they produce bizarre error messages. See
  * https://github.com/mlpack/mlpack/issues/100 for more information.
  */
-class CLI
+class MLPACK_API CLI
 {
  public:
   /**

--- a/src/mlpack/core/util/cli_deleter.hpp
+++ b/src/mlpack/core/util/cli_deleter.hpp
@@ -7,6 +7,8 @@
 #ifndef MLPACK_CORE_UTIL_CLI_DELETER_HPP
 #define MLPACK_CORE_UTIL_CLI_DELETER_HPP
 
+#include <mlpack/prereqs.hpp>
+
 namespace mlpack {
 namespace util {
 
@@ -17,7 +19,7 @@ namespace util {
  * CLIDeleter class, which will be initialized at the beginning of the program
  * and deleted at the end.  The destructor destroys the CLI singleton.
  */
-class CLIDeleter
+class MLPACK_API CLIDeleter
 {
  public:
   CLIDeleter();

--- a/src/mlpack/core/util/cli_impl.hpp
+++ b/src/mlpack/core/util/cli_impl.hpp
@@ -13,6 +13,8 @@
 // Include option.hpp here because it requires CLI but is also templated.
 #include "option.hpp"
 
+#include "mlpack/prereqs.hpp"
+
 namespace mlpack {
 
 /**
@@ -64,7 +66,7 @@ void CLI::Add(const std::string& path,
 }
 
 // We specialize this in cli.cpp.
-template<>
+template<> MLPACK_API
 bool& CLI::GetParam<bool>(const std::string& identifier);
 
 /**

--- a/src/mlpack/core/util/log.hpp
+++ b/src/mlpack/core/util/log.hpp
@@ -47,7 +47,7 @@ namespace mlpack {
  *
  * @see PrefixedOutStream, NullOutStream, CLI
  */
-class Log
+class MLPACK_API Log
 {
  public:
   /**

--- a/src/mlpack/core/util/option.hpp
+++ b/src/mlpack/core/util/option.hpp
@@ -72,7 +72,7 @@ class Option
  *
  * @see core/io/cli.hpp, mlpack::CLI
  */
-class ProgramDoc
+class MLPACK_API ProgramDoc
 {
  public:
   /**

--- a/src/mlpack/core/util/prefixedoutstream.hpp
+++ b/src/mlpack/core/util/prefixedoutstream.hpp
@@ -20,6 +20,7 @@
 
 #include <mlpack/core/util/sfinae_utility.hpp>
 #include <mlpack/core/util/string_util.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace util {
@@ -49,7 +50,7 @@ namespace util {
  * These objects are used for the mlpack::Log levels (DEBUG, INFO, WARN, and
  * FATAL).
  */
-class PrefixedOutStream
+class MLPACK_API PrefixedOutStream
 {
  public:
   /**

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <chrono> // chrono library for cross platform timer calculation
 
+#include <mlpack/prereqs.hpp>
+
 #if defined(_WIN32)
  // uint64_t isn't defined on every windows.
   #if !defined(HAVE_UINT64_T)
@@ -30,7 +32,7 @@ namespace mlpack {
  * methods contained in this class allow a named timer to be started and
  * stopped, and its value to be obtained.
  */
-class Timer
+class MLPACK_API Timer
 {
  public:
   /**

--- a/src/mlpack/methods/ann/pooling_rules/max_pooling.hpp
+++ b/src/mlpack/methods/ann/pooling_rules/max_pooling.hpp
@@ -16,7 +16,7 @@ namespace ann /** Artificial Neural Network. */ {
  * The max pooling rule for convolution neural networks. Take the maximum value
  * within the receptive block.
  */
-class MaxPooling
+class MLPACK_API MaxPooling
 {
  public:
   /*

--- a/src/mlpack/methods/ann/pooling_rules/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/pooling_rules/mean_pooling.hpp
@@ -16,7 +16,7 @@ namespace ann /** Artificial Neural Network. */ {
  * The mean pooling rule for convolution neural networks. Average all values
  * within the receptive block.
  */
-class MeanPooling
+class MLPACK_API MeanPooling
 {
  public:
   /*

--- a/src/mlpack/methods/cf/cf.hpp
+++ b/src/mlpack/methods/cf/cf.hpp
@@ -72,7 +72,7 @@ struct FactorizerTraits
  *     the rating matrix (a W and H matrix).  This must implement the method
  *     Apply(arma::sp_mat& data, size_t rank, arma::mat& W, arma::mat& H).
  */
-class CF
+class MLPACK_API CF
 {
  public:
   /**

--- a/src/mlpack/methods/det/dt_utils.cpp
+++ b/src/mlpack/methods/det/dt_utils.cpp
@@ -192,7 +192,7 @@ DTree* mlpack::det::Trainer(arma::mat& dataset,
   {
     // Break up data into train and test sets.
     size_t start = fold * testSize;
-    size_t end = std::min((fold + 1) * testSize, (size_t) cvData.n_cols);
+    size_t end = std::min((size_t) (fold + 1) * testSize, (size_t) cvData.n_cols);
 
     arma::mat test = cvData.cols(start, end - 1);
     arma::mat train(cvData.n_rows, cvData.n_cols - test.n_cols);

--- a/src/mlpack/methods/det/dt_utils.hpp
+++ b/src/mlpack/methods/det/dt_utils.hpp
@@ -25,6 +25,7 @@ namespace det {
  * @param numClasses Number of classes in dataset.
  * @param leafClassMembershipFile Name of file to print to (optional).
  */
+MLPACK_API
 void PrintLeafMembership(DTree* dtree,
                          const arma::mat& data,
                          const arma::Mat<size_t>& labels,
@@ -39,6 +40,7 @@ void PrintLeafMembership(DTree* dtree,
  * @param dtree Density tree to use.
  * @param viFile Name of file to print to (optional).
  */
+MLPACK_API
 void PrintVariableImportance(const DTree* dtree,
                              const std::string viFile = "");
 
@@ -54,6 +56,7 @@ void PrintVariableImportance(const DTree* dtree,
  * @param minLeafSize Minimum number of points allowed in a leaf.
  * @param unprunedTreeOutput Filename to print unpruned tree to (optional).
  */
+MLPACK_API
 DTree* Trainer(arma::mat& dataset,
                const size_t folds,
                const bool useVolumeReg = false,

--- a/src/mlpack/methods/det/dtree.hpp
+++ b/src/mlpack/methods/det/dtree.hpp
@@ -36,7 +36,7 @@ namespace det /** Density Estimation Trees */ {
  * }
  * @endcode
  */
-class DTree
+class MLPACK_API DTree
 {
  public:
   /**

--- a/src/mlpack/methods/fastmks/fastmks_model.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_model.hpp
@@ -15,7 +15,7 @@ namespace fastmks {
 
 //! A utility struct to contain all the possible FastMKS models, for use by the
 //! mlpack_fastmks program.
-class FastMKSModel
+class MLPACK_API FastMKSModel
 {
  public:
   //! A list of all the kernels we support.

--- a/src/mlpack/methods/gmm/diagonal_constraint.hpp
+++ b/src/mlpack/methods/gmm/diagonal_constraint.hpp
@@ -15,7 +15,7 @@ namespace gmm {
 /**
  * Force a covariance matrix to be diagonal.
  */
-class DiagonalConstraint
+class MLPACK_API DiagonalConstraint
 {
  public:
   //! Force a covariance matrix to be diagonal.

--- a/src/mlpack/methods/gmm/eigenvalue_ratio_constraint.hpp
+++ b/src/mlpack/methods/gmm/eigenvalue_ratio_constraint.hpp
@@ -19,7 +19,7 @@ namespace gmm {
  * holds a reference to that vector instead of copying it.  (This doesn't apply
  * if you are deserializing the object from a file.)
  */
-class EigenvalueRatioConstraint
+class MLPACK_API EigenvalueRatioConstraint
 {
  public:
   /**

--- a/src/mlpack/methods/gmm/gmm.hpp
+++ b/src/mlpack/methods/gmm/gmm.hpp
@@ -71,7 +71,7 @@ namespace gmm /** Gaussian Mixture Models. */ {
  * arma::vec observation = g.Random();
  * @endcode
  */
-class GMM
+class MLPACK_API GMM
 {
  private:
   //! The number of Gaussians in the model.

--- a/src/mlpack/methods/gmm/no_constraint.hpp
+++ b/src/mlpack/methods/gmm/no_constraint.hpp
@@ -17,7 +17,7 @@ namespace gmm {
  * way, although depending on your situation you may end up with a
  * non-invertible covariance matrix.
  */
-class NoConstraint
+class MLPACK_API NoConstraint
 {
  public:
   //! Do nothing, and do not modify the covariance matrix.

--- a/src/mlpack/methods/gmm/positive_definite_constraint.hpp
+++ b/src/mlpack/methods/gmm/positive_definite_constraint.hpp
@@ -19,7 +19,7 @@ namespace gmm {
  * forcing here is also done in order to bring the condition number of the
  * matrix under 1e5 (10k), which should help with numerical stability.
  */
-class PositiveDefiniteConstraint
+class MLPACK_API PositiveDefiniteConstraint
 {
  public:
   /**

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -81,7 +81,7 @@ namespace regression {
  * }
  * @endcode
  */
-class LARS
+class MLPACK_API LARS
 {
  public:
   /**

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -18,7 +18,7 @@ namespace regression /** Regression methods. */ {
  * Optionally, this class can perform ridge regression, if the lambda parameter
  * is set to a number greater than zero.
  */
-class LinearRegression
+class MLPACK_API LinearRegression
 {
  public:
   /**

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -71,7 +71,7 @@ namespace lcc {
  * }
  * @endcode
  */
-class LocalCoordinateCoding
+class MLPACK_API LocalCoordinateCoding
 {
  public:
   /**

--- a/src/mlpack/methods/matrix_completion/matrix_completion.hpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.hpp
@@ -45,7 +45,7 @@ namespace matrix_completion {
  *
  * @see LRSDP
  */
-class MatrixCompletion
+class MLPACK_API MatrixCompletion
 {
  public:
   /**

--- a/src/mlpack/methods/mvu/mvu.hpp
+++ b/src/mlpack/methods/mvu/mvu.hpp
@@ -24,7 +24,7 @@ namespace mvu {
  * - dataset
  * - new dimensionality
  */
-class MVU
+class MLPACK_API MVU
 {
  public:
   MVU(const arma::mat& dataIn);

--- a/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp
@@ -19,7 +19,7 @@ namespace neighbor {
  * minimum distance is the best (so, when used with NeighborSearch, the output
  * is furthest neighbors).
  */
-class FurthestNeighborSort
+class MLPACK_API FurthestNeighborSort
 {
  public:
   /**

--- a/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp
@@ -23,7 +23,7 @@ namespace neighbor {
  * SortPolicy.  All of the methods implemented here must be implemented by any
  * other SortPolicy classes.
  */
-class NearestNeighborSort
+class MLPACK_API NearestNeighborSort
 {
  public:
   /**

--- a/src/mlpack/methods/neighbor_search/unmap.hpp
+++ b/src/mlpack/methods/neighbor_search/unmap.hpp
@@ -27,6 +27,7 @@ namespace neighbor {
  * @param distancesOut Matrix to store unmapped distances into.
  * @param squareRoot If true, take the square root of the distances.
  */
+MLPACK_API
 void Unmap(const arma::Mat<size_t>& neighbors,
            const arma::mat& distances,
            const std::vector<size_t>& referenceMap,
@@ -48,6 +49,7 @@ void Unmap(const arma::Mat<size_t>& neighbors,
  * @param distancesOut Matrix to store unmapped distances into.
  * @param squareRoot If true, take the square root of the distances.
  */
+MLPACK_API
 void Unmap(const arma::Mat<size_t>& neighbors,
            const arma::mat& distances,
            const std::vector<size_t>& referenceMap,

--- a/src/mlpack/methods/nystroem_method/ordered_selection.hpp
+++ b/src/mlpack/methods/nystroem_method/ordered_selection.hpp
@@ -14,7 +14,7 @@
 namespace mlpack {
 namespace kernel {
 
-class OrderedSelection
+class MLPACK_API OrderedSelection
 {
  public:
   /**

--- a/src/mlpack/methods/nystroem_method/random_selection.hpp
+++ b/src/mlpack/methods/nystroem_method/random_selection.hpp
@@ -14,7 +14,7 @@
 namespace mlpack {
 namespace kernel {
 
-class RandomSelection
+class MLPACK_API RandomSelection
 {
  public:
   /**

--- a/src/mlpack/methods/pca/pca.hpp
+++ b/src/mlpack/methods/pca/pca.hpp
@@ -20,7 +20,7 @@ namespace pca {
  * found in almost any statistics or machine learning textbook, and all over the
  * internet.
  */
-class PCA
+class MLPACK_API PCA
 {
  public:
   /**

--- a/src/mlpack/methods/radical/radical.hpp
+++ b/src/mlpack/methods/radical/radical.hpp
@@ -35,7 +35,7 @@ namespace radical {
  * }
  * @endcode
  */
-class Radical
+class MLPACK_API Radical
 {
  public:
   /**

--- a/src/mlpack/methods/range_search/rs_model.hpp
+++ b/src/mlpack/methods/range_search/rs_model.hpp
@@ -19,7 +19,7 @@
 namespace mlpack {
 namespace range {
 
-class RSModel
+class MLPACK_API RSModel
 {
  public:
   enum TreeTypes

--- a/src/mlpack/methods/rann/ra_util.hpp
+++ b/src/mlpack/methods/rann/ra_util.hpp
@@ -13,7 +13,7 @@
 namespace mlpack {
 namespace neighbor {
 
-class RAUtil
+class MLPACK_API RAUtil
 {
  public:
   /**

--- a/src/mlpack/methods/regularized_svd/regularized_svd_function.hpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd_function.hpp
@@ -14,7 +14,7 @@
 namespace mlpack {
 namespace svd {
 
-class RegularizedSVDFunction
+class MLPACK_API RegularizedSVDFunction
 {
  public:
 

--- a/src/mlpack/methods/softmax_regression/softmax_regression_function.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_function.hpp
@@ -13,7 +13,7 @@
 namespace mlpack {
 namespace regression {
 
-class SoftmaxRegressionFunction
+class MLPACK_API SoftmaxRegressionFunction
 {
  public:
   /**

--- a/src/mlpack/methods/sparse_autoencoder/maximal_inputs.hpp
+++ b/src/mlpack/methods/sparse_autoencoder/maximal_inputs.hpp
@@ -74,6 +74,7 @@ namespace nn {
  * @param parameters The parameters of the autoencoder.
  * @param output Matrix to store the maximal inputs in.
  */
+MLPACK_API
 void MaximalInputs(const arma::mat& parameters, arma::mat& output);
 
 /**
@@ -83,6 +84,7 @@ void MaximalInputs(const arma::mat& parameters, arma::mat& output);
  * @param input The input data to normalize.
  * @param output A matrix to store the input data in after normalization.
  */
+MLPACK_API
 void NormalizeColByMax(const arma::mat& input, arma::mat& output);
 
 } // namespace nn

--- a/src/mlpack/methods/sparse_autoencoder/sparse_autoencoder_function.hpp
+++ b/src/mlpack/methods/sparse_autoencoder/sparse_autoencoder_function.hpp
@@ -18,7 +18,7 @@ namespace nn {
  * to create learning models like self-taught learning, stacked autoencoders,
  * conditional random fields (CRFs), and so forth.
  */
-class SparseAutoencoderFunction
+class MLPACK_API SparseAutoencoderFunction
 {
  public:
   /**

--- a/src/mlpack/methods/sparse_coding/random_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/random_initializer.hpp
@@ -17,7 +17,7 @@ namespace sparse_coding {
  * A DictionaryInitializer for use with the SparseCoding class.  This provides a
  * random, normally distributed dictionary, such that each atom has a norm of 1.
  */
-class RandomInitializer
+class MLPACK_API RandomInitializer
 {
  public:
   /**

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -107,7 +107,7 @@ namespace sparse_coding {
  *     dictionary; must have 'void Initialize(const arma::mat& data, arma::mat&
  *     dictionary)' function.
  */
-class SparseCoding
+class MLPACK_API SparseCoding
 {
  public:
   /**

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -79,4 +79,40 @@
   #pragma warning(disable : 4519)
 #endif
 
+
+/* From http://gcc.gnu.org/wiki/Visibility */
+/* Generic helper definitions for shared library support */
+#if defined _WIN32 || defined __CYGWIN__
+#define MLPACK_HELPER_DLL_IMPORT __declspec(dllimport)
+#define MLPACK_HELPER_DLL_EXPORT __declspec(dllexport)
+#define MLPACK_HELPER_DLL_LOCAL
+#else
+#if __GNUC__ >= 4
+#define MLPACK_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
+#define MLPACK_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+#define MLPACK_HELPER_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define MLPACK_HELPER_DLL_IMPORT
+#define MLPACK_HELPER_DLL_EXPORT
+#define MLPACK_HELPER_DLL_LOCAL
+#endif
+#endif
+
+/* Now we use the generic helper definitions above to define MLPACK_API and MLPACK_LOCAL.
+ * MLPACK_API is used for the public API symbols. It either DLL imports or DLL exports (or does nothing for static build)
+ * MLPACK_LOCAL is used for non-api symbols. */
+
+#ifndef MLPACK_STATIC /* defined if MLPACK is compiled as a DLL */
+#ifdef mlpack_EXPORTS /* defined if we are building the MLPACK DLL (instead of using it) */
+#define MLPACK_API MLPACK_HELPER_DLL_EXPORT
+#else
+#define MLPACK_API MLPACK_HELPER_DLL_IMPORT
+#endif /* MLPACK_DLL_EXPORTS */
+#define MLPACK_LOCAL MLPACK_HELPER_DLL_LOCAL
+#else /* MLPACK_STATIC is defined: this means MLPACK is a static lib. */
+#define MLPACK_API
+#define MLPACK_LOCAL
+#endif /* !MLPACK_STATIC */
+
+
 #endif


### PR DESCRIPTION
The BUILD_SHARED_LIBS option can now turn on shared libs also for win32 target.

Every non-template class or single function must export it's symbols.
A macro MLPACK_API is added to prereqs.hpp for this.

Succeeded to build the dll, cli executables as well as tests on mingw-w64 !

MLPACK_STATIC must be defined when using the static lib.
