### PR TITLE
Fixed an error in MidpointSplit that may lead to a segfault

### DIFF
--- a/src/mlpack/core/tree/binary_space_tree/midpoint_split_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/midpoint_split_impl.hpp
@@ -78,9 +78,7 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
     delete[] ranges;
   }
 
-  assert(splitVal != DBL_MAX);
-
-  if (maxWidth == 0) // All these points are the same.  We can't split.
+  if (maxWidth <= 0) // All these points are the same.  We can't split.
     return false;
 
   // Perform the actual splitting.  This will order the dataset such that points
@@ -157,9 +155,7 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
     delete[] ranges;
   }
 
-  assert(splitVal != DBL_MAX);
-
-  if (maxWidth == 0) // All these points are the same.  We can't split.
+  if (maxWidth <= 0) // All these points are the same.  We can't split.
     return false;
 
   // Perform the actual splitting.  This will order the dataset such that points

--- a/src/mlpack/core/tree/binary_space_tree/midpoint_split_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/midpoint_split_impl.hpp
@@ -24,6 +24,7 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
 {
   size_t splitDimension = data.n_rows; // Indicate invalid.
   double maxWidth = -1;
+  double splitVal = DBL_MAX;
 
   // Find the split dimension.  If the bound is tight, we only need to consult
   // the bound's width.
@@ -37,6 +38,9 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
       {
         maxWidth = width;
         splitDimension = d;
+
+        // Split in the midpoint of that dimension.
+        splitVal = bound[d].Mid();
       }
     }
   }
@@ -65,17 +69,19 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
       {
         maxWidth = width;
         splitDimension = d;
+
+        // Split in the midpoint of that dimension.
+        splitVal = ranges[d].Mid();
       }
     }
 
     delete[] ranges;
   }
 
+  assert(splitVal != DBL_MAX);
+
   if (maxWidth == 0) // All these points are the same.  We can't split.
     return false;
-
-  // Split in the midpoint of that dimension.
-  double splitVal = bound[splitDimension].Mid();
 
   // Perform the actual splitting.  This will order the dataset such that points
   // with value in dimension splitDimension less than or equal to splitVal are
@@ -96,6 +102,7 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
 {
   size_t splitDimension = data.n_rows; // Indicate invalid.
   double maxWidth = -1;
+  double splitVal = DBL_MAX;
 
   // Find the split dimension.  If the bound is tight, we only need to consult
   // the bound's width.
@@ -109,6 +116,9 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
       {
         maxWidth = width;
         splitDimension = d;
+
+        // Split in the midpoint of that dimension.
+        splitVal = bound[d].Mid();
       }
     }
   }
@@ -132,21 +142,25 @@ bool MidpointSplit<BoundType, MatType>::SplitNode(const BoundType& bound,
     // Now, which is the widest?
     for (size_t d = 0; d < data.n_rows; d++)
     {
-      const double width = bound[d].Width();
+      const double width = ranges[d].Width();
 
       if (width > maxWidth)
       {
         maxWidth = width;
         splitDimension = d;
+
+        // Split in the midpoint of that dimension.
+        splitVal = ranges[d].Mid();
       }
     }
+
+    delete[] ranges;
   }
+
+  assert(splitVal != DBL_MAX);
 
   if (maxWidth == 0) // All these points are the same.  We can't split.
     return false;
-
-  // Split in the midpoint of that dimension.
-  double splitVal = bound[splitDimension].Mid();
 
   // Perform the actual splitting.  This will order the dataset such that points
   // with value in dimension splitDimension less than or equal to splitVal are


### PR DESCRIPTION
I tried to compare the vantage point tree with `BallTree` and came across a segfault.

Since `BallBound[d].Mid()` is equal to the center, one child may be empty. In this case the following loop may lead to a segfault (if `right = 0` then `right-1 = SIZE_MAX`)
```
 while ((data(splitDimension, right) >= splitVal) && (left <= right))
   right--;
```