### PR TITLE
Adding test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ before_install:
   - export CXX=g++-4.8
   - printenv
   - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp
+  - pip install --user cpp-coveralls
 install:
-  - mkdir build && cd build && cmake -DDEBUG=OFF -DPROFILE=OFF .. && make -j4
+  - mkdir build && cd build && cmake -DBUILD_WITH_COVERAGE=ON .. && make -j4
 script:
-  - travis_wait 30 ./bin/mlpack_test -p
+  - travis_wait 30 ./bin/mlpack_test -p --run_test=BinarizeTest
+after_success:
+  - cd build && coveralls -E '.*(CMakeFiles|tests).*'
 notifications:
   email:
     - mlpack-git@cc.gatech.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - travis_wait 30 ./bin/mlpack_test -p --run_test=BinarizeTest
 after_success:
-  - cd build && coveralls -E '.*(CMakeFiles|tests).*'
+  - coveralls -E '.*(CMakeFiles|tests).*'
 notifications:
   email:
     - mlpack-git@cc.gatech.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ before_install:
   - export CXX=g++-4.8
   - printenv
   - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp
-  - pip install --user cpp-coveralls
+  - sudo apt-get install ruby lcov
+  - sudo gem install coveralls-lcov
 install:
   - mkdir build && cd build && cmake -DBUILD_WITH_COVERAGE=ON .. && make -j4
 script:
-  - travis_wait 30 ./bin/mlpack_test -p --run_test=BinarizeTest
+  - travis_wait 30 ./mlpack_coverage -g gcov-4.8
 after_success:
-  - coveralls -E '.*(CMakeFiles|tests).*'
+  - coveralls-lcov .coverage.total
 notifications:
   email:
     - mlpack-git@cc.gatech.edu

--- a/CMake/mlpack_coverage.in
+++ b/CMake/mlpack_coverage.in
@@ -1,15 +1,20 @@
 #!/bin/bash
 
 test_case=""
+gcov_loc=""
 
-while getopts ":t:" opt; do
+while getopts ":t:g:" opt; do
   case $opt in
     t)
       test_case=$OPTARG
       echo "Finding coverage with $OPTARG tests."
       ;;
+    g)
+      gcov_loc=$OPTARG
+      echo "Using gcov: $OPTARG"
+      ;;
     \?)
-      echo "Invalid option: -$OPTARG" >&2
+      echo "Invalid option: -$OPTARG"
       exit 1
       ;;
     :)
@@ -23,14 +28,18 @@ done
 lcov -b . -c -i -d ./ -o .coverage.wtest.base
 
 # Run the tests
-if [$test_case -eq ""]
+if [ "$test_case" = "" ];
 then ${CMAKE_BINARY_DIR}/bin/mlpack_test
 else
   ${CMAKE_BINARY_DIR}/bin/mlpack_test --run_test=$test_case
 fi
 
 # Generate coverage based on executed tests
-lcov -b . -c -d ./ -o .coverage.wtest.run
+if [ "$gcov_loc" = "" ];
+then lcov -b . -c -d ./ -o .coverage.wtest.run
+else 
+  lcov -b . -c -d ./ -o .coverage.wtest.run --gcov-tool=$gcov_loc
+fi
 
 # Merge coverage tracefiles
 lcov -a .coverage.wtest.base -a .coverage.wtest.run  -o .coverage.total
@@ -58,7 +67,4 @@ genhtml -o ./coverage/ .coverage.total
 # Extra: Preserve coverage file in coveragehistory folder
 [[ -d ./coveragehistory/ ]] || mkdir coveragehistory
 cp .coverage.total ./coveragehistory/`date +'%Y.%m.%d-coverage'`
-
-# Cleanup
-rm .coverage.*
 

--- a/CMake/mlpack_coverage.in
+++ b/CMake/mlpack_coverage.in
@@ -4,16 +4,16 @@ test_case=""
 
 while getopts ":t:" opt; do
   case $opt in
-    a)
+    t)
       test_case=$OPTARG
-      echo "Finding coverage with $OPTARG tests." >&2
+      echo "Finding coverage with $OPTARG tests."
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       exit 1
       ;;
     :)
-      echo "Option -$OPTARG requires an argument." >&2
+      echo "Option -$OPTARG requires an argument."
       exit 1
       ;;
   esac

--- a/CMake/mlpack_coverage.in
+++ b/CMake/mlpack_coverage.in
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+test_case=""
+
+while getopts ":t:" opt; do
+  case $opt in
+    a)
+      test_case=$OPTARG
+      echo "Finding coverage with $OPTARG tests." >&2
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Generate initial coverage information
+lcov -b . -c -i -d ./ -o .coverage.wtest.base
+
+# Run the tests
+if [$test_case -eq ""]
+then ${CMAKE_BINARY_DIR}/bin/mlpack_test
+else
+  ${CMAKE_BINARY_DIR}/bin/mlpack_test --run_test=$test_case
+fi
+
+# Generate coverage based on executed tests
+lcov -b . -c -d ./ -o .coverage.wtest.run
+
+# Merge coverage tracefiles
+lcov -a .coverage.wtest.base -a .coverage.wtest.run  -o .coverage.total
+
+# Filtering, extracting project files
+lcov -e .coverage.total "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/*" -o .coverage.total.filtered
+
+# Filtering, removing test-files and main.cpp
+lcov -r .coverage.total.filtered "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/*/*_main.cpp" -o .coverage.total.filtered
+lcov -r .coverage.total.filtered "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/tests/*" -o .coverage.total.filtered
+
+# Extra:  Replace /build/ with /src/ to unify directories
+cat .coverage.total.filtered > .coverage.total
+
+# Extra: Clear up previous data, create html folder
+if [[ -d ./coverage/ ]] ; then
+    rm -rf ./coverage/*
+else
+    mkdir coverage
+fi
+
+# Step 9: Generate webpage
+genhtml -o ./coverage/ .coverage.total
+
+# Extra: Preserve coverage file in coveragehistory folder
+[[ -d ./coveragehistory/ ]] || mkdir coveragehistory
+cp .coverage.total ./coveragehistory/`date +'%Y.%m.%d-coverage'`
+
+# Cleanup
+rm .coverage.*
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if(BUILD_WITH_COVERAGE)
     endif()
 
     configure_file(CMake/mlpack_coverage.in mlpack_coverage)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -fkeep-inline-functions")
     message(WARNING "Adding debug options for coverage")
     # Remove optimizations for better line coverage
     set(DEBUG ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,16 +86,17 @@ if(BUILD_WITH_COVERAGE)
       message(FATAL_ERROR "gcov not found! Aborting...")
     endif()
 
-    if(NOT LCOV)
-      message(FATAL_ERROR "lcov not found! Aborting...")
-    endif()
-
-    configure_file(CMake/mlpack_coverage.in mlpack_coverage)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -fkeep-inline-functions")
     message(WARNING "Adding debug options for coverage")
     # Remove optimizations for better line coverage
     set(DEBUG ON)
-    add_custom_target(mlpack_coverage DEPENDS mlpack_test COMMAND ${PROJECT_BINARY_DIR}/mlpack_coverage)
+
+    if(LCOV)
+      configure_file(CMake/mlpack_coverage.in mlpack_coverage)
+      add_custom_target(mlpack_coverage DEPENDS mlpack_test COMMAND ${PROJECT_BINARY_DIR}/mlpack_coverage)
+    else()
+      message(WARNING "'lcov' not found, local coverage report is disabled. Install 'lcov' and rerun cmake to generate local coverage report.")
+    endif()
   else()
     message(FATAL_ERROR "Coverage will only work with GNU environment.")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(BUILD_TESTS "Build tests." ON)
 option(BUILD_CLI_EXECUTABLES "Build command-line executables" ON)
 option(BUILD_SHARED_LIBS
     "Compile shared libraries (if OFF, static libraries are compiled)" ON)
-
+option(BUILD_WITH_COVERAGE "Build with COVTOOL" OFF)
 enable_testing()
 
 # Include modules in the CMake directory.
@@ -72,6 +72,33 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lm")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lm")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -lm")
+endif()
+
+# Setup build for test coverage
+if(BUILD_WITH_COVERAGE)
+  # Currently coverage only works with GNU g++
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # Find gcov and lcov
+    find_program(GCOV gcov)
+    find_program(LCOV lcov)
+
+    if(NOT GCOV)
+      message(FATAL_ERROR "gcov not found! Aborting...")
+    endif()
+
+    if(NOT LCOV)
+      message(FATAL_ERROR "lcov not found! Aborting...")
+    endif()
+
+    configure_file(CMake/mlpack_coverage.in mlpack_coverage)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    message(WARNING "Adding debug options for coverage")
+    # Remove optimizations for better line coverage
+    set(DEBUG ON)
+    add_custom_target(mlpack_coverage DEPENDS mlpack_test COMMAND ${PROJECT_BINARY_DIR}/mlpack_coverage)
+  else()
+    message(FATAL_ERROR "Coverage will only work with GNU environment.")
+  endif()
 endif()
 
 # Debugging CFLAGS.  Turn optimizations off; turn debugging symbols on.


### PR DESCRIPTION
The test coverage is not complete though the basic framework is ready.

Completed things are - 
* Using gcov and lcov to calculate test coverage
* Added cmake option BUILD_WITH_COVERAGE to build mlpack with appropriate GCC flags
* Added cmake target mlpack_coverage to generate coverage with all tests
* bash script 'mlpack_coverage' will be generated in build folder which takes test suite as parameter('-t') for generate coverage for specific test
* Coverage result will be available in build/coverage/index.html

TODO list:
1) Coverage results get accumulated with every run. We need to make sure the previous result gets deleted for every run. 
2) Where to show these results? and how to upload it automatically?
3) Some hacks are needed for templated functions and classes.

Opening this pull request for discussion. 