### PR TITLE
GammaDistribution: Adds functionality to solve #733

### DIFF
--- a/src/mlpack/core/dists/gamma_distribution.cpp
+++ b/src/mlpack/core/dists/gamma_distribution.cpp
@@ -206,11 +206,11 @@ arma::vec GammaDistribution::Random() const
 {
   arma::vec randVec(alpha.n_elem);
 
-  std::default_random_engine generator;
   for (size_t d = 0; d < alpha.n_elem; ++d)
   {
     std::gamma_distribution<double> dist(alpha(d), beta(d));
-    randVec(d) = dist(generator);
+    // Use the mlpack random object.
+    randVec(d) = dist(mlpack::math::randGen);
   }
 
   return randVec;

--- a/src/mlpack/core/dists/gamma_distribution.cpp
+++ b/src/mlpack/core/dists/gamma_distribution.cpp
@@ -41,7 +41,6 @@ inline bool GammaDistribution::Converged(const double aOld,
   return (std::abs(aNew - aOld) / aNew) < tol;
 }
 
-
 // Fits an alpha and beta parameter to each dimension of the data.
 void GammaDistribution::Train(const arma::mat& rdata, const double tol)
 {
@@ -156,10 +155,10 @@ void GammaDistribution::Probability(const arma::mat& observations,
     for (size_t d = 0; d < observations.n_rows; ++d)
     {
       // Compute probability using Multiplication Law.
-      probabilities(i) *= 
-        std::pow(observations(d, i), alpha(d) - 1) *
-        std::exp(-observations(d, i) / beta(d)) /
-        denominators(d);
+      double factor = std::exp(-observations(d, i) / beta(d));
+      double numerator = std::pow(observations(d, i), alpha(d) - 1);
+      
+      probabilities(i) *= factor * numerator / denominators(d);
     }
   }
 }
@@ -194,10 +193,10 @@ void GammaDistribution::LogProbability(const arma::mat& observations,
     {
       // Compute probability using Multiplication Law and Logarithm addition
       // property.
-      LogProbabilities(i) += std::log( 
-        std::pow(observations(d, i), alpha(d) - 1) 
-        * std::exp(-observations(d, i) / beta(d)) 
-        / denominators(d));
+      double factor = std::exp(-observations(d, i) / beta(d));
+      double numerator = std::pow(observations(d, i), alpha(d) - 1);
+
+      LogProbabilities(i) += std::log( numerator * factor / denominators(d));
     }
   }
 }

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -63,6 +63,14 @@ class GammaDistribution
     GammaDistribution(const arma::mat& data, const double tol = 1e-8);
 
     /**
+     * Construct the Gamma distribution given two vectors alpha and beta.
+     *
+     * @param alpha The vector of alphas, one per dimension.
+     * @param beta The vector of betas, one per dimension.
+     */
+    GammaDistribution(const arma::vec& alpha, const arma::vec& beta);
+
+    /**
      * Destructor.
      */
     ~GammaDistribution() {};
@@ -77,6 +85,19 @@ class GammaDistribution
      *    smaller than tol.
      */
     void Train(const arma::mat& rdata, const double tol = 1e-8);
+    
+    /** Fits an alpha and beta parameter according to observation probabilities.
+     * 
+     * @param observations The reference data, one observation per column
+     * @param probabilities The probability of each observation. One value per
+     *     column of the observations matrix.
+     * @param tol Convergence tolerance. This is *not* an absolute measure:
+     *    It will stop the approximation once the *change* in the value is 
+     *    smaller than tol.
+     */
+    void Train(const arma::mat& observations, 
+                                  const arma::vec& probabilities,
+                                  const double tol = 1e-8);
     
     /**
      * This function trains (fits distribution parameters) to a dataset with
@@ -93,6 +114,58 @@ class GammaDistribution
                const arma::vec& meanLogxVec, 
                const arma::vec& meanxVec,
                const double tol = 1e-8);
+
+
+    /**
+     * This function returns the probability of a group of observations.
+     *
+     * The probability of the value x is
+     *
+     * \frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+     * {-\frac{x}{\beta}}
+     *
+     * for one dimension. This implementation assumes each dimension is
+     * independent, so the product rule is used.
+     *
+     * @param observations Matrix of observations, one per column.
+     * @param probabilities column vector of probabilities, one per observation.
+     */
+    void Probability(const arma::mat& observations, 
+                     arma::vec& Probabilities) const;
+
+    /*
+     * This is a shortcut to the Probability(arma::mat&, arma::vec&) function
+     * for when we want to evaluate only the probability of one dimension of the
+     * gamma.
+     *
+     * @param x The 1-dimensional observation.
+     * @param dim The dimension for which to calculate the probability
+     */
+    double Probability(double x, size_t dim) const;
+
+    /**
+     * This function returns the logarithm of the probability of a group of
+     * observations.
+     *
+     * The logarithm of the probability of a value x is
+     *
+     * log(\frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+     * {-\frac{x}{\beta}})
+     *
+     * for one dimension. This implementation assumes each dimension is
+     * independent, so the product rule is used.
+     *
+     * @param observations Matrix of observations, one per column.
+     * @param logProbabilities column vector of log probabilities, one per 
+     *     observation.
+     */
+    void LogProbability(const arma::mat& observations, 
+                     arma::vec& LogProbabilities) const;
+
+    /**
+     * This function returns an observation of this distribution
+     */
+    arma::vec Random() const;
 
     // Access to Gamma distribution parameters.
 

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -86,7 +86,8 @@ class GammaDistribution
      */
     void Train(const arma::mat& rdata, const double tol = 1e-8);
     
-    /** Fits an alpha and beta parameter according to observation probabilities.
+    /** 
+     * Fits an alpha and beta parameter according to observation probabilities.
      * 
      * @param observations The reference data, one observation per column
      * @param probabilities The probability of each observation. One value per
@@ -96,8 +97,8 @@ class GammaDistribution
      *    smaller than tol.
      */
     void Train(const arma::mat& observations, 
-                                  const arma::vec& probabilities,
-                                  const double tol = 1e-8);
+               const arma::vec& probabilities,
+               const double tol = 1e-8);
     
     /**
      * This function trains (fits distribution parameters) to a dataset with
@@ -160,7 +161,7 @@ class GammaDistribution
      *     observation.
      */
     void LogProbability(const arma::mat& observations, 
-                     arma::vec& LogProbabilities) const;
+                        arma::vec& LogProbabilities) const;
 
     /**
      * This function returns an observation of this distribution

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -539,6 +539,32 @@ BOOST_AUTO_TEST_CASE(GammaDistributionTrainStatisticsTest)
   BOOST_REQUIRE_CLOSE(d1.Beta(0), d2.Beta(0), 1e-5);
 }
 
+/**
+ * Tests that Random() generates points that can be reasonably well fit by the
+ * distribution that generated them.
+ */
+BOOST_AUTO_TEST_CASE(GammaDistributionRandomTest)
+{
+  const arma::vec a("2.0 2.5 3.0"), b("0.4 0.6 1.3");
+  const size_t numPoints = 2000;
+
+  // Distribution to generate points.
+  GammaDistribution d1(a, b);
+  arma::mat data(3, numPoints); // 3-d points.
+
+  for (size_t i = 0; i < numPoints; ++i)
+    //std::cout << d1.Random() << "====" << std::endl;
+    data.col(i) = d1.Random();
+  
+  // Distribution to fit points.
+  GammaDistribution d2(data);
+  for (size_t i = 0; i < 3; ++i)
+  {
+    BOOST_REQUIRE_CLOSE(d2.Alpha(i), a(i), 10); // Within 10%
+    BOOST_REQUIRE_CLOSE(d2.Beta(i), b(i), 10);
+  }
+}
+
 BOOST_AUTO_TEST_CASE(GammaDistributionProbabilityTest)
 {
   // Train two 1-dimensional distributions.

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -539,4 +539,74 @@ BOOST_AUTO_TEST_CASE(GammaDistributionTrainStatisticsTest)
   BOOST_REQUIRE_CLOSE(d1.Beta(0), d2.Beta(0), 1e-5);
 }
 
+BOOST_AUTO_TEST_CASE(GammaDistributionProbabilityTest)
+{
+  // Train two 1-dimensional distributions.
+  const arma::vec a1("2.0"), b1("0.9"), a2("3.1"), b2("1.4");
+  arma::mat x1("2.0"), x2("2.94");
+  arma::vec prob1, prob2;
+
+  // Evaluated at wolfram|alpha
+  GammaDistribution d1(a1, b1);
+  d1.Probability(x1, prob1);
+  BOOST_REQUIRE_CLOSE(prob1(0), 0.267575, 1e-3);
+
+  // Evaluated at wolfram|alpha
+  GammaDistribution d2(a2, b2);
+  d2.Probability(x2, prob2);
+  BOOST_REQUIRE_CLOSE(prob2(0), 0.189043, 1e-3);
+
+  // Check that the overload that returns the probability for 1 dimension
+  // agrees.
+  BOOST_REQUIRE_CLOSE(prob2(0), d2.Probability(2.94, 0), 1e-5);
+
+  // Combine into one 2-dimensional distribution.
+  const arma::vec a3("2.0 3.1"), b3("0.9 1.4");
+  arma::mat x3(2, 2);
+  x3
+    << 2.0 << 2.94 << arma::endr
+    << 2.0 << 2.94;
+  arma::vec prob3;
+
+  // Expect that the 2-dimensional distribution returns the product of the
+  // 1-dimensional distributions (evaluated at wolfram|alpha).
+  GammaDistribution d3(a3, b3);
+  d3.Probability(x3, prob3);
+  BOOST_REQUIRE_CLOSE(prob3(0), 0.04408, 1e-2);
+  BOOST_REQUIRE_CLOSE(prob3(1), 0.026165, 1e-2);
+}
+
+BOOST_AUTO_TEST_CASE(GammaDistributionLogProbabilityTest)
+{
+  // Train two 1-dimensional distributions.
+  const arma::vec a1("2.0"), b1("0.9"), a2("3.1"), b2("1.4");
+  arma::mat x1("2.0"), x2("2.94");
+  arma::vec prob1, prob2;
+
+  // Evaluated at wolfram|alpha
+  GammaDistribution d1(a1, b1);
+  d1.LogProbability(x1, prob1);
+  BOOST_REQUIRE_CLOSE(prob1(0), std::log(0.267575), 1e-3);
+
+  // Evaluated at wolfram|alpha
+  GammaDistribution d2(a2, b2);
+  d2.LogProbability(x2, prob2);
+  BOOST_REQUIRE_CLOSE(prob2(0), std::log(0.189043), 1e-3);
+
+  // Combine into one 2-dimensional distribution.
+  const arma::vec a3("2.0 3.1"), b3("0.9 1.4");
+  arma::mat x3(2, 2);
+  x3
+    << 2.0 << 2.94 << arma::endr
+    << 2.0 << 2.94;
+  arma::vec prob3;
+
+  // Expect that the 2-dimensional distribution returns the product of the
+  // 1-dimensional distributions (evaluated at wolfram|alpha).
+  GammaDistribution d3(a3, b3);
+  d3.LogProbability(x3, prob3);
+  BOOST_REQUIRE_CLOSE(prob3(0), std::log(0.04408), 1e-3);
+  BOOST_REQUIRE_CLOSE(prob3(1), std::log(0.026165), 1e-3);
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
While implementing LSHModel I realized I would need the `GammaDistribution::Probability(x)` function. I remembered I mentioned in https://github.com/mlpack/mlpack/issues/733 I said I'd do it at some point, so I completed it now.

I also added a `Probability(x, dimension)`, for evaluating a single dimension at a time. This is useful for my implementation, and might prove useful to others since the gammas are completely independent here.

There's only one thing that bugs me: I'm not sure how to test the `Train(observations, probability)` function, so I haven't written a test for that yet.