### PR TITLE
add TrainTestSplit() without label

### DIFF
--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -1,8 +1,8 @@
 /**
  * @file split_data.hpp
- * @author Tham Ngap Wei
+ * @author Tham Ngap Wei, Keon Kim
  *
- * Defines TrainTestSplit(), a utility function to split a dataset into a
+ * Defines TrainTestSplit() and LabelTrainTestSplit(), utility functions to split a dataset into a
  * training set and a test set.
  */
 #ifndef MLPACK_CORE_UTIL_SPLIT_DATA_HPP
@@ -12,7 +12,6 @@
 
 namespace mlpack {
 namespace data {
-
 /**
  * Given an input dataset and labels, split into a training set and test set.
  * Example usage below.  This overload places the split dataset into the four
@@ -29,7 +28,7 @@ namespace data {
  *
  * // Split the dataset into a training and test set, with 30% of the data being
  * // held out for the test set.
- * TrainTestSplit(input, label, trainData,
+ * LabelTrainTestSplit(input, label, trainData,
  *                testData, trainLabel, testLabel, 0.3);
  * @endcode
  *
@@ -42,13 +41,13 @@ namespace data {
  * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
  */
 template<typename T, typename U>
-void TrainTestSplit(const arma::Mat<T>& input,
-                    const arma::Row<U>& inputLabel,
-                    arma::Mat<T>& trainData,
-                    arma::Mat<T>& testData,
-                    arma::Row<U>& trainLabel,
-                    arma::Row<U>& testLabel,
-                    const double testRatio)
+void LabelTrainTestSplit(const arma::Mat<T>& input,
+                         const arma::Row<U>& inputLabel,
+                         arma::Mat<T>& trainData,
+                         arma::Mat<T>& testData,
+                         arma::Row<U>& trainLabel,
+                         arma::Row<U>& testLabel,
+                         const double testRatio)
 {
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
   const size_t trainSize = input.n_cols - testSize;
@@ -75,6 +74,52 @@ void TrainTestSplit(const arma::Mat<T>& input,
 }
 
 /**
+ * Given an input dataset, split into a training set and test set.
+ * Example usage below. This overload places the split dataset into the two
+ * output parameters given (trainData, testData).
+ *
+ * @code
+ * arma::mat input = loadData();
+ * arma::mat trainData;
+ * arma::mat testData;
+ * math::RandomSeed(100); // Set the seed if you like.
+ *
+ * // Split the dataset into a training and test set, with 30% of the data being
+ * // held out for the test set.
+ * TrainTestSplit(input, trainData, testData, 0.3);
+ * @endcode
+ *
+ * @param input Input dataset to split.
+ * @param trainData Matrix to store training data into.
+ * @param testData Matrix to store test data into.
+ * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
+ */
+template<typename T>
+void TrainTestSplit(const arma::Mat<T>& input,
+                    arma::Mat<T>& trainData,
+                    arma::Mat<T>& testData
+                    const double testRatio)
+{
+  const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
+  const size_t trainSize = input.n_cols - testSize;
+  trainData.set_size(input.n_rows, trainSize);
+  testData.set_size(input.n_rows, testSize);
+
+  const arma::Col<size_t> order =
+      arma::shuffle(arma::linspace<arma::Col<size_t>>(0, input.n_cols -1,
+                                                      input.n_cols));
+
+  for (size_t i = 0; i != trainSize; ++i)
+  {
+     trainData.col(i) = input.col(order[i]);
+  }
+  for (size_t i = 0; i != testSize; ++i)
+  {
+     testData.col(i) = input.col(order[i + trainSize]);
+  }
+}
+
+/**
  * Given an input dataset and labels, split into a training set and test set.
  * Example usage below.  This overload returns the split dataset as a std::tuple
  * with four elements: an arma::Mat<T> containing the training data, an
@@ -84,34 +129,58 @@ void TrainTestSplit(const arma::Mat<T>& input,
  * @code
  * arma::mat input = loadData();
  * arma::Row<size_t> label = loadLabel();
- * auto splitResult = TrainTestSplit(input, label, 0.2);
+ * auto splitResult = LabelTrainTestSplit(input, label, 0.2);
  * @endcode
  *
  * @param input Input dataset to split.
  * @param label Input labels to split.
- * @param trainData Matrix to store training data into.
- * @param testData Matrix to store test data into.
- * @param trainLabel Vector to store training labels into.
- * @param testLabel Vector to store test labels into.
  * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
  * @return std::tuple containing trainData (arma::Mat<T>), testData
  *      (arma::Mat<T>), trainLabel (arma::Row<U>), and testLabel (arma::Row<U>).
  */
 template<typename T,typename U>
 std::tuple<arma::Mat<T>, arma::Mat<T>, arma::Row<U>, arma::Row<U>>
-TrainTestSplit(const arma::Mat<T>& input,
-               const arma::Row<U>& inputLabel,
-               const double testRatio)
+LabelTrainTestSplit(const arma::Mat<T>& input,
+                    const arma::Row<U>& inputLabel,
+                    const double testRatio)
 {
   arma::Mat<T> trainData;
   arma::Mat<T> testData;
   arma::Row<U> trainLabel;
   arma::Row<U> testLabel;
 
-  TrainTestSplit(input, inputLabel, trainData, testData, trainLabel, testLabel,
+  LabelTrainTestSplit(input, inputLabel, trainData, testData, trainLabel, testLabel,
       testRatio);
 
   return std::make_tuple(trainData, testData, trainLabel, testLabel);
+}
+
+/**
+ * Given an input dataset, split into a training set and test set.
+ * Example usage below.  This overload returns the split dataset as a std::tuple
+ * with two elements: an arma::Mat<T> containing the training data and an
+ * arma::Mat<T> containing the test data.
+ *
+ * @code
+ * arma::mat input = loadData();
+ * auto splitResult = TrainTestSplit(input, 0.2);
+ * @endcode
+ *
+ * @param input Input dataset to split.
+ * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
+ * @return std::tuple containing trainData (arma::Mat<T>)
+ *      and testData (arma::Mat<T>).
+ */
+template<typename T>
+std::tuple<arma::Mat<t>, arma::Mat<t>>
+TrainTestSplit(const arma::Mat<T>& input,
+               const double testRatio)
+{
+  arma::Mat<T> trainData;
+  arma::Mat<T> testData;
+  TrainTestSplit(input, trainData, testData, testRatio);
+
+  return std::make_tuple(trainData, testData);
 }
 
 } // namespace data

--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -15,6 +15,7 @@ endmacro ()
 
 # Recurse into each method mlpack provides.
 set(DIRS
+  preprocess
   adaboost
   amf
   ann

--- a/src/mlpack/methods/preprocess/CMakeLists.txt
+++ b/src/mlpack/methods/preprocess/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Define the files we need to compile.
+# Anything not in this list will not be compiled into mlpack.
+set(SOURCES
+)
+
+# Add directory name to sources.
+set(DIR_SRCS)
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+# Append sources (with directory name) to list of all mlpack sources (used at
+# the parent scope).
+set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)
+
+#add_cli_executable(preprocess_stats)
+add_cli_executable(preprocess_split)
+#add_cli_executable(preprocess_scan)
+#add_cli_executable(preprocess_imputer)

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file preprocess_split_main.cpp
+ * @author Keon Woo Kim
+ *
+ * split data CLI executable
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/core/data/split_data.hpp>
+
+PROGRAM_INFO("Split into Train and Test Data", "This "
+    "utility takes data and labels and split into a training "
+    "set and a test set.");
+
+// Define parameters for data
+PARAM_STRING_REQ("input_file", "File containing data,", "i");
+PARAM_STRING_REQ("output_train_data", "File name to save train data", "d");
+PARAM_STRING_REQ("output_test_data", "File name to save test data", "D");
+
+// Define parameters for labels
+PARAM_STRING_REQ("input_label", "File containing labels", "I");
+PARAM_STRING_REQ("output_train_label", "File name to save train label", "l");
+PARAM_STRING_REQ("output_test_label", "File name to save test label", "L");
+
+// Define optional test ratio, default is 0.2 (Test 20% Train 80%)
+PARAM_DOUBLE("test_ratio", "Ratio of test set, defaults to 0.2"
+    "if not set", "r", 0.2);
+
+using namespace mlpack;
+using namespace arma;
+using namespace std;
+
+int main(int argc, char** argv)
+{
+  // Parse command line options.
+  CLI::ParseCommandLine(argc, argv);
+
+  // data
+  const string inputFile = CLI::GetParam<string>("input_file");
+  const string outputTrainData = CLI::GetParam<string>("output_train_data");
+  const string outputTestData = CLI::GetParam<string>("output_test_data");
+  // labels
+  const string inputLabel = CLI::GetParam<string>("input_label");
+  const string outputTrainLabel = CLI::GetParam<string>("output_train_label");
+  const string outputTestLabel = CLI::GetParam<string>("output_test_label");
+
+  // Ratio
+  const double testRatio = CLI::GetParam<double>("test_ratio");
+
+  // container for input data and labels
+  arma::mat data;
+  arma::Mat<size_t> labels;
+
+  // Load Data and Labels
+  data::Load(inputFile, data, true);
+  data::Load(inputLabel, labels, true);
+  arma::Row<size_t> labels_row = labels.row(0); // extract first row
+
+  // Split Data
+  const auto value = data::TrainTestSplit(data, labels_row, testRatio);
+  Log::Info << "Train Data Count: " << get<0>(value).n_cols << endl;
+  Log::Info << "Test Data Count: " << get<1>(value).n_cols << endl;
+  Log::Info << "Train Label Count: " << get<2>(value).n_cols << endl;
+  Log::Info << "Test Label Count: " << get<3>(value).n_cols << endl;
+
+  // Save Train Data
+  data::Save(outputTrainData, get<0>(value), false);
+
+  // Save Test Data
+  data::Save(outputTestData, get<1>(value), false);
+
+  // Save Train Label
+  data::Save(outputTrainLabel, get<2>(value), false);
+
+  // Save Test Label
+  data::Save(outputTestLabel, get<3>(value), false);
+}
+

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -13,17 +13,15 @@ PROGRAM_INFO("Split into Train and Test Data", "This "
 
 // Define parameters for data
 PARAM_STRING_REQ("input_file", "File containing data,", "i");
-PARAM_STRING_REQ("output_train_data", "File name to save train data", "d");
-PARAM_STRING_REQ("output_test_data", "File name to save test data", "D");
-
-// Define parameters for labels
 PARAM_STRING_REQ("input_label", "File containing labels", "I");
-PARAM_STRING_REQ("output_train_label", "File name to save train label", "l");
-PARAM_STRING_REQ("output_test_label", "File name to save test label", "L");
+PARAM_STRING_REQ("training_file", "File name to save train data", "t");
+PARAM_STRING_REQ("test_file", "File name to save test data", "T");
+PARAM_STRING_REQ("training_labels_file", "File name to save train label", "l");
+PARAM_STRING_REQ("test_labels_file", "File name to save test label", "L");
 
 // Define optional test ratio, default is 0.2 (Test 20% Train 80%)
-PARAM_DOUBLE("test_ratio", "Ratio of test set, defaults to 0.2"
-    "if not set", "r", 0.2);
+PARAM_DOUBLE("test_ratio", "Ratio of test set, if not set,"
+    "the ratio defaults to 0.2", "r", 0.2);
 
 using namespace mlpack;
 using namespace arma;
@@ -34,16 +32,12 @@ int main(int argc, char** argv)
   // Parse command line options.
   CLI::ParseCommandLine(argc, argv);
 
-  // data
   const string inputFile = CLI::GetParam<string>("input_file");
-  const string outputTrainData = CLI::GetParam<string>("output_train_data");
-  const string outputTestData = CLI::GetParam<string>("output_test_data");
-  // labels
   const string inputLabel = CLI::GetParam<string>("input_label");
-  const string outputTrainLabel = CLI::GetParam<string>("output_train_label");
-  const string outputTestLabel = CLI::GetParam<string>("output_test_label");
-
-  // Ratio
+  const string trainingFile = CLI::GetParam<string>("training_file");
+  const string testFile = CLI::GetParam<string>("test_file");
+  const string trainingLabelsFile = CLI::GetParam<string>("training_labels_file");
+  const string testLabelsFile = CLI::GetParam<string>("test_labels_file");
   const double testRatio = CLI::GetParam<double>("test_ratio");
 
   // container for input data and labels
@@ -62,16 +56,9 @@ int main(int argc, char** argv)
   Log::Info << "Train Label Count: " << get<2>(value).n_cols << endl;
   Log::Info << "Test Label Count: " << get<3>(value).n_cols << endl;
 
-  // Save Train Data
-  data::Save(outputTrainData, get<0>(value), false);
-
-  // Save Test Data
-  data::Save(outputTestData, get<1>(value), false);
-
-  // Save Train Label
-  data::Save(outputTrainLabel, get<2>(value), false);
-
-  // Save Test Label
-  data::Save(outputTestLabel, get<3>(value), false);
+  data::Save(trainingFile, get<0>(value), false);
+  data::Save(testFile, get<1>(value), false);
+  data::Save(trainingLabelsFile, get<2>(value), false);
+  data::Save(testLabelsFile, get<3>(value), false);
 }
 


### PR DESCRIPTION
I added `TrainTestSplit()` and renamed old ones to `LabelTrainTestSplit()`.
This is just a naive implementation mostly copied from Tham's work.
I believe LabelTrainTestSplit can just reuse the code in TrainTestSplit twice for both data and labels.
