### PR TITLE
Added missing function argument

### DIFF
--- a/src/mlpack/methods/gmm/gmm_impl.hpp
+++ b/src/mlpack/methods/gmm/gmm_impl.hpp
@@ -154,7 +154,7 @@ double GMM::Train(const arma::mat& observations,
         weightsTrial = weightsOrig;
       }
 
-      fitter.Estimate(observations, distsTrial, weightsTrial, useExistingModel);
+      fitter.Estimate(observations, probabilities, distsTrial, weightsTrial, useExistingModel);
 
       // Check to see if the log-likelihood of this one is better.
       double newLikelihood = LogLikelihood(observations, distsTrial,


### PR DESCRIPTION
The probabilities variable is not passed to the fitter when running multiple trials.