### PR TITLE
Replaced SortStruct by std::pair

### DIFF
--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split_impl.hpp
@@ -22,6 +22,8 @@ template<typename TreeType>
 void RPlusTreeSplit<SplitPolicyType, SweepType>::
 SplitLeafNode(TreeType* tree, std::vector<bool>& relevels)
 {
+  typedef typename TreeType::ElemType ElemType;
+
   if (tree->Count() == 1)
   {
     // Check if an intermediate node was added during the insertion process.
@@ -64,8 +66,8 @@ SplitLeafNode(TreeType* tree, std::vector<bool>& relevels)
     return;
   }
 
-  size_t cutAxis;
-  typename TreeType::ElemType cut;
+  size_t cutAxis = tree->Bound().Dim();
+  ElemType cut = std::numeric_limits<ElemType>::lowest();
 
   // Try to find a partiotion of the node.
   if (!PartitionNode(tree, cutAxis, cut))
@@ -117,6 +119,7 @@ template<typename TreeType>
 bool RPlusTreeSplit<SplitPolicyType, SweepType>::
 SplitNonLeafNode(TreeType* tree, std::vector<bool>& relevels)
 {
+  typedef typename TreeType::ElemType ElemType;
   // If we are splitting the root node, we need will do things differently so
   // that the constructor and other methods don't confuse the end user by giving
   // an address of another node.
@@ -133,8 +136,8 @@ SplitNonLeafNode(TreeType* tree, std::vector<bool>& relevels)
     RPlusTreeSplit::SplitNonLeafNode(copy,relevels);
     return true;
   }
-  size_t cutAxis;
-  typename TreeType::ElemType cut;
+  size_t cutAxis = tree->Bound().Dim();
+  ElemType cut = std::numeric_limits<ElemType>::lowest();
 
   // Try to find a partiotion of the node.
   if ( !PartitionNode(tree, cutAxis, cut))

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split.hpp
@@ -42,6 +42,17 @@ class RStarTreeSplit
    */
   template <typename TreeType>
   static void InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode);
+
+  /**
+   * Comparator for sorting with std::pair. This comparator works a little bit
+   * faster then the default comparator.
+   */
+  template<typename ElemType>
+  static bool PairComp(const std::pair<ElemType, size_t>& p1,
+                       const std::pair<ElemType, size_t>& p2)
+  {
+    return p1.first < p2.first;
+  }
 };
 
 } // namespace tree

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split.hpp
@@ -38,26 +38,6 @@ class RStarTreeSplit
 
  private:
   /**
-   * Class to allow for faster sorting.
-   */
-  template<typename ElemType>
-  struct SortStruct
-  {
-    ElemType d;
-    int n;
-  };
-
-  /**
-   * Comparator for sorting with SortStruct.
-   */
-  template<typename ElemType>
-  static bool StructComp(const SortStruct<ElemType>& s1,
-                         const SortStruct<ElemType>& s2)
-  {
-    return s1.d < s2.d;
-  }
-
-  /**
    * Insert a node into another node.
    */
   template <typename TreeType>

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
@@ -26,6 +26,7 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
 {
   // Convenience typedef.
   typedef typename TreeType::ElemType ElemType;
+  typedef bound::HRectBound<metric::EuclideanDistance, ElemType> BoundType;
 
   if (tree->Count() <= tree->MaxLeafSize())
     return;
@@ -65,25 +66,30 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
       return;
     }
 
-    std::vector<SortStruct<ElemType>> sorted(tree->Count());
+    std::vector<std::pair<ElemType, size_t>> sorted(tree->Count());
     arma::Col<ElemType> center;
     tree->Bound().Center(center); // Modifies centroid.
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Metric().Evaluate(center,
+      sorted[i].first = tree->Metric().Evaluate(center,
           tree->Dataset().col(tree->Point(i)));
-      sorted[i].n = i;
+      sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(), StructComp<ElemType>);
+    std::sort(sorted.begin(), sorted.end(),
+        [] (const std::pair<ElemType, size_t>& p1,
+            const std::pair<ElemType, size_t>& p2)
+        {
+          return p1.first < p2.first;
+        });
     std::vector<size_t> pointIndices(p);
 
     for (size_t i = 0; i < p; i++)
     {
       // We start from the end of sorted.
-      pointIndices[i] = tree->Point(sorted[sorted.size() - 1 - i].n);
+      pointIndices[i] = tree->Point(sorted[sorted.size() - 1 - i].second);
 
-      root->DeletePoint(tree->Point(sorted[sorted.size() - 1 - i].n),
+      root->DeletePoint(tree->Point(sorted[sorted.size() - 1 - i].second),
           relevels);
     }
 
@@ -106,14 +112,19 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
   {
     ElemType axisScore = 0.0;
     // Since we only have points in the leaf nodes, we only need to sort once.
-    std::vector<SortStruct<ElemType>> sorted(tree->Count());
+    std::vector<std::pair<ElemType, size_t>> sorted(tree->Count());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Dataset().col(tree->Point(i))[j];
-      sorted[i].n = i;
+      sorted[i].first = tree->Dataset().col(tree->Point(i))[j];
+      sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(), StructComp<ElemType>);
+    std::sort(sorted.begin(), sorted.end(),
+        [] (const std::pair<ElemType, size_t>& p1,
+            const std::pair<ElemType, size_t>& p2)
+        {
+          return p1.first < p2.first;
+        });
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxLeafSize() - 2 * tree->MinLeafSize() +
@@ -138,46 +149,21 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
 
       size_t cutOff = tree->MinLeafSize() + i;
 
-      // We'll calculate the max and min in each dimension by hand to save time.
-      std::vector<ElemType> maxG1(tree->Bound().Dim());
-      std::vector<ElemType> minG1(maxG1.size());
-      std::vector<ElemType> maxG2(maxG1.size());
-      std::vector<ElemType> minG2(maxG1.size());
-      for (size_t k = 0; k < tree->Bound().Dim(); k++)
-      {
-        minG1[k] = maxG1[k] = tree->Dataset().col(tree->Point(sorted[0].n))[k];
-        minG2[k] = maxG2[k] =
-            tree->Dataset().col(tree->Point(sorted[sorted.size() - 1].n))[k];
+      BoundType bound1(tree->Bound().Dim());
+      BoundType bound2(tree->Bound().Dim());
 
-        for (size_t l = 1; l < tree->Count() - 1; l++)
-        {
-          if (l < cutOff)
-          {
-            if (tree->Dataset().col(tree->Point(sorted[l].n))[k] < minG1[k])
-              minG1[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
-            else if (tree->Dataset().col(tree->Point(sorted[l].n))[k] > maxG1[k])
-              maxG1[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
-          }
-          else
-          {
-            if (tree->Dataset().col(tree->Point(sorted[l].n))[k] < minG2[k])
-              minG2[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
-            else if (tree->Dataset().col(tree->Point(sorted[l].n))[k] > maxG2[k])
-              maxG2[k] = tree->Dataset().col(tree->Point(sorted[l].n))[k];
-          }
-        }
-      }
+      for (size_t l = 0; l < cutOff; l++)
+        bound1 |= tree->Dataset().col(tree->Point(sorted[l].second));
 
-      ElemType area1 = 1.0, area2 = 1.0;
-      ElemType oArea = 1.0;
-      for (size_t k = 0; k < maxG1.size(); k++)
-      {
-        margins[i] += maxG1[k] - minG1[k] + maxG2[k] - minG2[k];
-        area1 *= maxG1[k] - minG1[k];
-        area2 *= maxG2[k] - minG2[k];
-        oArea *= (maxG1[k] < minG2[k] || maxG2[k] < minG1[k]) ? 0.0 :
-            (std::min(maxG1[k], maxG2[k]) - std::max(minG1[k], minG2[k]));
-      }
+      for (size_t l = cutOff; l < tree->Count(); l++)
+        bound2 |= tree->Dataset().col(tree->Point(sorted[l].second));
+
+      ElemType area1 = bound1.Volume();
+      ElemType area2 = bound2.Volume();
+      ElemType oArea = bound1.Overlap(bound2);
+
+      for (size_t k = 0; k < bound1.Dim(); k++)
+        margins[i] += bound1[k].Width() + bound2[k].Width();
 
       areas[i] += area1 + area2;
       overlapedAreas[i] += oArea;
@@ -210,14 +196,19 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     }
   }
 
-  std::vector<SortStruct<ElemType>> sorted(tree->Count());
+  std::vector<std::pair<ElemType, size_t>> sorted(tree->Count());
   for (size_t i = 0; i < sorted.size(); i++)
   {
-    sorted[i].d = tree->Dataset().col(tree->Point(i))[bestAxis];
-    sorted[i].n = i;
+    sorted[i].first = tree->Dataset().col(tree->Point(i))[bestAxis];
+    sorted[i].second = i;
   }
 
-  std::sort(sorted.begin(), sorted.end(), StructComp<ElemType>);
+  std::sort(sorted.begin(), sorted.end(),
+      [] (const std::pair<ElemType, size_t>& p1,
+          const std::pair<ElemType, size_t>& p2)
+      {
+        return p1.first < p2.first;
+      });
 
   TreeType* treeOne = new TreeType(tree->Parent());
   TreeType* treeTwo = new TreeType(tree->Parent());
@@ -227,9 +218,9 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < tree->Count(); i++)
     {
       if (i < bestAreaIndexOnBestAxis + tree->MinLeafSize())
-        treeOne->InsertPoint(tree->Point(sorted[i].n));
+        treeOne->InsertPoint(tree->Point(sorted[i].second));
       else
-        treeTwo->InsertPoint(tree->Point(sorted[i].n));
+        treeTwo->InsertPoint(tree->Point(sorted[i].second));
     }
   }
   else
@@ -237,9 +228,9 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     for (size_t i = 0; i < tree->Count(); i++)
     {
       if (i < bestOverlapIndexOnBestAxis + tree->MinLeafSize())
-        treeOne->InsertPoint(tree->Point(sorted[i].n));
+        treeOne->InsertPoint(tree->Point(sorted[i].second));
       else
-        treeTwo->InsertPoint(tree->Point(sorted[i].n));
+        treeTwo->InsertPoint(tree->Point(sorted[i].second));
     }
   }
 
@@ -278,6 +269,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
 {
   // Convenience typedef.
   typedef typename TreeType::ElemType ElemType;
+  typedef bound::HRectBound<metric::EuclideanDistance, ElemType> BoundType;
 
   // If we are splitting the root node, we need will do things differently so
   // that the constructor and other methods don't confuse the end user by giving
@@ -369,14 +361,19 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     ElemType axisScore = 0.0;
 
     // We'll do Bound().Lo() now and use Bound().Hi() later.
-    std::vector<SortStruct<ElemType>> sorted(tree->NumChildren());
+    std::vector<std::pair<ElemType, size_t>> sorted(tree->NumChildren());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Child(i).Bound()[j].Lo();
-      sorted[i].n = i;
+      sorted[i].first = tree->Child(i).Bound()[j].Lo();
+      sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(), StructComp<ElemType>);
+    std::sort(sorted.begin(), sorted.end(),
+        [] (const std::pair<ElemType, size_t>& p1,
+            const std::pair<ElemType, size_t>& p2)
+        {
+          return p1.first < p2.first;
+        });
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxNumChildren() -
@@ -401,49 +398,21 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
 
       size_t cutOff = tree->MinNumChildren() + i;
 
-      // We'll calculate the max and min in each dimension by hand to save time.
-      std::vector<ElemType> maxG1(tree->Bound().Dim());
-      std::vector<ElemType> minG1(maxG1.size());
-      std::vector<ElemType> maxG2(maxG1.size());
-      std::vector<ElemType> minG2(maxG1.size());
-      for (size_t k = 0; k < tree->Bound().Dim(); k++)
-      {
-        minG1[k] = tree->Child(sorted[0].n).Bound()[k].Lo();
-        maxG1[k] = tree->Child(sorted[0].n).Bound()[k].Hi();
-        minG2[k] =
-            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Lo();
-        maxG2[k] =
-            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Hi();
+      BoundType bound1(tree->Bound().Dim());
+      BoundType bound2(tree->Bound().Dim());
 
-        for (size_t l = 1; l < tree->NumChildren() - 1; l++)
-        {
-          if (l < cutOff)
-          {
-            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG1[k])
-              minG1[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
-            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG1[k])
-              maxG1[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
-          }
-          else
-          {
-            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG2[k])
-              minG2[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
-            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG2[k])
-              maxG2[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
-          }
-        }
-      }
+      for (size_t l = 0; l < cutOff; l++)
+        bound1 |= tree->Child(sorted[l].second).Bound();
 
-      ElemType area1 = 1.0, area2 = 1.0;
-      ElemType oArea = 1.0;
-      for (size_t k = 0; k < maxG1.size(); k++)
-      {
-        margins[i] += maxG1[k] - minG1[k] + maxG2[k] - minG2[k];
-        area1 *= maxG1[k] - minG1[k];
-        area2 *= maxG2[k] - minG2[k];
-        oArea *= (maxG1[k] < minG2[k] || maxG2[k] < minG1[k]) ? 0.0 :
-            (std::min(maxG1[k], maxG2[k]) - std::max(minG1[k], minG2[k]));
-      }
+      for (size_t l = cutOff; l < tree->NumChildren(); l++)
+        bound2 |= tree->Child(sorted[l].second).Bound();
+
+      ElemType area1 = bound1.Volume();
+      ElemType area2 = bound2.Volume();
+      ElemType oArea = bound1.Overlap(bound2);
+
+      for (size_t k = 0; k < bound1.Dim(); k++)
+        margins[i] += bound1[k].Width() + bound2[k].Width();
 
       areas[i] += area1 + area2;
       overlapedAreas[i] += oArea;
@@ -480,15 +449,19 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
   {
     ElemType axisScore = 0.0;
 
-    // We'll do Bound().Lo() now and use Bound().Hi() later.
-    std::vector<SortStruct<ElemType>> sorted(tree->NumChildren());
+    std::vector<std::pair<ElemType, size_t>> sorted(tree->NumChildren());
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Child(i).Bound()[j].Hi();
-      sorted[i].n = i;
+      sorted[i].first = tree->Child(i).Bound()[j].Hi();
+      sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(), StructComp<ElemType>);
+    std::sort(sorted.begin(), sorted.end(),
+        [] (const std::pair<ElemType, size_t>& p1,
+            const std::pair<ElemType, size_t>& p2)
+        {
+          return p1.first < p2.first;
+        });
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxNumChildren() -
@@ -513,51 +486,21 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
 
       size_t cutOff = tree->MinNumChildren() + i;
 
-      // We'll calculate the max and min in each dimension by hand to save time.
-      std::vector<ElemType> maxG1(tree->Bound().Dim());
-      std::vector<ElemType> minG1(maxG1.size());
-      std::vector<ElemType> maxG2(maxG1.size());
-      std::vector<ElemType> minG2(maxG1.size());
+      BoundType bound1(tree->Bound().Dim());
+      BoundType bound2(tree->Bound().Dim());
 
-      for (size_t k = 0; k < tree->Bound().Dim(); k++)
-      {
-        minG1[k] = tree->Child(sorted[0].n).Bound()[k].Lo();
-        maxG1[k] = tree->Child(sorted[0].n).Bound()[k].Hi();
-        minG2[k] =
-            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Lo();
-        maxG2[k] =
-            tree->Child(sorted[sorted.size() - 1].n).Bound()[k].Hi();
+      for (size_t l = 0; l < cutOff; l++)
+        bound1 |= tree->Child(sorted[l].second).Bound();
 
-        for (size_t l = 1; l < tree->NumChildren() - 1; l++)
-        {
-          if (l < cutOff)
-          {
-            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG1[k])
-              minG1[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
-            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG1[k])
-              maxG1[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
-          }
-          else
-          {
-            if (tree->Child(sorted[l].n).Bound()[k].Lo() < minG2[k])
-              minG2[k] = tree->Child(sorted[l].n).Bound()[k].Lo();
-            else if (tree->Child(sorted[l].n).Bound()[k].Hi() > maxG2[k])
-              maxG2[k] = tree->Child(sorted[l].n).Bound()[k].Hi();
-          }
-        }
-      }
+      for (size_t l = cutOff; l < tree->NumChildren(); l++)
+        bound2 |= tree->Child(sorted[l].second).Bound();
 
-      ElemType area1 = 1.0, area2 = 1.0;
-      ElemType oArea = 1.0;
+      ElemType area1 = bound1.Volume();
+      ElemType area2 = bound2.Volume();
+      ElemType oArea = bound1.Overlap(bound2);
 
-      for (size_t k = 0; k < maxG1.size(); k++)
-      {
-        margins[i] += maxG1[k] - minG1[k] + maxG2[k] - minG2[k];
-        area1 *= maxG1[k] - minG1[k];
-        area2 *= maxG2[k] - minG2[k];
-        oArea *= (maxG1[k] < minG2[k] || maxG2[k] < minG1[k]) ? 0.0 :
-            (std::min(maxG1[k], maxG2[k]) - std::max(minG1[k], minG2[k]));
-      }
+      for (size_t k = 0; k < bound1.Dim(); k++)
+        margins[i] += bound1[k].Width() + bound2[k].Width();
 
       areas[i] += area1 + area2;
       overlapedAreas[i] += oArea;
@@ -591,25 +534,30 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     }
   }
 
-  std::vector<SortStruct<ElemType>> sorted(tree->NumChildren());
+  std::vector<std::pair<ElemType, size_t>> sorted(tree->NumChildren());
   if (lowIsBest)
   {
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Child(i).Bound()[bestAxis].Lo();
-      sorted[i].n = i;
+      sorted[i].first = tree->Child(i).Bound()[bestAxis].Lo();
+      sorted[i].second = i;
     }
   }
   else
   {
     for (size_t i = 0; i < sorted.size(); i++)
     {
-      sorted[i].d = tree->Child(i).Bound()[bestAxis].Hi();
-      sorted[i].n = i;
+      sorted[i].first = tree->Child(i).Bound()[bestAxis].Hi();
+      sorted[i].second = i;
     }
   }
 
-  std::sort(sorted.begin(), sorted.end(), StructComp<ElemType>);
+  std::sort(sorted.begin(), sorted.end(),
+      [] (const std::pair<ElemType, size_t>& p1,
+          const std::pair<ElemType, size_t>& p2)
+      {
+        return p1.first < p2.first;
+      });
 
   TreeType* treeOne = new TreeType(tree->Parent());
   TreeType* treeTwo = new TreeType(tree->Parent());
@@ -619,9 +567,9 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     for (size_t i = 0; i < tree->NumChildren(); i++)
     {
       if (i < bestAreaIndexOnBestAxis + tree->MinNumChildren())
-        InsertNodeIntoTree(treeOne, &(tree->Child(sorted[i].n)));
+        InsertNodeIntoTree(treeOne, &(tree->Child(sorted[i].second)));
       else
-        InsertNodeIntoTree(treeTwo, &(tree->Child(sorted[i].n)));
+        InsertNodeIntoTree(treeTwo, &(tree->Child(sorted[i].second)));
     }
   }
   else
@@ -629,9 +577,9 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     for (size_t i = 0; i < tree->NumChildren(); i++)
     {
       if (i < bestOverlapIndexOnBestAxis + tree->MinNumChildren())
-        InsertNodeIntoTree(treeOne, &(tree->Child(sorted[i].n)));
+        InsertNodeIntoTree(treeOne, &(tree->Child(sorted[i].second)));
       else
-        InsertNodeIntoTree(treeTwo, &(tree->Child(sorted[i].n)));
+        InsertNodeIntoTree(treeTwo, &(tree->Child(sorted[i].second)));
     }
   }
 

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
@@ -76,12 +76,7 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
     std::vector<size_t> pointIndices(p);
 
     for (size_t i = 0; i < p; i++)
@@ -119,12 +114,7 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxLeafSize() - 2 * tree->MinLeafSize() +
@@ -203,12 +193,7 @@ void RStarTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     sorted[i].second = i;
   }
 
-  std::sort(sorted.begin(), sorted.end(),
-      [] (const std::pair<ElemType, size_t>& p1,
-          const std::pair<ElemType, size_t>& p2)
-      {
-        return p1.first < p2.first;
-      });
+  std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
   TreeType* treeOne = new TreeType(tree->Parent());
   TreeType* treeTwo = new TreeType(tree->Parent());
@@ -368,12 +353,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxNumChildren() -
@@ -456,12 +436,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxNumChildren() -
@@ -552,12 +527,7 @@ bool RStarTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels
     }
   }
 
-  std::sort(sorted.begin(), sorted.end(),
-      [] (const std::pair<ElemType, size_t>& p1,
-          const std::pair<ElemType, size_t>& p2)
-      {
-        return p1.first < p2.first;
-      });
+  std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
   TreeType* treeOne = new TreeType(tree->Parent());
   TreeType* treeTwo = new TreeType(tree->Parent());

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split.hpp
@@ -52,6 +52,18 @@ class XTreeSplit
    */
   template<typename TreeType>
   static void InsertNodeIntoTree(TreeType* destTree, TreeType* srcNode);
+
+  /**
+   * Comparator for sorting with std::pair. This comparator works a little bit
+   * faster then the default comparator.
+   */
+  template<typename ElemType>
+  static bool PairComp(const std::pair<ElemType, size_t>& p1,
+                       const std::pair<ElemType, size_t>& p2)
+  {
+    return p1.first < p2.first;
+  }
+
 };
 
 } // namespace tree

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split.hpp
@@ -48,27 +48,6 @@ class XTreeSplit
 
  private:
   /**
-   * Class to allow for faster sorting.
-   */
-  template<typename ElemType>
-  class sortStruct
-  {
-   public:
-    ElemType d;
-    int n;
-  };
-
-  /**
-   * Comparator for sorting with sortStruct.
-   */
-  template<typename ElemType>
-  static bool structComp(const sortStruct<ElemType>& s1,
-                         const sortStruct<ElemType>& s2)
-  {
-    return s1.d < s2.d;
-  }
-
-  /**
    * Insert a node into another node.
    */
   template<typename TreeType>

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
@@ -75,12 +75,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
        sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
     std::vector<size_t> pointIndices(p);
 
     for (size_t i = 0; i < p; i++)
@@ -129,12 +124,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxLeafSize() -
@@ -210,12 +200,7 @@ void XTreeSplit::SplitLeafNode(TreeType *tree,std::vector<bool>& relevels)
     sorted[i].second = i;
   }
 
-  std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+  std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
   TreeType* treeOne = new TreeType(tree->Parent(),
                             tree->AuxiliaryInfo().NormalNodeMaxNumChildren());
@@ -390,12 +375,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxNumChildren() -
@@ -500,12 +480,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
       sorted[i].second = i;
     }
 
-    std::sort(sorted.begin(), sorted.end(),
-        [] (const std::pair<ElemType, size_t>& p1,
-            const std::pair<ElemType, size_t>& p2)
-        {
-          return p1.first < p2.first;
-        });
+    std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
     // We'll store each of the three scores for each distribution.
     std::vector<ElemType> areas(tree->MaxNumChildren() -
@@ -619,12 +594,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
     }
   }
 
-  std::sort(sorted.begin(), sorted.end(),
-      [] (const std::pair<ElemType, size_t>& p1,
-          const std::pair<ElemType, size_t>& p2)
-      {
-        return p1.first < p2.first;
-      });
+  std::sort(sorted.begin(), sorted.end(), PairComp<ElemType>);
 
   TreeType* treeOne = new TreeType(tree->Parent(), tree->MaxNumChildren());
   TreeType* treeTwo = new TreeType(tree->Parent(), tree->MaxNumChildren());
@@ -688,12 +658,7 @@ bool XTreeSplit::SplitNonLeafNode(TreeType *tree,std::vector<bool>& relevels)
           sorted2[i].second = i;
         }
       }
-      std::sort(sorted2.begin(), sorted2.end(),
-          [] (const std::pair<ElemType, size_t>& p1,
-              const std::pair<ElemType, size_t>& p2)
-          {
-            return p1.first < p2.first;
-          });
+      std::sort(sorted2.begin(), sorted2.end(), PairComp<ElemType>);
 
       for (size_t i = 0; i < tree->NumChildren(); i++)
       {

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -208,7 +208,7 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
   }
 
   arma::colvec cMRow;
-  arma::uword maxIndex;
+  arma::uword maxIndex = 0;
 
   for (size_t i = 0; i < predictedLabels.n_cols; i++)
   {

--- a/src/mlpack/methods/ann/layer/one_hot_layer.hpp
+++ b/src/mlpack/methods/ann/layer/one_hot_layer.hpp
@@ -58,7 +58,7 @@ class OneHotLayer
     output = inputActivations;
     output.zeros();
 
-    arma::uword maxIndex;
+    arma::uword maxIndex = 0;
     inputActivations.max(maxIndex);
     output(maxIndex) = 1;
   }

--- a/src/mlpack/methods/ann/layer/vr_class_reward_layer.hpp
+++ b/src/mlpack/methods/ann/layer/vr_class_reward_layer.hpp
@@ -71,7 +71,7 @@ class VRClassRewardLayer
   double Forward(const arma::Mat<eT>& input, const arma::Mat<eT>& target)
   {
     reward = 0;
-    arma::uword index;
+    arma::uword index = 0;
 
     for (size_t i = 0; i < input.n_cols; i++)
     {

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -108,7 +108,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
     arma::Row<size_t>& predictedLabels)
 {
   arma::vec tempLabelMat;
-  arma::uword maxIndex;
+  arma::uword maxIndex = 0;
 
   // Could probably be faster if done in batch.
   for (size_t i = 0; i < test.n_cols; i++)

--- a/src/mlpack/methods/radical/radical.cpp
+++ b/src/mlpack/methods/radical/radical.cpp
@@ -85,7 +85,7 @@ double Radical::DoRadical2D(const mat& matX)
     values(i) = Vasicek(candidateY1) + Vasicek(candidateY2);
   }
 
-  uword indOpt;
+  uword indOpt = 0;
   values.min(indOpt); // we ignore the return value; we don't care about it
   return (indOpt / (double) angles) * M_PI / 2.0;
 }


### PR DESCRIPTION
I replaced `SortStruct` by `std::pair` in the R* tree and the X tree and fixed some compiler warnings about uninitialized variables. I did some tests, `std::pair` provides some speedups in `mlpack_knn` for the R* tree and the X tree.