### PR TITLE
Deprecated arma function replaced by new arma constant

### DIFF
--- a/src/mlpack/methods/ann/activation_functions/logistic_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/logistic_function.hpp
@@ -33,9 +33,9 @@ class LogisticFunction
   template<typename eT>
   static double fn(const eT x)
   {
-    if(x < arma::Math<eT>::log_max())
+    if(x < arma::Datum<eT>::log_max)
     {
-      if (x > -arma::Math<eT>::log_max())
+      if (x > -arma::Datum<eT>::log_max)
         return 1.0 /  (1.0 + std::exp(-x));
 
       return 0.0;


### PR DESCRIPTION
`arma::Math<>` has been deprecated and instead have new `arma::Datum<>` with exactly same constants. So, changing the `arma::Math<eT>::log_max()` to `arma::Datum<eT>::log_max`.