### PR TITLE
Fix a cast in dt_utils.cpp

### DIFF
--- a/src/mlpack/methods/det/dt_utils.cpp
+++ b/src/mlpack/methods/det/dt_utils.cpp
@@ -192,7 +192,7 @@ DTree* mlpack::det::Trainer(arma::mat& dataset,
   {
     // Break up data into train and test sets.
     size_t start = fold * testSize;
-    size_t end = std::min((fold + 1) * testSize, (size_t) cvData.n_cols);
+    size_t end = std::min((size_t) (fold + 1) * testSize, (size_t) cvData.n_cols);
 
     arma::mat test = cvData.cols(start, end - 1);
     arma::mat train(cvData.n_rows, cvData.n_cols - test.n_cols);


### PR DESCRIPTION
Apparently I have to cast altough both fold and testSize are of size_t type:
```
/home/xantares/projects/mlpack/src/mlpack/methods/det/dt_utils.cpp: In function ‘mlpack::det::DTree* mlpack::det::Trainer(arma::mat&, size_t, bool, size_t, size_t, std::__cxx11::string)’:
/home/xantares/projects/mlpack/src/mlpack/methods/det/dt_utils.cpp:195:72: error: no matching function for call to ‘min(intmax_t, arma::uword)’
     size_t end = std::min((fold + 1) * testSize, (size_t) cvData.n_cols);
                                                                        ^
```