### PR TITLE
Approximate Neighbor Search for Dual tree algorithms.

### DIFF
--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -72,8 +72,10 @@ PARAM_INT("seed", "Random seed (if 0, std::time(NULL) is used).", "s", 0);
 PARAM_FLAG("naive", "If true, O(n^2) naive mode is used for computation.", "N");
 PARAM_FLAG("single_mode", "If true, single-tree search is used (as opposed to "
     "dual-tree search).", "s");
-PARAM_DOUBLE("epsilon", "If specified, will do approximate furthest neighbor "
-    "search with given relative error.", "e", 0);
+PARAM_DOUBLE("percentage", "If specified, will do approximate furthest neighbor"
+    " search. Must be in the range (0,1] (decimal form). Resultant neighbors "
+    "will be at least (p*100) % of the distance as the true furthest neighbor.",
+    "p", 1);
 
 // Convenience typedef.
 typedef NSModel<FurthestNeighborSort> KFNModel;
@@ -140,11 +142,11 @@ int main(int argc, char *argv[])
     Log::Fatal << "Invalid leaf size: " << lsInt << ".  Must be greater than 0."
         << endl;
 
-  // Sanity check on epsilon.
-  const double epsilon = CLI::GetParam<double>("epsilon");
-  if (epsilon < 0)
-    Log::Fatal << "Invalid epsilon: " << epsilon << ".  Must be non-negative. "
-        << endl;
+  // Sanity check on percentage.
+  const double percentage = CLI::GetParam<double>("percentage");
+  if (percentage <= 0 || percentage > 1)
+    Log::Fatal << "Invalid percentage: " << percentage
+        << ".  Must be in the range (0,1] (decimal form)."<< endl;
 
   // We either have to load the reference data, or we have to load the model.
   NSModel<FurthestNeighborSort> kfn;
@@ -184,7 +186,7 @@ int main(int argc, char *argv[])
         << referenceSet.n_rows << "x" << referenceSet.n_cols << ")." << endl;
 
     kfn.BuildModel(std::move(referenceSet), size_t(lsInt), naive, singleMode,
-        epsilon);
+        1 - percentage);
   }
   else
   {
@@ -200,7 +202,7 @@ int main(int argc, char *argv[])
     kfn.SingleMode() = CLI::HasParam("single_mode");
     kfn.Naive() = CLI::HasParam("naive");
     kfn.LeafSize() = size_t(lsInt);
-    kfn.Epsilon() = epsilon;
+    kfn.Epsilon() = 1 - percentage;
   }
 
   // Perform search, if desired.

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -72,6 +72,8 @@ PARAM_INT("seed", "Random seed (if 0, std::time(NULL) is used).", "s", 0);
 PARAM_FLAG("naive", "If true, O(n^2) naive mode is used for computation.", "N");
 PARAM_FLAG("single_mode", "If true, single-tree search is used (as opposed to "
     "dual-tree search).", "s");
+PARAM_DOUBLE("epsilon", "If specified, will do approximate furthest neighbor "
+    "search with given relative error.", "e", 0);
 
 // Convenience typedef.
 typedef NSModel<FurthestNeighborSort> KFNModel;
@@ -138,6 +140,12 @@ int main(int argc, char *argv[])
     Log::Fatal << "Invalid leaf size: " << lsInt << ".  Must be greater than 0."
         << endl;
 
+  // Sanity check on epsilon.
+  const double epsilon = CLI::GetParam<double>("epsilon");
+  if (epsilon < 0)
+    Log::Fatal << "Invalid epsilon: " << epsilon << ".  Must be non-negative. "
+        << endl;
+
   // We either have to load the reference data, or we have to load the model.
   NSModel<FurthestNeighborSort> kfn;
   const bool naive = CLI::HasParam("naive");
@@ -175,7 +183,8 @@ int main(int argc, char *argv[])
     Log::Info << "Loaded reference data from '" << referenceFile << "' ("
         << referenceSet.n_rows << "x" << referenceSet.n_cols << ")." << endl;
 
-    kfn.BuildModel(std::move(referenceSet), size_t(lsInt), naive, singleMode);
+    kfn.BuildModel(std::move(referenceSet), size_t(lsInt), naive, singleMode,
+        epsilon);
   }
   else
   {
@@ -191,6 +200,7 @@ int main(int argc, char *argv[])
     kfn.SingleMode() = CLI::HasParam("single_mode");
     kfn.Naive() = CLI::HasParam("naive");
     kfn.LeafSize() = size_t(lsInt);
+    kfn.Epsilon() = epsilon;
   }
 
   // Perform search, if desired.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -84,11 +84,13 @@ class NeighborSearch
    *      dual-tree search).  This overrides singleMode (if it is set to true).
    * @param singleMode If true, single-tree search will be used (as opposed to
    *      dual-tree search).
+   * @param epsilon Relative approximate error (non-negative).
    * @param metric An optional instance of the MetricType class.
    */
   NeighborSearch(const MatType& referenceSet,
                  const bool naive = false,
                  const bool singleMode = false,
+                 const double epsilon = 0,
                  const MetricType metric = MetricType());
 
   /**
@@ -108,11 +110,13 @@ class NeighborSearch
    *      dual-tree search).  This overrides singleMode (if it is set to true).
    * @param singleMode If true, single-tree search will be used (as opposed to
    *      dual-tree search).
+   * @param epsilon Relative approximate error (non-negative).
    * @param metric An optional instance of the MetricType class.
    */
   NeighborSearch(MatType&& referenceSet,
                  const bool naive = false,
                  const bool singleMode = false,
+                 const double epsilon = 0,
                  const MetricType metric = MetricType());
 
   /**
@@ -138,10 +142,12 @@ class NeighborSearch
    * @param referenceSet Set of reference points corresponding to referenceTree.
    * @param singleMode Whether single-tree computation should be used (as
    *      opposed to dual-tree computation).
+   * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
   NeighborSearch(Tree* referenceTree,
                  const bool singleMode = false,
+                 const double epsilon = 0,
                  const MetricType metric = MetricType());
 
   /**
@@ -152,10 +158,12 @@ class NeighborSearch
    * @param naive Whether to use naive search.
    * @param singleMode Whether single-tree computation should be used (as
    *      opposed to dual-tree computation).
+   * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated metric.
    */
   NeighborSearch(const bool naive = false,
                  const bool singleMode = false,
+                 const double epsilon = 0,
                  const MetricType metric = MetricType());
 
 
@@ -270,6 +278,11 @@ class NeighborSearch
   //! Modify whether or not search is done in single-tree mode.
   bool& SingleMode() { return singleMode; }
 
+  //! Access the relative error to be considered in approximate search.
+  double Epsilon() const { return epsilon; }
+  //! Modify the relative error to be considered in approximate search.
+  double& Epsilon() { return epsilon; }
+
   //! Access the reference dataset.
   const MatType& ReferenceSet() const { return *referenceSet; }
 
@@ -294,6 +307,8 @@ class NeighborSearch
   bool naive;
   //! Indicates if single-tree search is being used (as opposed to dual-tree).
   bool singleMode;
+  //! Indicates the relative error to be considered in approximate search.
+  double epsilon;
 
   //! Instantiation of metric.
   MetricType metric;

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -75,6 +75,7 @@ NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
 NeighborSearch(const MatType& referenceSetIn,
                const bool naive,
                const bool singleMode,
+               const double epsilon,
                const MetricType metric) :
     referenceTree(naive ? NULL :
         BuildTree<MatType, Tree>(referenceSetIn, oldFromNewReferences)),
@@ -83,12 +84,14 @@ NeighborSearch(const MatType& referenceSetIn,
     setOwner(false),
     naive(naive),
     singleMode(!naive && singleMode), // No single mode if naive.
+    epsilon(epsilon),
     metric(metric),
     baseCases(0),
     scores(0),
     treeNeedsReset(false)
 {
-  // Nothing to do.
+  if (epsilon < 0)
+    throw std::invalid_argument("epsilon must be non-negative");
 }
 
 // Construct the object.
@@ -103,6 +106,7 @@ NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
 NeighborSearch(MatType&& referenceSetIn,
                const bool naive,
                const bool singleMode,
+               const double epsilon,
                const MetricType metric) :
     referenceTree(naive ? NULL :
         BuildTree<MatType, Tree>(std::move(referenceSetIn),
@@ -113,12 +117,14 @@ NeighborSearch(MatType&& referenceSetIn,
     setOwner(naive),
     naive(naive),
     singleMode(!naive && singleMode),
+    epsilon(epsilon),
     metric(metric),
     baseCases(0),
     scores(0),
     treeNeedsReset(false)
 {
-  // Nothing to do.
+  if (epsilon < 0)
+    throw std::invalid_argument("epsilon must be non-negative");
 }
 
 // Construct the object.
@@ -132,6 +138,7 @@ template<typename SortPolicy,
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
 NeighborSearch(Tree* referenceTree,
                const bool singleMode,
+               const double epsilon,
                const MetricType metric) :
     referenceTree(referenceTree),
     referenceSet(&referenceTree->Dataset()),
@@ -139,12 +146,14 @@ NeighborSearch(Tree* referenceTree,
     setOwner(false),
     naive(false),
     singleMode(singleMode),
+    epsilon(epsilon),
     metric(metric),
     baseCases(0),
     scores(0),
     treeNeedsReset(false)
 {
-  // Nothing else to initialize.
+  if (epsilon < 0)
+    throw std::invalid_argument("epsilon must be non-negative");
 }
 
 // Construct the object without a reference dataset.
@@ -158,6 +167,7 @@ template<typename SortPolicy,
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
     NeighborSearch(const bool naive,
                    const bool singleMode,
+                   const double epsilon,
                    const MetricType metric) :
     referenceTree(NULL),
     referenceSet(new MatType()), // Empty matrix.
@@ -165,11 +175,14 @@ NeighborSearch<SortPolicy, MetricType, MatType, TreeType, TraversalType>::
     setOwner(true),
     naive(naive),
     singleMode(singleMode),
+    epsilon(epsilon),
     metric(metric),
     baseCases(0),
     scores(0),
     treeNeedsReset(false)
 {
+  if (epsilon < 0)
+    throw std::invalid_argument("epsilon must be non-negative");
   // Build the tree on the empty dataset, if necessary.
   if (!naive)
   {
@@ -364,7 +377,8 @@ Search(const MatType& querySet,
   if (naive)
   {
     // Create the helper object for the tree traversal.
-    RuleType rules(*referenceSet, querySet, *neighborPtr, *distancePtr, metric);
+    RuleType rules(*referenceSet, querySet, *neighborPtr, *distancePtr, metric,
+        epsilon);
 
     // The naive brute-force traversal.
     for (size_t i = 0; i < querySet.n_cols; ++i)
@@ -376,7 +390,8 @@ Search(const MatType& querySet,
   else if (singleMode)
   {
     // Create the helper object for the tree traversal.
-    RuleType rules(*referenceSet, querySet, *neighborPtr, *distancePtr, metric);
+    RuleType rules(*referenceSet, querySet, *neighborPtr, *distancePtr, metric,
+        epsilon);
 
     // Create the traverser.
     typename Tree::template SingleTreeTraverser<RuleType> traverser(rules);
@@ -402,7 +417,7 @@ Search(const MatType& querySet,
 
     // Create the helper object for the tree traversal.
     RuleType rules(*referenceSet, queryTree->Dataset(), *neighborPtr,
-        *distancePtr, metric);
+        *distancePtr, metric, epsilon);
 
     // Create the traverser.
     TraversalType<RuleType> traverser(rules);
@@ -527,7 +542,8 @@ Search(Tree* queryTree,
 
   // Create the helper object for the traversal.
   typedef NeighborSearchRules<SortPolicy, MetricType, Tree> RuleType;
-  RuleType rules(*referenceSet, querySet, *neighborPtr, distances, metric);
+  RuleType rules(*referenceSet, querySet, *neighborPtr, distances, metric,
+      epsilon);
 
   // Create the traverser.
   TraversalType<RuleType> traverser(rules);
@@ -598,7 +614,7 @@ Search(const size_t k,
   // Create the helper object for the traversal.
   typedef NeighborSearchRules<SortPolicy, MetricType, Tree> RuleType;
   RuleType rules(*referenceSet, *referenceSet, *neighborPtr, *distancePtr,
-      metric, true /* don't return the same point as nearest neighbor */);
+      metric, epsilon, true /* don't return the same point as nearest neighbor */);
 
   if (naive)
   {

--- a/src/mlpack/methods/neighbor_search/neighbor_search_rules.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_rules.hpp
@@ -22,6 +22,7 @@ class NeighborSearchRules
                       arma::Mat<size_t>& neighbors,
                       arma::mat& distances,
                       MetricType& metric,
+                      const double epsilon = 0,
                       const bool sameSet = false);
   /**
    * Get the distance from the query point to the reference point.
@@ -119,6 +120,9 @@ class NeighborSearchRules
 
   //! Denotes whether or not the reference and query sets are the same.
   bool sameSet;
+
+  //! Relative error to be considered in approximate search.
+  const double epsilon;
 
   //! The last query point BaseCase() was called with.
   size_t lastQueryIndex;

--- a/src/mlpack/methods/neighbor_search/neighbor_search_rules_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_rules_impl.hpp
@@ -1,8 +1,8 @@
 /**
- * @file nearest_neighbor_rules_impl.hpp
+ * @file neighbor_search_rules_impl.hpp
  * @author Ryan Curtin
  *
- * Implementation of NearestNeighborRules.
+ * Implementation of NeighborSearchRules.
  */
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_NEAREST_NEIGHBOR_RULES_IMPL_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_NEAREST_NEIGHBOR_RULES_IMPL_HPP

--- a/src/mlpack/methods/neighbor_search/ns_model.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model.hpp
@@ -69,7 +69,11 @@ class MonoSearchVisitor : public boost::static_visitor<void>
 
   MonoSearchVisitor(const size_t k,
                     arma::Mat<size_t>& neighbors,
-                    arma::mat& distances);
+                    arma::mat& distances) :
+      k(k),
+      neighbors(neighbors),
+      distances(distances)
+  {};
 };
 
 /**

--- a/src/mlpack/methods/neighbor_search/ns_model.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model.hpp
@@ -178,6 +178,16 @@ class NaiveVisitor : public boost::static_visitor<bool&>
 };
 
 /**
+ * EpsilonVisitor exposes the Epsilon method of the given NSType.
+ */
+class EpsilonVisitor : public boost::static_visitor<double&>
+{
+ public:
+  template<typename NSType>
+  double& operator()(NSType *ns) const;
+};
+
+/**
  * ReferenceSetVisitor exposes the referenceSet of the given NSType.
  */
 class ReferenceSetVisitor : public boost::static_visitor<const arma::mat&>
@@ -266,6 +276,10 @@ class NSModel
   bool Naive() const;
   bool& Naive();
 
+  //! Expose Epsilon.
+  double Epsilon() const;
+  double& Epsilon();
+
   //! Expose leafSize.
   size_t LeafSize() const { return leafSize; }
   size_t& LeafSize() { return leafSize; }
@@ -282,7 +296,8 @@ class NSModel
   void BuildModel(arma::mat&& referenceSet,
                   const size_t leafSize,
                   const bool naive,
-                  const bool singleMode);
+                  const bool singleMode,
+                  const double epsilon = 0);
 
   //! Perform neighbor search.  The query set will be reordered.
   void Search(arma::mat&& querySet,

--- a/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
@@ -416,9 +416,8 @@ void NSModel<SortPolicy>::Search(arma::mat&& querySet,
 
   Log::Info << "Searching for " << k;
   if (Epsilon() != 0)
-    Log::Info << " approximate nearest neighbors (e=" << Epsilon() << ") with ";
-  else
-    Log::Info << " nearest neighbors with ";
+    Log::Info << " approximate (e=" << Epsilon() << ")";
+  Log::Info << " neighbors with ";
   if (!Naive() && !SingleMode())
     Log::Info << "dual-tree " << TreeName() << " search..." << std::endl;
   else if (!Naive())
@@ -437,7 +436,10 @@ void NSModel<SortPolicy>::Search(const size_t k,
                                  arma::Mat<size_t>& neighbors,
                                  arma::mat& distances)
 {
-  Log::Info << "Searching for " << k << " nearest neighbors with ";
+  Log::Info << "Searching for " << k;
+  if (Epsilon() != 0)
+    Log::Info << " approximate (e=" << Epsilon() << ")";
+  Log::Info << " neighbors with ";
   if (!Naive() && !SingleMode())
     Log::Info << "dual-tree " << TreeName() << " search..." << std::endl;
   else if (!Naive())

--- a/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
@@ -414,16 +414,16 @@ void NSModel<SortPolicy>::Search(arma::mat&& querySet,
   if (randomBasis)
     querySet = q * querySet;
 
-  Log::Info << "Searching for " << k;
-  if (Epsilon() != 0)
-    Log::Info << " approximate (e=" << Epsilon() << ")";
-  Log::Info << " neighbors with ";
+  Log::Info << "Searching for " << k << " neighbors with ";
   if (!Naive() && !SingleMode())
     Log::Info << "dual-tree " << TreeName() << " search..." << std::endl;
   else if (!Naive())
     Log::Info << "single-tree " << TreeName() << " search..." << std::endl;
   else
     Log::Info << "brute-force (naive) search..." << std::endl;
+  if (Epsilon() != 0 && !Naive())
+    Log::Info << "Maximum of " << Epsilon() * 100 << "% relative error."
+        << std::endl;
 
   BiSearchVisitor<SortPolicy> search(querySet, k, neighbors, distances,
       leafSize);
@@ -436,16 +436,16 @@ void NSModel<SortPolicy>::Search(const size_t k,
                                  arma::Mat<size_t>& neighbors,
                                  arma::mat& distances)
 {
-  Log::Info << "Searching for " << k;
-  if (Epsilon() != 0)
-    Log::Info << " approximate (e=" << Epsilon() << ")";
-  Log::Info << " neighbors with ";
+  Log::Info << "Searching for " << k << " neighbors with ";
   if (!Naive() && !SingleMode())
     Log::Info << "dual-tree " << TreeName() << " search..." << std::endl;
   else if (!Naive())
     Log::Info << "single-tree " << TreeName() << " search..." << std::endl;
   else
     Log::Info << "brute-force (naive) search..." << std::endl;
+  if (Epsilon() != 0 && !Naive())
+    Log::Info << "Maximum of " << Epsilon() * 100 << "% relative error."
+        << std::endl;
 
   MonoSearchVisitor search(k, neighbors, distances);
   boost::apply_visitor(search, nSearch);

--- a/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
@@ -18,15 +18,6 @@
 namespace mlpack {
 namespace neighbor {
 
-//! Save parameters for monochromatic neighbor search.
-MonoSearchVisitor::MonoSearchVisitor(const size_t k,
-                                     arma::Mat<size_t>& neighbors,
-                                     arma::mat& distances) :
-    k(k),
-    neighbors(neighbors),
-    distances(distances)
-{}
-
 //! Monochromatic neighbor search on the given NSType instance.
 template<typename NSType>
 void MonoSearchVisitor::operator()(NSType *ns) const

--- a/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.cpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.cpp
@@ -1,5 +1,5 @@
 /***
- * @file nearest_neighbor_sort.cpp
+ * @file furthest_neighbor_sort.cpp
  * @author Ryan Curtin
  *
  * Implementation of the simple FurthestNeighborSort policy class.
@@ -12,7 +12,7 @@ size_t FurthestNeighborSort::SortDistance(const arma::vec& list,
                                           const arma::Col<size_t>& indices,
                                           double newDistance)
 {
-  // The first element in the list is the nearest neighbor.  We only want to
+  // The first element in the list is the furthest neighbor.  We only want to
   // insert if the new distance is greater than the last element in the list.
   if (newDistance < list[list.n_elem - 1])
     return (size_t() - 1); // Do not insert.

--- a/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp
@@ -145,6 +145,23 @@ class FurthestNeighborSort
    */
   static inline double CombineWorst(const double a, const double b)
   { return std::max(a - b, 0.0); }
+
+  /**
+   * Return the given value relaxed.
+   *
+   * @param value Value to relax.
+   * @param epsilon Relative error (non-negative).
+   *
+   * @return double Value relaxed.
+   */
+  static inline double Relax(const double value, const double epsilon)
+  {
+    if (value == 0)
+      return 0;
+    if (value == DBL_MAX || epsilon >= 1)
+      return DBL_MAX;
+    return (1 / (1 - epsilon)) * value;
+  }
 };
 
 } // namespace neighbor

--- a/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp
@@ -150,6 +150,21 @@ class NearestNeighborSort
       return DBL_MAX;
     return a + b;
   }
+
+  /**
+   * Return the given value relaxed.
+   *
+   * @param value Value to relax.
+   * @param epsilon Relative error (non-negative).
+   *
+   * @return double Value relaxed.
+   */
+  static inline double Relax(const double value, const double epsilon)
+  {
+    if (value == DBL_MAX)
+      return DBL_MAX;
+    return (1 / (1 + epsilon)) * value;
+  }
 };
 
 } // namespace neighbor

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(mlpack_test
   kernel_pca_test.cpp
   kernel_traits_test.cpp
   kfn_test.cpp
+  akfn_test.cpp
   kmeans_test.cpp
   knn_test.cpp
   krann_search_test.cpp

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(mlpack_test
   kmeans_test.cpp
   knn_test.cpp
   krann_search_test.cpp
+  aknn_test.cpp
   lars_test.cpp
   lbfgs_test.cpp
   lin_alg_test.cpp

--- a/src/mlpack/tests/activation_functions_test.cpp
+++ b/src/mlpack/tests/activation_functions_test.cpp
@@ -25,7 +25,7 @@
 #include <mlpack/methods/ann/layer/hard_tanh_layer.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/ada_delta_test.cpp
+++ b/src/mlpack/tests/ada_delta_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/methods/logistic_regression/logistic_regression.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace arma;
 using namespace mlpack::optimization;

--- a/src/mlpack/tests/adaboost_test.cpp
+++ b/src/mlpack/tests/adaboost_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/adaboost/adaboost.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 using namespace arma;

--- a/src/mlpack/tests/adam_test.cpp
+++ b/src/mlpack/tests/adam_test.cpp
@@ -11,7 +11,7 @@
 #include <mlpack/methods/logistic_regression/logistic_regression.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace arma;
 using namespace mlpack::optimization;

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
     kfn->Search(dataset, 15, neighborsTree, distancesTree);
 
     for (size_t i = 0; i < neighborsTree.n_elem; i++)
-      BOOST_REQUIRE_CLOSE(distancesTree(i), distancesNaive(i), epsilon * 100);
+      REQUIRE_RELATIVE_ERR(distancesTree(i), distancesNaive(i), epsilon);
 
     // Clean the memory.
     delete kfn;
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(DualTreeVsNaive2)
   kfn.Search(15, neighborsTree, distancesTree);
 
   for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    BOOST_REQUIRE_CLOSE(distancesTree[i], distancesNaive[i], 5);
+    REQUIRE_RELATIVE_ERR(distancesTree[i], distancesNaive[i], 0.05);
 }
 
 /**
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(SingleTreeVsNaive)
   kfn.Search(15, neighborsTree, distancesTree);
 
   for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    BOOST_REQUIRE_CLOSE(distancesTree[i], distancesNaive[i], 5);
+    REQUIRE_RELATIVE_ERR(distancesTree[i], distancesNaive[i], 0.05);
 }
 
 /**
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
   coverTreeSearch.Search(data, 15, coverTreeNeighbors, coverTreeDistances);
 
   for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(coverTreeDistances[i], naiveDistances[i], 5);
+    REQUIRE_RELATIVE_ERR(coverTreeDistances[i], naiveDistances[i], 0.05);
 }
 
 /**
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   coverTreeSearch.Search(dataset, 15, coverTreeNeighbors, coverTreeDistances);
 
   for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(coverTreeDistances[i], naiveDistances[i], 5);
+    REQUIRE_RELATIVE_ERR(coverTreeDistances[i], naiveDistances[i], 0.05);
 }
 
 /**
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
   ballTreeSearch.Search(data, 15, ballNeighbors, ballDistances);
 
   for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
 }
 
 /**
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(DualBallTreeTest)
   ballTreeSearch.Search(15, ballNeighbors, ballDistances);
 
   for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -1,0 +1,241 @@
+/**
+ * @file akfn_test.cpp
+ *
+ * Tests for KFN (k-furthest-neighbors) with different values of epsilon.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/neighbor_search/neighbor_search.hpp>
+#include <mlpack/core/tree/cover_tree.hpp>
+#include <boost/test/unit_test.hpp>
+#include "old_boost_test_definitions.hpp"
+
+using namespace mlpack;
+using namespace mlpack::neighbor;
+using namespace mlpack::tree;
+using namespace mlpack::metric;
+using namespace mlpack::bound;
+
+BOOST_AUTO_TEST_SUITE(AKFNTest);
+
+/**
+ * Test the dual-tree furthest-neighbors method with different values for
+ * epsilon. This uses both a query and reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
+{
+  arma::mat dataset;
+
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
+
+  KFN naive(dataset, true);
+  arma::Mat<size_t> neighborsNaive;
+  arma::mat distancesNaive;
+  naive.Search(dataset, 15, neighborsNaive, distancesNaive);
+
+  for (size_t c = 0; c < 4; c++)
+  {
+    KFN* kfn;
+    double epsilon;
+
+    switch (c)
+    {
+      case 0: // Use the dual-tree method with e=0.02.
+        epsilon = 0.02;
+        break;
+      case 1: // Use the dual-tree method with e=0.05.
+        epsilon = 0.05;
+        break;
+      case 2: // Use the dual-tree method with e=0.10.
+        epsilon = 0.10;
+        break;
+      case 3: // Use the dual-tree method with e=0.20.
+        epsilon = 0.20;
+        break;
+    }
+
+    kfn = new KFN(dataset, false, false, epsilon);
+
+    // Now perform the actual calculation.
+    arma::Mat<size_t> neighborsTree;
+    arma::mat distancesTree;
+    kfn->Search(dataset, 15, neighborsTree, distancesTree);
+
+    for (size_t i = 0; i < neighborsTree.n_elem; i++)
+      BOOST_REQUIRE_CLOSE(distancesTree(i), distancesNaive(i), epsilon * 100);
+
+    // Clean the memory.
+    delete kfn;
+  }
+}
+
+/**
+ * Test the dual-tree furthest-neighbors method with the naive method.  This
+ * uses only a reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualTreeVsNaive2)
+{
+  arma::mat dataset;
+
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
+
+  KFN naive(dataset, true);
+  arma::Mat<size_t> neighborsNaive;
+  arma::mat distancesNaive;
+  naive.Search(15, neighborsNaive, distancesNaive);
+
+  KFN kfn(dataset, false, false, 0.05);
+  arma::Mat<size_t> neighborsTree;
+  arma::mat distancesTree;
+  kfn.Search(15, neighborsTree, distancesTree);
+
+  for (size_t i = 0; i < neighborsTree.n_elem; i++)
+    BOOST_REQUIRE_CLOSE(distancesTree[i], distancesNaive[i], 5);
+}
+
+/**
+ * Test the single-tree furthest-neighbors method with the naive method.  This
+ * uses only a reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(SingleTreeVsNaive)
+{
+  arma::mat dataset;
+
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
+
+  KFN naive(dataset, true);
+  arma::Mat<size_t> neighborsNaive;
+  arma::mat distancesNaive;
+  naive.Search(15, neighborsNaive, distancesNaive);
+
+  KFN kfn(dataset, false, true, 0.05);
+  arma::Mat<size_t> neighborsTree;
+  arma::mat distancesTree;
+  kfn.Search(15, neighborsTree, distancesTree);
+
+  for (size_t i = 0; i < neighborsTree.n_elem; i++)
+    BOOST_REQUIRE_CLOSE(distancesTree[i], distancesNaive[i], 5);
+}
+
+/**
+ * Test the cover tree single-tree furthest-neighbors method against the naive
+ * method.  This uses only a random reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
+{
+  arma::mat data;
+  data.randu(75, 1000); // 75 dimensional, 1000 points.
+
+  KFN naive(data, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+
+  StandardCoverTree<EuclideanDistance, NeighborSearchStat<FurthestNeighborSort>,
+      arma::mat> tree(data);
+
+  NeighborSearch<FurthestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
+      coverTreeSearch(&tree, true, 0.05);
+
+  arma::Mat<size_t> coverTreeNeighbors;
+  arma::mat coverTreeDistances;
+  coverTreeSearch.Search(data, 15, coverTreeNeighbors, coverTreeDistances);
+
+  for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(coverTreeDistances[i], naiveDistances[i], 5);
+}
+
+/**
+ * Test the cover tree dual-tree furthest neighbors method against the naive
+ * method.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
+{
+  arma::mat dataset;
+  data::Load("test_data_3_1000.csv", dataset);
+
+  KFN naive(dataset, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(dataset, 15, naiveNeighbors, naiveDistances);
+
+  StandardCoverTree<EuclideanDistance, NeighborSearchStat<FurthestNeighborSort>,
+      arma::mat> referenceTree(dataset);
+
+  NeighborSearch<FurthestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
+      coverTreeSearch(&referenceTree, false, 0.05);
+
+  arma::Mat<size_t> coverTreeNeighbors;
+  arma::mat coverTreeDistances;
+  coverTreeSearch.Search(dataset, 15, coverTreeNeighbors, coverTreeDistances);
+
+  for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(coverTreeDistances[i], naiveDistances[i], 5);
+}
+
+/**
+ * Test the ball tree single-tree furthest-neighbors method against the naive
+ * method.  This uses only a random reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
+{
+  arma::mat data;
+  data.randu(75, 1000); // 75 dimensional, 1000 points.
+
+  KFN naive(data, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+
+  NeighborSearch<FurthestNeighborSort, EuclideanDistance, arma::mat, BallTree>
+      ballTreeSearch(data, false, true, 0.05);
+
+  arma::Mat<size_t> ballNeighbors;
+  arma::mat ballDistances;
+  ballTreeSearch.Search(data, 15, ballNeighbors, ballDistances);
+
+  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+}
+
+/**
+ * Test the ball tree dual-tree furthest neighbors method against the naive
+ * method.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualBallTreeTest)
+{
+  arma::mat dataset;
+  data::Load("test_data_3_1000.csv", dataset);
+
+  KFN naive(dataset, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(15, naiveNeighbors, naiveDistances);
+
+  NeighborSearch<FurthestNeighborSort, EuclideanDistance, arma::mat, BallTree>
+      ballTreeSearch(dataset, false, false, 0.05);
+  arma::Mat<size_t> ballNeighbors;
+  arma::mat ballDistances;
+  ballTreeSearch.Search(15, ballNeighbors, ballDistances);
+
+  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -23,21 +23,21 @@ BOOST_AUTO_TEST_SUITE(AKFNTest);
  *
  * Errors are produced if the results are not according to relative error.
  */
-BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
+BOOST_AUTO_TEST_CASE(AproxVsExact1)
 {
   arma::mat dataset;
 
   if (!data::Load("test_data_3_1000.csv", dataset))
     BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
-  KFN naive(dataset, true);
-  arma::Mat<size_t> neighborsNaive;
-  arma::mat distancesNaive;
-  naive.Search(dataset, 15, neighborsNaive, distancesNaive);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   for (size_t c = 0; c < 4; c++)
   {
-    KFN* kfn;
+    KFN* akfn;
     double epsilon;
 
     switch (c)
@@ -56,107 +56,106 @@ BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
         break;
     }
 
-    kfn = new KFN(dataset, false, false, epsilon);
-
     // Now perform the actual calculation.
-    arma::Mat<size_t> neighborsTree;
-    arma::mat distancesTree;
-    kfn->Search(dataset, 15, neighborsTree, distancesTree);
+    akfn = new KFN(dataset, false, false, epsilon);
+    arma::Mat<size_t> neighborsAprox;
+    arma::mat distancesAprox;
+    akfn->Search(dataset, 15, neighborsAprox, distancesAprox);
 
-    for (size_t i = 0; i < neighborsTree.n_elem; i++)
-      REQUIRE_RELATIVE_ERR(distancesTree(i), distancesNaive(i), epsilon);
+    for (size_t i = 0; i < neighborsAprox.n_elem; i++)
+      REQUIRE_RELATIVE_ERR(distancesAprox(i), distancesExact(i), epsilon);
 
     // Clean the memory.
-    delete kfn;
+    delete akfn;
   }
 }
 
 /**
- * Test the dual-tree furthest-neighbors method with the naive method.  This
+ * Test the dual-tree furthest-neighbors method with the exact method.  This
  * uses only a reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
-BOOST_AUTO_TEST_CASE(DualTreeVsNaive2)
+BOOST_AUTO_TEST_CASE(AproxVsExact2)
 {
   arma::mat dataset;
 
   if (!data::Load("test_data_3_1000.csv", dataset))
     BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
-  KFN naive(dataset, true);
-  arma::Mat<size_t> neighborsNaive;
-  arma::mat distancesNaive;
-  naive.Search(15, neighborsNaive, distancesNaive);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(15, neighborsExact, distancesExact);
 
-  KFN kfn(dataset, false, false, 0.05);
-  arma::Mat<size_t> neighborsTree;
-  arma::mat distancesTree;
-  kfn.Search(15, neighborsTree, distancesTree);
+  KFN akfn(dataset, false, false, 0.05);
+  arma::Mat<size_t> neighborsAprox;
+  arma::mat distancesAprox;
+  akfn.Search(15, neighborsAprox, distancesAprox);
 
-  for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    REQUIRE_RELATIVE_ERR(distancesTree[i], distancesNaive[i], 0.05);
+  for (size_t i = 0; i < neighborsAprox.n_elem; i++)
+    REQUIRE_RELATIVE_ERR(distancesAprox[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the single-tree furthest-neighbors method with the naive method.  This
+ * Test the single-tree furthest-neighbors method with the exact method.  This
  * uses only a reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
-BOOST_AUTO_TEST_CASE(SingleTreeVsNaive)
+BOOST_AUTO_TEST_CASE(SingleTreeVsExact)
 {
   arma::mat dataset;
 
   if (!data::Load("test_data_3_1000.csv", dataset))
     BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
-  KFN naive(dataset, true);
-  arma::Mat<size_t> neighborsNaive;
-  arma::mat distancesNaive;
-  naive.Search(15, neighborsNaive, distancesNaive);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(15, neighborsExact, distancesExact);
 
-  KFN kfn(dataset, false, true, 0.05);
-  arma::Mat<size_t> neighborsTree;
-  arma::mat distancesTree;
-  kfn.Search(15, neighborsTree, distancesTree);
+  KFN akfn(dataset, false, true, 0.05);
+  arma::Mat<size_t> neighborsAprox;
+  arma::mat distancesAprox;
+  akfn.Search(15, neighborsAprox, distancesAprox);
 
-  for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    REQUIRE_RELATIVE_ERR(distancesTree[i], distancesNaive[i], 0.05);
+  for (size_t i = 0; i < neighborsAprox.n_elem; i++)
+    REQUIRE_RELATIVE_ERR(distancesAprox[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the cover tree single-tree furthest-neighbors method against the naive
+ * Test the cover tree single-tree furthest-neighbors method against the exact
  * method.  This uses only a random reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
 BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
 {
-  arma::mat data;
-  data.randu(75, 1000); // 75 dimensional, 1000 points.
+  arma::mat dataset;
+  dataset.randu(75, 1000); // 75 dimensional, 1000 points.
 
-  KFN naive(data, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   StandardCoverTree<EuclideanDistance, NeighborSearchStat<FurthestNeighborSort>,
-      arma::mat> tree(data);
+      arma::mat> tree(dataset);
 
   NeighborSearch<FurthestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
       coverTreeSearch(&tree, true, 0.05);
 
-  arma::Mat<size_t> coverTreeNeighbors;
-  arma::mat coverTreeDistances;
-  coverTreeSearch.Search(data, 15, coverTreeNeighbors, coverTreeDistances);
+  arma::Mat<size_t> neighborsCoverTree;
+  arma::mat distancesCoverTree;
+  coverTreeSearch.Search(dataset, 15, neighborsCoverTree, distancesCoverTree);
 
-  for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(coverTreeDistances[i], naiveDistances[i], 0.05);
+  for (size_t i = 0; i < neighborsCoverTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesCoverTree[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the cover tree dual-tree furthest neighbors method against the naive
+ * Test the cover tree dual-tree furthest neighbors method against the exact
  * method.
  *
  * Errors are produced if the results are not according to relative error.
@@ -166,10 +165,10 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   arma::mat dataset;
   data::Load("test_data_3_1000.csv", dataset);
 
-  KFN naive(dataset, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(dataset, 15, naiveNeighbors, naiveDistances);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   StandardCoverTree<EuclideanDistance, NeighborSearchStat<FurthestNeighborSort>,
       arma::mat> referenceTree(dataset);
@@ -177,43 +176,43 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   NeighborSearch<FurthestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
       coverTreeSearch(&referenceTree, false, 0.05);
 
-  arma::Mat<size_t> coverTreeNeighbors;
-  arma::mat coverTreeDistances;
-  coverTreeSearch.Search(dataset, 15, coverTreeNeighbors, coverTreeDistances);
+  arma::Mat<size_t> neighborsCoverTree;
+  arma::mat distancesCoverTree;
+  coverTreeSearch.Search(dataset, 15, neighborsCoverTree, distancesCoverTree);
 
-  for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(coverTreeDistances[i], naiveDistances[i], 0.05);
+  for (size_t i = 0; i < neighborsCoverTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesCoverTree[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the ball tree single-tree furthest-neighbors method against the naive
+ * Test the ball tree single-tree furthest-neighbors method against the exact
  * method.  This uses only a random reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
 BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
 {
-  arma::mat data;
-  data.randu(75, 1000); // 75 dimensional, 1000 points.
+  arma::mat dataset;
+  dataset.randu(75, 1000); // 75 dimensional, 1000 points.
 
-  KFN naive(data, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   NeighborSearch<FurthestNeighborSort, EuclideanDistance, arma::mat, BallTree>
-      ballTreeSearch(data, false, true, 0.05);
+      ballTreeSearch(dataset, false, true, 0.05);
 
-  arma::Mat<size_t> ballNeighbors;
-  arma::mat ballDistances;
-  ballTreeSearch.Search(data, 15, ballNeighbors, ballDistances);
+  arma::Mat<size_t> neighborsBallTree;
+  arma::mat distancesBallTree;
+  ballTreeSearch.Search(dataset, 15, neighborsBallTree, distancesBallTree);
 
-  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
+  for (size_t i = 0; i < neighborsBallTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesBallTree(i), distancesExact(i), 0.05);
 }
 
 /**
- * Test the ball tree dual-tree furthest neighbors method against the naive
+ * Test the ball tree dual-tree furthest neighbors method against the exact
  * method.
  *
  * Errors are produced if the results are not according to relative error.
@@ -223,19 +222,19 @@ BOOST_AUTO_TEST_CASE(DualBallTreeTest)
   arma::mat dataset;
   data::Load("test_data_3_1000.csv", dataset);
 
-  KFN naive(dataset, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(15, naiveNeighbors, naiveDistances);
+  KFN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(15, neighborsExact, distancesExact);
 
   NeighborSearch<FurthestNeighborSort, EuclideanDistance, arma::mat, BallTree>
       ballTreeSearch(dataset, false, false, 0.05);
-  arma::Mat<size_t> ballNeighbors;
-  arma::mat ballDistances;
-  ballTreeSearch.Search(15, ballNeighbors, ballDistances);
+  arma::Mat<size_t> neighborsBallTree;
+  arma::mat distancesBallTree;
+  ballTreeSearch.Search(15, neighborsBallTree, distancesBallTree);
 
-  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
+  for (size_t i = 0; i < neighborsBallTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesBallTree(i), distancesExact(i), 0.05);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 #include <mlpack/core/tree/cover_tree.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::neighbor;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -1,0 +1,397 @@
+/**
+ * @file aknn_test.cpp
+ *
+ * Test file for KNN class with different values of epsilon.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/neighbor_search/neighbor_search.hpp>
+#include <mlpack/methods/neighbor_search/unmap.hpp>
+#include <mlpack/methods/neighbor_search/ns_model.hpp>
+#include <mlpack/core/tree/cover_tree.hpp>
+#include <mlpack/core/tree/example_tree.hpp>
+#include <boost/test/unit_test.hpp>
+#include "old_boost_test_definitions.hpp"
+
+using namespace mlpack;
+using namespace mlpack::neighbor;
+using namespace mlpack::tree;
+using namespace mlpack::metric;
+using namespace mlpack::bound;
+
+BOOST_AUTO_TEST_SUITE(AKNNTest);
+
+/**
+ * Test the dual-tree nearest-neighbors method with different values for
+ * epsilon. This uses both a query and reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
+{
+  arma::mat dataset;
+
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
+
+  KNN naive(dataset, true);
+  arma::Mat<size_t> neighborsNaive;
+  arma::mat distancesNaive;
+  naive.Search(dataset, 15, neighborsNaive, distancesNaive);
+
+  for (size_t c = 0; c < 4; c++)
+  {
+    KNN* knn;
+    double epsilon;
+
+    switch (c)
+    {
+      case 0: // Use the dual-tree method with e=0.02.
+        epsilon = 0.02;
+        break;
+      case 1: // Use the dual-tree method with e=0.05.
+        epsilon = 0.05;
+        break;
+      case 2: // Use the dual-tree method with e=0.10.
+        epsilon = 0.10;
+        break;
+      case 3: // Use the dual-tree method with e=0.20.
+        epsilon = 0.20;
+        break;
+    }
+
+    knn = new KNN(dataset, false, false, epsilon);
+
+    // Now perform the actual calculation.
+    arma::Mat<size_t> neighborsTree;
+    arma::mat distancesTree;
+    knn->Search(dataset, 15, neighborsTree, distancesTree);
+
+    for (size_t i = 0; i < neighborsTree.n_elem; i++)
+      BOOST_REQUIRE_CLOSE(distancesTree(i), distancesNaive(i), epsilon * 100);
+
+    // Clean the memory.
+    delete knn;
+  }
+}
+
+/**
+ * Test the dual-tree nearest-neighbors method with the naive method.  This uses
+ * only a reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualTreeVsNaive2)
+{
+  arma::mat dataset;
+
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
+
+  KNN naive(dataset, true);
+  arma::Mat<size_t> neighborsNaive;
+  arma::mat distancesNaive;
+  naive.Search(15, neighborsNaive, distancesNaive);
+
+  KNN knn(dataset, false, false, 0.05);
+  arma::Mat<size_t> neighborsTree;
+  arma::mat distancesTree;
+  knn.Search(15, neighborsTree, distancesTree);
+
+  for (size_t i = 0; i < neighborsTree.n_elem; i++)
+    BOOST_REQUIRE_CLOSE(distancesTree(i), distancesNaive(i), 5);
+}
+
+/**
+ * Test the single-tree nearest-neighbors method with the naive method.  This
+ * uses only a reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(SingleTreeVsNaive)
+{
+  arma::mat dataset;
+
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
+
+  KNN naive(dataset, true);
+  arma::Mat<size_t> neighborsNaive;
+  arma::mat distancesNaive;
+  naive.Search(15, neighborsNaive, distancesNaive);
+
+  KNN knn(dataset, false, true, 0.05);
+  arma::Mat<size_t> neighborsTree;
+  arma::mat distancesTree;
+  knn.Search(15, neighborsTree, distancesTree);
+
+  for (size_t i = 0; i < neighborsTree.n_elem; i++)
+    BOOST_REQUIRE_CLOSE(distancesTree[i], distancesNaive[i], 5);
+}
+
+/**
+ * Test the cover tree single-tree nearest-neighbors method against the naive
+ * method.  This uses only a random reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
+{
+  arma::mat data;
+  data.randu(75, 1000); // 75 dimensional, 1000 points.
+
+  KNN naive(data, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+
+  StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
+      arma::mat> tree(data);
+
+  NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
+      coverTreeSearch(&tree, true, 0.05);
+
+  arma::Mat<size_t> coverTreeNeighbors;
+  arma::mat coverTreeDistances;
+  coverTreeSearch.Search(data, 15, coverTreeNeighbors, coverTreeDistances);
+
+  for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(coverTreeDistances[i], naiveDistances[i], 5);
+}
+
+/**
+ * Test the cover tree dual-tree nearest neighbors method against the naive
+ * method.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
+{
+  arma::mat dataset;
+  data::Load("test_data_3_1000.csv", dataset);
+
+  KNN naive(dataset, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(dataset, 15, naiveNeighbors, naiveDistances);
+
+  StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
+      arma::mat> referenceTree(dataset);
+
+  NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      StandardCoverTree> coverTreeSearch(&referenceTree, false, 0.05);
+
+  arma::Mat<size_t> coverNeighbors;
+  arma::mat coverDistances;
+  coverTreeSearch.Search(&referenceTree, 15, coverNeighbors, coverDistances);
+
+  for (size_t i = 0; i < coverNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(coverDistances[i], naiveDistances[i], 5);
+}
+
+/**
+ * Test the ball tree single-tree nearest-neighbors method against the naive
+ * method.  This uses only a random reference dataset.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
+{
+  arma::mat data;
+  data.randu(50, 300); // 50 dimensional, 300 points.
+
+  KNN naive(data, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+
+  NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat, BallTree>
+      ballTreeSearch(data, false, true, 0.05);
+
+  arma::Mat<size_t> ballNeighbors;
+  arma::mat ballDistances;
+  ballTreeSearch.Search(data, 15, ballNeighbors, ballDistances);
+
+  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+}
+
+/**
+ * Test the ball tree dual-tree nearest neighbors method against the naive
+ * method.
+ *
+ * Errors are produced if the results are not according to relative error.
+ */
+BOOST_AUTO_TEST_CASE(DualBallTreeTest)
+{
+  arma::mat dataset;
+  data::Load("test_data_3_1000.csv", dataset);
+
+  KNN naive(dataset, true);
+  arma::Mat<size_t> naiveNeighbors;
+  arma::mat naiveDistances;
+  naive.Search(15, naiveNeighbors, naiveDistances);
+
+  NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat, BallTree>
+      ballTreeSearch(dataset, false, false, 0.05);
+  arma::Mat<size_t> ballNeighbors;
+  arma::mat ballDistances;
+  ballTreeSearch.Search(15, ballNeighbors, ballDistances);
+
+  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+}
+
+// Make sure sparse nearest neighbors works with kd trees.
+BOOST_AUTO_TEST_CASE(SparseKNNKDTreeTest)
+{
+  // The dimensionality of these datasets must be high so that the probability
+  // of a completely empty point is very low.  In this case, with dimensionality
+  // 70, the probability of all 70 dimensions being zero is 0.8^70 = 1.65e-7 in
+  // the reference set and 0.9^70 = 6.27e-4 in the query set.
+  arma::sp_mat queryDataset;
+  queryDataset.sprandu(70, 200, 0.2);
+  arma::sp_mat referenceDataset;
+  referenceDataset.sprandu(70, 500, 0.1);
+  arma::mat denseQuery(queryDataset);
+  arma::mat denseReference(referenceDataset);
+
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::sp_mat,
+      KDTree> SparseKNN;
+
+  SparseKNN a(referenceDataset, false, false, 0.05);
+  KNN naive(denseReference, true);
+
+  arma::mat sparseDistances;
+  arma::Mat<size_t> sparseNeighbors;
+  a.Search(queryDataset, 10, sparseNeighbors, sparseDistances);
+
+  arma::mat naiveDistances;
+  arma::Mat<size_t> naiveNeighbors;
+  naive.Search(denseQuery, 10, naiveNeighbors, naiveDistances);
+
+  for (size_t i = 0; i < naiveNeighbors.n_cols; ++i)
+    for (size_t j = 0; j < naiveNeighbors.n_rows; ++j)
+      BOOST_REQUIRE_CLOSE(naiveDistances(j, i), sparseDistances(j, i), 5);
+}
+
+// Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
+// results.
+BOOST_AUTO_TEST_CASE(KNNModelTest)
+{
+  typedef NSModel<NearestNeighborSort> KNNModel;
+
+  arma::mat queryData = arma::randu<arma::mat>(10, 50);
+  arma::mat referenceData = arma::randu<arma::mat>(10, 200);
+
+  // Build all the possible models.
+  KNNModel models[12];
+  models[0] = KNNModel(KNNModel::TreeTypes::KD_TREE, true);
+  models[1] = KNNModel(KNNModel::TreeTypes::KD_TREE, false);
+  models[2] = KNNModel(KNNModel::TreeTypes::COVER_TREE, true);
+  models[3] = KNNModel(KNNModel::TreeTypes::COVER_TREE, false);
+  models[4] = KNNModel(KNNModel::TreeTypes::R_TREE, true);
+  models[5] = KNNModel(KNNModel::TreeTypes::R_TREE, false);
+  models[6] = KNNModel(KNNModel::TreeTypes::R_STAR_TREE, true);
+  models[7] = KNNModel(KNNModel::TreeTypes::R_STAR_TREE, false);
+  models[8] = KNNModel(KNNModel::TreeTypes::X_TREE, true);
+  models[9] = KNNModel(KNNModel::TreeTypes::X_TREE, false);
+  models[10] = KNNModel(KNNModel::TreeTypes::BALL_TREE, true);
+  models[11] = KNNModel(KNNModel::TreeTypes::BALL_TREE, false);
+
+  for (size_t j = 0; j < 3; ++j)
+  {
+    // Get a baseline.
+    KNN knn(referenceData);
+    arma::Mat<size_t> baselineNeighbors;
+    arma::mat baselineDistances;
+    knn.Search(queryData, 3, baselineNeighbors, baselineDistances);
+
+    for (size_t i = 0; i < 12; ++i)
+    {
+      // We only have std::move() constructors so make a copy of our data.
+      arma::mat referenceCopy(referenceData);
+      arma::mat queryCopy(queryData);
+      if (j == 0)
+        models[i].BuildModel(std::move(referenceCopy), 20, false, false, 0.05);
+      if (j == 1)
+        models[i].BuildModel(std::move(referenceCopy), 20, false, true, 0.05);
+      if (j == 2)
+        models[i].BuildModel(std::move(referenceCopy), 20, true, false);
+
+      arma::Mat<size_t> neighbors;
+      arma::mat distances;
+
+      models[i].Search(std::move(queryCopy), 3, neighbors, distances);
+
+      BOOST_REQUIRE_EQUAL(neighbors.n_rows, baselineNeighbors.n_rows);
+      BOOST_REQUIRE_EQUAL(neighbors.n_cols, baselineNeighbors.n_cols);
+      BOOST_REQUIRE_EQUAL(neighbors.n_elem, baselineNeighbors.n_elem);
+      BOOST_REQUIRE_EQUAL(distances.n_rows, baselineDistances.n_rows);
+      BOOST_REQUIRE_EQUAL(distances.n_cols, baselineDistances.n_cols);
+      BOOST_REQUIRE_EQUAL(distances.n_elem, baselineDistances.n_elem);
+      for (size_t k = 0; k < distances.n_elem; ++k)
+        BOOST_REQUIRE_CLOSE(distances[k], baselineDistances[k], 5);
+    }
+  }
+}
+
+// Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
+// results, in the case where the reference set is the same as the query set.
+BOOST_AUTO_TEST_CASE(KNNModelMonochromaticTest)
+{
+  typedef NSModel<NearestNeighborSort> KNNModel;
+
+  arma::mat referenceData = arma::randu<arma::mat>(10, 200);
+
+  // Build all the possible models.
+  KNNModel models[12];
+  models[0] = KNNModel(KNNModel::TreeTypes::KD_TREE, true);
+  models[1] = KNNModel(KNNModel::TreeTypes::KD_TREE, false);
+  models[2] = KNNModel(KNNModel::TreeTypes::COVER_TREE, true);
+  models[3] = KNNModel(KNNModel::TreeTypes::COVER_TREE, false);
+  models[4] = KNNModel(KNNModel::TreeTypes::R_TREE, true);
+  models[5] = KNNModel(KNNModel::TreeTypes::R_TREE, false);
+  models[6] = KNNModel(KNNModel::TreeTypes::R_STAR_TREE, true);
+  models[7] = KNNModel(KNNModel::TreeTypes::R_STAR_TREE, false);
+  models[8] = KNNModel(KNNModel::TreeTypes::X_TREE, true);
+  models[9] = KNNModel(KNNModel::TreeTypes::X_TREE, false);
+  models[10] = KNNModel(KNNModel::TreeTypes::BALL_TREE, true);
+  models[11] = KNNModel(KNNModel::TreeTypes::BALL_TREE, false);
+
+  for (size_t j = 0; j < 3; ++j)
+  {
+    // Get a baseline.
+    KNN knn(referenceData);
+    arma::Mat<size_t> baselineNeighbors;
+    arma::mat baselineDistances;
+    knn.Search(3, baselineNeighbors, baselineDistances);
+
+    for (size_t i = 0; i < 12; ++i)
+    {
+      // We only have a std::move() constructor... so copy the data.
+      arma::mat referenceCopy(referenceData);
+      if (j == 0)
+        models[i].BuildModel(std::move(referenceCopy), 20, false, false, 0.05);
+      if (j == 1)
+        models[i].BuildModel(std::move(referenceCopy), 20, false, true, 0.05);
+      if (j == 2)
+        models[i].BuildModel(std::move(referenceCopy), 20, true, false);
+
+      arma::Mat<size_t> neighbors;
+      arma::mat distances;
+
+      models[i].Search(3, neighbors, distances);
+
+      BOOST_REQUIRE_EQUAL(neighbors.n_rows, baselineNeighbors.n_rows);
+      BOOST_REQUIRE_EQUAL(neighbors.n_cols, baselineNeighbors.n_cols);
+      BOOST_REQUIRE_EQUAL(neighbors.n_elem, baselineNeighbors.n_elem);
+      BOOST_REQUIRE_EQUAL(distances.n_rows, baselineDistances.n_rows);
+      BOOST_REQUIRE_EQUAL(distances.n_cols, baselineDistances.n_cols);
+      BOOST_REQUIRE_EQUAL(distances.n_elem, baselineDistances.n_elem);
+      for (size_t k = 0; k < distances.n_elem; ++k)
+        BOOST_REQUIRE_CLOSE(distances[k], baselineDistances[k], 5);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/tree/cover_tree.hpp>
 #include <mlpack/core/tree/example_tree.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::neighbor;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -26,21 +26,21 @@ BOOST_AUTO_TEST_SUITE(AKNNTest);
  *
  * Errors are produced if the results are not according to relative error.
  */
-BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
+BOOST_AUTO_TEST_CASE(AproxVsExact1)
 {
   arma::mat dataset;
 
   if (!data::Load("test_data_3_1000.csv", dataset))
     BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
-  KNN naive(dataset, true);
-  arma::Mat<size_t> neighborsNaive;
-  arma::mat distancesNaive;
-  naive.Search(dataset, 15, neighborsNaive, distancesNaive);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   for (size_t c = 0; c < 4; c++)
   {
-    KNN* knn;
+    KNN* aknn;
     double epsilon;
 
     switch (c)
@@ -59,107 +59,106 @@ BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
         break;
     }
 
-    knn = new KNN(dataset, false, false, epsilon);
-
     // Now perform the actual calculation.
-    arma::Mat<size_t> neighborsTree;
-    arma::mat distancesTree;
-    knn->Search(dataset, 15, neighborsTree, distancesTree);
+    aknn = new KNN(dataset, false, false, epsilon);
+    arma::Mat<size_t> neighborsAprox;
+    arma::mat distancesAprox;
+    aknn->Search(dataset, 15, neighborsAprox, distancesAprox);
 
-    for (size_t i = 0; i < neighborsTree.n_elem; i++)
-      REQUIRE_RELATIVE_ERR(distancesTree(i), distancesNaive(i), epsilon);
+    for (size_t i = 0; i < neighborsAprox.n_elem; i++)
+      REQUIRE_RELATIVE_ERR(distancesAprox(i), distancesExact(i), epsilon);
 
     // Clean the memory.
-    delete knn;
+    delete aknn;
   }
 }
 
 /**
- * Test the dual-tree nearest-neighbors method with the naive method.  This uses
+ * Test the dual-tree nearest-neighbors method with the exact method.  This uses
  * only a reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
-BOOST_AUTO_TEST_CASE(DualTreeVsNaive2)
+BOOST_AUTO_TEST_CASE(AproxVsExact2)
 {
   arma::mat dataset;
 
   if (!data::Load("test_data_3_1000.csv", dataset))
     BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
-  KNN naive(dataset, true);
-  arma::Mat<size_t> neighborsNaive;
-  arma::mat distancesNaive;
-  naive.Search(15, neighborsNaive, distancesNaive);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(15, neighborsExact, distancesExact);
 
-  KNN knn(dataset, false, false, 0.05);
-  arma::Mat<size_t> neighborsTree;
-  arma::mat distancesTree;
-  knn.Search(15, neighborsTree, distancesTree);
+  KNN aknn(dataset, false, false, 0.05);
+  arma::Mat<size_t> neighborsAprox;
+  arma::mat distancesAprox;
+  aknn.Search(15, neighborsAprox, distancesAprox);
 
-  for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    REQUIRE_RELATIVE_ERR(distancesTree(i), distancesNaive(i), 0.05);
+  for (size_t i = 0; i < neighborsAprox.n_elem; i++)
+    REQUIRE_RELATIVE_ERR(distancesAprox(i), distancesExact(i), 0.05);
 }
 
 /**
- * Test the single-tree nearest-neighbors method with the naive method.  This
+ * Test the single-tree nearest-neighbors method with the exact method.  This
  * uses only a reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
-BOOST_AUTO_TEST_CASE(SingleTreeVsNaive)
+BOOST_AUTO_TEST_CASE(SingleTreeAproxVsExact)
 {
   arma::mat dataset;
 
   if (!data::Load("test_data_3_1000.csv", dataset))
     BOOST_FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
-  KNN naive(dataset, true);
-  arma::Mat<size_t> neighborsNaive;
-  arma::mat distancesNaive;
-  naive.Search(15, neighborsNaive, distancesNaive);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(15, neighborsExact, distancesExact);
 
-  KNN knn(dataset, false, true, 0.05);
-  arma::Mat<size_t> neighborsTree;
-  arma::mat distancesTree;
-  knn.Search(15, neighborsTree, distancesTree);
+  KNN aknn(dataset, false, true, 0.05);
+  arma::Mat<size_t> neighborsAprox;
+  arma::mat distancesAprox;
+  aknn.Search(15, neighborsAprox, distancesAprox);
 
-  for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    REQUIRE_RELATIVE_ERR(distancesTree[i], distancesNaive[i], 0.05);
+  for (size_t i = 0; i < neighborsAprox.n_elem; i++)
+    REQUIRE_RELATIVE_ERR(distancesAprox[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the cover tree single-tree nearest-neighbors method against the naive
+ * Test the cover tree single-tree nearest-neighbors method against the exact
  * method.  This uses only a random reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
 BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
 {
-  arma::mat data;
-  data.randu(75, 1000); // 75 dimensional, 1000 points.
+  arma::mat dataset;
+  dataset.randu(75, 1000); // 75 dimensional, 1000 points.
 
-  KNN naive(data, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> tree(data);
+      arma::mat> tree(dataset);
 
   NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
       coverTreeSearch(&tree, true, 0.05);
 
-  arma::Mat<size_t> coverTreeNeighbors;
-  arma::mat coverTreeDistances;
-  coverTreeSearch.Search(data, 15, coverTreeNeighbors, coverTreeDistances);
+  arma::Mat<size_t> neighborsCoverTree;
+  arma::mat distancesCoverTree;
+  coverTreeSearch.Search(dataset, 15, neighborsCoverTree, distancesCoverTree);
 
-  for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(coverTreeDistances[i], naiveDistances[i], 0.05);
+  for (size_t i = 0; i < neighborsCoverTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesCoverTree[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the cover tree dual-tree nearest neighbors method against the naive
+ * Test the cover tree dual-tree nearest neighbors method against the exact
  * method.
  *
  * Errors are produced if the results are not according to relative error.
@@ -169,10 +168,10 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   arma::mat dataset;
   data::Load("test_data_3_1000.csv", dataset);
 
-  KNN naive(dataset, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(dataset, 15, naiveNeighbors, naiveDistances);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
       arma::mat> referenceTree(dataset);
@@ -180,43 +179,44 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
       StandardCoverTree> coverTreeSearch(&referenceTree, false, 0.05);
 
-  arma::Mat<size_t> coverNeighbors;
-  arma::mat coverDistances;
-  coverTreeSearch.Search(&referenceTree, 15, coverNeighbors, coverDistances);
+  arma::Mat<size_t> neighborsCoverTree;
+  arma::mat distancesCoverTree;
+  coverTreeSearch.Search(&referenceTree, 15, neighborsCoverTree,
+      distancesCoverTree);
 
-  for (size_t i = 0; i < coverNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(coverDistances[i], naiveDistances[i], 0.05);
+  for (size_t i = 0; i < neighborsCoverTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesCoverTree[i], distancesExact[i], 0.05);
 }
 
 /**
- * Test the ball tree single-tree nearest-neighbors method against the naive
+ * Test the ball tree single-tree nearest-neighbors method against the exact
  * method.  This uses only a random reference dataset.
  *
  * Errors are produced if the results are not according to relative error.
  */
 BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
 {
-  arma::mat data;
-  data.randu(50, 300); // 50 dimensional, 300 points.
+  arma::mat dataset;
+  dataset.randu(50, 300); // 50 dimensional, 300 points.
 
-  KNN naive(data, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(data, 15, naiveNeighbors, naiveDistances);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(dataset, 15, neighborsExact, distancesExact);
 
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat, BallTree>
-      ballTreeSearch(data, false, true, 0.05);
+      ballTreeSearch(dataset, false, true, 0.05);
 
-  arma::Mat<size_t> ballNeighbors;
-  arma::mat ballDistances;
-  ballTreeSearch.Search(data, 15, ballNeighbors, ballDistances);
+  arma::Mat<size_t> neighborsBallTree;
+  arma::mat distancesBallTree;
+  ballTreeSearch.Search(dataset, 15, neighborsBallTree, distancesBallTree);
 
-  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
+  for (size_t i = 0; i < neighborsBallTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesBallTree(i), distancesExact(i), 0.05);
 }
 
 /**
- * Test the ball tree dual-tree nearest neighbors method against the naive
+ * Test the ball tree dual-tree nearest neighbors method against the exact
  * method.
  *
  * Errors are produced if the results are not according to relative error.
@@ -226,19 +226,19 @@ BOOST_AUTO_TEST_CASE(DualBallTreeTest)
   arma::mat dataset;
   data::Load("test_data_3_1000.csv", dataset);
 
-  KNN naive(dataset, true);
-  arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
-  naive.Search(15, naiveNeighbors, naiveDistances);
+  KNN exact(dataset);
+  arma::Mat<size_t> neighborsExact;
+  arma::mat distancesExact;
+  exact.Search(15, neighborsExact, distancesExact);
 
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat, BallTree>
       ballTreeSearch(dataset, false, false, 0.05);
-  arma::Mat<size_t> ballNeighbors;
-  arma::mat ballDistances;
-  ballTreeSearch.Search(15, ballNeighbors, ballDistances);
+  arma::Mat<size_t> neighborsBallTree;
+  arma::mat distancesBallTree;
+  ballTreeSearch.Search(15, neighborsBallTree, distancesBallTree);
 
-  for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
+  for (size_t i = 0; i < neighborsBallTree.n_elem; ++i)
+    REQUIRE_RELATIVE_ERR(distancesBallTree(i), distancesExact(i), 0.05);
 }
 
 /**
@@ -260,20 +260,19 @@ BOOST_AUTO_TEST_CASE(SparseKNNKDTreeTest)
   typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::sp_mat,
       KDTree> SparseKNN;
 
-  SparseKNN a(referenceDataset, false, false, 0.05);
-  KNN naive(denseReference, true);
+  SparseKNN aknn(referenceDataset, false, false, 0.05);
+  arma::mat distancesSparse;
+  arma::Mat<size_t> neighborsSparse;
+  aknn.Search(queryDataset, 10, neighborsSparse, distancesSparse);
 
-  arma::mat sparseDistances;
-  arma::Mat<size_t> sparseNeighbors;
-  a.Search(queryDataset, 10, sparseNeighbors, sparseDistances);
+  KNN exact(denseReference);
+  arma::mat distancesExact;
+  arma::Mat<size_t> neighborsExact;
+  exact.Search(denseQuery, 10, neighborsExact, distancesExact);
 
-  arma::mat naiveDistances;
-  arma::Mat<size_t> naiveNeighbors;
-  naive.Search(denseQuery, 10, naiveNeighbors, naiveDistances);
-
-  for (size_t i = 0; i < naiveNeighbors.n_cols; ++i)
-    for (size_t j = 0; j < naiveNeighbors.n_rows; ++j)
-      REQUIRE_RELATIVE_ERR(sparseDistances(j, i), naiveDistances(j, i), 0.05);
+  for (size_t i = 0; i < neighborsExact.n_cols; ++i)
+    for (size_t j = 0; j < neighborsExact.n_rows; ++j)
+      REQUIRE_RELATIVE_ERR(distancesSparse(j, i), distancesExact(j, i), 0.05);
 }
 
 /**
@@ -305,10 +304,10 @@ BOOST_AUTO_TEST_CASE(KNNModelTest)
   for (size_t j = 0; j < 3; ++j)
   {
     // Get a baseline.
-    KNN knn(referenceData);
-    arma::Mat<size_t> baselineNeighbors;
-    arma::mat baselineDistances;
-    knn.Search(queryData, 3, baselineNeighbors, baselineDistances);
+    KNN aknn(referenceData);
+    arma::Mat<size_t> neighborsExact;
+    arma::mat distancesExact;
+    aknn.Search(queryData, 3, neighborsExact, distancesExact);
 
     for (size_t i = 0; i < 12; ++i)
     {
@@ -322,19 +321,19 @@ BOOST_AUTO_TEST_CASE(KNNModelTest)
       if (j == 2)
         models[i].BuildModel(std::move(referenceCopy), 20, true, false);
 
-      arma::Mat<size_t> neighbors;
-      arma::mat distances;
+      arma::Mat<size_t> neighborsAprox;
+      arma::mat distancesAprox;
 
-      models[i].Search(std::move(queryCopy), 3, neighbors, distances);
+      models[i].Search(std::move(queryCopy), 3, neighborsAprox, distancesAprox);
 
-      BOOST_REQUIRE_EQUAL(neighbors.n_rows, baselineNeighbors.n_rows);
-      BOOST_REQUIRE_EQUAL(neighbors.n_cols, baselineNeighbors.n_cols);
-      BOOST_REQUIRE_EQUAL(neighbors.n_elem, baselineNeighbors.n_elem);
-      BOOST_REQUIRE_EQUAL(distances.n_rows, baselineDistances.n_rows);
-      BOOST_REQUIRE_EQUAL(distances.n_cols, baselineDistances.n_cols);
-      BOOST_REQUIRE_EQUAL(distances.n_elem, baselineDistances.n_elem);
-      for (size_t k = 0; k < distances.n_elem; ++k)
-        REQUIRE_RELATIVE_ERR(distances[k], baselineDistances[k], 0.05);
+      BOOST_REQUIRE_EQUAL(neighborsAprox.n_rows, neighborsExact.n_rows);
+      BOOST_REQUIRE_EQUAL(neighborsAprox.n_cols, neighborsExact.n_cols);
+      BOOST_REQUIRE_EQUAL(neighborsAprox.n_elem, neighborsExact.n_elem);
+      BOOST_REQUIRE_EQUAL(distancesAprox.n_rows, distancesExact.n_rows);
+      BOOST_REQUIRE_EQUAL(distancesAprox.n_cols, distancesExact.n_cols);
+      BOOST_REQUIRE_EQUAL(distancesAprox.n_elem, distancesExact.n_elem);
+      for (size_t k = 0; k < distancesAprox.n_elem; ++k)
+        REQUIRE_RELATIVE_ERR(distancesAprox[k], distancesExact[k], 0.05);
     }
   }
 }
@@ -364,13 +363,13 @@ BOOST_AUTO_TEST_CASE(KNNModelMonochromaticTest)
   models[10] = KNNModel(KNNModel::TreeTypes::BALL_TREE, true);
   models[11] = KNNModel(KNNModel::TreeTypes::BALL_TREE, false);
 
-  for (size_t j = 0; j < 3; ++j)
+  for (size_t j = 0; j < 2; ++j)
   {
     // Get a baseline.
-    KNN knn(referenceData);
-    arma::Mat<size_t> baselineNeighbors;
-    arma::mat baselineDistances;
-    knn.Search(3, baselineNeighbors, baselineDistances);
+    KNN exact(referenceData);
+    arma::Mat<size_t> neighborsExact;
+    arma::mat distancesExact;
+    exact.Search(3, neighborsExact, distancesExact);
 
     for (size_t i = 0; i < 12; ++i)
     {
@@ -380,22 +379,20 @@ BOOST_AUTO_TEST_CASE(KNNModelMonochromaticTest)
         models[i].BuildModel(std::move(referenceCopy), 20, false, false, 0.05);
       if (j == 1)
         models[i].BuildModel(std::move(referenceCopy), 20, false, true, 0.05);
-      if (j == 2)
-        models[i].BuildModel(std::move(referenceCopy), 20, true, false);
 
-      arma::Mat<size_t> neighbors;
-      arma::mat distances;
+      arma::Mat<size_t> neighborsAprox;
+      arma::mat distancesAprox;
 
-      models[i].Search(3, neighbors, distances);
+      models[i].Search(3, neighborsAprox, distancesAprox);
 
-      BOOST_REQUIRE_EQUAL(neighbors.n_rows, baselineNeighbors.n_rows);
-      BOOST_REQUIRE_EQUAL(neighbors.n_cols, baselineNeighbors.n_cols);
-      BOOST_REQUIRE_EQUAL(neighbors.n_elem, baselineNeighbors.n_elem);
-      BOOST_REQUIRE_EQUAL(distances.n_rows, baselineDistances.n_rows);
-      BOOST_REQUIRE_EQUAL(distances.n_cols, baselineDistances.n_cols);
-      BOOST_REQUIRE_EQUAL(distances.n_elem, baselineDistances.n_elem);
-      for (size_t k = 0; k < distances.n_elem; ++k)
-        REQUIRE_RELATIVE_ERR(distances[k], baselineDistances[k], 0.05);
+      BOOST_REQUIRE_EQUAL(neighborsAprox.n_rows, neighborsExact.n_rows);
+      BOOST_REQUIRE_EQUAL(neighborsAprox.n_cols, neighborsExact.n_cols);
+      BOOST_REQUIRE_EQUAL(neighborsAprox.n_elem, neighborsExact.n_elem);
+      BOOST_REQUIRE_EQUAL(distancesAprox.n_rows, distancesExact.n_rows);
+      BOOST_REQUIRE_EQUAL(distancesAprox.n_cols, distancesExact.n_cols);
+      BOOST_REQUIRE_EQUAL(distancesAprox.n_elem, distancesExact.n_elem);
+      for (size_t k = 0; k < distancesAprox.n_elem; ++k)
+        REQUIRE_RELATIVE_ERR(distancesAprox[k], distancesExact[k], 0.05);
     }
   }
 }

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(DualTreeVsNaive1)
     knn->Search(dataset, 15, neighborsTree, distancesTree);
 
     for (size_t i = 0; i < neighborsTree.n_elem; i++)
-      BOOST_REQUIRE_CLOSE(distancesTree(i), distancesNaive(i), epsilon * 100);
+      REQUIRE_RELATIVE_ERR(distancesTree(i), distancesNaive(i), epsilon);
 
     // Clean the memory.
     delete knn;
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(DualTreeVsNaive2)
   knn.Search(15, neighborsTree, distancesTree);
 
   for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    BOOST_REQUIRE_CLOSE(distancesTree(i), distancesNaive(i), 5);
+    REQUIRE_RELATIVE_ERR(distancesTree(i), distancesNaive(i), 0.05);
 }
 
 /**
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(SingleTreeVsNaive)
   knn.Search(15, neighborsTree, distancesTree);
 
   for (size_t i = 0; i < neighborsTree.n_elem; i++)
-    BOOST_REQUIRE_CLOSE(distancesTree[i], distancesNaive[i], 5);
+    REQUIRE_RELATIVE_ERR(distancesTree[i], distancesNaive[i], 0.05);
 }
 
 /**
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
   coverTreeSearch.Search(data, 15, coverTreeNeighbors, coverTreeDistances);
 
   for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(coverTreeDistances[i], naiveDistances[i], 5);
+    REQUIRE_RELATIVE_ERR(coverTreeDistances[i], naiveDistances[i], 0.05);
 }
 
 /**
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   coverTreeSearch.Search(&referenceTree, 15, coverNeighbors, coverDistances);
 
   for (size_t i = 0; i < coverNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(coverDistances[i], naiveDistances[i], 5);
+    REQUIRE_RELATIVE_ERR(coverDistances[i], naiveDistances[i], 0.05);
 }
 
 /**
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
   ballTreeSearch.Search(data, 15, ballNeighbors, ballDistances);
 
   for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
 }
 
 /**
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(DualBallTreeTest)
   ballTreeSearch.Search(15, ballNeighbors, ballDistances);
 
   for (size_t i = 0; i < ballNeighbors.n_elem; ++i)
-    BOOST_REQUIRE_CLOSE(ballDistances(i), naiveDistances(i), 5);
+    REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
 }
 
 // Make sure sparse nearest neighbors works with kd trees.
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(SparseKNNKDTreeTest)
 
   for (size_t i = 0; i < naiveNeighbors.n_cols; ++i)
     for (size_t j = 0; j < naiveNeighbors.n_rows; ++j)
-      BOOST_REQUIRE_CLOSE(naiveDistances(j, i), sparseDistances(j, i), 5);
+      REQUIRE_RELATIVE_ERR(sparseDistances(j, i), naiveDistances(j, i), 0.05);
 }
 
 // Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_CASE(KNNModelTest)
       BOOST_REQUIRE_EQUAL(distances.n_cols, baselineDistances.n_cols);
       BOOST_REQUIRE_EQUAL(distances.n_elem, baselineDistances.n_elem);
       for (size_t k = 0; k < distances.n_elem; ++k)
-        BOOST_REQUIRE_CLOSE(distances[k], baselineDistances[k], 5);
+        REQUIRE_RELATIVE_ERR(distances[k], baselineDistances[k], 0.05);
     }
   }
 }
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(KNNModelMonochromaticTest)
       BOOST_REQUIRE_EQUAL(distances.n_cols, baselineDistances.n_cols);
       BOOST_REQUIRE_EQUAL(distances.n_elem, baselineDistances.n_elem);
       for (size_t k = 0; k < distances.n_elem; ++k)
-        BOOST_REQUIRE_CLOSE(distances[k], baselineDistances[k], 5);
+        REQUIRE_RELATIVE_ERR(distances[k], baselineDistances[k], 0.05);
     }
   }
 }

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -241,7 +241,9 @@ BOOST_AUTO_TEST_CASE(DualBallTreeTest)
     REQUIRE_RELATIVE_ERR(ballDistances(i), naiveDistances(i), 0.05);
 }
 
-// Make sure sparse nearest neighbors works with kd trees.
+/**
+ * Make sure sparse nearest neighbors works with kd trees.
+ */
 BOOST_AUTO_TEST_CASE(SparseKNNKDTreeTest)
 {
   // The dimensionality of these datasets must be high so that the probability
@@ -274,8 +276,10 @@ BOOST_AUTO_TEST_CASE(SparseKNNKDTreeTest)
       REQUIRE_RELATIVE_ERR(sparseDistances(j, i), naiveDistances(j, i), 0.05);
 }
 
-// Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
-// results.
+/**
+ * Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
+ * results.
+ */
 BOOST_AUTO_TEST_CASE(KNNModelTest)
 {
   typedef NSModel<NearestNeighborSort> KNNModel;
@@ -335,8 +339,10 @@ BOOST_AUTO_TEST_CASE(KNNModelTest)
   }
 }
 
-// Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
-// results, in the case where the reference set is the same as the query set.
+/**
+ * Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
+ * results, in the case where the reference set is the same as the query set.
+ */
 BOOST_AUTO_TEST_CASE(KNNModelMonochromaticTest)
 {
   typedef NSModel<NearestNeighborSort> KNNModel;

--- a/src/mlpack/tests/arma_extend_test.cpp
+++ b/src/mlpack/tests/arma_extend_test.cpp
@@ -7,7 +7,7 @@
 
 #include <mlpack/core.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace arma;

--- a/src/mlpack/tests/armadillo_svd_test.cpp
+++ b/src/mlpack/tests/armadillo_svd_test.cpp
@@ -2,7 +2,7 @@
 #include <mlpack/methods/cf/svd_wrapper.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(ArmadilloSVDTest);
 

--- a/src/mlpack/tests/aug_lagrangian_test.cpp
+++ b/src/mlpack/tests/aug_lagrangian_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/optimizers/aug_lagrangian/aug_lagrangian.hpp>
 #include <mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_test_functions.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::optimization;

--- a/src/mlpack/tests/binarize_test.cpp
+++ b/src/mlpack/tests/binarize_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/core/math/random.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace arma;

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 BOOST_AUTO_TEST_SUITE(CFTest);

--- a/src/mlpack/tests/cli_test.cpp
+++ b/src/mlpack/tests/cli_test.cpp
@@ -22,7 +22,7 @@
 #define DEFAULT_INT 42
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 #define BASH_RED "\033[0;31m"
 #define BASH_GREEN "\033[0;32m"

--- a/src/mlpack/tests/convolution_test.cpp
+++ b/src/mlpack/tests/convolution_test.cpp
@@ -13,7 +13,7 @@
 #include <mlpack/methods/ann/convolution_rules/svd_convolution.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/convolutional_network_test.cpp
+++ b/src/mlpack/tests/convolutional_network_test.cpp
@@ -23,7 +23,7 @@
 #include <mlpack/methods/ann/cnn.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/cosine_tree_test.cpp
+++ b/src/mlpack/tests/cosine_tree_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/core/tree/cosine_tree/cosine_tree.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(CosineTreeTest);
 

--- a/src/mlpack/tests/decision_stump_test.cpp
+++ b/src/mlpack/tests/decision_stump_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/decision_stump/decision_stump.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::decision_stump;

--- a/src/mlpack/tests/det_test.cpp
+++ b/src/mlpack/tests/det_test.cpp
@@ -7,7 +7,7 @@
  */
 #include <mlpack/core.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 // This trick does not work on Windows.  We will have to comment out the tests
 // that depend on it.

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::distribution;

--- a/src/mlpack/tests/emst_test.cpp
+++ b/src/mlpack/tests/emst_test.cpp
@@ -6,7 +6,7 @@
 #include <mlpack/core.hpp>
 #include <mlpack/methods/emst/dtb.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 #include <mlpack/core/tree/cover_tree.hpp>
 

--- a/src/mlpack/tests/fastmks_test.cpp
+++ b/src/mlpack/tests/fastmks_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/methods/fastmks/fastmks_model.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -24,7 +24,7 @@
 #include <mlpack/core/optimizers/rmsprop/rmsprop.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -15,7 +15,7 @@
 #include <mlpack/methods/gmm/eigenvalue_ratio_constraint.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::gmm;

--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/gmm/gmm.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::hmm;

--- a/src/mlpack/tests/hoeffding_tree_test.cpp
+++ b/src/mlpack/tests/hoeffding_tree_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/methods/hoeffding_trees/binary_numeric_split.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 #include <stack>

--- a/src/mlpack/tests/ind2sub_test.cpp
+++ b/src/mlpack/tests/ind2sub_test.cpp
@@ -6,7 +6,7 @@
  */
 #include <mlpack/core.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(ind2subTest);
 

--- a/src/mlpack/tests/init_rules_test.cpp
+++ b/src/mlpack/tests/init_rules_test.cpp
@@ -14,7 +14,7 @@
 #include <mlpack/methods/ann/init_rules/zero_init.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/kernel_pca_test.cpp
+++ b/src/mlpack/tests/kernel_pca_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/methods/kernel_pca/kernel_pca.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(KernelPCATest);
 

--- a/src/mlpack/tests/kernel_test.cpp
+++ b/src/mlpack/tests/kernel_test.cpp
@@ -19,7 +19,7 @@
 #include <mlpack/core/metrics/mahalanobis_distance.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::kernel;

--- a/src/mlpack/tests/kernel_traits_test.cpp
+++ b/src/mlpack/tests/kernel_traits_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::kernel;

--- a/src/mlpack/tests/kfn_test.cpp
+++ b/src/mlpack/tests/kfn_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 #include <mlpack/core/tree/cover_tree.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::neighbor;

--- a/src/mlpack/tests/kmeans_test.cpp
+++ b/src/mlpack/tests/kmeans_test.cpp
@@ -18,7 +18,7 @@
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::kmeans;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/tree/cover_tree.hpp>
 #include <mlpack/core/tree/example_tree.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::neighbor;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -888,7 +888,9 @@ BOOST_AUTO_TEST_CASE(DualBallTreeTest)
   }
 }
 
-// Make sure sparse nearest neighbors works with kd trees.
+/**
+ * Make sure sparse nearest neighbors works with kd trees.
+ */
 BOOST_AUTO_TEST_CASE(SparseKNNKDTreeTest)
 {
   // The dimensionality of these datasets must be high so that the probability

--- a/src/mlpack/tests/krann_search_test.cpp
+++ b/src/mlpack/tests/krann_search_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/tree/cover_tree.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 #include <mlpack/methods/rann/ra_search.hpp>
 #include <mlpack/methods/rann/ra_model.hpp>

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/methods/lars/lars.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::regression;

--- a/src/mlpack/tests/layer_traits_test.cpp
+++ b/src/mlpack/tests/layer_traits_test.cpp
@@ -13,7 +13,7 @@
 #include <mlpack/methods/ann/layer/multiclass_classification_layer.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/lbfgs_test.cpp
+++ b/src/mlpack/tests/lbfgs_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/optimizers/lbfgs/test_functions.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack::optimization;
 using namespace mlpack::optimization::test;

--- a/src/mlpack/tests/lin_alg_test.cpp
+++ b/src/mlpack/tests/lin_alg_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/math/lin_alg.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace arma;
 using namespace mlpack;

--- a/src/mlpack/tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/linear_regression_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/methods/linear_regression/linear_regression.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::regression;

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::data;

--- a/src/mlpack/tests/local_coordinate_coding_test.cpp
+++ b/src/mlpack/tests/local_coordinate_coding_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/methods/local_coordinate_coding/lcc.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 using namespace arma;

--- a/src/mlpack/tests/log_test.cpp
+++ b/src/mlpack/tests/log_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 

--- a/src/mlpack/tests/logistic_regression_test.cpp
+++ b/src/mlpack/tests/logistic_regression_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/core/optimizers/sgd/sgd.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::regression;

--- a/src/mlpack/tests/lrsdp_test.cpp
+++ b/src/mlpack/tests/lrsdp_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/core/optimizers/sdp/lrsdp.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::optimization;

--- a/src/mlpack/tests/lsh_test.cpp
+++ b/src/mlpack/tests/lsh_test.cpp
@@ -6,7 +6,7 @@
 #include <mlpack/core.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 #include <mlpack/methods/lsh/lsh_search.hpp>
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>

--- a/src/mlpack/tests/lstm_peephole_test.cpp
+++ b/src/mlpack/tests/lstm_peephole_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/methods/ann/layer/lstm_layer.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/math_test.cpp
+++ b/src/mlpack/tests/math_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/core/math/random.hpp>
 #include <mlpack/core/math/range.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace math;

--- a/src/mlpack/tests/matrix_completion_test.cpp
+++ b/src/mlpack/tests/matrix_completion_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/matrix_completion/matrix_completion.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::matrix_completion;

--- a/src/mlpack/tests/maximal_inputs_test.cpp
+++ b/src/mlpack/tests/maximal_inputs_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/methods/sparse_autoencoder/maximal_inputs.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 

--- a/src/mlpack/tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/mean_shift_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/mean_shift/mean_shift.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::meanshift;

--- a/src/mlpack/tests/metric_test.cpp
+++ b/src/mlpack/tests/metric_test.cpp
@@ -6,7 +6,7 @@
 #include <mlpack/core.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace std;
 using namespace mlpack::metric;

--- a/src/mlpack/tests/minibatch_sgd_test.cpp
+++ b/src/mlpack/tests/minibatch_sgd_test.cpp
@@ -13,7 +13,7 @@
 #include <mlpack/methods/logistic_regression/logistic_regression.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace std;
 using namespace arma;

--- a/src/mlpack/tests/mlpack_test.cpp
+++ b/src/mlpack/tests/mlpack_test.cpp
@@ -17,7 +17,7 @@
 #endif
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 /**
  * Provide a global fixture for each test.

--- a/src/mlpack/tests/nbc_test.cpp
+++ b/src/mlpack/tests/nbc_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/methods/naive_bayes/naive_bayes_classifier.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace naive_bayes;

--- a/src/mlpack/tests/nca_test.cpp
+++ b/src/mlpack/tests/nca_test.cpp
@@ -11,7 +11,7 @@
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::metric;

--- a/src/mlpack/tests/network_util_test.cpp
+++ b/src/mlpack/tests/network_util_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/nmf_test.cpp
+++ b/src/mlpack/tests/nmf_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/methods/amf/update_rules/nmf_mult_dist.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(NMFTest);
 

--- a/src/mlpack/tests/nystroem_method_test.cpp
+++ b/src/mlpack/tests/nystroem_method_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 #include <mlpack/methods/nystroem_method/ordered_selection.hpp>
 #include <mlpack/methods/nystroem_method/random_selection.hpp>

--- a/src/mlpack/tests/old_boost_test_definitions.hpp
+++ b/src/mlpack/tests/old_boost_test_definitions.hpp
@@ -35,4 +35,9 @@
 
 #endif
 
+// Require the approximation L to be within a relative error of E respect to the
+// actual value R.
+#define REQUIRE_RELATIVE_ERR( L, R, E ) \
+    BOOST_REQUIRE_LE( abs((R) - (L)), (E) * (R))
+
 #endif

--- a/src/mlpack/tests/pca_test.cpp
+++ b/src/mlpack/tests/pca_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/pca/pca.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(PCATest);
 

--- a/src/mlpack/tests/perceptron_test.cpp
+++ b/src/mlpack/tests/perceptron_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/perceptron/perceptron.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace arma;

--- a/src/mlpack/tests/performance_functions_test.cpp
+++ b/src/mlpack/tests/performance_functions_test.cpp
@@ -11,7 +11,7 @@
 #include <mlpack/methods/ann/performance_functions/sse_function.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/pooling_rules_test.cpp
+++ b/src/mlpack/tests/pooling_rules_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/methods/ann/pooling_rules/mean_pooling.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/quic_svd_test.cpp
+++ b/src/mlpack/tests/quic_svd_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/methods/quic_svd/quic_svd.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(QUICSVDTest);
 

--- a/src/mlpack/tests/radical_test.cpp
+++ b/src/mlpack/tests/radical_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/core.hpp>
 #include <mlpack/methods/radical/radical.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(RadicalTest);
 

--- a/src/mlpack/tests/range_search_test.cpp
+++ b/src/mlpack/tests/range_search_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/core/tree/cover_tree.hpp>
 #include <mlpack/methods/range_search/rs_model.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::range;

--- a/src/mlpack/tests/rectangle_tree_test.cpp
+++ b/src/mlpack/tests/rectangle_tree_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::neighbor;

--- a/src/mlpack/tests/recurrent_network_test.cpp
+++ b/src/mlpack/tests/recurrent_network_test.cpp
@@ -20,7 +20,7 @@
  #include <mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;

--- a/src/mlpack/tests/regularized_svd_test.cpp
+++ b/src/mlpack/tests/regularized_svd_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/regularized_svd/regularized_svd.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::svd;

--- a/src/mlpack/tests/rmsprop_test.cpp
+++ b/src/mlpack/tests/rmsprop_test.cpp
@@ -20,7 +20,7 @@
 #include <mlpack/methods/ann/layer/base_layer.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace arma;
 using namespace mlpack;

--- a/src/mlpack/tests/sa_test.cpp
+++ b/src/mlpack/tests/sa_test.cpp
@@ -14,7 +14,7 @@
 #include <mlpack/core/metrics/mahalanobis_distance.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace std;
 using namespace arma;

--- a/src/mlpack/tests/sdp_primal_dual_test.cpp
+++ b/src/mlpack/tests/sdp_primal_dual_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::optimization;

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -17,7 +17,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 namespace mlpack {
 

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 #include <mlpack/core/dists/regression_distribution.hpp>

--- a/src/mlpack/tests/sgd_test.cpp
+++ b/src/mlpack/tests/sgd_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/core/optimizers/sgd/test_function.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace std;
 using namespace arma;

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/softmax_regression/softmax_regression.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::regression;

--- a/src/mlpack/tests/sort_policy_test.cpp
+++ b/src/mlpack/tests/sort_policy_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::neighbor;

--- a/src/mlpack/tests/sparse_autoencoder_test.cpp
+++ b/src/mlpack/tests/sparse_autoencoder_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/methods/sparse_autoencoder/sparse_autoencoder.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::nn;

--- a/src/mlpack/tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/sparse_coding_test.cpp
@@ -11,7 +11,7 @@
 #include <mlpack/methods/sparse_coding/sparse_coding.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 #include "serialization.hpp"
 
 using namespace arma;

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -8,7 +8,7 @@
 #include <mlpack/core/data/split_data.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace arma;

--- a/src/mlpack/tests/svd_batch_test.cpp
+++ b/src/mlpack/tests/svd_batch_test.cpp
@@ -7,7 +7,7 @@
 #include <mlpack/methods/amf/termination_policies/simple_tolerance_termination.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(SVDBatchTest);
 

--- a/src/mlpack/tests/svd_incremental_test.cpp
+++ b/src/mlpack/tests/svd_incremental_test.cpp
@@ -9,7 +9,7 @@
 #include <mlpack/methods/amf/termination_policies/validation_RMSE_termination.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(SVDIncrementalTest);
 

--- a/src/mlpack/tests/termination_policy_test.cpp
+++ b/src/mlpack/tests/termination_policy_test.cpp
@@ -10,7 +10,7 @@
 #include <mlpack/methods/amf/update_rules/nmf_mult_div.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 BOOST_AUTO_TEST_SUITE(TerminationPolicyTest);
 

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -1,12 +1,11 @@
 /**
- * @file old_boost_test_definitions.hpp
+ * @file test_tools.hpp
  * @author Ryan Curtin
  *
- * Ancient Boost.Test versions don't act how we expect.  This file includes the
- * things we need to fix that.
+ * This file includes some useful macros for tests.
  */
-#ifndef MLPACK_TESTS_OLD_BOOST_TEST_DEFINITIONS_HPP
-#define MLPACK_TESTS_OLD_BOOST_TEST_DEFINITIONS_HPP
+#ifndef MLPACK_TESTS_TEST_TOOLS_HPP
+#define MLPACK_TESTS_TEST_TOOLS_HPP
 
 #include <boost/version.hpp>
 

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -37,6 +37,6 @@
 // Require the approximation L to be within a relative error of E respect to the
 // actual value R.
 #define REQUIRE_RELATIVE_ERR( L, R, E ) \
-    BOOST_REQUIRE_LE( abs((R) - (L)), (E) * (R))
+    BOOST_REQUIRE_LE( abs((R) - (L)), (E) * abs(R))
 
 #endif

--- a/src/mlpack/tests/tree_test.cpp
+++ b/src/mlpack/tests/tree_test.cpp
@@ -14,7 +14,7 @@
 #include <stack>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::math;

--- a/src/mlpack/tests/tree_traits_test.cpp
+++ b/src/mlpack/tests/tree_traits_test.cpp
@@ -15,7 +15,7 @@
 #include <mlpack/core/tree/rectangle_tree.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::tree;

--- a/src/mlpack/tests/union_find_test.cpp
+++ b/src/mlpack/tests/union_find_test.cpp
@@ -8,7 +8,7 @@
 
 #include <mlpack/core.hpp>
 #include <boost/test/unit_test.hpp>
-#include "old_boost_test_definitions.hpp"
+#include "test_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::emst;


### PR DESCRIPTION
@sumedhghaisas
Hi, this pull request include the implementation of approximate neighbor search. Some details:
+ I implemented the modification on the prune rule to do approximate neighbor search. Mainly, I modified the code to include an epsilon value, which is considered by rule_type.
+ We can use the epsilon to make a tighter bound B_1, (not B_2). I implemented a Relax(..) function, included in sort policies, to modify a given value according to epsilon. When doing dual tree search, the best between the modified B_1 bound and the original B_2 bound is chosen.
+ I updated the command line tools to include an extra option "-e", to specify the relative error (default value: 0).
+ Then, I added many test cases. I did that in different files, because I think knn_test.hpp and kfn_test.hpp are too big to include more test cases. I thought we could maintain separated files:
  - knn_test.hpp/kfn_test.hpp for exact neighbor search tests.
  - aknn_test.hpp/akfn_test.hpp for approximate neighbor search tests.
+ I defined a new macro to check the relative error in the tests: REQUIRE_RELATIVE_ERR(..). I included it in the file: old_boost_test_definitions.hpp. If you agree, I would like to change it to a new name like: test_tools.hpp, where we could include useful defines in the future as I do right now, not only old boost definitions.

Every feedback is welcome,

Thanks!