### PR TITLE
improve the imputer program

### DIFF
--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -60,28 +60,6 @@ class Imputer
     strategy.Impute(input, mappedValue, dimension, columnMajor);
   }
 
-  /**
-  * Given an input dataset, replace missing values of all dimensions with given
-  * imputation strategy. This function does not produce output matrix, but
-  * overwrites the result into the input matrix.
-  *
-  * @param input Input dataset to apply imputation.
-  * @oaran missingValue User defined missing value; it can be anything.
-  */
-  void Impute(arma::Mat<T>& input,
-              const std::string& missingValue)
-  {
-    const size_t dimensions = columnMajor ? input.n_rows : input.n_cols;
-    for (size_t i = 0; i < dimensions; ++i)
-    {
-      if (mapper.NumMappings(i) > 0)
-      {
-        T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, i));
-        strategy.Impute(input, mappedValue, i, columnMajor);
-      }
-    }
-  }
-
   //! Get the strategy
   const StrategyType& Strategy() const { return strategy; }
 

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -71,26 +71,13 @@ class Imputer
   void Impute(arma::Mat<T>& input,
               const std::string& missingValue)
   {
-    if (columnMajor)
+    const size_t dimensions = columnMajor ? input.n_rows : input.n_cols;
+    for (size_t i = 0; i < dimensions; ++i)
     {
-      for (size_t i = 0; i < input.n_rows; ++i)
+      if (mapper.NumMappings(i) > 0)
       {
-        if (mapper.NumMappings(i) > 0)
-        {
-          T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, i));
-          strategy.Impute(input, mappedValue, i, columnMajor);
-        }
-      }
-    }
-    else
-    {
-      for (size_t i = 0; i < input.n_rows; ++i)
-      {
-        if (mapper.NumMappings(i) > 0)
-        {
-          T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, i));
-          strategy.Impute(input, mappedValue, i, columnMajor);
-        }
+        T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, i));
+        strategy.Impute(input, mappedValue, i, columnMajor);
       }
     }
   }

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -44,9 +44,9 @@ class Imputer
   }
 
   /**
-  * Given an input dataset, replace missing values with given imputation
-  * strategy. This overload does not produce output matrix, but overwrites the
-  * result into the input matrix.
+  * Given an input dataset, replace missing values of a dimension with given
+  * imputation strategy. This function does not produce output matrix, but
+  * overwrites the result into the input matrix.
   *
   * @param input Input dataset to apply imputation.
   * @oaran missingValue User defined missing value; it can be anything.
@@ -58,6 +58,41 @@ class Imputer
   {
     T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, dimension));
     strategy.Impute(input, mappedValue, dimension, columnMajor);
+  }
+
+  /**
+  * Given an input dataset, replace missing values of all dimensions with given
+  * imputation strategy. This function does not produce output matrix, but
+  * overwrites the result into the input matrix.
+  *
+  * @param input Input dataset to apply imputation.
+  * @oaran missingValue User defined missing value; it can be anything.
+  */
+  void Impute(arma::Mat<T>& input,
+              const std::string& missingValue)
+  {
+    if (columnMajor)
+    {
+      for (size_t i = 0; i < input.n_rows; ++i)
+      {
+        if (mapper.NumMappings(i) > 0)
+        {
+          T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, i));
+          strategy.Impute(input, mappedValue, i, columnMajor);
+        }
+      }
+    }
+    else
+    {
+      for (size_t i = 0; i < input.n_rows; ++i)
+      {
+        if (mapper.NumMappings(i) > 0)
+        {
+          T mappedValue = static_cast<T>(mapper.UnmapValue(missingValue, i));
+          strategy.Impute(input, mappedValue, i, columnMajor);
+        }
+      }
+    }
   }
 
   //! Get the strategy

--- a/src/mlpack/core/data/map_policies/missing_policy.hpp
+++ b/src/mlpack/core/data/map_policies/missing_policy.hpp
@@ -86,11 +86,9 @@ class MissingPolicy
     }
     else
     {
-      // This string already exists in the mapping
-      // or not included in missingSet.
-      // Unlike IncrementPolicy, MissingPolicy counts all mapped values.
+      // This string already exists in the mapping or not included in
+      // the missingSet.
       size_t& numMappings = maps[dimension].second;
-      ++numMappings;
       return NaN;
     }
   }

--- a/src/mlpack/core/data/map_policies/missing_policy.hpp
+++ b/src/mlpack/core/data/map_policies/missing_policy.hpp
@@ -88,7 +88,6 @@ class MissingPolicy
     {
       // This string already exists in the mapping or not included in
       // the missingSet.
-      size_t& numMappings = maps[dimension].second;
       return NaN;
     }
   }

--- a/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
@@ -121,6 +121,14 @@ int main(int argc, char** argv)
     Log::Warn << "The file does not contain any user-defined missing "
         << "variables. The program did not perform any imputation." << endl;
   }
+  else if (CLI::HasParam("dimension") &&
+      !(std::find(dirtyDimensions.begin(), dirtyDimensions.end(), dimension)
+      != dirtyDimensions.end()))
+  {
+    Log::Warn << "The given dimension of the file does not contain any "
+      << "user-defined missing variables. The program did not perform any "
+      << "imputation." << endl;
+  }
   else
   {
     // Initialize imputer class

--- a/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
 
   if (dirtyDimensions.size() == 0)
   {
-    Log::Debug << "The file does not contain any user-defined missing "
+    Log::Warn << "The file does not contain any user-defined missing "
         << "variables. The program did not perform any imputation." << endl;
   }
   else

--- a/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
@@ -33,8 +33,8 @@ PARAM_STRING_IN_REQ("input_file", "File containing data,", "i");
 PARAM_STRING_OUT("output_file", "File to save output", "o");
 PARAM_STRING_IN("missing_value", "User defined missing value", "m", "");
 PARAM_STRING_IN("strategy", "imputation strategy to be applied. Strategies "
-    "should be one of 'custom', 'mean', 'median', and 'listwise_deletion'.", "s"
-    , "");
+    "should be one of 'custom', 'mean', 'median', and 'listwise_deletion'.",
+    "s", "");
 PARAM_DOUBLE_IN("custom_value", "user_defined custom value", "c", 0.0);
 PARAM_INT_IN("dimension", "the dimension to apply imputation", "d", 0);
 

--- a/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
@@ -158,10 +158,7 @@ int main(int argc, char** argv)
     Log::Info << "Performing '" << strategy << "' imputation strategy "
         << "to replace '" << missingValue << "' on all dimensions." << endl;
 
-    for (size_t i : dirtyDimensions)
-    {
-      imputer.Impute(input, missingValue, i);
-    }
+    imputer.Impute(input, missingValue);
   }
   Timer::Stop("imputation");
 

--- a/src/mlpack/tests/imputation_test.cpp
+++ b/src/mlpack/tests/imputation_test.cpp
@@ -40,10 +40,7 @@ BOOST_AUTO_TEST_CASE(DatasetMapperImputerTest)
   f.close();
 
   arma::mat input;
-
-  std::set<string> mset;
-  mset.insert("a");
-  MissingPolicy policy(mset);
+  MissingPolicy policy({"a"});
   DatasetMapper<MissingPolicy> info(policy);
   BOOST_REQUIRE(data::Load("test_file.csv", input, info) == true);
 
@@ -81,31 +78,6 @@ BOOST_AUTO_TEST_CASE(DatasetMapperImputerTest)
   BOOST_REQUIRE_CLOSE(input(2, 0), 3.0, 1e-5);
   BOOST_REQUIRE(std::isnan(input(2, 1)) == true); // remains as NaN
   BOOST_REQUIRE_CLOSE(input(2, 2), 10.0, 1e-5);
-
-  // Now, try impute() overload with all dimensions.
-  arma::mat allInput;
-  MissingPolicy allPolicy({"a"});
-  DatasetMapper<MissingPolicy> allInfo(allPolicy);
-  BOOST_REQUIRE(data::Load("test_file.csv", allInput, allInfo) == true);
-
-  // convert missing vals to 99.
-  CustomImputation<double> allCustomStrategy(99);
-  Imputer<double,
-          DatasetMapper<MissingPolicy>,
-          CustomImputation<double>> allImputer(allInfo, allCustomStrategy);
-  // convert a or nan to 99 for all dimensions.
-  allImputer.Impute(allInput, "a");
-
-  // Custom imputation result check
-  BOOST_REQUIRE_CLOSE(allInput(0, 0), 99.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(0, 1), 5.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(0, 2), 8.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(1, 0), 2.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(1, 1), 6.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(1, 2), 9.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(2, 0), 3.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(2, 1), 99.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(allInput(2, 2), 10.0, 1e-5);
 
   // Remove the file.
   remove("test_file.csv");

--- a/src/mlpack/tests/imputation_test.cpp
+++ b/src/mlpack/tests/imputation_test.cpp
@@ -47,12 +47,12 @@ BOOST_AUTO_TEST_CASE(DatasetMapperImputerTest)
   DatasetMapper<MissingPolicy> info(policy);
   BOOST_REQUIRE(data::Load("test_file.csv", input, info) == true);
 
-  // row and column test
+  // row and column test.
   BOOST_REQUIRE_EQUAL(input.n_rows, 3);
   BOOST_REQUIRE_EQUAL(input.n_cols, 3);
 
   // Load check
-  // MissingPolicy should convert strings to nans
+  // MissingPolicy should convert strings to nans.
   BOOST_REQUIRE(std::isnan(input(0, 0)) == true);
   BOOST_REQUIRE_CLOSE(input(0, 1), 5.0, 1e-5);
   BOOST_REQUIRE_CLOSE(input(0, 2), 8.0, 1e-5);
@@ -68,10 +68,10 @@ BOOST_AUTO_TEST_CASE(DatasetMapperImputerTest)
   Imputer<double,
           DatasetMapper<MissingPolicy>,
           CustomImputation<double>> imputer(info, customStrategy);
-  // convert a or nan to 99 for dimension 0
+  // convert a or nan to 99 for dimension 0.
   imputer.Impute(input, "a", 0);
 
-  // Custom imputation result check
+  // Custom imputation result check.
   BOOST_REQUIRE_CLOSE(input(0, 0), 99.0, 1e-5);
   BOOST_REQUIRE_CLOSE(input(0, 1), 5.0, 1e-5);
   BOOST_REQUIRE_CLOSE(input(0, 2), 8.0, 1e-5);
@@ -81,6 +81,31 @@ BOOST_AUTO_TEST_CASE(DatasetMapperImputerTest)
   BOOST_REQUIRE_CLOSE(input(2, 0), 3.0, 1e-5);
   BOOST_REQUIRE(std::isnan(input(2, 1)) == true); // remains as NaN
   BOOST_REQUIRE_CLOSE(input(2, 2), 10.0, 1e-5);
+
+  // Now, try impute() overload with all dimensions.
+  arma::mat allInput;
+  MissingPolicy allPolicy({"a"});
+  DatasetMapper<MissingPolicy> allInfo(allPolicy);
+  BOOST_REQUIRE(data::Load("test_file.csv", allInput, allInfo) == true);
+
+  // convert missing vals to 99.
+  CustomImputation<double> allCustomStrategy(99);
+  Imputer<double,
+          DatasetMapper<MissingPolicy>,
+          CustomImputation<double>> allImputer(allInfo, allCustomStrategy);
+  // convert a or nan to 99 for all dimensions.
+  allImputer.Impute(allInput, "a");
+
+  // Custom imputation result check
+  BOOST_REQUIRE_CLOSE(allInput(0, 0), 99.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(0, 1), 5.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(0, 2), 8.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(1, 0), 2.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(1, 1), 6.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(1, 2), 9.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(2, 0), 3.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(2, 1), 99.0, 1e-5);
+  BOOST_REQUIRE_CLOSE(allInput(2, 2), 10.0, 1e-5);
 
   // Remove the file.
   remove("test_file.csv");


### PR DESCRIPTION
added an overload that applies imputation to all "dirty" dimensions.
All dimensions that have more than 0 NumMappings are applied.