### PR TITLE
Removes trailing whitespaces at end of lines

### DIFF
--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -277,7 +277,7 @@ span.charliteral {
 color: #FFFF00;
 }
 
-span.vhdldigit { 
+span.vhdldigit {
   color: #FFFF00;
 }
 
@@ -285,11 +285,11 @@ span.vhdlchar {
   color: #FFFF00;
 }
 
-span.vhdlkeyword { 
+span.vhdlkeyword {
   color: #FF0000;
 }
 
-span.vhdllogic { 
+span.vhdllogic {
   color: #FF0000;
 }
 
@@ -465,7 +465,7 @@ table.memberdecls {
 .params .paramtype {
   font-style: italic;
   vertical-align: top;
-}       
+}
 
 .params .paramdir {
   font-family: "courier new",courier,monospace;

--- a/doc/guide/formats.hpp
+++ b/doc/guide/formats.hpp
@@ -34,7 +34,7 @@ following file types:
  - ARFF, denoted by .arff (<b>note: this is not supported by all mlpack"
    command-line programs </b>; see \ref formatcat )
 
-Datasets that are loaded by mlpack should be stored with <b>one row for 
+Datasets that are loaded by mlpack should be stored with <b>one row for
 one point</b> and <b>one column for one dimension</b>.  Therefore, a dataset
 with three two-dimensional points \f$(0, 1)\f$, \f$(3, 1)\f$, and \f$(5, -5)\f$
 would be stored in a csv file as:

--- a/doc/guide/iodoc.hpp
+++ b/doc/guide/iodoc.hpp
@@ -19,7 +19,7 @@ mlpack has four logging levels:
  - Log::Warn
  - Log::Fatal
 
-Output to Log::Debug does not show (and has no performance penalty) when mlpack 
+Output to Log::Debug does not show (and has no performance penalty) when mlpack
 is compiled without debugging symbols.  Output to Log::Info is only shown when
 the program is run with the --verbose (or -v) flag.  Log::Warn is always shown,
 and Log::Fatal will throw a std::runtime_error exception, when a newline is sent

--- a/doc/tutorials/emst/emst.txt
+++ b/doc/tutorials/emst/emst.txt
@@ -60,7 +60,7 @@ The output file contains an edge list representation of the MST in an
 points and the third column is the edge weight.  The edges are sorted in order
 of increasing weight.
 
-Below are several examples of simple usage (and the resultant output).  The 
+Below are several examples of simple usage (and the resultant output).  The
 \c -v option is used so that verbose output is given.  Further documentation on
 each individual option can be found by typing
 

--- a/doc/tutorials/linear_regression/linear_regression.txt
+++ b/doc/tutorials/linear_regression/linear_regression.txt
@@ -201,7 +201,7 @@ dataset used to create the model, one.  If the model generating dataset has
 $ linear_regression --input_model_file lr.xml --test_file predict.csv -v
 [INFO ] Loading 'predict.csv' as raw ASCII formatted data.  Size is 1 x 3.
 [INFO ] Saving CSV data to 'predictions.csv'.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   help: false
 [INFO ]   info: ""
@@ -214,7 +214,7 @@ $ linear_regression --input_model_file lr.xml --test_file predict.csv -v
 [INFO ]   training_responses: ""
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   load_model: 0.000264s
 [INFO ]   load_test_points: 0.000186s

--- a/doc/tutorials/neighbor_search/neighbor_search.txt
+++ b/doc/tutorials/neighbor_search/neighbor_search.txt
@@ -78,7 +78,7 @@ $ mlpack_knn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 5 -v
 [INFO ] Search complete.
 [INFO ] Saving CSV data to 'neighbors_out.csv'.
 [INFO ] Saving CSV data to 'distances_out.csv'.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   distances_file: distances_out.csv
 [INFO ]   help: false
@@ -97,7 +97,7 @@ $ mlpack_knn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 5 -v
 [INFO ]   tree_type: kd
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   computing_neighbors: 0.108968s
 [INFO ]   loading_data: 0.006495s
@@ -158,7 +158,7 @@ $ mlpack_knn -q query_dataset.csv -r reference_dataset.csv \
 [INFO ] Search complete.
 [INFO ] Saving CSV data to 'neighbors_out.csv'.
 [INFO ] Saving CSV data to 'distances_out.csv'.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   distances_file: distances_out.csv
 [INFO ]   help: false
@@ -177,7 +177,7 @@ $ mlpack_knn -q query_dataset.csv -r reference_dataset.csv \
 [INFO ]   tree_type: kd
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   computing_neighbors: 0.022589s
 [INFO ]   loading_data: 0.003572s
@@ -200,7 +200,7 @@ $ allknn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 3 -l 15 -v
 [INFO ] Search complete.
 [INFO ] Saving CSV data to 'neighbors_out.csv'.
 [INFO ] Saving CSV data to 'distances_out.csv'.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   distances_file: distances_out.csv
 [INFO ]   help: false
@@ -219,7 +219,7 @@ $ allknn -r dataset.csv -n neighbors_out.csv -d distances_out.csv -k 3 -l 15 -v
 [INFO ]   tree_type: kd
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   computing_neighbors: 0.059020s
 [INFO ]   loading_data: 0.002791s

--- a/doc/tutorials/range_search/range_search.txt
+++ b/doc/tutorials/range_search/range_search.txt
@@ -82,7 +82,7 @@ $ mlpack_range_search -r dataset.csv -n neighbors_out.csv -d distances_out.csv \
 [INFO ] Search for points in the range [0, 0.076] with dual-tree kd-tree
 search...
 [INFO ] Search complete.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   distances_file: distances_out.csv
 [INFO ]   help: false
@@ -102,7 +102,7 @@ search...
 [INFO ]   tree_type: kd
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   loading_data: 0.005201s
 [INFO ]   range_search/computing_neighbors: 0.017110s
@@ -159,7 +159,7 @@ $ range_search -q query_dataset.csv -r reference_dataset.csv -n \
 [INFO ] Building query tree...
 [INFO ] Tree built.
 [INFO ] Search complete.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   distances_file: distances_out.csv
 [INFO ]   help: false
@@ -179,7 +179,7 @@ $ range_search -q query_dataset.csv -r reference_dataset.csv -n \
 [INFO ]   tree_type: kd
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   loading_data: 0.006199s
 [INFO ]   range_search/computing_neighbors: 0.024427s
@@ -205,7 +205,7 @@ $ range_search -r dataset.csv -n neighbors_out.csv -d distances_out.csv -L 0.7 \
 [INFO ] Search for points in the range [0.7, 0.8] with dual-tree kd-tree
 search...
 [INFO ] Search complete.
-[INFO ] 
+[INFO ]
 [INFO ] Execution parameters:
 [INFO ]   distances_file: distances_out.csv
 [INFO ]   help: false
@@ -225,7 +225,7 @@ search...
 [INFO ]   tree_type: kd
 [INFO ]   verbose: true
 [INFO ]   version: false
-[INFO ] 
+[INFO ]
 [INFO ] Program timers:
 [INFO ]   loading_data: 0.006298s
 [INFO ]   range_search/computing_neighbors: 0.411041s

--- a/src/mlpack/bindings/matlab/allknn/allknn.m
+++ b/src/mlpack/bindings/matlab/allknn/allknn.m
@@ -6,32 +6,32 @@ function [distances neighbors] = allknn(dataPoints, k, varargin)
 %  be optimally fast). You may specify a separate set of reference points and
 %  query points, or just a reference set which will be used as both the reference
 %  and query set.
-%  
+%
 %  For example, the following will calculate the 5 nearest neighbors of eachpoint
 %  in 'input.csv' and store the distances in 'distances.csv' and the neighbors in
 %  the file 'neighbors.csv':
-  
+
 %  $ allknn --k=5 --reference_file=input.csv --distances_file=distances.csv
 %    --neighbors_file=neighbors.csv
-  
+
 %  The output files are organized such that row i and column j in the neighbors
 %  output file corresponds to the index of the point in the reference set which
-%  is the i'th nearest neighbor from the point in the query set with index j. 
+%  is the i'th nearest neighbor from the point in the query set with index j.
 %  Row i and column j in the distances output file corresponds to the distance
 %  between those two points.
 %
 % Parameters:
-% dataPoints - the matrix of data points. Columns are assumed to represent dimensions, 
-%              with rows representing seperate points. 
-% method     - the algorithm for computing the tree. 'naive' or 'boruvka', with 
+% dataPoints - the matrix of data points. Columns are assumed to represent dimensions,
+%              with rows representing seperate points.
+% method     - the algorithm for computing the tree. 'naive' or 'boruvka', with
 %              'boruvka' being the default algorithm.
-% leafSize   - Leaf size in the kd-tree.  One-element leaves give the 
+% leafSize   - Leaf size in the kd-tree.  One-element leaves give the
 %              empirically best performance, but at the cost of greater memory
-%              requirements. One is default. 
-% 
+%              requirements. One is default.
+%
 % Examples:
 % result = emst(dataPoints);
-% or 
+% or
 % esult = emst(dataPoints,'method','naive');
 
 % a parser for the inputs

--- a/src/mlpack/bindings/matlab/gmm/gmm.m
+++ b/src/mlpack/bindings/matlab/gmm/gmm.m
@@ -7,7 +7,7 @@ function result = gmm(dataPoints, varargin)
 %
 %Parameters:
 % dataPoints- (required) Matrix containing the data on which the model will be fit
-% seed      - (optional) Random seed.  If 0, 'std::time(NULL)' is used. 
+% seed      - (optional) Random seed.  If 0, 'std::time(NULL)' is used.
 %					    Default value is 0.
 % gaussians - (optional) Number of gaussians in the GMM. Default value is 1.
 

--- a/src/mlpack/bindings/matlab/hmm/hmm_generate.m
+++ b/src/mlpack/bindings/matlab/hmm/hmm_generate.m
@@ -9,7 +9,7 @@ function sequence = hmm_generate(model, sequence_length, varargin)
 % model           - (required) HMM model struct.
 % sequence_length - (required) Length of the sequence to produce.
 % start_state	    - (optional) Starting state of sequence.  Default value 0.
-% seed            - (optional) Random seed.  If 0, 'std::time(NULL)' is used. 
+% seed            - (optional) Random seed.  If 0, 'std::time(NULL)' is used.
 %                   Default value 0.
 
 % a parser for the inputs
@@ -21,7 +21,7 @@ p.addParamValue('seed', 0, @isscalar);
 p.parse(varargin{:});
 parsed = p.Results;
 
-% interfacing with mlpack. 
+% interfacing with mlpack.
 sequence = mex_hmm_generate(model, sequence_length, ...
 	parsed.start_state, parsed.seed);
 

--- a/src/mlpack/bindings/matlab/kernel_pca/kernel_pca.m
+++ b/src/mlpack/bindings/matlab/kernel_pca/kernel_pca.m
@@ -5,29 +5,29 @@ function result = kernel_pca(dataPoints, kernel, varargin)
 %  specified dataset with the specified kernel.  This will transform the data
 %  onto the kernel principal components, and optionally reduce the dimensionality
 %  by ignoring the kernel principal components with the smallest eigenvalues.
-%  
+%
 %  For the case where a linear kernel is used, this reduces to regular PCA.
-%  
+%
 %  The kernels that are supported are listed below:
-%  
+%
 %   * 'linear': the standard linear dot product (same as normal PCA):
 %      K(x, y) = x^T y
-%  
+%
 %   * 'gaussian': a Gaussian kernel; requires bandwidth:
 %      K(x, y) = exp(-(|| x - y || ^ 2) / (2 * (bandwidth ^ 2)))
-%  
+%
 %   * 'polynomial': polynomial kernel; requires offset and degree:
 %      K(x, y) = (x^T y + offset) ^ degree
-%  
+%
 %   * 'hyptan': hyperbolic tangent kernel; requires scale and offset:
 %      K(x, y) = tanh(scale * (x^T y) + offset)
-%  
+%
 %   * 'laplacian': Laplacian kernel; requires bandwidth:
 %      K(x, y) = exp(-(|| x - y ||) / bandwidth)
-%  
+%
 %   * 'cosine': cosine distance:
 %      K(x, y) = 1 - (x^T y) / (|| x || * || y ||)
-%  
+%
 %  The parameters for each of the kernels should be specified with the options
 %  bandwidth, kernel_scale, offset, or degree (or a combination of those
 %  options).
@@ -38,9 +38,9 @@ function result = kernel_pca(dataPoints, kernel, varargin)
 % new_dimensionality - (optional) If not 0, reduce the dimensionality of the
 %                      dataset by ignoring the dimensions with the smallest
 %                      eighenvalues.
-% bandwidth          - (optional) Bandwidt, for gaussian or laplacian kernels. 
+% bandwidth          - (optional) Bandwidt, for gaussian or laplacian kernels.
 %                      Default value is 1.
-% degree             - (optional)  Degree of polynomial, for 'polynomial' kernel. 
+% degree             - (optional)  Degree of polynomial, for 'polynomial' kernel.
 %                      Default value 1.
 % kernel_scale       - (optional) Scale, for 'hyptan' kernel.  Default value 1.
 % offset             - (optional) Offset, for 'hyptan' and 'polynomial' kernels.
@@ -61,7 +61,7 @@ p.addParamValue('scale', false, @(x) (x == true) || (x == false));
 p.parse(varargin{:});
 parsed = p.Results;
 
-% interfacing with mlpack. transposing to machine learning standards. 
+% interfacing with mlpack. transposing to machine learning standards.
 result = mex_kernel_pca(dataPoints', kernel, ...
 	parsed.new_dimensionality, parsed.scale, ...
 	parsed.degree, parsed.offset, ...

--- a/src/mlpack/bindings/matlab/kmeans/kmeans.m
+++ b/src/mlpack/bindings/matlab/kmeans/kmeans.m
@@ -19,7 +19,7 @@ p.addParamValue('seed', 0, @isscalar);
 p.parse(varargin{:});
 parsed = p.Results;
 
-% interfacing with mlpack. transposing to machine learning standards. 
+% interfacing with mlpack. transposing to machine learning standards.
 assignments = mex_kmeans(dataPoints', clusters, parsed.max_iterations, ...
 	parsed.overclustering, parsed.allow_empty_clusters, ...
 	parsed.fast_kmeans, parsed.seed);

--- a/src/mlpack/bindings/matlab/lars/lars.m
+++ b/src/mlpack/bindings/matlab/lars/lars.m
@@ -4,21 +4,21 @@ function beta = lars(X, Y, varargin)
 %  An implementation of LARS: Least Angle Regression (Stagewise/laSso).  This is
 %  a stage-wise homotopy-based algorithm for L1-regularized linear regression
 %  (LASSO) and L1+L2-regularized linear regression (Elastic Net).
-%  
+%
 %  Let X be a matrix where each row is a point and each column is a dimension,
 %  and let y be a vector of targets.
-%  
+%
 %  The Elastic Net problem is to solve
-%  
+%
 %    min_beta 0.5 || X * beta - y ||_2^2 + lambda_1 ||beta||_1 +
 %        0.5 lambda_2 ||beta||_2^2
-%  
+%
 %  If lambda_1 > 0 and lambda_2 = 0, the problem is the LASSO.
 %  If lambda_1 > 0 and lambda_2 > 0, the problem is the Elastic Net.
 %  If lambda_1 = 0 and lambda_2 > 0, the problem is Ridge Regression.
 %  If lambda_1 = 0 and lambda_2 = 0, the problem is unregularized linear
 %  regression.
-%  
+%
 %  For efficiency reasons, it is not recommended to use this algorithm with
 %  lambda_1 = 0.
 %

--- a/src/mlpack/bindings/matlab/nca/nca.m
+++ b/src/mlpack/bindings/matlab/nca/nca.m
@@ -8,7 +8,7 @@ function result = nca(dataPoints, labels)
 %  value of k.  It works by using stochastic ("soft") neighbor assignments and
 %  using optimization techniques over the gradient of the accuracy of the
 %  neighbor assignments.
-%  
+%
 %  To work, this algorithm needs labeled data.  It can be given as the last row
 %  of the input dataset (--input_file), or alternatively in a separate file
 %  (--labels_file).
@@ -17,7 +17,7 @@ function result = nca(dataPoints, labels)
 % dataPoints - Input dataset to run NCA on.
 % labels     - Labels for input dataset.
 
-% interfacing with mlpack. transposing to machine learning standards. 
+% interfacing with mlpack. transposing to machine learning standards.
 result = mex_nca(dataPoints', labels);
 result = result';
 

--- a/src/mlpack/bindings/matlab/nmf/nmf.m
+++ b/src/mlpack/bindings/matlab/nmf/nmf.m
@@ -3,21 +3,21 @@ function [W H] = nmf(dataPoints, rank, varargin)
 %
 %  This program performs non-negative matrix factorization on the given dataset,
 %  storing the resulting decomposed matrices in the specified files.  For an
-%  input dataset V, NMF decomposes V into two matrices W and H such that 
-%  
+%  input dataset V, NMF decomposes V into two matrices W and H such that
+%
 %  V = W * H
-%  
+%
 %  where all elements in W and H are non-negative.  If V is of size (n x m), then
 %  W will be of size (n x r) and H will be of size (r x m), where r is the rank
 %  of the factorization (specified by --rank).
-%  
+%
 %  Optionally, the desired update rules for each NMF iteration can be chosen from
 %  the following list:
-%  
+%
 %   - multdist: multiplicative distance-based update rules (Lee and Seung 1999)
 %   - multdiv: multiplicative divergence-based update rules (Lee and Seung 1999)
 %   - als: alternating least squares update rules (Paatero and Tapper 1994)
-%  
+%
 %  The maximum number of iterations is specified with 'max_iterations', and the
 %  minimum residue required for algorithm termination is specified with
 %  'min_residue'.
@@ -30,7 +30,7 @@ function [W H] = nmf(dataPoints, rank, varargin)
 % min_residue			  - (optional) The minimum root mean square residue allowed for
 %                                each iteration, below which the program
 %                                terminates.  Default value 1e-05.
-% seed							- (optional) Random seed.If 0, 'std::time(NULL)' is used. 
+% seed							- (optional) Random seed.If 0, 'std::time(NULL)' is used.
 %														     Default 0.
 % update rules			- (optional) Update rules for each iteration; ( multdist |
 %                                multdiv | als ).  Default value 'multdist'.
@@ -46,7 +46,7 @@ p.addParamValue('seed', 0, @isscalar);
 p.parse(varargin{:});
 parsed = p.Results;
 
-% interfacing with mlpack. transposing for machine learning standards. 
+% interfacing with mlpack. transposing for machine learning standards.
 [W H] = mex_nmf(dataPoints', rank, ...
 	parsed.max_iterations, parsed.min_residue, ...
 	parsed.update_rules, parsed.seed);

--- a/src/mlpack/bindings/matlab/pca/pca.m
+++ b/src/mlpack/bindings/matlab/pca/pca.m
@@ -9,7 +9,7 @@ function result = pca(dataPoints, varargin)
 %Parameters:
 % dataPoints        - (required) Matrix to perform PCA on.
 % newDimensionality - (optional) Desired dimensionality of output dataset.  If 0,
-%                                no dimensionality reduction is performed. 
+%                                no dimensionality reduction is performed.
 %                                Default value 0.
 % scale             - (optional) If set, the data will be scaled before running
 %                                PCA, such that the variance of each feature is

--- a/src/mlpack/bindings/matlab/range_search/range_search.m
+++ b/src/mlpack/bindings/matlab/range_search/range_search.m
@@ -6,11 +6,11 @@ function result = range_search(dataPoints, maxDistance, varargin)
 %  program will return all of the reference points with distance to the query
 %  point in the given range.  This is performed for an entire set of query
 %  points. You may specify a separate set of reference and query points, or only
-%  a reference set -- which is then used as both the reference and query set. 
+%  a reference set -- which is then used as both the reference and query set.
 %  The given range is taken to be inclusive (that is, points with a distance
 %  exactly equal to the minimum and maximum of the range are included in the
 %  results).
-%  
+%
 %  For example, the following will calculate the points within the range [2, 5]
 %  of each point in 'input.csv' and store the distances in 'distances.csv' and
 %  the neighbors in 'neighbors.csv':
@@ -22,7 +22,7 @@ function result = range_search(dataPoints, maxDistance, varargin)
 % queryPoints - (optional) Range search query points.
 % leafSize    - (optional) Leaf size for tree building.  Default value 20.
 % naive			  - (optional) If true, O(n^2) naive mode is used for computation.
-% singleMode  - (optional) If true, single-tree search is used (as opposed to 
+% singleMode  - (optional) If true, single-tree search is used (as opposed to
 %               dual-tree search.
 
 % a parser for the inputs

--- a/src/mlpack/core/arma_extend/Cube_extra_meat.hpp
+++ b/src/mlpack/core/arma_extend/Cube_extra_meat.hpp
@@ -14,7 +14,7 @@ void Cube<eT>::serialize(Archive& ar, const unsigned int /* version */)
   ar & make_nvp("n_cols", access::rw(n_cols));
   ar & make_nvp("n_elem_slice", access::rw(n_elem_slice));
   ar & make_nvp("n_slices", access::rw(n_slices));
-  ar & make_nvp("n_elem", access::rw(n_elem));    
+  ar & make_nvp("n_elem", access::rw(n_elem));
 
   // mem_state will always be 0 on load, so we don't need to save it.
   if (Archive::is_loading::value)

--- a/src/mlpack/core/boost_backport/unordered_collections_load_imp.hpp
+++ b/src/mlpack/core/boost_backport/unordered_collections_load_imp.hpp
@@ -10,7 +10,7 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // unordered_collections_load_imp.hpp: serialization for loading stl collections
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -24,8 +24,8 @@
 #include <cstddef> // size_t
 #include <boost/config.hpp> // msvc 6.0 needs this for warning suppression
 #if defined(BOOST_NO_STDC_NAMESPACE)
-namespace std{ 
-    using ::size_t; 
+namespace std{
+    using ::size_t;
 } // namespace std
 #endif
 #include <boost/detail/workaround.hpp>
@@ -67,7 +67,7 @@ inline void load_unordered_collection(Archive & ar, Container &s)
     }
 }
 
-} // namespace stl 
+} // namespace stl
 } // namespace serialization
 } // namespace boost
 

--- a/src/mlpack/core/boost_backport/unordered_collections_save_imp.hpp
+++ b/src/mlpack/core/boost_backport/unordered_collections_save_imp.hpp
@@ -9,7 +9,7 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // hash_collections_save_imp.hpp: serialization for stl collections
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -69,8 +69,8 @@ inline void save_unordered_collection(Archive & ar, const Container &s)
     while(count-- > 0){
         // note borland emits a no-op without the explicit namespace
         boost::serialization::save_construct_data_adl(
-            ar, 
-            &(*it), 
+            ar,
+            &(*it),
             boost::serialization::version<
                 typename Container::value_type
             >::value
@@ -79,7 +79,7 @@ inline void save_unordered_collection(Archive & ar, const Container &s)
     }
 }
 
-} // namespace stl 
+} // namespace stl
 } // namespace serialization
 } // namespace boost
 

--- a/src/mlpack/core/boost_backport/unordered_map.hpp
+++ b/src/mlpack/core/boost_backport/unordered_map.hpp
@@ -10,7 +10,7 @@
 // serialization/unordered_map.hpp:
 // serialization for stl unordered_map templates
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -27,7 +27,7 @@
 #include "unordered_collections_load_imp.hpp"
 #include <boost/serialization/split_free.hpp>
 
-namespace boost { 
+namespace boost {
 namespace serialization {
 
 namespace stl {
@@ -37,19 +37,19 @@ template<class Archive, class Container>
 struct archive_input_unordered_map
 {
     inline void operator()(
-        Archive &ar, 
-        Container &s, 
+        Archive &ar,
+        Container &s,
         const unsigned int v
     ){
         typedef typename Container::value_type type;
         detail::stack_construct<Archive, type> t(ar, v);
         // borland fails silently w/o full namespace
         ar >> boost::serialization::make_nvp("item", t.reference());
-        std::pair<typename Container::const_iterator, bool> result = 
+        std::pair<typename Container::const_iterator, bool> result =
             s.insert(t.reference());
         // note: the following presumes that the map::value_type was NOT tracked
         // in the archive.  This is the usual case, but here there is no way
-        // to determine that.  
+        // to determine that.
         if(result.second){
             ar.reset_object_address(
                 & (result.first->second),
@@ -64,19 +64,19 @@ template<class Archive, class Container>
 struct archive_input_unordered_multimap
 {
     inline void operator()(
-        Archive &ar, 
-        Container &s, 
+        Archive &ar,
+        Container &s,
         const unsigned int v
     ){
         typedef typename Container::value_type type;
         detail::stack_construct<Archive, type> t(ar, v);
         // borland fails silently w/o full namespace
         ar >> boost::serialization::make_nvp("item", t.reference());
-        typename Container::const_iterator result 
+        typename Container::const_iterator result
             = s.insert(t.reference());
         // note: the following presumes that the map::value_type was NOT tracked
         // in the archive.  This is the usual case, but here there is no way
-        // to determine that.  
+        // to determine that.
         ar.reset_object_address(
             & result->second,
             & t.reference()
@@ -87,9 +87,9 @@ struct archive_input_unordered_multimap
 } // stl
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -101,7 +101,7 @@ inline void save(
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
-        Archive, 
+        Archive,
         std::unordered_map<
             Key, HashFcn, EqualKey, Allocator
         >
@@ -109,9 +109,9 @@ inline void save(
 }
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -128,7 +128,7 @@ inline void load(
             Key, HashFcn, EqualKey, Allocator
         >,
         boost::serialization::stl::archive_input_unordered_map<
-            Archive, 
+            Archive,
             std::unordered_map<
                 Key, HashFcn, EqualKey, Allocator
             >
@@ -139,9 +139,9 @@ inline void load(
 // split non-intrusive serialization function member into separate
 // non intrusive save/load member functions
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -157,9 +157,9 @@ inline void serialize(
 
 // unordered_multimap
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -171,7 +171,7 @@ inline void save(
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
-        Archive, 
+        Archive,
         std::unordered_multimap<
             Key, HashFcn, EqualKey, Allocator
         >
@@ -179,9 +179,9 @@ inline void save(
 }
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -198,7 +198,7 @@ inline void load(
             Key, HashFcn, EqualKey, Allocator
         >,
         boost::serialization::stl::archive_input_unordered_multimap<
-            Archive, 
+            Archive,
             std::unordered_multimap<
                 Key, HashFcn, EqualKey, Allocator
             >
@@ -209,9 +209,9 @@ inline void load(
 // split non-intrusive serialization function member into separate
 // non intrusive save/load member functions
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >

--- a/src/mlpack/core/kernels/cosine_distance.hpp
+++ b/src/mlpack/core/kernels/cosine_distance.hpp
@@ -47,7 +47,7 @@ class KernelTraits<CosineDistance>
  public:
   //! The cosine kernel is normalized: K(x, x) = 1 for all x.
   static const bool IsNormalized = true;
-  
+
   //! The cosine kernel doesn't include a squared distance.
   static const bool UsesSquaredDistance = false;
 };

--- a/src/mlpack/core/kernels/epanechnikov_kernel.cpp
+++ b/src/mlpack/core/kernels/epanechnikov_kernel.cpp
@@ -32,7 +32,7 @@ double EpanechnikovKernel::Evaluate(const double distance) const
 }
 
 /**
- * Evaluate gradient of the kernel not for two points 
+ * Evaluate gradient of the kernel not for two points
  * but for a numerical value.
  */
 double EpanechnikovKernel::Gradient(const double distance) const {

--- a/src/mlpack/core/kernels/epanechnikov_kernel.hpp
+++ b/src/mlpack/core/kernels/epanechnikov_kernel.hpp
@@ -52,12 +52,12 @@ class EpanechnikovKernel
   double Evaluate(const double distance) const;
 
   /**
-   * Evaluate the Gradient of Epanechnikov kernel 
+   * Evaluate the Gradient of Epanechnikov kernel
    * given that the distance between the two
    * input points is known.
    */
   double Gradient(const double distance) const;
-  
+
   /**
    * Evaluate the Gradient of Epanechnikov kernel
    * given that the squared distance between the two

--- a/src/mlpack/core/kernels/gaussian_kernel.hpp
+++ b/src/mlpack/core/kernels/gaussian_kernel.hpp
@@ -74,9 +74,9 @@ class GaussianKernel
     // The precalculation of gamma saves us a little computation time.
     return exp(gamma * std::pow(t, 2.0));
   }
-  
+
   /**
-   * Evaluation of the gradient of Gaussian kernel 
+   * Evaluation of the gradient of Gaussian kernel
    * given the distance between two points.
    *
    * @param t The distance between the two points the kernel is evaluated on.
@@ -86,7 +86,7 @@ class GaussianKernel
   double Gradient(const double t) const {
     return 2 * t * gamma * exp(gamma * std::pow(t, 2.0));
   }
-  
+
   /**
    * Evaluation of the gradient of Gaussian kernel
    * given the squared distance between two points.

--- a/src/mlpack/core/kernels/kernel_traits.hpp
+++ b/src/mlpack/core/kernels/kernel_traits.hpp
@@ -26,7 +26,7 @@ class KernelTraits
    * If true, then the kernel is normalized: K(x, x) = K(y, y) = 1 for all x.
    */
   static const bool IsNormalized = false;
-  
+
   /**
    * If true, then the kernel include a squared distance, ||x - y||^2 .
    */

--- a/src/mlpack/core/kernels/laplacian_kernel.hpp
+++ b/src/mlpack/core/kernels/laplacian_kernel.hpp
@@ -72,7 +72,7 @@ class LaplacianKernel
     // The precalculation of gamma saves us a little computation time.
     return exp(-t / bandwidth);
   }
-  
+
   /**
    * Evaluation of the gradient of the Laplacian kernel
    * given the distance between two points.

--- a/src/mlpack/core/kernels/triangular_kernel.hpp
+++ b/src/mlpack/core/kernels/triangular_kernel.hpp
@@ -57,9 +57,9 @@ class TriangularKernel
   {
     return std::max(0.0, (1 - distance) / bandwidth);
   }
-  
+
   /**
-   * Evaluate the gradient of triangular kernel 
+   * Evaluate the gradient of triangular kernel
    * given that the distance between the two
    * points is known.
    *

--- a/src/mlpack/core/optimizers/adadelta/ada_delta.hpp
+++ b/src/mlpack/core/optimizers/adadelta/ada_delta.hpp
@@ -33,7 +33,7 @@ namespace optimization {
  * }
  * @endcode
  *
- 
+
  * For AdaDelta to work, a DecomposableFunctionType template parameter is
  * required. This class must implement the following function:
  *
@@ -81,7 +81,7 @@ class AdaDelta
       const size_t maxIterations = 100000,
       const double tolerance = 1e-5,
       const bool shuffle = true);
-  
+
   /**
    * Optimize the given function using AdaDelta. The given starting point will
    * be modified to store the finishing point of the algorithm, and the final

--- a/src/mlpack/core/optimizers/adadelta/ada_delta_impl.hpp
+++ b/src/mlpack/core/optimizers/adadelta/ada_delta_impl.hpp
@@ -15,7 +15,7 @@ namespace optimization {
 
 template<typename DecomposableFunctionType>
 AdaDelta<DecomposableFunctionType>::AdaDelta(DecomposableFunctionType& function,
-                                           const double rho, 
+                                           const double rho,
                                            const double eps,
                                            const size_t maxIterations,
                                            const double tolerance,
@@ -60,7 +60,7 @@ double AdaDelta<DecomposableFunctionType>::Optimize(arma::mat& iterate)
   // Leaky sum of squares of parameter gradient.
   arma::mat meanSquaredGradientDx = arma::zeros<arma::mat>(iterate.n_rows,
       iterate.n_cols);
-      
+
   for (size_t i = 1; i != maxIterations; ++i, ++currentFunction)
   {
     // Is this iteration the start of a sequence?
@@ -99,7 +99,7 @@ double AdaDelta<DecomposableFunctionType>::Optimize(arma::mat& iterate)
       function.Gradient(iterate, visitationOrder[currentFunction], gradient);
     else
       function.Gradient(iterate, currentFunction, gradient);
-      
+
     // Accumulate gradient.
     meanSquaredGradient *= rho;
     meanSquaredGradient += (1 - rho) * (gradient % gradient);
@@ -112,7 +112,7 @@ double AdaDelta<DecomposableFunctionType>::Optimize(arma::mat& iterate)
 
     // Apply update.
     iterate -= dx;
-    
+
     // Now add that to the overall objective function.
     if (shuffle)
       overallObjective += function.Evaluate(iterate,

--- a/src/mlpack/core/optimizers/adam/adam_impl.hpp
+++ b/src/mlpack/core/optimizers/adam/adam_impl.hpp
@@ -76,7 +76,7 @@ double Adam<DecomposableFunctionType>::Optimize(arma::mat& iterate)
 
       if (std::isnan(overallObjective) || std::isinf(overallObjective))
       {
-        Log::Warn << "Adam: converged to " << overallObjective 
+        Log::Warn << "Adam: converged to " << overallObjective
             << "; terminating with failure. Try a smaller step size?"
             << std::endl;
         return overallObjective;

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
@@ -77,7 +77,7 @@ void XTreeSplit::SplitLeafNode(TreeType* tree, std::vector<bool>& relevels)
       root->DeletePoint(tree->Points()[sorted[sorted.size() - 1 - i].n],
           relevels);
     }
-   
+
     for (size_t i = 0; i < p; i++)
     {
       // We reverse the order again to reinsert the closest points first.

--- a/src/mlpack/core/util/backtrace.hpp
+++ b/src/mlpack/core/util/backtrace.hpp
@@ -22,17 +22,17 @@ namespace mlpack {
 /**
  * Provides a backtrace.
  *
- * The Backtrace class retrieve addresses of each called function from the 
- * stack and decode file name, function & line number. Retrieved informations 
+ * The Backtrace class retrieve addresses of each called function from the
+ * stack and decode file name, function & line number. Retrieved informations
  * can be printed in form:
- * 
+ *
  * @code
  * [b]: (count) /directory/to/file.cpp:function(args):line_number
  * @endcode
  *
  * Backtrace is printed always when Log::Assert failed.
  * An example is given below.
- * 
+ *
  * @code
  * if (!someImportantCondition())
  * {
@@ -40,18 +40,18 @@ namespace mlpack {
  *   Log::Fatal << std::endl;
  * }
  * @endcode
- * 
+ *
  * @note Log::Assert will not be shown when compiling in non-debug mode.
  *
  * @see PrefixedOutStream, Log
  */
 class Backtrace
 {
- public:   
+ public:
   /**
    * Constructor initialize fields and call GetAddress to retrieve addresses
    * for each frame of backtrace.
-   * 
+   *
    * @param maxDepth Maximum depth of backtrace. Default 32 steps.
    */
 #ifdef HAS_BFD_DL
@@ -65,21 +65,21 @@ class Backtrace
  private:
   /**
    * Gets addresses of each called function from the stack.
-   * 
+   *
    * @param maxDepth Maximum depth of backtrace. Default 32 steps.
    */
   static void GetAddress(int maxDepth);
-   
+
   /**
    * Decodes file name, function & line number.
-   * 
+   *
    * @param address Address of traced frame.
    */
   static void DecodeAddress(long address);
-  
+
   //! Demangles function name.
   static void DemangleFunction();
-  
+
   //! Backtrace datastructure.
   struct Frames
   {

--- a/src/mlpack/core/util/log.cpp
+++ b/src/mlpack/core/util/log.cpp
@@ -53,7 +53,7 @@ void Log::Assert(bool condition, const std::string& message)
   {
 #ifdef HAS_BFD_DL
     Backtrace bt;
-  
+
     Log::Debug << bt.ToString();
 #endif
     Log::Debug << message << std::endl;

--- a/src/mlpack/methods/ann/cnn_impl.hpp
+++ b/src/mlpack/methods/ann/cnn_impl.hpp
@@ -30,7 +30,7 @@ CNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
        const arma::mat& responses,
        OptimizerType<NetworkType>& optimizer,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction)),
@@ -70,7 +70,7 @@ CNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
        const arma::cube& predictors,
        const arma::mat& responses,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction))
@@ -99,7 +99,7 @@ CNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
 >::CNN(LayerType &&network,
        OutputType &&outputLayer,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction))

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -260,7 +260,7 @@ private:
 
     std::get<I>(network).Forward(std::get<I>(network).InputParameter(),
         std::get<I>(network).OutputParameter());
-    
+
     ForwardTail<I + 1, Tp...>(network);
   }
 
@@ -277,7 +277,7 @@ private:
   {
     std::get<I>(network).Forward(std::get<I - 1>(network).OutputParameter(),
                            std::get<I>(network).OutputParameter());
-    
+
     ForwardTail<I + 1, Tp...>(network);
   }
 
@@ -343,7 +343,7 @@ private:
   template<size_t I = 1, typename DataType, typename... Tp>
   typename std::enable_if<I < (sizeof...(Tp)), void>::type
   BackwardTail(const DataType& error, std::tuple<Tp...>& network)
-  {    
+  {
     std::get<sizeof...(Tp) - I>(network).Backward(
         std::get<sizeof...(Tp) - I>(network).OutputParameter(),
         std::get<sizeof...(Tp) - I + 1>(network).Delta(),
@@ -371,7 +371,7 @@ private:
   >
   typename std::enable_if<I < Max, void>::type
   UpdateGradients(std::tuple<Tp...>& network)
-  {   
+  {
     Update(std::get<I>(network), std::get<I>(network).OutputParameter(),
            std::get<I + 1>(network).Delta());
 

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -30,7 +30,7 @@ FFN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
        const arma::mat& responses,
        OptimizerType<NetworkType>& optimizer,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction)),
@@ -70,7 +70,7 @@ FFN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
        const arma::mat& predictors,
        const arma::mat& responses,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction))
@@ -99,7 +99,7 @@ FFN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
 >::FFN(LayerType &&network,
        OutputType &&outputLayer,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction))

--- a/src/mlpack/methods/ann/init_rules/oivs_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/oivs_init.hpp
@@ -67,7 +67,7 @@ class OivsInitialization
       k(k), gamma(gamma),
       b(std::abs(ActivationFunction::inv(1 - epsilon) -
                  ActivationFunction::inv(epsilon)))
-  {    
+  {
   }
 
   /**

--- a/src/mlpack/methods/ann/layer/base_layer.hpp
+++ b/src/mlpack/methods/ann/layer/base_layer.hpp
@@ -133,7 +133,7 @@ class BaseLayer
   OutputDataType const& Delta() const { return delta; }
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/bias_layer.hpp
+++ b/src/mlpack/methods/ann/layer/bias_layer.hpp
@@ -133,7 +133,7 @@ class BiasLayer
   InputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   InputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/binary_classification_layer.hpp
+++ b/src/mlpack/methods/ann/layer/binary_classification_layer.hpp
@@ -68,7 +68,7 @@ class BinaryClassificationLayer
   double const& Confidence() const { return confidence; }
   //! Modify the confidence parameter.
   double& Confidence() { return confidence; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/conv_layer.hpp
+++ b/src/mlpack/methods/ann/layer/conv_layer.hpp
@@ -69,7 +69,7 @@ class ConvLayer
   {
     weights.set_size(wfilter, hfilter, inMaps * outMaps);
   }
-  
+
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
    * f(x) by propagating the activity forward through f.
@@ -186,7 +186,7 @@ class ConvLayer
   OutputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   OutputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/dropconnect_layer.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_layer.hpp
@@ -2,7 +2,7 @@
  * @file dropconnect_layer.hpp
  * @author Palash Ahuja
  *
- * Definition of the DropConnectLayer class, which implements a regularizer 
+ * Definition of the DropConnectLayer class, which implements a regularizer
  * that randomly sets connections to zero. Preventing units from co-adapting.
  */
 #ifndef __MLPACK_METHODS_ANN_LAYER_DROPCONNECT_LAYER_HPP
@@ -286,7 +286,7 @@ class DropConnectLayer
   {
     if(uselayer)
       return baseLayer.Gradient();
-    
+
     return gradient;
   }
 

--- a/src/mlpack/methods/ann/layer/dropout_layer.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_layer.hpp
@@ -64,7 +64,7 @@ class DropoutLayer
       rescale(rescale)
   {
     // Nothing to do here.
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of the dropout layer.
@@ -180,7 +180,7 @@ class DropoutLayer
   bool Rescale() const {return rescale; }
   //! Modify the value of the rescale parameter.
   bool& Rescale() {return rescale; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/empty_layer.hpp
+++ b/src/mlpack/methods/ann/layer/empty_layer.hpp
@@ -78,13 +78,13 @@ class EmptyLayer
 
   //! Get the weights.
   OutputDataType const& Weights() const { return weights; }
-  
+
   //! Modify the weights.
   OutputDataType& Weights() { return weights; }
-  
+
   //! Get the input parameter.
   InputDataType const& InputParameter() const { return inputParameter; }
-  
+
   //! Modify the input parameter.
   InputDataType& InputParameter() { return inputParameter; }
 
@@ -96,7 +96,7 @@ class EmptyLayer
 
   //! Get the delta.
   OutputDataType const& Delta() const { return delta; }
-  
+
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
 
@@ -105,7 +105,7 @@ class EmptyLayer
 
   //! Modify the gradient.
   OutputDataType& Gradient() { return gradient; }
-  
+
   //! Locally-stored weight object.
   OutputDataType weights;
 

--- a/src/mlpack/methods/ann/layer/hard_tanh_layer.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh_layer.hpp
@@ -183,7 +183,7 @@ class HardTanHLayer
    * @param x Input data.
    * @param y The resulting output activation.
    */
-   
+
   template<typename eT>
   void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
   {

--- a/src/mlpack/methods/ann/layer/leaky_relu_layer.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu_layer.hpp
@@ -2,8 +2,8 @@
  * @file leaky_relu_layer.hpp
  * @author Dhawal Arora
  *
- * Definition and implementation of LeakyReLULayer layer first introduced 
- * in the acoustic model, Andrew L. Maas, Awni Y. Hannun, Andrew Y. Ng, 
+ * Definition and implementation of LeakyReLULayer layer first introduced
+ * in the acoustic model, Andrew L. Maas, Awni Y. Hannun, Andrew Y. Ng,
  * "Rectifier Nonlinearities Improve Neural Network Acoustic Models", 2014
  */
 #ifndef __MLPACK_METHODS_ANN_LAYER_LEAKYRELU_LAYER_HPP
@@ -40,9 +40,9 @@ class LeakyReLULayer
 {
  public:
   /**
-   * Create the LeakyReLULayer object using the specified parameters. 
-   * The non zero gradient can be adjusted by specifying tha parameter 
-   * alpha in the range 0 to 1. Default (alpha = 0.03) 
+   * Create the LeakyReLULayer object using the specified parameters.
+   * The non zero gradient can be adjusted by specifying tha parameter
+   * alpha in the range 0 to 1. Default (alpha = 0.03)
    *
    * @param alpha Non zero gradient
    */
@@ -57,7 +57,7 @@ class LeakyReLULayer
    *
    * @param input Input data used for evaluating the specified function.
    * @param output Resulting output activation.
-   */  
+   */
   template<typename InputType, typename OutputType>
   void Forward(const InputType& input, OutputType& output)
   {

--- a/src/mlpack/methods/ann/layer/linear_layer.hpp
+++ b/src/mlpack/methods/ann/layer/linear_layer.hpp
@@ -97,7 +97,7 @@ class LinearLayer
   {
     g = weights.t() * gy;
   }
-  
+
   /*
    * Calculate the gradient using the output delta and the input activation.
    *
@@ -137,7 +137,7 @@ class LinearLayer
   OutputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   OutputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer
    */

--- a/src/mlpack/methods/ann/layer/log_softmax_layer.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_layer.hpp
@@ -17,7 +17,7 @@ namespace ann /** Artificial Neural Network. */ {
  * the multinomial logistic loss of the softmax of its inputs. This layer is
  * meant to be used in combination with the negative log likelihood layer
  * (NegativeLogLikelihoodLayer), which expects that the input contains
- * log-probabilities for each class.  
+ * log-probabilities for each class.
  *
  * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
  *         arma::sp_mat or arma::cube).

--- a/src/mlpack/methods/ann/layer/lstm_layer.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_layer.hpp
@@ -63,7 +63,7 @@ class LSTMLayer
     {
       peepholeWeights.set_size(0, 0);
     }
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -258,7 +258,7 @@ class LSTMLayer
           outGate.col(queryOffset).t());
 
       peepholeDerivatives.zeros();
-    }    
+    }
   }
 
   //! Get the peephole weights.
@@ -290,7 +290,7 @@ class LSTMLayer
   size_t SeqLen() const { return seqLen; }
   //! Modify the sequence length.
   size_t& SeqLen() { return seqLen; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/multiclass_classification_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multiclass_classification_layer.hpp
@@ -61,13 +61,13 @@ class MulticlassClassificationLayer
   {
     output = inputActivations;
   }
-  
+
   /**
    * Serialize the layer
    */
   template<typename Archive>
   void Serialize(Archive& ar, const unsigned int /* version */)
-  {    			
+  {
   }
 }; // class MulticlassClassificationLayer
 

--- a/src/mlpack/methods/ann/layer/one_hot_layer.hpp
+++ b/src/mlpack/methods/ann/layer/one_hot_layer.hpp
@@ -62,7 +62,7 @@ class OneHotLayer
     inputActivations.max(maxIndex);
     output(maxIndex) = 1;
   }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/pooling_layer.hpp
+++ b/src/mlpack/methods/ann/layer/pooling_layer.hpp
@@ -43,7 +43,7 @@ class PoolingLayer
       kSize(kSize), pooling(pooling)
   {
     // Nothing to do here.
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -146,7 +146,7 @@ class PoolingLayer
   OutputDataType const& Delta() const { return delta; }
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/recurrent_layer.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_layer.hpp
@@ -55,7 +55,7 @@ class RecurrentLayer
       recurrentParameter(arma::zeros<InputDataType>(outSize, 1))
   {
     weights.set_size(outSize, inSize);
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -131,7 +131,7 @@ class RecurrentLayer
   OutputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   OutputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/softmax_layer.hpp
+++ b/src/mlpack/methods/ann/layer/softmax_layer.hpp
@@ -34,7 +34,7 @@ class SoftmaxLayer
   SoftmaxLayer()
   {
     // Nothing to do here.
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -82,7 +82,7 @@ class SoftmaxLayer
   InputDataType const& Delta() const { return delta; }
   //! Modify the delta.
   InputDataType& Delta() { return delta; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/sparse_bias_layer.hpp
+++ b/src/mlpack/methods/ann/layer/sparse_bias_layer.hpp
@@ -42,7 +42,7 @@ class SparseBiasLayer
       batchSize(batchSize)
   {
     weights.set_size(outSize, 1);
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -53,7 +53,7 @@ class SparseBiasLayer
    */
   template<typename eT>
   void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
-  {    
+  {
     output = input + arma::repmat(weights, 1, input.n_cols);
   }
 
@@ -72,7 +72,7 @@ class SparseBiasLayer
                 ErrorType& g)
   {
     g = gy;
-  }  
+  }
 
   /*
    * Calculate the gradient using the output delta and the bias.
@@ -85,7 +85,7 @@ class SparseBiasLayer
   void Gradient(const InputType& /* input */,
                 const arma::Mat<eT>& d,
                 InputDataType& g)
-  {    
+  {
     g = arma::sum(d, 1) / static_cast<typename InputDataType::value_type>(
         batchSize);
   }
@@ -119,7 +119,7 @@ class SparseBiasLayer
   InputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   InputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/sparse_input_layer.hpp
+++ b/src/mlpack/methods/ann/layer/sparse_input_layer.hpp
@@ -47,7 +47,7 @@ class SparseInputLayer
     lambda(lambda)
   {
     weights.set_size(outSize, inSize);
-  }  
+  }
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -119,7 +119,7 @@ class SparseInputLayer
   OutputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   OutputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/sparse_output_layer.hpp
+++ b/src/mlpack/methods/ann/layer/sparse_output_layer.hpp
@@ -61,7 +61,7 @@ class SparseOutputLayer
   {
     output = weights * input;
     // Average activations of the hidden layer.
-    rhoCap = arma::sum(input, 1) / static_cast<double>(input.n_cols);    
+    rhoCap = arma::sum(input, 1) / static_cast<double>(input.n_cols);
   }
 
   /**
@@ -97,11 +97,11 @@ class SparseOutputLayer
    */
   template<typename InputType, typename eT>
   void Gradient(const InputType input, const arma::Mat<eT>& d, arma::Mat<eT>& g)
-  {        
+  {
     g = d * input.t() / static_cast<typename InputType::value_type>(
         input.n_cols) + lambda * weights;
   }
-  
+
   //! Sets the KL divergence parameter.
   void Beta(const double b)
   {
@@ -155,7 +155,7 @@ class SparseOutputLayer
   OutputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.
   OutputDataType& Gradient() { return gradient; }
-  
+
   /**
    * Serialize the layer.
    */
@@ -174,13 +174,13 @@ class SparseOutputLayer
 
   //! Locally-stored number of output units.
   size_t outSize;
-  
+
   //! L2-regularization parameter.
   double lambda;
 
   //! KL divergence parameter.
   double beta;
-  
+
   //! Sparsity parameter.
   double rho;
 

--- a/src/mlpack/methods/ann/network_util_impl.hpp
+++ b/src/mlpack/methods/ann/network_util_impl.hpp
@@ -54,7 +54,7 @@ NetworkWeights(arma::mat& weights,
   NetworkWeights<I + 1, Tp...>(weights, network,
       offset + LayerWeights(std::get<I>(network), weights,
       offset, std::get<I>(network).OutputParameter()));
-  
+
 }
 
 template<size_t I, typename... Tp>

--- a/src/mlpack/methods/ann/performance_functions/sparse_function.hpp
+++ b/src/mlpack/methods/ann/performance_functions/sparse_function.hpp
@@ -30,7 +30,7 @@ class SparseErrorFunction
    */
   SparseErrorFunction(const double lambda = 0.0001,
                       const double beta = 3,
-                      const double rho = 0.01) :    
+                      const double rho = 0.01) :
     lambda(lambda), beta(beta), rho(rho)
   {
     // Nothing to do here.
@@ -39,10 +39,10 @@ class SparseErrorFunction
   SparseErrorFunction(SparseErrorFunction &&layer) noexcept
   {
     *this = std::move(layer);
-  }  
+  }
 
   SparseErrorFunction& operator=(SparseErrorFunction &&layer) noexcept
-  {    
+  {
     lambda = layer.lambda;
     beta = layer.beta;
     rho = layer.rho;

--- a/src/mlpack/methods/ann/performance_functions/sse_function.hpp
+++ b/src/mlpack/methods/ann/performance_functions/sse_function.hpp
@@ -26,7 +26,7 @@ class SumSquaredErrorFunction
    * @param target Target data.
    * @param error same as place holder
    * @return sum of squared errors.
-   */  
+   */
   template<typename DataType, typename... Tp>
   static double Error(const std::tuple<Tp...>& network,
                       const DataType& target,

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -9,7 +9,7 @@
 
 #include <mlpack/core.hpp>
 
-#include <boost/ptr_container/ptr_vector.hpp> 
+#include <boost/ptr_container/ptr_vector.hpp>
 
 #include <mlpack/methods/ann/network_util.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
@@ -332,7 +332,7 @@ class RNN
   InitLayer(const InputDataType& /* unused */,
             const TargetDataType& target,
             std::tuple<Tp...>& /* unused */)
-  { 
+  {
     seqOutput = outputSize < target.n_elem ? true : false;
   }
 
@@ -345,7 +345,7 @@ class RNN
   {
     Init(std::get<I>(network), std::get<I>(network).OutputParameter(),
        std::get<I + 1>(network).Delta());
-    
+
     InitLayer<I + 1, InputDataType, TargetDataType, Tp...>(input, target,
         network);
   }
@@ -636,7 +636,7 @@ class RNN
     BackwardRecurrent(std::get<sizeof...(Tp) - I - 1>(network),
         std::get<sizeof...(Tp) - I - 1>(network).InputParameter(),
         std::get<sizeof...(Tp) - I + 1>(network).Delta());
-    
+
     std::get<sizeof...(Tp) - I>(network).Backward(
         std::get<sizeof...(Tp) - I>(network).OutputParameter(),
         std::get<sizeof...(Tp) - I + 1>(network).Delta(),

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -30,7 +30,7 @@ RNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
        const arma::mat& responses,
        OptimizerType<NetworkType>& optimizer,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction)),
@@ -72,7 +72,7 @@ RNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
        const arma::mat& predictors,
        const arma::mat& responses,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction)),
@@ -103,7 +103,7 @@ RNN<LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
 >::RNN(LayerType &&network,
        OutputType &&outputLayer,
        InitializationRuleType initializeRule,
-       PerformanceFunction performanceFunction) : 
+       PerformanceFunction performanceFunction) :
     network(std::forward<LayerType>(network)),
     outputLayer(std::forward<OutputType>(outputLayer)),
     performanceFunc(std::move(performanceFunction)),
@@ -315,7 +315,7 @@ LayerTypes, OutputLayerType, InitializationRuleType, PerformanceFunction
     {
       Backward(error, network);
     }
-    
+
     // Link the parameters and update the gradients.
     LinkParameter(network);
     UpdateGradients<>(network);

--- a/src/mlpack/tests/cli_test.cpp
+++ b/src/mlpack/tests/cli_test.cpp
@@ -273,14 +273,14 @@ BOOST_AUTO_TEST_CASE(MultiRunTimerTest)
 BOOST_AUTO_TEST_CASE(TwiceStartTimerTest)
 {
   Timer::Start("test_timer");
-  
+
   BOOST_REQUIRE_THROW(Timer::Start("test_timer"), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(TwiceStopTimerTest)
 {
   Timer::Stop("test_timer");
-  
+
   BOOST_REQUIRE_THROW(Timer::Stop("test_timer"), std::runtime_error);
 }
 

--- a/src/mlpack/tests/convolutional_network_test.cpp
+++ b/src/mlpack/tests/convolutional_network_test.cpp
@@ -137,7 +137,7 @@ void BuildVanillaNetwork()
  */
 BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
 {
-  BuildVanillaNetwork<LogisticFunction>();  
+  BuildVanillaNetwork<LogisticFunction>();
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/fastmks_test.cpp
+++ b/src/mlpack/tests/fastmks_test.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(SparseFastMKSTest)
 
   // Store the results in these.
   arma::Mat<size_t> sparseIndices, denseIndices;
-  arma::mat sparseKernels, denseKernels; 
+  arma::mat sparseKernels, denseKernels;
 
   // Do the searches.
   sparsemks.Search(3, sparseIndices, sparseKernels);
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(SparsePolynomialFastMKSTest)
 
   // Store the results in these.
   arma::Mat<size_t> sparseIndices, denseIndices;
-  arma::mat sparseKernels, denseKernels; 
+  arma::mat sparseKernels, denseKernels;
 
   // Do the searches.
   sparsepoly.Search(3, sparseIndices, sparseKernels);

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
                       BinaryClassificationLayer,
                       MeanSquaredErrorFunction>
       (trainData, trainLabels, testData, testLabels, 8, 200, 0.1);
-  
+
   dataset.load("mnist_first250_training_4s_and_9s.arm");
 
   // Normalize each point since these are images.
@@ -304,7 +304,7 @@ void BuildDropConnectNetwork(MatType& trainData,
                              MatType& testLabels,
                              const size_t hiddenLayerSize,
                              const size_t maxEpochs,
-                             const double classificationErrorThreshold) 
+                             const double classificationErrorThreshold)
 {
  /*
   *  Construct a feed forward network with trainData.n_rows input nodes,
@@ -366,8 +366,8 @@ void BuildDropConnectNetwork(MatType& trainData,
 
   double classificationError = 1 - double(error) / testData.n_cols;
   BOOST_REQUIRE_LE(classificationError, classificationErrorThreshold);
-}   
-    
+}
+
 /**
  * Train and evaluate a DropConnect network(with a linearlayer) with the
  * specified structure.
@@ -384,7 +384,7 @@ void BuildDropConnectNetworkLinear(MatType& trainData,
                                    MatType& testLabels,
                                    const size_t hiddenLayerSize,
                                    const size_t maxEpochs,
-                                   const double classificationErrorThreshold) 
+                                   const double classificationErrorThreshold)
 {
  /*
   * Construct a feed forward network with trainData.n_rows input nodes,

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -66,7 +66,7 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   BOOST_REQUIRE_EQUAL(x.n_elem_slice, orig.n_elem_slice);
   BOOST_REQUIRE_EQUAL(x.n_slices, orig.n_slices);
   BOOST_REQUIRE_EQUAL(x.n_elem, orig.n_elem);
-   
+
   for(size_t slice = 0; slice != x.n_slices; ++slice){
 	auto const &orig_slice = orig.slice(slice);
 	auto const &x_slice = x.slice(slice);


### PR DESCRIPTION
Unnecessary end of line whitespace is generally frowned upon. In addition some
editors remove end of line whitespace automatically, making diffs hard to read.
This commit removes all trailing witespaces. Using some sed magic in bash:

find . -name "*.*" -type f -print0 | xargs gsed -i 's/[ \t]*$//'