### PR TITLE
RectangleTree::NumDescendants() optimization and some RectangleTree fixes

### DIFF
--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value_impl.hpp
@@ -45,7 +45,7 @@ DiscreteHilbertValue<TreeElemType>::DiscreteHilbertValue(const TreeType* tree) :
   // Calculate the Hilbert value for all points.
   if (!tree->Parent()) // This is the root node.
     ownsLocalHilbertValues = true;
-  else if (tree->Parent()->Children()[0]->IsLeaf())
+  else if (tree->Parent()->Child(0).IsLeaf())
   {
     // This is a leaf node.
     assert(tree->Parent()->NumChildren() > 0);
@@ -342,12 +342,12 @@ RemoveNode(TreeType* node, const size_t nodeIndex)
   if (nodeIndex + 1 == node->NumChildren())
   {
     // Update the largest Hilbert value if the value exists
-    TreeType* child = node->Children()[nodeIndex - 1];
-    if (child->AuxiliaryInfo.HilbertValue().NumValues() != 0)
+    TreeType& child = node->Child(nodeIndex - 1);
+    if (child.AuxiliaryInfo.HilbertValue().NumValues() != 0)
     {
-      numValues = child->AuxiliaryInfo.HilbertValue().NumValues();
+      numValues = child.AuxiliaryInfo.HilbertValue().NumValues();
       localHilbertValues =
-          child->AuxiliaryInfo.HilbertValue().LocalHilbertValues();
+          child.AuxiliaryInfo.HilbertValue().LocalHilbertValues();
     }
     else
     {
@@ -382,10 +382,10 @@ void DiscreteHilbertValue<TreeElemType>::UpdateLargestValue(TreeType* node)
   if (!node->IsLeaf())
   {
     // Update the largest Hilbert value
-    localHilbertValues = node->Children()[node->NumChildren() -
-        1]->AuxiliaryInfo().HilbertValue().LocalHilbertValues();
-    numValues = node->Children()[node->NumChildren() -
-        1]->AuxiliaryInfo().HilbertValue().NumValues();
+    localHilbertValues = node->Child(node->NumChildren() -
+        1).AuxiliaryInfo().HilbertValue().LocalHilbertValues();
+    numValues = node->Child(node->NumChildren() -
+        1).AuxiliaryInfo().HilbertValue().NumValues();
   }
 }
 
@@ -399,7 +399,7 @@ void DiscreteHilbertValue<TreeElemType>::RedistributeHilbertValues(
   // We need to update the local dataset if points were redistributed.
   size_t numPoints = 0;
   for (size_t i = firstSibling; i <= lastSibling; i++)
-    numPoints += parent->Children()[i]->NumPoints();
+    numPoints += parent->Child(i).NumPoints();
 
   // Copy the local Hilbert values.
   arma::Mat<HilbertElemType> tmp(localHilbertValues->n_rows, numPoints);
@@ -408,7 +408,7 @@ void DiscreteHilbertValue<TreeElemType>::RedistributeHilbertValues(
   for (size_t i = firstSibling; i<= lastSibling; i++)
   {
     DiscreteHilbertValue<TreeElemType> &value =
-        parent->Children()[i]->AuxiliaryInfo().HilbertValue();
+        parent->Child(i).AuxiliaryInfo().HilbertValue();
 
     for (size_t j = 0; j < value.NumValues(); j++)
     {
@@ -424,14 +424,14 @@ void DiscreteHilbertValue<TreeElemType>::RedistributeHilbertValues(
   for (size_t i = firstSibling; i <= lastSibling; i++)
   {
     DiscreteHilbertValue<TreeElemType> &value =
-        parent->Children()[i]->AuxiliaryInfo().HilbertValue();
+        parent->Child(i).AuxiliaryInfo().HilbertValue();
 
-    for (size_t j = 0; j < parent->Children()[i]->NumPoints(); j++)
+    for (size_t j = 0; j < parent->Child(i).NumPoints(); j++)
     {
       value.LocalHilbertValues()->col(j) = tmp.col(iPoint);
       iPoint++;
     }
-    value.NumValues() = parent->Children()[i]->NumPoints();
+    value.NumValues() = parent->Child(i).NumPoints();
   }
 
   assert(iPoint == numPoints);

--- a/src/mlpack/core/tree/rectangle_tree/dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/dual_tree_traverser_impl.hpp
@@ -103,7 +103,7 @@ DualTreeTraverser<RuleType>::Traverse(RectangleTree& queryNode,
     for (size_t i = 0; i < referenceNode.NumChildren(); i++)
     {
       rule.TraversalInfo() = traversalInfo;
-      nodesAndScores[i].node = referenceNode.Children()[i];
+      nodesAndScores[i].node = &(referenceNode.Child(i));
       nodesAndScores[i].score = rule.Score(queryNode,
           *(nodesAndScores[i].node));
       nodesAndScores[i].travInfo = rule.TraversalInfo();
@@ -138,7 +138,7 @@ DualTreeTraverser<RuleType>::Traverse(RectangleTree& queryNode,
       for (size_t i = 0; i < referenceNode.NumChildren(); i++)
       {
         rule.TraversalInfo() = traversalInfo;
-        nodesAndScores[i].node = referenceNode.Children()[i];
+        nodesAndScores[i].node = &(referenceNode.Child(i));
         nodesAndScores[i].score = rule.Score(queryNode.Child(j),
             *nodesAndScores[i].node);
         nodesAndScores[i].travInfo = rule.TraversalInfo();

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_auxiliary_information_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_auxiliary_information_impl.hpp
@@ -75,16 +75,16 @@ HandleNodeInsertion(TreeType* node, TreeType* nodeToInsert, bool insertionLevel)
     // The node should be inserted according to its Hilbert value.
     for (pos = 0; pos < node->NumChildren(); pos++)
       if (HilbertValueType<ElemType>::CompareValues(
-                 node->Children()[pos]->AuxiliaryInfo().HilbertValue(),
+                 node->Child(pos).AuxiliaryInfo().HilbertValue(),
                  nodeToInsert->AuxiliaryInfo().HilbertValue()) < 0)
           break;
 
     // Move nodes.
     for (size_t i = node->NumChildren(); i > pos; i--)
-      node->Children()[i] = node->Children()[i - 1];
+      node->children[i] = node->children[i - 1];
 
     // Insert the node.
-    node->Children()[pos] = nodeToInsert;
+    node->children[pos] = nodeToInsert;
     nodeToInsert->Parent() = node;
 
     // Update the largest Hilbert value.
@@ -120,7 +120,7 @@ HandleNodeRemoval(TreeType* node, const size_t nodeIndex)
   hilbertValue.RemoveNode(node,nodeIndex);
 
   for (size_t i = nodeIndex + 1; nodeIndex < node->NumChildren(); i++)
-    node->Children()[i - 1] = node->Children()[i];
+    node->children[i - 1] = node->children[i];
 
   node->NumChildren()--;
   return true;
@@ -134,10 +134,10 @@ UpdateAuxiliaryInfo(TreeType* node)
   if (node->IsLeaf())  //  Should already be updated
     return true;
 
-  TreeType* child = node->Children()[node->NumChildren() - 1];
-  if (hilbertValue.CompareWith(child->AuxiliaryInfo().HilbertValue()) < 0)
+  TreeType& child = node->Child(node->NumChildren() - 1);
+  if (hilbertValue.CompareWith(child.AuxiliaryInfo().HilbertValue()) < 0)
   {
-    hilbertValue = node->AuxiliaryInfo().HilbertValue();
+    hilbertValue = child.AuxiliaryInfo().HilbertValue();
     return true;
   }
   return false;

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_descent_heuristic_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_descent_heuristic_impl.hpp
@@ -21,7 +21,7 @@ size_t HilbertRTreeDescentHeuristic::ChooseDescentNode(
   size_t bestIndex = 0;
 
   for (bestIndex = 0; bestIndex < node->NumChildren() - 1; bestIndex++)
-    if (node->Children()[bestIndex]->AuxiliaryInfo().HilbertValue().
+    if (node->Child(bestIndex).AuxiliaryInfo().HilbertValue().
         CompareWithCachedPoint(node->Dataset().col(point)) > 0)
       break;
 
@@ -36,7 +36,7 @@ size_t HilbertRTreeDescentHeuristic::ChooseDescentNode(
   size_t bestIndex = 0;
 
   for (bestIndex = 0; bestIndex < node->NumChildren() - 1; bestIndex++)
-    if (node->Children()[bestIndex]->AuxiliaryInfo().HilbertValue().
+    if (node->Child(bestIndex).AuxiliaryInfo().HilbertValue().
         CompareWith(node, node->AuxiliaryInfo().HilbertValue()) > 0)
       break;
 

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split_impl.hpp
@@ -231,10 +231,12 @@ RedistributeNodesEvenly(const TreeType *parent,
     // Since we redistribute children of a sibling we should recalculate the
     // bound.
     parent->Child(i).Bound().Clear();
+    parent->Child(i).numDescendants = 0;
 
     for (size_t j = 0; j < numChildrenPerNode; j++)
     {
       parent->Child(i).Bound() |= children[iChild]->Bound();
+      parent->Child(i).numDescendants += children[iChild]->numDescendants;
       parent->Child(i).children[j] = children[iChild];
       children[iChild]->Parent() = parent->children[i];
       iChild++;
@@ -242,6 +244,7 @@ RedistributeNodesEvenly(const TreeType *parent,
     if (numRestChildren > 0)
     {
       parent->Child(i).Bound() |= children[iChild]->Bound();
+      parent->Child(i).numDescendants += children[iChild]->numDescendants;
       parent->Child(i).children[numChildrenPerNode] = children[iChild];
       children[iChild]->Parent() = parent->children[i];
       parent->Child(i).NumChildren() = numChildrenPerNode + 1;
@@ -313,6 +316,8 @@ RedistributePointsEvenly(TreeType* parent,
     {
       parent->Child(i).Count() = numPointsPerNode;
     }
+    parent->Child(i).numDescendants = parent->Child(i).Count();
+
     assert(parent->Child(i).NumPoints() <=
            parent->Child(i).MaxLeafSize());
   }

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split_impl.hpp
@@ -30,14 +30,14 @@ void HilbertRTreeSplit<splitOrder>::SplitLeafNode(TreeType* tree,
     tree->Count() = 0;
     tree->NullifyData();
     // Because this was a leaf node, numChildren must be 0.
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
     SplitLeafNode(copy, relevels);
     return;
   }
 
   TreeType* parent = tree->Parent();
   size_t iTree = 0;
-  for (iTree = 0; parent->Children()[iTree] != tree; iTree++);
+  for (iTree = 0; parent->children[iTree] != tree; iTree++);
 
   // Try to find splitOrder cooperating siblings in order to redistribute points
   // among them and avoid split.
@@ -54,11 +54,11 @@ void HilbertRTreeSplit<splitOrder>::SplitLeafNode(TreeType* tree,
                         iTree + splitOrder : parent->NumChildren());
 
   for (size_t i = parent->NumChildren(); i > iNewSibling ; i--)
-    parent->Children()[i] = parent->Children()[i - 1];
+    parent->children[i] = parent->children[i - 1];
 
   parent->NumChildren()++;
 
-  parent->Children()[iNewSibling] = new TreeType(parent);
+  parent->children[iNewSibling] = new TreeType(parent);
 
   lastSibling = (iTree + splitOrder < parent->NumChildren() ?
                  iTree + splitOrder : parent->NumChildren() - 1);
@@ -91,7 +91,7 @@ SplitNonLeafNode(TreeType* tree, std::vector<bool>& relevels)
     copy->Parent() = tree;
     tree->NumChildren() = 0;
     tree->NullifyData();
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
 
     SplitNonLeafNode(copy, relevels);
     return true;
@@ -100,7 +100,7 @@ SplitNonLeafNode(TreeType* tree, std::vector<bool>& relevels)
   TreeType* parent = tree->Parent();
 
   size_t iTree = 0;
-  for (iTree = 0; parent->Children()[iTree] != tree; iTree++);
+  for (iTree = 0; parent->children[iTree] != tree; iTree++);
 
   // Try to find splitOrder cooperating siblings in order to redistribute
   // children among them and avoid split.
@@ -117,11 +117,11 @@ SplitNonLeafNode(TreeType* tree, std::vector<bool>& relevels)
                         iTree + splitOrder : parent->NumChildren());
 
   for (size_t i = parent->NumChildren(); i > iNewSibling ; i--)
-    parent->Children()[i] = parent->Children()[i - 1];
+    parent->children[i] = parent->children[i - 1];
 
   parent->NumChildren()++;
 
-  parent->Children()[iNewSibling] = new TreeType(parent);
+  parent->children[iNewSibling] = new TreeType(parent);
 
   lastSibling = (iTree + splitOrder < parent->NumChildren() ?
                  iTree + splitOrder : parent->NumChildren() - 1);
@@ -155,20 +155,20 @@ bool HilbertRTreeSplit<splitOrder>::FindCooperatingSiblings(
   size_t iUnderfullSibling;
 
   // Try to find empty space among cooperating siblings.
-  if (parent->Children()[iTree]->NumChildren() != 0)
+  if (parent->Child(iTree).NumChildren() != 0)
   {
     for (iUnderfullSibling = start; iUnderfullSibling < end;
          iUnderfullSibling++)
-      if (parent->Children()[iUnderfullSibling]->NumChildren() <
-          parent->Children()[iUnderfullSibling]->MaxNumChildren() - 1)
+      if (parent->Child(iUnderfullSibling).NumChildren() <
+          parent->Child(iUnderfullSibling).MaxNumChildren() - 1)
         break;
   }
   else
   {
     for (iUnderfullSibling = start; iUnderfullSibling < end;
          iUnderfullSibling++)
-      if (parent->Children()[iUnderfullSibling]->NumPoints() <
-          parent->Children()[iUnderfullSibling]->MaxLeafSize() - 1)
+      if (parent->Child(iUnderfullSibling).NumPoints() <
+          parent->Child(iUnderfullSibling).MaxLeafSize() - 1)
         break;
   }
 
@@ -207,7 +207,7 @@ RedistributeNodesEvenly(const TreeType *parent,
   size_t numChildrenPerNode, numRestChildren;
 
   for (size_t i = firstSibling; i <= lastSibling; i++)
-    numChildren += parent->Children()[i]->NumChildren();
+    numChildren += parent->Child(i).NumChildren();
 
   numChildrenPerNode = numChildren / (lastSibling - firstSibling + 1);
   numRestChildren = numChildren % (lastSibling - firstSibling + 1);
@@ -218,9 +218,9 @@ RedistributeNodesEvenly(const TreeType *parent,
   size_t iChild = 0;
   for (size_t i = firstSibling; i <= lastSibling; i++)
   {
-    for (size_t j = 0; j < parent->Children()[i]->NumChildren(); j++)
+    for (size_t j = 0; j < parent->Child(i).NumChildren(); j++)
     {
-      children[iChild] = parent->Children()[i]->Children()[j];
+      children[iChild] = parent->Child(i).children[j];
       iChild++;
     }
   }
@@ -230,34 +230,34 @@ RedistributeNodesEvenly(const TreeType *parent,
   {
     // Since we redistribute children of a sibling we should recalculate the
     // bound.
-    parent->Children()[i]->Bound().Clear();
+    parent->Child(i).Bound().Clear();
 
     for (size_t j = 0; j < numChildrenPerNode; j++)
     {
-      parent->Children()[i]->Bound() |= children[iChild]->Bound();
-      parent->Children()[i]->Children()[j] = children[iChild];
-      children[iChild]->Parent() = parent->Children()[i];
+      parent->Child(i).Bound() |= children[iChild]->Bound();
+      parent->Child(i).children[j] = children[iChild];
+      children[iChild]->Parent() = parent->children[i];
       iChild++;
     }
     if (numRestChildren > 0)
     {
-      parent->Children()[i]->Bound() |= children[iChild]->Bound();
-      parent->Children()[i]->Children()[numChildrenPerNode] = children[iChild];
-      children[iChild]->Parent() = parent->Children()[i];
-      parent->Children()[i]->NumChildren() = numChildrenPerNode + 1;
+      parent->Child(i).Bound() |= children[iChild]->Bound();
+      parent->Child(i).children[numChildrenPerNode] = children[iChild];
+      children[iChild]->Parent() = parent->children[i];
+      parent->Child(i).NumChildren() = numChildrenPerNode + 1;
       numRestChildren--;
       iChild++;
     }
     else
     {
-      parent->Children()[i]->NumChildren() = numChildrenPerNode;
+      parent->Child(i).NumChildren() = numChildrenPerNode;
     }
-    assert(parent->Children()[i]->NumChildren() <=
-           parent->Children()[i]->MaxNumChildren());
+    assert(parent->Child(i).NumChildren() <=
+           parent->Child(i).MaxNumChildren());
 
     // Fix the largest Hilbert value of the sibling.
-    parent->Children()[i]->AuxiliaryInfo().HilbertValue().UpdateLargestValue(
-        parent->Children()[i]);
+    parent->Child(i).AuxiliaryInfo().HilbertValue().UpdateLargestValue(
+        parent->children[i]);
   }
 }
 
@@ -272,7 +272,7 @@ RedistributePointsEvenly(TreeType* parent,
   size_t numPointsPerNode, numRestPoints;
 
   for (size_t i = firstSibling; i <= lastSibling; i++)
-    numPoints += parent->Children()[i]->NumPoints();
+    numPoints += parent->Child(i).NumPoints();
 
   numPointsPerNode = numPoints / (lastSibling - firstSibling + 1);
   numRestPoints = numPoints % (lastSibling - firstSibling + 1);
@@ -283,8 +283,8 @@ RedistributePointsEvenly(TreeType* parent,
   size_t iPoint = 0;
   for (size_t i = firstSibling; i <= lastSibling; i++)
   {
-    for (size_t j = 0; j < parent->Children()[i]->NumPoints(); j++)
-      points[iPoint++] = parent->Children()[i]->Point(j);
+    for (size_t j = 0; j < parent->Child(i).NumPoints(); j++)
+      points[iPoint++] = parent->Child(i).Point(j);
   }
 
   iPoint = 0;
@@ -292,29 +292,29 @@ RedistributePointsEvenly(TreeType* parent,
   {
     // Since we redistribute points of a sibling we should recalculate the
     // bound.
-    parent->Children()[i]->Bound().Clear();
+    parent->Child(i).Bound().Clear();
 
     size_t j;
     for (j = 0; j < numPointsPerNode; j++)
     {
-      parent->Children()[i]->Bound() |= parent->Dataset().col(points[iPoint]);
-      parent->Children()[i]->Point(j) = points[iPoint];
+      parent->Child(i).Bound() |= parent->Dataset().col(points[iPoint]);
+      parent->Child(i).Point(j) = points[iPoint];
       iPoint++;
     }
     if (numRestPoints > 0)
     {
-      parent->Children()[i]->Bound() |= parent->Dataset().col(points[iPoint]);
-      parent->Children()[i]->Point(j) = points[iPoint];
-      parent->Children()[i]->Count() = numPointsPerNode + 1;
+      parent->Child(i).Bound() |= parent->Dataset().col(points[iPoint]);
+      parent->Child(i).Point(j) = points[iPoint];
+      parent->Child(i).Count() = numPointsPerNode + 1;
       numRestPoints--;
       iPoint++;
     }
     else
     {
-      parent->Children()[i]->Count() = numPointsPerNode;
+      parent->Child(i).Count() = numPointsPerNode;
     }
-    assert(parent->Children()[i]->NumPoints() <=
-           parent->Children()[i]->MaxLeafSize());
+    assert(parent->Child(i).NumPoints() <=
+           parent->Child(i).MaxLeafSize());
   }
 
   // Fix the largest Hilbert values of the siblings.

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_descent_heuristic_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_descent_heuristic_impl.hpp
@@ -25,7 +25,7 @@ inline size_t RStarTreeDescentHeuristic::ChooseDescentNode(
   std::vector<ElemType> originalScores(node->NumChildren());
   ElemType origMinScore = std::numeric_limits<ElemType>::max();
 
-  if (node->Children()[0]->IsLeaf())
+  if (node->Child(0).IsLeaf())
   {
     // If its children are leaf nodes, use minimum overlap to choose.
     size_t bestIndex = 0;
@@ -42,11 +42,22 @@ inline size_t RStarTreeDescentHeuristic::ChooseDescentNode(
           for (size_t k = 0; k < node->Bound().Dim(); k++)
           {
             ElemType newHigh = std::max(node->Dataset().col(point)[k],
-                node->Children()[i]->Bound()[k].Hi());
+                node->Child(i).Bound()[k].Hi());
             ElemType newLow = std::min(node->Dataset().col(point)[k],
-                node->Children()[i]->Bound()[k].Lo());
-            overlap *= node->Children()[i]->Bound()[k].Hi() < node->Children()[j]->Bound()[k].Lo() || node->Children()[i]->Bound()[k].Lo() > node->Children()[j]->Bound()[k].Hi() ? 0 : std::min(node->Children()[i]->Bound()[k].Hi(), node->Children()[j]->Bound()[k].Hi()) - std::max(node->Children()[i]->Bound()[k].Lo(), node->Children()[j]->Bound()[k].Lo());
-            newOverlap *= newHigh < node->Children()[j]->Bound()[k].Lo() || newLow > node->Children()[j]->Bound()[k].Hi() ? 0 : std::min(newHigh, node->Children()[j]->Bound()[k].Hi()) - std::max(newLow, node->Children()[j]->Bound()[k].Lo());
+                node->Child(i).Bound()[k].Lo());
+            overlap *= node->Child(i).Bound()[k].Hi() <
+                node->Child(j).Bound()[k].Lo() ||
+                node->Child(i).Bound()[k].Lo() >
+                node->Child(j).Bound()[k].Hi() ? 0 :
+                  std::min(node->Child(i).Bound()[k].Hi(),
+                           node->Child(j).Bound()[k].Hi()) -
+                  std::max(node->Child(i).Bound()[k].Lo(),
+                           node->Child(j).Bound()[k].Lo());
+
+            newOverlap *= newHigh < node->Child(j).Bound()[k].Lo() ||
+                newLow > node->Child(j).Bound()[k].Hi() ? 0 :
+                std::min(newHigh, node->Child(j).Bound()[k].Hi()) -
+                std::max(newLow, node->Child(j).Bound()[k].Lo());
           }
           sc += newOverlap - overlap;
         }
@@ -90,9 +101,13 @@ inline size_t RStarTreeDescentHeuristic::ChooseDescentNode(
       ElemType v2 = 1.0;
       for (size_t j = 0; j < node->Bound().Dim(); j++)
       {
-        v1 *= node->Children()[i]->Bound()[j].Width();
-        v2 *= node->Children()[i]->Bound()[j].Contains(node->Dataset().col(point)[j]) ? node->Children()[i]->Bound()[j].Width() : (node->Children()[i]->Bound()[j].Hi() < node->Dataset().col(point)[j] ? (node->Dataset().col(point)[j] - node->Children()[i]->Bound()[j].Lo()) :
-            (node->Children()[i]->Bound()[j].Hi() - node->Dataset().col(point)[j]));
+        v1 *= node->Child(i).Bound()[j].Width();
+        v2 *= node->Child(i).Bound()[j].Contains(
+            node->Dataset().col(point)[j]) ?
+            node->Child(i).Bound()[j].Width() :
+            (node->Child(i).Bound()[j].Hi() < node->Dataset().col(point)[j] ?
+              (node->Dataset().col(point)[j] - node->Child(i).Bound()[j].Lo()) :
+              (node->Child(i).Bound()[j].Hi() - node->Dataset().col(point)[j]));
       }
 
       assert(v2 - v1 >= 0);
@@ -157,11 +172,16 @@ inline size_t RStarTreeDescentHeuristic::ChooseDescentNode(
   {
     ElemType v1 = 1.0;
     ElemType v2 = 1.0;
-    for (size_t j = 0; j < node->Children()[i]->Bound().Dim(); j++)
+    for (size_t j = 0; j < node->Child(i).Bound().Dim(); j++)
     {
-      v1 *= node->Children()[i]->Bound()[j].Width();
-      v2 *= node->Children()[i]->Bound()[j].Contains(insertedNode->Bound()[j]) ? node->Children()[i]->Bound()[j].Width() :
-              (insertedNode->Bound()[j].Contains(node->Children()[i]->Bound()[j]) ? insertedNode->Bound()[j].Width() : (insertedNode->Bound()[j].Lo() < node->Children()[i]->Bound()[j].Lo() ? (node->Children()[i]->Bound()[j].Hi() - insertedNode->Bound()[j].Lo()) : (insertedNode->Bound()[j].Hi() - node->Children()[i]->Bound()[j].Lo())));
+      v1 *= node->Child(i).Bound()[j].Width();
+      v2 *= node->Child(i).Bound()[j].Contains(insertedNode->Bound()[j]) ?
+          node->Child(i).Bound()[j].Width() :
+          (insertedNode->Bound()[j].Contains(node->Child(i).Bound()[j]) ?
+            insertedNode->Bound()[j].Width() :
+            (insertedNode->Bound()[j].Lo() < node->Child(i).Bound()[j].Lo() ?
+            (node->Child(i).Bound()[j].Hi() - insertedNode->Bound()[j].Lo()) :
+            (insertedNode->Bound()[j].Hi() - node->Child(i).Bound()[j].Lo())));
     }
 
     assert(v2 - v1 >= 0);

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
@@ -675,6 +675,7 @@ template<typename TreeType>
 void RStarTreeSplit::InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode)
 {
   destTree->Bound() |= srcNode->Bound();
+  destTree->numDescendants += srcNode->numDescendants;
   destTree->children[destTree->NumChildren()++] = srcNode;
 }
 

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
@@ -38,7 +38,7 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     tree->Count() = 0;
     tree->NullifyData();
     // Because this was a leaf node, numChildren must be 0.
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
     assert(tree->NumChildren() == 1);
 
     RStarTreeSplit::SplitLeafNode(copy,relevels);
@@ -243,11 +243,11 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
   // Remove this node and insert treeOne and treeTwo.
   TreeType* par = tree->Parent();
   size_t index = 0;
-  while (par->Children()[index] != tree) { index++; }
+  while (par->children[index] != tree) { index++; }
 
   assert(index != par->NumChildren());
-  par->Children()[index] = treeOne;
-  par->Children()[par->NumChildren()++] = treeTwo;
+  par->children[index] = treeOne;
+  par->children[par->NumChildren()++] = treeTwo;
 
   // We only add one at a time, so we should only need to test for equality
   // just in case, we use an assert.
@@ -287,7 +287,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     copy->Parent() = tree;
     tree->NumChildren() = 0;
     tree->NullifyData();
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
 
     RStarTreeSplit::SplitNonLeafNode(copy,relevels);
     return true;
@@ -369,7 +369,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     std::vector<SortStruct<ElemType>> sorted(tree->NumChildren());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[j].Lo();
+      sorted[i].d = tree->Child(i).Bound()[j].Lo();
       sorted[i].n = i;
     }
 
@@ -405,28 +405,28 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
       std::vector<ElemType> minG2(maxG1.size());
       for (size_t k = 0; k < tree->Bound().Dim(); k++)
       {
-        minG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Lo();
-        maxG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Hi();
+        minG1[k] = tree->Child(sorted[0].n).Bound()[k].Lo();
+        maxG1[k] = tree->Child(sorted[0].n).Bound()[k].Hi();
         minG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Lo();
+            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Lo();
         maxG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Hi();
+            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Hi();
 
         for (size_t l = 1; l < tree->NumChildren() - 1; l++)
         {
           if (l < cutOff)
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG1[k])
-              minG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG1[k])
-              maxG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG1[k])
+              minG1[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG1[k])
+              maxG1[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
           else
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG2[k])
-              minG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG2[k])
-              maxG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG2[k])
+              minG2[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG2[k])
+              maxG2[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
         }
       }
@@ -481,7 +481,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     std::vector<SortStruct<ElemType>> sorted(tree->NumChildren());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[j].Hi();
+      sorted[i].d = tree->Child(i).Bound()[j].Hi();
       sorted[i].n = i;
     }
 
@@ -518,28 +518,28 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
 
       for (size_t k = 0; k < tree->Bound().Dim(); k++)
       {
-        minG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Lo();
-        maxG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Hi();
+        minG1[k] = tree->Child(sorted[0].n).Bound()[k].Lo();
+        maxG1[k] = tree->Child(sorted[0].n).Bound()[k].Hi();
         minG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Lo();
+            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Lo();
         maxG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Hi();
+            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Hi();
 
         for (size_t l = 1; l < tree->NumChildren() - 1; l++)
         {
           if (l < cutOff)
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG1[k])
-              minG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG1[k])
-              maxG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG1[k])
+              minG1[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG1[k])
+              maxG1[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
           else
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG2[k])
-              minG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG2[k])
-              maxG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG2[k])
+              minG2[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG2[k])
+              maxG2[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
         }
       }
@@ -593,7 +593,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
   {
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[bestAxis].Lo();
+      sorted[i].d = tree->Child(i).Bound()[bestAxis].Lo();
       sorted[i].n = i;
     }
   }
@@ -601,7 +601,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
   {
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[bestAxis].Hi();
+      sorted[i].d = tree->Child(i).Bound()[bestAxis].Hi();
       sorted[i].n = i;
     }
   }
@@ -616,9 +616,9 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     for (size_t i = 0; i < tree->NumChildren(); i++)
     {
       if (i < bestAreaIndexOnBestAxis + tree->MinNumChildren())
-        InsertNodeIntoTree(treeOne, tree->Children()[sorted[i].n]);
+        InsertNodeIntoTree(treeOne, &(tree->Child(sorted[i].n)));
       else
-        InsertNodeIntoTree(treeTwo, tree->Children()[sorted[i].n]);
+        InsertNodeIntoTree(treeTwo, &(tree->Child(sorted[i].n)));
     }
   }
   else
@@ -626,19 +626,19 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     for (size_t i = 0; i < tree->NumChildren(); i++)
     {
       if (i < bestOverlapIndexOnBestAxis + tree->MinNumChildren())
-        InsertNodeIntoTree(treeOne, tree->Children()[sorted[i].n]);
+        InsertNodeIntoTree(treeOne, &(tree->Child(sorted[i].n)));
       else
-        InsertNodeIntoTree(treeTwo, tree->Children()[sorted[i].n]);
+        InsertNodeIntoTree(treeTwo, &(tree->Child(sorted[i].n)));
     }
   }
 
   // Remove this node and insert treeOne and treeTwo
   TreeType* par = tree->Parent();
   size_t index = 0;
-  while (par->Children()[index] != tree) { index++; }
+  while (par->children[index] != tree) { index++; }
 
-  par->Children()[index] = treeOne;
-  par->Children()[par->NumChildren()++] = treeTwo;
+  par->children[index] = treeOne;
+  par->children[par->NumChildren()++] = treeTwo;
 
   // We only add one at a time, so we should only need to test for equality
   // just in case, we use an assert.
@@ -649,10 +649,10 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
   // We have to update the children of each of these new nodes so that they
   // record the correct parent.
   for (size_t i = 0; i < treeOne->NumChildren(); i++)
-    treeOne->Children()[i]->Parent() = treeOne;
+    treeOne->children[i]->Parent() = treeOne;
 
   for (size_t i = 0; i < treeTwo->NumChildren(); i++)
-    treeTwo->Children()[i]->Parent() = treeTwo;
+    treeTwo->children[i]->Parent() = treeTwo;
 
   assert(treeOne->Parent()->NumChildren() <= treeOne->MaxNumChildren());
   assert(treeOne->Parent()->NumChildren() >= treeOne->MinNumChildren());
@@ -675,7 +675,7 @@ template<typename TreeType>
 void RStarTreeSplit::InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode)
 {
   destTree->Bound() |= srcNode->Bound();
-  destTree->Children()[destTree->NumChildren()++] = srcNode;
+  destTree->children[destTree->NumChildren()++] = srcNode;
 }
 
 } // namespace tree

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_descent_heuristic_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_descent_heuristic_impl.hpp
@@ -28,14 +28,14 @@ inline size_t RTreeDescentHeuristic::ChooseDescentNode(const TreeType* node,
   {
     ElemType v1 = 1.0;
     ElemType v2 = 1.0;
-    for (size_t j = 0; j < node->Children()[i]->Bound().Dim(); j++)
+    for (size_t j = 0; j < node->Child(i).Bound().Dim(); j++)
     {
-      v1 *= node->Children()[i]->Bound()[j].Width();
-      v2 *= node->Children()[i]->Bound()[j].Contains(node->Dataset().col(point)[j]) ?
-          node->Children()[i]->Bound()[j].Width() :
-          (node->Children()[i]->Bound()[j].Hi() < node->Dataset().col(point)[j] ?
-              (node->Dataset().col(point)[j] - node->Children()[i]->Bound()[j].Lo()) :
-              (node->Children()[i]->Bound()[j].Hi() - node->Dataset().col(point)[j]));
+      v1 *= node->Child(i).Bound()[j].Width();
+      v2 *= node->Child(i).Bound()[j].Contains(node->Dataset().col(point)[j]) ?
+          node->Child(i).Bound()[j].Width() :
+          (node->Child(i).Bound()[j].Hi() < node->Dataset().col(point)[j] ?
+              (node->Dataset().col(point)[j] - node->Child(i).Bound()[j].Lo()) :
+              (node->Child(i).Bound()[j].Hi() - node->Dataset().col(point)[j]));
     }
 
     assert(v2 - v1 >= 0);
@@ -72,17 +72,17 @@ inline size_t RTreeDescentHeuristic::ChooseDescentNode(
   {
     ElemType v1 = 1.0;
     ElemType v2 = 1.0;
-    for (size_t j = 0; j < node->Children()[i]->Bound().Dim(); j++)
+    for (size_t j = 0; j < node->Child(i).Bound().Dim(); j++)
     {
-      v1 *= node->Children()[i]->Bound()[j].Width();
-      v2 *= node->Children()[i]->Bound()[j].Contains(insertedNode->Bound()[j]) ?
-          node->Children()[i]->Bound()[j].Width() :
-          (insertedNode->Bound()[j].Contains(node->Children()[i]->Bound()[j]) ?
+      v1 *= node->Child(i).Bound()[j].Width();
+      v2 *= node->Child(i).Bound()[j].Contains(insertedNode->Bound()[j]) ?
+          node->Child(i).Bound()[j].Width() :
+          (insertedNode->Bound()[j].Contains(node->Child(i).Bound()[j]) ?
           insertedNode->Bound()[j].Width() :
-          (insertedNode->Bound()[j].Lo() < node->Children()[i]->Bound()[j].Lo()
-          ? (node->Children()[i]->Bound()[j].Hi() -
+          (insertedNode->Bound()[j].Lo() < node->Child(i).Bound()[j].Lo()
+          ? (node->Child(i).Bound()[j].Hi() -
           insertedNode->Bound()[j].Lo()) : (insertedNode->Bound()[j].Hi() -
-          node->Children()[i]->Bound()[j].Lo())));
+          node->Child(i).Bound()[j].Lo())));
     }
 
     assert(v2 - v1 >= 0);

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
@@ -34,7 +34,7 @@ void RTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     tree->Count() = 0;
     tree->NullifyData();
     // Because this was a leaf node, numChildren must be 0.
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
     RTreeSplit::SplitLeafNode(copy,relevels);
     return;
   }
@@ -57,10 +57,10 @@ void RTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
   // Remove this node and insert treeOne and treeTwo.
   TreeType* par = tree->Parent();
   size_t index = 0;
-  while (par->Children()[index] != tree) { ++index; }
+  while (par->children[index] != tree) { ++index; }
 
-  par->Children()[index] = treeOne;
-  par->Children()[par->NumChildren()++] = treeTwo;
+  par->children[index] = treeOne;
+  par->children[par->NumChildren()++] = treeTwo;
 
   // We only add one at a time, so we should only need to test for equality
   // just in case, we use an assert.
@@ -97,7 +97,7 @@ bool RTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
     copy->Parent() = tree;
     tree->NumChildren() = 0;
     tree->NullifyData();
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
     RTreeSplit::SplitNonLeafNode(copy,relevels);
     return true;
   }
@@ -117,14 +117,14 @@ bool RTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
   // Remove this node and insert treeOne and treeTwo.
   TreeType* par = tree->Parent();
   size_t index = 0;
-  while (par->Children()[index] != tree) { ++index; }
+  while (par->children[index] != tree) { ++index; }
 
   assert(index != par->NumChildren());
-  par->Children()[index] = treeOne;
-  par->Children()[par->NumChildren()++] = treeTwo;
+  par->children[index] = treeOne;
+  par->children[par->NumChildren()++] = treeTwo;
 
   for (size_t i = 0; i < par->NumChildren(); i++)
-    assert(par->Children()[i] != tree);
+    assert(par->children[i] != tree);
 
   // We only add one at a time, so should only need to test for equality just in
   // case, we use an assert.
@@ -136,10 +136,10 @@ bool RTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
   // We have to update the children of each of these new nodes so that they
   // record the correct parent.
   for (size_t i = 0; i < treeOne->NumChildren(); i++)
-    treeOne->Children()[i]->Parent() = treeOne;
+    treeOne->children[i]->Parent() = treeOne;
 
   for (size_t i = 0; i < treeTwo->NumChildren(); i++)
-    treeTwo->Children()[i]->Parent() = treeTwo;
+    treeTwo->children[i]->Parent() = treeTwo;
 
   assert(treeOne->NumChildren() <= treeOne->MaxNumChildren());
   assert(treeTwo->NumChildren() <= treeTwo->MaxNumChildren());
@@ -369,22 +369,22 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
 
   for (size_t i = 0; i < oldTree->NumChildren(); i++)
     for (size_t j = i + 1; j < oldTree->NumChildren(); j++)
-      assert(oldTree->Children()[i] != oldTree->Children()[j]);
+      assert(oldTree->children[i] != oldTree->children[j]);
 
-  InsertNodeIntoTree(treeOne, oldTree->Children()[intI]);
-  InsertNodeIntoTree(treeTwo, oldTree->Children()[intJ]);
+  InsertNodeIntoTree(treeOne, oldTree->children[intI]);
+  InsertNodeIntoTree(treeTwo, oldTree->children[intJ]);
 
   // If intJ is the last node in the tree, we need to switch the order so that
   // we remove the correct nodes.
   if (intI > intJ)
   {
-    oldTree->Children()[intI] = oldTree->Children()[--end];
-    oldTree->Children()[intJ] = oldTree->Children()[--end];
+    oldTree->children[intI] = oldTree->children[--end];
+    oldTree->children[intJ] = oldTree->children[--end];
   }
   else
   {
-    oldTree->Children()[intJ] = oldTree->Children()[--end];
-    oldTree->Children()[intI] = oldTree->Children()[--end];
+    oldTree->children[intJ] = oldTree->children[--end];
+    oldTree->children[intI] = oldTree->children[--end];
   }
 
   assert(treeOne->NumChildren() == 1);
@@ -392,13 +392,13 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
 
   for (size_t i = 0; i < end; i++)
     for (size_t j = i + 1; j < end; j++)
-      assert(oldTree->Children()[i] != oldTree->Children()[j]);
+      assert(oldTree->children[i] != oldTree->children[j]);
 
   for (size_t i = 0; i < end; i++)
-    assert(oldTree->Children()[i] != treeOne->Children()[0]);
+    assert(oldTree->children[i] != treeOne->children[0]);
 
   for (size_t i = 0; i < end; i++)
-    assert(oldTree->Children()[i] != treeTwo->Children()[0]);
+    assert(oldTree->children[i] != treeTwo->children[0]);
 
   size_t numAssignTreeOne = 1;
   size_t numAssignTreeTwo = 1;
@@ -471,16 +471,16 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
     // to the appropriate rectangle.
     if (bestRect == 1)
     {
-      InsertNodeIntoTree(treeOne, oldTree->Children()[bestIndex]);
+      InsertNodeIntoTree(treeOne, oldTree->children[bestIndex]);
       numAssignTreeOne++;
     }
     else
     {
-      InsertNodeIntoTree(treeTwo, oldTree->Children()[bestIndex]);
+      InsertNodeIntoTree(treeTwo, oldTree->children[bestIndex]);
       numAssignTreeTwo++;
     }
 
-    oldTree->Children()[bestIndex] = oldTree->Children()[--end];
+    oldTree->children[bestIndex] = oldTree->children[--end];
   }
 
   // See if we need to satisfy the minimum fill.
@@ -490,7 +490,7 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
     {
       for (size_t i = 0; i < end; i++)
       {
-        InsertNodeIntoTree(treeOne, oldTree->Children()[i]);
+        InsertNodeIntoTree(treeOne, oldTree->children[i]);
         numAssignTreeOne++;
       }
     }
@@ -498,7 +498,7 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
     {
       for (size_t i = 0; i < end; i++)
       {
-        InsertNodeIntoTree(treeTwo, oldTree->Children()[i]);
+        InsertNodeIntoTree(treeTwo, oldTree->children[i]);
         numAssignTreeTwo++;
       }
     }
@@ -506,11 +506,11 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
 
   for (size_t i = 0; i < treeOne->NumChildren(); i++)
     for (size_t j = i + 1; j < treeOne->NumChildren(); j++)
-      assert(treeOne->Children()[i] != treeOne->Children()[j]);
+      assert(treeOne->children[i] != treeOne->children[j]);
 
   for (size_t i = 0; i < treeTwo->NumChildren(); i++)
     for (size_t j = i + 1; j < treeTwo->NumChildren(); j++)
-      assert(treeTwo->Children()[i] != treeTwo->Children()[j]);
+      assert(treeTwo->children[i] != treeTwo->children[j]);
 }
 
 /**
@@ -521,7 +521,7 @@ template<typename TreeType>
 void RTreeSplit::InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode)
 {
   destTree->Bound() |= srcNode->Bound();
-  destTree->Children()[destTree->NumChildren()++] = srcNode;
+  destTree->children[destTree->NumChildren()++] = srcNode;
 }
 
 } // namespace tree

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
@@ -521,6 +521,7 @@ template<typename TreeType>
 void RTreeSplit::InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode)
 {
   destTree->Bound() |= srcNode->Bound();
+  destTree->numDescendants += srcNode->numDescendants;
   destTree->children[destTree->NumChildren()++] = srcNode;
 }
 

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -56,7 +56,8 @@ class RectangleTree
   typedef MatType Mat;
   //! The element type held by the matrix type.
   typedef typename MatType::elem_type ElemType;
-
+  //! The auxiliary information type held by the tree.
+  typedef AuxiliaryInformationType<RectangleTree> AuxiliaryInformation;
  private:
   //! The max number of child nodes a non-leaf node can have.
   size_t maxNumChildren;
@@ -515,7 +516,7 @@ class RectangleTree
   friend SplitType;
 
   //! Give friend access for AuxiliaryInformationType.
-  friend class AuxiliaryInformationType<RectangleTree>;
+  friend AuxiliaryInformation;
 
  public:
   /**

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -76,6 +76,8 @@ class RectangleTree
   //! The number of points in the dataset contained in this node (and its
   //! children).
   size_t count;
+  //! The number of descendants of this node.
+  size_t numDescendants;
   //! The max leaf size.
   size_t maxLeafSize;
   //! The minimum leaf size.

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -339,11 +339,6 @@ class RectangleTree
   //! Modify the number of child nodes.  Be careful.
   size_t& NumChildren() { return numChildren; }
 
-  //! Get the children of this node.
-  const std::vector<RectangleTree*>& Children() const { return children; }
-  //! Modify the children of this node.
-  std::vector<RectangleTree*>& Children() { return children; }
-
   /**
    * Return the furthest distance to a point held in this node.  If this is not
    * a leaf node, then the distance is 0 because the node holds no points.
@@ -513,6 +508,12 @@ class RectangleTree
 
   //! Friend access is given for the default constructor.
   friend class boost::serialization::access;
+
+  //! Give friend access for SplitType.
+  friend SplitType;
+
+  //! Give friend access for AuxiliaryInformationType.
+  friend class AuxiliaryInformationType<RectangleTree>;
 
  public:
   /**

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree_impl.hpp
@@ -162,11 +162,11 @@ RectangleTree(
     if (numChildren > 0)
     {
       for (size_t i = 0; i < numChildren; i++)
-        children[i] = new RectangleTree(*(other.Children()[i]));
+        children[i] = new RectangleTree(other.Child(i));
     }
   }
   else
-    children = other.Children();
+    children = other.children;
 }
 
 /**
@@ -477,7 +477,7 @@ bool RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
 
     bool contains = true;
     for (size_t j = 0; j < node->Bound().Dim(); j++)
-      contains &= Children()[i]->Bound()[j].Contains(node->Bound()[j]);
+      contains &= Child(i).Bound()[j].Contains(node->Bound()[j]);
 
     if (contains)
       if (children[i]->RemoveNode(node, relevels))
@@ -517,7 +517,7 @@ size_t RectangleTree<MetricType, StatisticType, MatType, SplitType,
 
   while (!currentNode->IsLeaf())
   {
-    currentNode = currentNode->Children()[0];
+    currentNode = currentNode->children[0];
     n++;
   }
 
@@ -743,12 +743,12 @@ void RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
     // We can't delete the root node.
     for (size_t i = 0; i < parent->NumChildren(); i++)
     {
-      if (parent->Children()[i] == this)
+      if (parent->children[i] == this)
       {
         // Decrement numChildren.
         if (!auxiliaryInfo.HandleNodeRemoval(parent, i))
         {
-          parent->Children()[i] = parent->Children()[--parent->NumChildren()];
+          parent->children[i] = parent->children[--parent->NumChildren()];
         }
 
         // We find the root and shrink bounds at the same time.
@@ -796,12 +796,12 @@ void RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
       // The normal case.  We need to be careful with the root.
       for (size_t j = 0; j < parent->NumChildren(); j++)
       {
-        if (parent->Children()[j] == this)
+        if (parent->children[j] == this)
         {
           // Decrement numChildren.
           if (!auxiliaryInfo.HandleNodeRemoval(parent,j))
           {
-            parent->Children()[j] = parent->Children()[--parent->NumChildren()];
+            parent->children[j] = parent->children[--parent->NumChildren()];
           }
           size_t level = TreeDepth();
 
@@ -854,7 +854,7 @@ void RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
       }
 
       for (size_t i = 0; i < child->NumChildren(); i++) {
-        children[i] = child->Children()[i];
+        children[i] = child->children[i];
         children[i]->Parent() = this;
       }
 

--- a/src/mlpack/core/tree/rectangle_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/single_tree_traverser_impl.hpp
@@ -59,7 +59,7 @@ SingleTreeTraverser<RuleType>::Traverse(
   std::vector<NodeAndScore> nodesAndScores(referenceNode.NumChildren());
   for (size_t i = 0; i < referenceNode.NumChildren(); i++)
   {
-    nodesAndScores[i].node = referenceNode.Children()[i];
+    nodesAndScores[i].node = &(referenceNode.Child(i));
     nodesAndScores[i].score = rule.Score(queryIndex, *nodesAndScores[i].node);
   }
 

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
@@ -37,7 +37,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     tree->Count() = 0;
     tree->NullifyData();
     // Because this was a leaf node, numChildren must be 0.
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
     assert(tree->NumChildren() == 1);
     XTreeSplit::SplitLeafNode(copy,relevels);
     return;
@@ -254,15 +254,15 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
   size_t index = par->NumChildren();
   for (size_t i = 0; i < par->NumChildren(); i++)
   {
-    if (par->Children()[i] == tree)
+    if (par->children[i] == tree)
     {
       index = i;
       break;
     }
   }
   assert(index != par->NumChildren());
-  par->Children()[index] = treeOne;
-  par->Children()[par->NumChildren()++] = treeTwo;
+  par->children[index] = treeOne;
+  par->children[par->NumChildren()++] = treeTwo;
 
   // We now update the split history of each new node.
   treeOne->AuxiliaryInfo().SplitHistory().history[bestAxis] = true;
@@ -312,7 +312,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
     copy->Parent() = tree;
     tree->NumChildren() = 0;
     tree->NullifyData();
-    tree->Children()[(tree->NumChildren())++] = copy;
+    tree->children[(tree->NumChildren())++] = copy;
     XTreeSplit::SplitNonLeafNode(copy,relevels);
     return true;
   }
@@ -388,7 +388,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
     std::vector<sortStruct<ElemType>> sorted(tree->NumChildren());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[j].Lo();
+      sorted[i].d = tree->Child(i).Bound()[j].Lo();
       sorted[i].n = i;
     }
 
@@ -422,27 +422,27 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       std::vector<ElemType> minG2(maxG1.size());
       for (size_t k = 0; k < tree->Bound().Dim(); k++)
       {
-        minG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Lo();
-        maxG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Hi();
+        minG1[k] = tree->Child(sorted[0].n).Bound()[k].Lo();
+        maxG1[k] = tree->Child(sorted[0].n).Bound()[k].Hi();
         minG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Lo();
+            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Lo();
         maxG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Hi();
+            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Hi();
         for (size_t l = 1; l < tree->NumChildren() - 1; l++)
         {
           if (l < cutOff)
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG1[k])
-              minG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG1[k])
-              maxG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG1[k])
+              minG1[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG1[k])
+              maxG1[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
           else
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG2[k])
-              minG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG2[k])
-              maxG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG2[k])
+              minG2[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG2[k])
+              maxG2[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
         }
       }
@@ -519,7 +519,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
     std::vector<sortStruct<ElemType>> sorted(tree->NumChildren());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[j].Hi();
+      sorted[i].d = tree->Child(i).Bound()[j].Hi();
       sorted[i].n = i;
     }
 
@@ -553,27 +553,25 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       std::vector<ElemType> minG2(maxG1.size());
       for (size_t k = 0; k < tree->Bound().Dim(); k++)
       {
-        minG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Lo();
-        maxG1[k] = tree->Children()[sorted[0].n]->Bound()[k].Hi();
-        minG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Lo();
-        maxG2[k] =
-            tree->Children()[sorted[sorted.size() - 1].n]->Bound()[k].Hi();
+        minG1[k] = tree->Child(sorted[0].n).Bound()[k].Lo();
+        maxG1[k] = tree->Child(sorted[0].n).Bound()[k].Hi();
+        minG2[k] = tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Lo();
+        maxG2[k] = tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Hi();
         for (size_t l = 1; l < tree->NumChildren() - 1; l++)
         {
           if (l < cutOff)
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG1[k])
-              minG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG1[k])
-              maxG1[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG1[k])
+              minG1[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG1[k])
+              maxG1[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
           else
           {
-            if (tree->Children()[sorted[l].n]->Bound()[k].Lo() < minG2[k])
-              minG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Lo();
-            else if (tree->Children()[sorted[l].n]->Bound()[k].Hi() > maxG2[k])
-              maxG2[k] = tree->Children()[sorted[l].n]->Bound()[k].Hi();
+            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG2[k])
+              minG2[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
+            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG2[k])
+              maxG2[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
           }
         }
       }
@@ -649,7 +647,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
   {
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[bestAxis].Lo();
+      sorted[i].d = tree->Child(i).Bound()[bestAxis].Lo();
       sorted[i].n = i;
     }
   }
@@ -657,7 +655,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
   {
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Children()[i]->Bound()[bestAxis].Hi();
+      sorted[i].d = tree->Child(i).Bound()[bestAxis].Hi();
       sorted[i].n = i;
     }
   }
@@ -676,9 +674,9 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       for (size_t i = 0; i < tree->NumChildren(); i++)
       {
         if (i < bestAreaIndexOnBestAxis + tree->MinNumChildren())
-          InsertNodeIntoTree(treeOne, tree->Children()[sorted[i].n]);
+          InsertNodeIntoTree(treeOne, tree->children[sorted[i].n]);
         else
-          InsertNodeIntoTree(treeTwo, tree->Children()[sorted[i].n]);
+          InsertNodeIntoTree(treeTwo, tree->children[sorted[i].n]);
       }
     }
     else
@@ -691,9 +689,9 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       for (size_t i = 0; i < tree->NumChildren(); i++)
       {
         if (i < bestOverlapIndexOnBestAxis + tree->MinNumChildren())
-          InsertNodeIntoTree(treeOne, tree->Children()[sorted[i].n]);
+          InsertNodeIntoTree(treeOne, tree->children[sorted[i].n]);
         else
-          InsertNodeIntoTree(treeTwo, tree->Children()[sorted[i].n]);
+          InsertNodeIntoTree(treeTwo, tree->children[sorted[i].n]);
       }
     }
     else
@@ -714,7 +712,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       {
         for (size_t i = 0; i < sorted2.size(); i++)
         {
-          sorted2[i].d = tree->Children()[i]->Bound()[bestAxis].Hi();
+          sorted2[i].d = tree->Child(i).Bound()[bestAxis].Hi();
           sorted2[i].n = i;
         }
       }
@@ -722,7 +720,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       {
         for (size_t i = 0; i < sorted2.size(); i++)
         {
-          sorted2[i].d = tree->Children()[i]->Bound()[bestAxis].Lo();
+          sorted2[i].d = tree->Child(i).Bound()[bestAxis].Lo();
           sorted2[i].n = i;
         }
       }
@@ -730,9 +728,9 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       for (size_t i = 0; i < tree->NumChildren(); i++)
       {
         if (i < bestIndexMinOverlapSplit + tree->MinNumChildren())
-          InsertNodeIntoTree(treeOne, tree->Children()[sorted[i].n]);
+          InsertNodeIntoTree(treeOne, tree->children[sorted[i].n]);
         else
-          InsertNodeIntoTree(treeTwo, tree->Children()[sorted[i].n]);
+          InsertNodeIntoTree(treeTwo, tree->children[sorted[i].n]);
       }
     }
     else
@@ -752,11 +750,11 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
         // We make the root a supernode instead.
         tree->Parent()->MaxNumChildren() = tree->MaxNumChildren() + 
                               tree->AuxiliaryInfo().NormalNodeMaxNumChildren();
-        tree->Parent()->Children().resize(tree->Parent()->MaxNumChildren() + 1);
+        tree->Parent()->children.resize(tree->Parent()->MaxNumChildren() + 1);
         tree->Parent()->NumChildren() = tree->NumChildren();
         for (size_t i = 0; i < tree->NumChildren(); i++)
         {
-          tree->Parent()->Children()[i] = tree->Children()[i];
+          tree->Parent()->children[i] = tree->children[i];
           tree->Child(i).Parent() = tree->Parent();
         }
 
@@ -770,7 +768,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       // If we don't have to worry about the root, we just enlarge this node.
       tree->MaxNumChildren() += 
                               tree->AuxiliaryInfo().NormalNodeMaxNumChildren();
-      tree->Children().resize(tree->MaxNumChildren() + 1);
+      tree->children.resize(tree->MaxNumChildren() + 1);
       for (size_t i = 0; i < tree->NumChildren(); i++)
         tree->Child(i).Parent() = tree;
 
@@ -792,15 +790,15 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
   size_t index = 0;
   for (size_t i = 0; i < par->NumChildren(); i++)
   {
-    if (par->Children()[i] == tree)
+    if (par->children[i] == tree)
     {
       index = i;
       break;
     }
   }
 
-  par->Children()[index] = treeOne;
-  par->Children()[par->NumChildren()++] = treeTwo;
+  par->children[index] = treeOne;
+  par->children[par->NumChildren()++] = treeTwo;
 
   // we only add one at a time, so we should only need to test for equality
   // just in case, we use an assert.
@@ -816,9 +814,9 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
   // We have to update the children of each of these new nodes so that they
   // record the correct parent.
   for (size_t i = 0; i < treeOne->NumChildren(); i++)
-    treeOne->Children()[i]->Parent() = treeOne;
+    treeOne->Child(i).Parent() = treeOne;
   for (size_t i = 0; i < treeTwo->NumChildren(); i++)
-    treeTwo->Children()[i]->Parent() = treeTwo;
+    treeTwo->Child(i).Parent() = treeTwo;
 
   assert(treeOne->Parent()->NumChildren() <=
       treeOne->Parent()->MaxNumChildren());
@@ -842,7 +840,7 @@ template<typename TreeType>
 void XTreeSplit::InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode)
 {
   destTree->Bound() |= srcNode->Bound();
-  destTree->Children()[destTree->NumChildren()] = srcNode;
+  destTree->children[destTree->NumChildren()] = srcNode;
   destTree->NumChildren()++;
 }
 

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
@@ -840,6 +840,7 @@ template<typename TreeType>
 void XTreeSplit::InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode)
 {
   destTree->Bound() |= srcNode->Bound();
+  destTree->numDescendants += srcNode->numDescendants;
   destTree->children[destTree->NumChildren()] = srcNode;
   destTree->NumChildren()++;
 }

--- a/src/mlpack/tests/rectangle_tree_test.cpp
+++ b/src/mlpack/tests/rectangle_tree_test.cpp
@@ -316,6 +316,28 @@ int GetMinLevel(const TreeType& tree)
   return min;
 }
 
+/**
+ * A function to check that numDescendants values are set correctly.
+ */
+template<typename TreeType>
+size_t CheckNumDescendants(const TreeType& tree)
+{
+  if (tree.IsLeaf())
+  {
+    BOOST_REQUIRE_EQUAL(tree.NumDescendants(), tree.Count());
+    return tree.Count();
+  }
+
+  size_t numDescendants = 0;
+
+  for (size_t i = 0; i < tree.NumChildren(); i++)
+    numDescendants += CheckNumDescendants(tree.Child(i));
+
+  BOOST_REQUIRE_EQUAL(tree.NumDescendants(), numDescendants);
+
+  return numDescendants;
+}
+
 // A test to ensure that all leaf nodes are stored on the same level of the
 // tree.
 BOOST_AUTO_TEST_CASE(TreeBalance)
@@ -378,6 +400,7 @@ BOOST_AUTO_TEST_CASE(PointDeletion)
 
   CheckContainment(tree);
   CheckExactContainment(tree);
+  CheckNumDescendants(tree);
 
   // Single-tree search.
   NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
@@ -460,6 +483,7 @@ BOOST_AUTO_TEST_CASE(PointDynamicAdd)
   BOOST_REQUIRE_EQUAL(tree.NumDescendants(), 1000 + numIter);
   CheckContainment(tree);
   CheckExactContainment(tree);
+  CheckNumDescendants(tree);
 
   // Now we will compare the output of the R Tree vs the output of a naive
   // search.
@@ -510,6 +534,7 @@ BOOST_AUTO_TEST_CASE(SingleTreeTraverserTest)
   CheckContainment(rTree);
   CheckExactContainment(rTree);
   CheckHierarchy(rTree);
+  CheckNumDescendants(rTree);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -552,6 +577,7 @@ BOOST_AUTO_TEST_CASE(XTreeTraverserTest)
   CheckContainment(xTree);
   CheckExactContainment(xTree);
   CheckHierarchy(xTree);
+  CheckNumDescendants(xTree);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -592,6 +618,7 @@ BOOST_AUTO_TEST_CASE(HilbertRTreeTraverserTest)
   CheckContainment(hilbertRTree);
   CheckExactContainment(hilbertRTree);
   CheckHierarchy(hilbertRTree);
+  CheckNumDescendants(hilbertRTree);
 
   knn1.Search(5, neighbors1, distances1);
 

--- a/src/mlpack/tests/rectangle_tree_test.cpp
+++ b/src/mlpack/tests/rectangle_tree_test.cpp
@@ -69,7 +69,7 @@ std::vector<arma::vec*> GetAllPointsInTree(const TreeType& tree)
   {
     for (size_t i = 0; i < tree.NumChildren(); i++)
     {
-      std::vector<arma::vec*> tmp = GetAllPointsInTree(*(tree.Children()[i]));
+      std::vector<arma::vec*> tmp = GetAllPointsInTree(tree.Child(i));
       vec.insert(vec.begin(), tmp.begin(), tmp.end());
     }
   }
@@ -137,9 +137,9 @@ void CheckContainment(const TreeType& tree)
     for (size_t i = 0; i < tree.NumChildren(); i++)
     {
       for (size_t j = 0; j < tree.Bound().Dim(); j++)
-        BOOST_REQUIRE(tree.Bound()[j].Contains(tree.Children()[i]->Bound()[j]));
+        BOOST_REQUIRE(tree.Bound()[j].Contains(tree.Child(i).Bound()[j]));
 
-      CheckContainment(*(tree.Children()[i]));
+      CheckContainment(tree.Child(i));
     }
   }
 }
@@ -244,7 +244,7 @@ void CheckFills(const TreeType& tree)
       BOOST_REQUIRE(tree.NumChildren() >= tree.MinNumChildren() ||
                     tree.Parent() == NULL);
       BOOST_REQUIRE(tree.NumChildren() <= tree.MaxNumChildren());
-      CheckFills(*tree.Children()[i]);
+      CheckFills(tree.Child(i));
     }
   }
 }
@@ -279,7 +279,7 @@ int GetMaxLevel(const TreeType& tree)
     int m = 0;
     for (size_t i = 0; i < tree.NumChildren(); i++)
     {
-      int n = GetMaxLevel(*tree.Children()[i]);
+      int n = GetMaxLevel(tree.Child(i));
       if (n > m)
         m = n;
     }
@@ -306,7 +306,7 @@ int GetMinLevel(const TreeType& tree)
     int m = INT_MAX;
     for (size_t i = 0; i < tree.NumChildren(); i++)
     {
-      int n = GetMinLevel(*tree.Children()[i]);
+      int n = GetMinLevel(tree.Child(i));
       if (n < m)
         m = n;
     }
@@ -853,77 +853,77 @@ BOOST_AUTO_TEST_CASE(RTreeSplitTest)
   BOOST_REQUIRE_EQUAL(rTree.TreeDepth(), 3);
 
   int firstChild = 0, secondChild = 1;
-  if (rTree.Children()[firstChild]->NumChildren() == 2)
+  if (rTree.Child(firstChild).NumChildren() == 2)
   {
     firstChild = 1;
     secondChild = 0;
   }
 
-  BOOST_REQUIRE_SMALL(rTree.Children()[firstChild]->Bound()[0].Lo(), 1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[firstChild]->Bound()[0].Hi(), 0.1,
+  BOOST_REQUIRE_SMALL(rTree.Child(firstChild).Bound()[0].Lo(), 1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(firstChild).Bound()[0].Hi(), 0.1,
       1e-15);
-  BOOST_REQUIRE_SMALL(rTree.Children()[firstChild]->Bound()[1].Lo(), 1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[firstChild]->Bound()[1].Hi(), 1.0,
-      1e-15);
-
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[0].Lo(), 0.3,
-      1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[0].Hi(), 1.0,
-      1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[1].Lo(), 0.1,
-      1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[1].Hi(), 0.9,
+  BOOST_REQUIRE_SMALL(rTree.Child(firstChild).Bound()[1].Lo(), 1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(firstChild).Bound()[1].Hi(), 1.0,
       1e-15);
 
-  BOOST_REQUIRE_EQUAL(rTree.Children()[firstChild]->NumChildren(), 1);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[0].Lo(), 0.3,
+      1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[0].Hi(), 1.0,
+      1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[1].Lo(), 0.1,
+      1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[1].Hi(), 0.9,
+      1e-15);
+
+  BOOST_REQUIRE_EQUAL(rTree.Child(firstChild).NumChildren(), 1);
   BOOST_REQUIRE_SMALL(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[0].Lo(), 1e-15);
+      rTree.Child(firstChild).Child(0).Bound()[0].Lo(), 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[0].Hi(), 0.1,
+      rTree.Child(firstChild).Child(0).Bound()[0].Hi(), 0.1,
       1e-15);
   BOOST_REQUIRE_SMALL(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[1].Lo(), 1e-15);
+      rTree.Child(firstChild).Child(0).Bound()[1].Lo(), 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[1].Hi(), 1.0,
+      rTree.Child(firstChild).Child(0).Bound()[1].Hi(), 1.0,
       1e-15);
-  BOOST_REQUIRE_EQUAL(rTree.Children()[firstChild]->Children()[0]->Count(), 3);
+  BOOST_REQUIRE_EQUAL(rTree.Child(firstChild).Child(0).Count(), 3);
 
   int firstPrime = 0, secondPrime = 1;
-  if (rTree.Children()[secondChild]->Children()[firstPrime]->Count() == 3)
+  if (rTree.Child(secondChild).Child(firstPrime).Count() == 3)
   {
     firstPrime = 1;
     secondPrime = 0;
   }
 
-  BOOST_REQUIRE_EQUAL(rTree.Children()[secondChild]->NumChildren(), 2);
+  BOOST_REQUIRE_EQUAL(rTree.Child(secondChild).NumChildren(), 2);
   BOOST_REQUIRE_EQUAL(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Count(), 4);
+      rTree.Child(secondChild).Child(firstPrime).Count(), 4);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[0].Lo(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[0].Lo(),
       0.3, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[0].Hi(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[0].Hi(),
       0.7, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[1].Lo(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[1].Lo(),
       0.3, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[1].Hi(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[1].Hi(),
       0.7, 1e-15);
 
   BOOST_REQUIRE_EQUAL(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Count(), 3);
+      rTree.Child(secondChild).Child(secondPrime).Count(), 3);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[0].Lo(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[0].Lo(),
       0.9, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[0].Hi(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[0].Hi(),
       1.0, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[1].Lo(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[1].Lo(),
       0.1, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[1].Hi(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[1].Hi(),
       0.9, 1e-15);
 }
 
@@ -955,75 +955,75 @@ BOOST_AUTO_TEST_CASE(RStarTreeSplitTest)
   BOOST_REQUIRE_EQUAL(rTree.TreeDepth(), 3);
 
   int firstChild = 0, secondChild = 1;
-  if (rTree.Children()[firstChild]->NumChildren() == 2)
+  if (rTree.Child(firstChild).NumChildren() == 2)
   {
     firstChild = 1;
     secondChild = 0;
   }
 
-  BOOST_REQUIRE_SMALL(rTree.Children()[firstChild]->Bound()[0].Lo(), 1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[firstChild]->Bound()[0].Hi(), 0.1,
+  BOOST_REQUIRE_SMALL(rTree.Child(firstChild).Bound()[0].Lo(), 1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(firstChild).Bound()[0].Hi(), 0.1,
       1e-15);
-  BOOST_REQUIRE_SMALL(rTree.Children()[firstChild]->Bound()[1].Lo(), 1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[firstChild]->Bound()[1].Hi(), 1.0,
-      1e-15);
-
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[0].Lo(), 0.3,
-      1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[0].Hi(), 1.0,
-      1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[1].Lo(), 0.1,
-      1e-15);
-  BOOST_REQUIRE_CLOSE(rTree.Children()[secondChild]->Bound()[1].Hi(), 0.9,
+  BOOST_REQUIRE_SMALL(rTree.Child(firstChild).Bound()[1].Lo(), 1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(firstChild).Bound()[1].Hi(), 1.0,
       1e-15);
 
-  BOOST_REQUIRE_EQUAL(rTree.Children()[firstChild]->NumChildren(), 1);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[0].Lo(), 0.3,
+      1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[0].Hi(), 1.0,
+      1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[1].Lo(), 0.1,
+      1e-15);
+  BOOST_REQUIRE_CLOSE(rTree.Child(secondChild).Bound()[1].Hi(), 0.9,
+      1e-15);
+
+  BOOST_REQUIRE_EQUAL(rTree.Child(firstChild).NumChildren(), 1);
   BOOST_REQUIRE_SMALL(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[0].Lo(), 1e-15);
+      rTree.Child(firstChild).Child(0).Bound()[0].Lo(), 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[0].Hi(), 0.1, 1e-15);
+      rTree.Child(firstChild).Child(0).Bound()[0].Hi(), 0.1, 1e-15);
   BOOST_REQUIRE_SMALL(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[1].Lo(), 1e-15);
+      rTree.Child(firstChild).Child(0).Bound()[1].Lo(), 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[firstChild]->Children()[0]->Bound()[1].Hi(), 1.0, 1e-15);
-  BOOST_REQUIRE_EQUAL(rTree.Children()[firstChild]->Children()[0]->Count(), 3);
+      rTree.Child(firstChild).Child(0).Bound()[1].Hi(), 1.0, 1e-15);
+  BOOST_REQUIRE_EQUAL(rTree.Child(firstChild).Child(0).Count(), 3);
 
   int firstPrime = 0, secondPrime = 1;
-  if (rTree.Children()[secondChild]->Children()[firstPrime]->Count() == 3)
+  if (rTree.Child(secondChild).Child(firstPrime).Count() == 3)
   {
     firstPrime = 1;
     secondPrime = 0;
   }
 
-  BOOST_REQUIRE_EQUAL(rTree.Children()[secondChild]->NumChildren(), 2);
+  BOOST_REQUIRE_EQUAL(rTree.Child(secondChild).NumChildren(), 2);
   BOOST_REQUIRE_EQUAL(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Count(), 4);
+      rTree.Child(secondChild).Child(firstPrime).Count(), 4);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[0].Lo(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[0].Lo(),
       0.3, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[0].Hi(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[0].Hi(),
       0.7, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[1].Lo(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[1].Lo(),
       0.3, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[firstPrime]->Bound()[1].Hi(),
+      rTree.Child(secondChild).Child(firstPrime).Bound()[1].Hi(),
       0.7, 1e-15);
 
   BOOST_REQUIRE_EQUAL(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Count(), 3);
+      rTree.Child(secondChild).Child(secondPrime).Count(), 3);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[0].Lo(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[0].Lo(),
       0.9, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[0].Hi(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[0].Hi(),
       1.0, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[1].Lo(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[1].Lo(),
       0.1, 1e-15);
   BOOST_REQUIRE_CLOSE(
-      rTree.Children()[secondChild]->Children()[secondPrime]->Bound()[1].Hi(),
+      rTree.Child(secondChild).Child(secondPrime).Bound()[1].Hi(),
       0.9, 1e-15);
 }
 


### PR DESCRIPTION
I removed `RectangleTree::Children()`. Thus, `SplitType` and `AuxiliaryInformationType` become friend classes of the `RectangleTree` class.
Moreover, I made some RectangleTree::NumDescendants() optimizations proposed by Marcos Pividori.