### PR TITLE
fix performance issue--forgot to move name parameters

### DIFF
--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -111,7 +111,10 @@ TrainTestSplit(const arma::Mat<T>& input,
   TrainTestSplit(input, inputLabel, trainData, testData, trainLabel, testLabel,
       testRatio);
 
-  return std::make_tuple(trainData, testData, trainLabel, testLabel);
+  return std::make_tuple(std::move(trainData),
+                         std::move(testData),
+                         std::move(trainLabel),
+                         std::move(testLabel));
 }
 
 } // namespace data


### PR DESCRIPTION
As the title said, std::make_tuple do not need to move, because the compiler will 

1 : directly construct the tuple when it can
2 : move the tuple if case 1 can not be done

move is good, but direct construct is even better, use std::move to move the tuple would forbid the compiler to do the optimization