### PR TITLE
Removed RectangleTree::Points()

### DIFF
--- a/src/mlpack/core/tree/rectangle_tree/dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/dual_tree_traverser_impl.hpp
@@ -67,14 +67,14 @@ DualTreeTraverser<RuleType>::Traverse(RectangleTree& queryNode,
     {
       // Restore the traversal information.
       rule.TraversalInfo() = traversalInfo;
-      const double childScore = rule.Score(queryNode.Points()[query],
+      const double childScore = rule.Score(queryNode.Point(query),
           referenceNode);
 
       if (childScore == DBL_MAX)
         continue;  // We don't require a search in this reference node.
 
       for(size_t ref = 0; ref < referenceNode.Count(); ++ref)
-        rule.BaseCase(queryNode.Points()[query], referenceNode.Points()[ref]);
+        rule.BaseCase(queryNode.Point(query), referenceNode.Point(ref));
 
       numBaseCases += referenceNode.Count();
     }

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_auxiliary_information_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_auxiliary_information_impl.hpp
@@ -47,10 +47,10 @@ HandlePointInsertion(TreeType* node, const size_t point)
 
     // Move points.
     for (size_t i = node->NumPoints(); i > pos; i--)
-      node->Points()[i] = node->Points()[i - 1];
+      node->Point(i) = node->Point(i - 1);
 
     // Insert the point.
-    node->Points()[pos] = point;
+    node->Point(pos) = point;
     node->Count()++;
   }
   else
@@ -105,7 +105,7 @@ HandlePointDeletion(TreeType* node, const size_t localIndex)
   hilbertValue.DeletePoint(node,localIndex);
 
   for (size_t i = localIndex + 1; localIndex < node->NumPoints(); i++)
-    node->Points()[i - 1] = node->Points()[i];
+    node->Point(i - 1) = node->Point(i);
 
   node->NumPoints()--;
   return true;

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split_impl.hpp
@@ -284,7 +284,7 @@ RedistributePointsEvenly(TreeType* parent,
   for (size_t i = firstSibling; i <= lastSibling; i++)
   {
     for (size_t j = 0; j < parent->Children()[i]->NumPoints(); j++)
-      points[iPoint++] = parent->Children()[i]->Points()[j];
+      points[iPoint++] = parent->Children()[i]->Point(j);
   }
 
   iPoint = 0;
@@ -298,13 +298,13 @@ RedistributePointsEvenly(TreeType* parent,
     for (j = 0; j < numPointsPerNode; j++)
     {
       parent->Children()[i]->Bound() |= parent->Dataset().col(points[iPoint]);
-      parent->Children()[i]->Points()[j] = points[iPoint];
+      parent->Children()[i]->Point(j) = points[iPoint];
       iPoint++;
     }
     if (numRestPoints > 0)
     {
       parent->Children()[i]->Bound() |= parent->Dataset().col(points[iPoint]);
-      parent->Children()[i]->Points()[j] = points[iPoint];
+      parent->Children()[i]->Point(j) = points[iPoint];
       parent->Children()[i]->Count() = numPointsPerNode + 1;
       numRestPoints--;
       iPoint++;

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
@@ -78,9 +78,9 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < p; i++)
     {
       // We start from the end of sorted.
-      pointIndices[i] = tree->Points()[sorted[sorted.size() - 1 - i].n];
+      pointIndices[i] = tree->Point(sorted[sorted.size() - 1 - i].n);
 
-      root->DeletePoint(tree->Points()[sorted[sorted.size() - 1 - i].n],
+      root->DeletePoint(tree->Point(sorted[sorted.size() - 1 - i].n),
           relevels);
     }
 
@@ -224,9 +224,9 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < tree->Count(); i++)
     {
       if (i < bestAreaIndexOnBestAxis + tree->MinLeafSize())
-        treeOne->InsertPoint(tree->Points()[sorted[i].n]);
+        treeOne->InsertPoint(tree->Point(sorted[i].n));
       else
-        treeTwo->InsertPoint(tree->Points()[sorted[i].n]);
+        treeTwo->InsertPoint(tree->Point(sorted[i].n));
     }
   }
   else
@@ -234,9 +234,9 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < tree->Count(); i++)
     {
       if (i < bestOverlapIndexOnBestAxis + tree->MinLeafSize())
-        treeOne->InsertPoint(tree->Points()[sorted[i].n]);
+        treeOne->InsertPoint(tree->Point(sorted[i].n));
       else
-        treeTwo->InsertPoint(tree->Points()[sorted[i].n]);
+        treeTwo->InsertPoint(tree->Point(sorted[i].n));
     }
   }
 

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
@@ -199,10 +199,10 @@ void RTreeSplit::GetBoundSeeds(const TreeType *tree,int& iRet, int& jRet)
       ElemType score = 1.0;
       for (size_t k = 0; k < tree->Bound().Dim(); k++)
       {
-        const ElemType hiMax = std::max(tree->Children()[i]->Bound()[k].Hi(),
-                                        tree->Children()[j]->Bound()[k].Hi());
-        const ElemType loMin = std::min(tree->Children()[i]->Bound()[k].Lo(),
-                                        tree->Children()[j]->Bound()[k].Lo());
+        const ElemType hiMax = std::max(tree->Child(i).Bound()[k].Hi(),
+                                        tree->Child(j).Bound()[k].Hi());
+        const ElemType loMin = std::min(tree->Child(i).Bound()[k].Lo(),
+                                        tree->Child(j).Bound()[k].Lo());
         score *= (hiMax - loMin);
       }
 
@@ -235,20 +235,20 @@ void RTreeSplit::AssignPointDestNode(TreeType* oldTree,
   treeOne->Count() = 0;
   treeTwo->Count() = 0;
 
-  treeOne->InsertPoint(oldTree->Points()[intI]);
-  treeTwo->InsertPoint(oldTree->Points()[intJ]);
+  treeOne->InsertPoint(oldTree->Point(intI));
+  treeTwo->InsertPoint(oldTree->Point(intJ));
 
   // If intJ is the last point in the tree, we need to switch the order so that
   // we remove the correct points.
   if (intI > intJ)
   {
-    oldTree->Points()[intI] = oldTree->Points()[--end]; // Decrement end.
-    oldTree->Points()[intJ] = oldTree->Points()[--end]; // Decrement end.
+    oldTree->Point(intI) = oldTree->Point(--end); // Decrement end.
+    oldTree->Point(intJ) = oldTree->Point(--end); // Decrement end.
   }
   else
   {
-    oldTree->Points()[intJ] = oldTree->Points()[--end]; // Decrement end.
-    oldTree->Points()[intI] = oldTree->Points()[--end]; // Decrement end.
+    oldTree->Point(intJ) = oldTree->Point(--end); // Decrement end.
+    oldTree->Point(intI) = oldTree->Point(--end); // Decrement end.
   }
 
   size_t numAssignedOne = 1;
@@ -324,16 +324,16 @@ void RTreeSplit::AssignPointDestNode(TreeType* oldTree,
     // to the appropriate rectangle.
     if (bestRect == 1)
     {
-      treeOne->InsertPoint(oldTree->Points()[bestIndex]);
+      treeOne->InsertPoint(oldTree->Point(bestIndex));
       numAssignedOne++;
     }
     else
     {
-      treeTwo->InsertPoint(oldTree->Points()[bestIndex]);
+      treeTwo->InsertPoint(oldTree->Point(bestIndex));
       numAssignedTwo++;
     }
 
-    oldTree->Points()[bestIndex] = oldTree->Points()[--end]; // Decrement end.
+    oldTree->Point(bestIndex) = oldTree->Point(--end); // Decrement end.
   }
 
   // See if we need to satisfy the minimum fill.
@@ -342,12 +342,12 @@ void RTreeSplit::AssignPointDestNode(TreeType* oldTree,
     if (numAssignedOne < numAssignedTwo)
     {
       for (size_t i = 0; i < end; i++)
-        treeOne->InsertPoint(oldTree->Points()[i]);
+        treeOne->InsertPoint(oldTree->Point(i));
     }
     else
     {
       for (size_t i = 0; i < end; i++)
-        treeTwo->InsertPoint(oldTree->Points()[i]);
+        treeTwo->InsertPoint(oldTree->Point(i));
     }
   }
 }
@@ -432,7 +432,7 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
         // For each of the new rectangles, find the width in this dimension if
         // we add the rectangle at index to the new rectangle.
         const math::RangeType<ElemType>& range =
-            oldTree->Children()[index]->Bound()[i];
+            oldTree->Child(index).Bound()[i];
         newVolOne *= treeOne->Bound()[i].Contains(range) ?
             treeOne->Bound()[i].Width() : (range.Contains(treeOne->Bound()[i]) ?
             range.Width() : (range.Lo() < treeOne->Bound()[i].Lo() ?

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -328,11 +328,6 @@ class RectangleTree
   //! Modify the dataset which the tree is built on.  Be careful!
   MatType& Dataset() { return const_cast<MatType&>(*dataset); }
 
-  //! Get the points vector for this node.
-  const std::vector<size_t>& Points() const { return points; }
-  //! Modify the points vector for this node.  Be careful!
-  std::vector<size_t>& Points() { return points; }
-
   //! Get the metric which the tree uses.
   MetricType Metric() const { return MetricType(); }
 
@@ -424,7 +419,10 @@ class RectangleTree
    *
    * @param index Index of point for which a dataset index is wanted.
    */
-  size_t Point(const size_t index) const;
+  const size_t& Point(const size_t index) const { return points[index]; }
+
+  //! Modify the index of a particular point in this node.
+  size_t& Point(const size_t index) { return points[index]; }
 
   //! Return the minimum distance to another node.
   ElemType MinDistance(const RectangleTree* other) const

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree_impl.hpp
@@ -154,7 +154,7 @@ RectangleTree(
     parentDistance(other.ParentDistance()),
     dataset(deepCopy ? new MatType(*other.dataset) : &other.Dataset()),
     ownsDataset(deepCopy),
-    points(other.Points()),
+    points(other.points),
     auxiliaryInfo(other.auxiliaryInfo)
 {
   if (deepCopy)
@@ -660,21 +660,6 @@ inline size_t RectangleTree<MetricType, StatisticType, MatType, SplitType,
 }
 
 /**
- * Return the index of a particular point contained in this node.
- */
-template<typename MetricType,
-         typename StatisticType,
-         typename MatType,
-         typename SplitType,
-         typename DescentType,
-         template<typename> class AuxiliaryInformationType>
-inline size_t RectangleTree<MetricType, StatisticType, MatType, SplitType,
-         DescentType, AuxiliaryInformationType>::Point(const size_t index) const
-{
-  return points[index];
-}
-
-/**
  * Split the tree.  This calls the SplitType code to split a node.  This method
  * should only be called on a leaf node.
  */
@@ -878,7 +863,7 @@ void RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
       for (size_t i = 0; i < child->Count(); i++)
       {
         // In case the tree has a height of two.
-        points[i] = child->Points()[i];
+        points[i] = child->Point(i);
       }
 
       auxiliaryInfo = child->AuxiliaryInfo();

--- a/src/mlpack/core/tree/rectangle_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/single_tree_traverser_impl.hpp
@@ -49,7 +49,7 @@ SingleTreeTraverser<RuleType>::Traverse(
   if (referenceNode.IsLeaf())
   {
     for (size_t i = 0; i < referenceNode.Count(); i++)
-      rule.BaseCase(queryIndex, referenceNode.Points()[i]);
+      rule.BaseCase(queryIndex, referenceNode.Point(i));
 
     return;
   }

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
@@ -67,7 +67,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < sorted.size(); i++)
     {
       sorted[i].d = tree->Metric().Evaluate(center,
-          tree->Dataset().col(tree->Points()[i]));
+          tree->Dataset().col(tree->Point(i)));
        sorted[i].n = i;
     }
 
@@ -77,9 +77,9 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < p; i++)
     {
       // We start from the end of sorted.
-      pointIndices[i] = tree->Points()[sorted[sorted.size() - 1 - i].n];
+      pointIndices[i] = tree->Point(sorted[sorted.size() - 1 - i].n);
 
-      root->DeletePoint(tree->Points()[sorted[sorted.size() - 1 - i].n],
+      root->DeletePoint(tree->Point(sorted[sorted.size() - 1 - i].n),
           relevels);
     }
 
@@ -115,7 +115,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     // Since we only have points in the leaf nodes, we only need to sort once.
     std::vector<sortStruct<ElemType>> sorted(tree->Count());
     for (size_t i = 0; i < sorted.size(); i++) {
-      sorted[i].d = tree->Dataset().col(tree->Points()[i])[j];
+      sorted[i].d = tree->Dataset().col(tree->Point(i))[j];
       sorted[i].n = i;
     }
 
@@ -148,25 +148,25 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
       std::vector<ElemType> minG2(maxG1.size());
       for (size_t k = 0; k < tree->Bound().Dim(); k++)
       {
-        minG1[k] = maxG1[k] = tree->Dataset().col(tree->Points()[sorted[0].n])[k];
+        minG1[k] = maxG1[k] = tree->Dataset().col(tree->Point(sorted[0].n))[k];
         minG2[k] = maxG2[k] = tree->Dataset().col(
-            tree->Points()[sorted[sorted.size() - 1].n])[k];
+            tree->Point(sorted[sorted.size() - 1].n))[k];
 
         for (size_t l = 1; l < tree->Count() - 1; l++)
         {
           if (l < cutOff)
           {
-            if (tree->Dataset().col(tree->Points()[sorted[l].n])[k] < minG1[k])
-              minG1[k] = tree->Dataset().col(tree->Points()[sorted[l].n])[k];
-            else if (tree->Dataset().col(tree->Points()[sorted[l].n])[k] > maxG1[k])
-              maxG1[k] = tree->Dataset().col(tree->Points()[sorted[l].n])[k];
+            if (tree->Dataset().col(tree->Point(sorted[l].n))[k] < minG1[k])
+              minG1[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
+            else if (tree->Dataset().col(tree->Point(sorted[l].n))[k] > maxG1[k])
+              maxG1[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
           }
           else
           {
-            if (tree->Dataset().col(tree->Points()[sorted[l].n])[k] < minG2[k])
-              minG2[k] = tree->Dataset().col(tree->Points()[sorted[l].n])[k];
-            else if (tree->Dataset().col(tree->Points()[sorted[l].n])[k] > maxG2[k])
-              maxG2[k] = tree->Dataset().col(tree->Points()[sorted[l].n])[k];
+            if (tree->Dataset().col(tree->Point(sorted[l].n))[k] < minG2[k])
+              minG2[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
+            else if (tree->Dataset().col(tree->Point(sorted[l].n))[k] > maxG2[k])
+              maxG2[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
           }
         }
       }
@@ -214,7 +214,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
   std::vector<sortStruct<ElemType>> sorted(tree->Count());
   for (size_t i = 0; i < sorted.size(); i++)
   {
-    sorted[i].d = tree->Dataset().col(tree->Points()[i])[bestAxis];
+    sorted[i].d = tree->Dataset().col(tree->Point(i))[bestAxis];
     sorted[i].n = i;
   }
 
@@ -233,9 +233,9 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < tree->Count(); i++)
     {
       if (i < bestAreaIndexOnBestAxis + tree->MinLeafSize())
-        treeOne->InsertPoint(tree->Points()[sorted[i].n]);
+        treeOne->InsertPoint(tree->Point(sorted[i].n));
       else
-        treeTwo->InsertPoint(tree->Points()[sorted[i].n]);
+        treeTwo->InsertPoint(tree->Point(sorted[i].n));
     }
   }
   else
@@ -243,9 +243,9 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < tree->Count(); i++)
     {
       if (i < bestOverlapIndexOnBestAxis + tree->MinLeafSize())
-        treeOne->InsertPoint(tree->Points()[sorted[i].n]);
+        treeOne->InsertPoint(tree->Point(sorted[i].n));
       else
-        treeTwo->InsertPoint(tree->Points()[sorted[i].n]);
+        treeTwo->InsertPoint(tree->Point(sorted[i].n));
     }
   }
 

--- a/src/mlpack/tests/rectangle_tree_test.cpp
+++ b/src/mlpack/tests/rectangle_tree_test.cpp
@@ -77,7 +77,7 @@ std::vector<arma::vec*> GetAllPointsInTree(const TreeType& tree)
   {
     for (size_t i = 0; i < tree.Count(); i++)
     {
-      arma::vec* c = new arma::vec(tree.Dataset().col(tree.Points()[i]));
+      arma::vec* c = new arma::vec(tree.Dataset().col(tree.Point(i)));
       vec.push_back(c);
     }
   }
@@ -130,7 +130,7 @@ void CheckContainment(const TreeType& tree)
   {
     for (size_t i = 0; i < tree.Count(); i++)
       BOOST_REQUIRE(tree.Bound().Contains(
-          tree.Dataset().unsafe_col(tree.Points()[i])));
+          tree.Dataset().unsafe_col(tree.Point(i))));
   }
   else
   {
@@ -159,9 +159,9 @@ void CheckExactContainment(const TreeType& tree)
       for(size_t j = 0; j < tree.Count(); j++)
       {
         if (tree.Dataset().col(tree.Point(j))[i] < min)
-          min = tree.Dataset().col(tree.Points()[j])[i];
+          min = tree.Dataset().col(tree.Point(j))[i];
         if (tree.Dataset().col(tree.Point(j))[i] > max)
-          max = tree.Dataset().col(tree.Points()[j])[i];
+          max = tree.Dataset().col(tree.Point(j))[i];
       }
       BOOST_REQUIRE_EQUAL(max, tree.Bound()[i].Hi());
       BOOST_REQUIRE_EQUAL(min, tree.Bound()[i].Lo());
@@ -619,7 +619,7 @@ void CheckHilbertOrdering(const TreeType& tree)
           0);
 
     BOOST_REQUIRE_EQUAL(tree.AuxiliaryInfo().HilbertValue().CompareWith(
-        tree.Dataset().col(tree.Points()[tree.NumPoints() - 1])),
+        tree.Dataset().col(tree.Point(tree.NumPoints() - 1))),
         0);
   }
   else
@@ -665,7 +665,7 @@ void CheckDiscreteHilbertValueSync(const TreeType& tree)
     for (size_t i = 0; i < tree.NumPoints(); i++)
     {
       arma::Col<HilbertElemType> pointValue =
-          HilbertValue::CalculateValue(tree.Dataset().col(tree.Points()[i]));
+          HilbertValue::CalculateValue(tree.Dataset().col(tree.Point(i)));
 
       const int equal = HilbertValue::CompareValues(
           value.LocalHilbertValues()->col(i), pointValue);


### PR DESCRIPTION
I removed the `RectangleTree::Points()` method. Unfortunately, we can not remove `RectangleTree::Children()` so easy since sometimes we have to modify the pointers. We can use friend classes instead i.e. use `tree.children[i]` instead of `tree.Children()[i]`.