### PR TITLE
BUG: Misplaced parenthesis in comparison of absolute values

### DIFF
--- a/src/mlpack/core/kernels/epanechnikov_kernel.cpp
+++ b/src/mlpack/core/kernels/epanechnikov_kernel.cpp
@@ -38,7 +38,7 @@ double EpanechnikovKernel::Evaluate(const double distance) const
 double EpanechnikovKernel::Gradient(const double distance) const {
   if (std::abs(bandwidth) < std::abs(distance)) {
     return 0;
-  } else if (std::abs(bandwidth > std::abs(distance))) {
+  } else if (std::abs(bandwidth) > std::abs(distance)) {
     return -2 * inverseBandwidthSquared * distance;
   } else {
     // The gradient doesn't exist.


### PR DESCRIPTION
The misplaced parenthesis around the comparison of the absolute
values of bandwidth and distance could cause erronus results. In
addition, this caused a "-Wabsolute-value" warning:

src/mlpack/core/kernels/epanechnikov_kernel.cpp:41:14:
warning: taking the absolute value of unsigned type 'bool' has no effect [-Wabsolute-value]
  } else if (std::abs(bandwidth > std::abs(distance)))