### PR TITLE
file closed after performing operation

### DIFF
--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -211,6 +211,8 @@ void LoadARFF(const std::string& filename,
     }
     ++row;
   }
+  //close the file after operation
+  ifs.close(filename);
 }
 
 } // namespace data


### PR DESCRIPTION
In C++, whenever a file is opened for any operation, 
then we are suppose to close that very file.   