### PR TITLE
Remove non-existent man page targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,8 +356,6 @@ if (UNIX)
           mlpack_adaboost
           mlpack_kfn
           mlpack_knn
-          mlpack_allkfn
-          mlpack_allknn
           mlpack_allkrann
           mlpack_cf
           mlpack_decision_stump


### PR DESCRIPTION
Since mlpack_allkfn/mlpack_allknn have been renamed, no man pages will
be generated for them.