### PR TITLE
Use move semantics to set a given reference tree in NeighborSearch class.

### DIFF
--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -203,6 +203,7 @@
 #include <mlpack/core/util/arma_traits.hpp>
 #include <mlpack/core/util/log.hpp>
 #include <mlpack/core/util/cli.hpp>
+#include <mlpack/core/util/deprecated.hpp>
 #include <mlpack/core/data/load.hpp>
 #include <mlpack/core/data/save.hpp>
 #include <mlpack/core/data/normalize_labels.hpp>

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
@@ -407,6 +407,12 @@ BinarySpaceTree(BinarySpaceTree&& other) :
   other.furthestDescendantDistance = 0.0;
   other.minimumBoundDistance = 0.0;
   other.dataset = NULL;
+
+  //Set new parent.
+  if (left)
+    left->parent = this;
+  if (right)
+    right->parent = this;
 }
 
 /**

--- a/src/mlpack/core/tree/binary_space_tree/traits.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/traits.hpp
@@ -37,14 +37,14 @@ class TreeTraits<BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
   static const bool HasOverlappingChildren = false;
 
   /**
+   * Each binary space tree node doesn't share points with any other node.
+   */
+  static const bool HasDuplicatedPoints = false;
+
+  /**
    * There is no guarantee that the first point in a node is its centroid.
    */
   static const bool FirstPointIsCentroid = false;
-
-  /**
-   * The tree has not got duplicated points.
-   */
-  static const bool HasDuplicatedPoints = false;
 
   /**
    * Points are not contained at multiple levels of the binary space tree.

--- a/src/mlpack/core/tree/cover_tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree.hpp
@@ -223,6 +223,14 @@ class CoverTree
   CoverTree(const CoverTree& other);
 
   /**
+   * Move constructor for a Cover Tree, possess all the members of the given
+   * tree.
+   *
+   * @param other Cover Tree to move.
+   */
+  CoverTree(CoverTree&& other);
+
+  /**
    * Create a cover tree from a boost::serialization archive.
    */
   template<typename Archive>

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -521,6 +521,46 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
   }
 }
 
+template<
+    typename MetricType,
+    typename StatisticType,
+    typename MatType,
+    typename RootPointPolicy
+>
+CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
+    CoverTree&& other) :
+    dataset(other.dataset),
+    point(other.point),
+    children(std::move(other.children)),
+    scale(other.scale),
+    base(other.base),
+    stat(std::move(other.stat)),
+    numDescendants(other.numDescendants),
+    parent(other.parent),
+    parentDistance(other.parentDistance),
+    furthestDescendantDistance(other.furthestDescendantDistance),
+    localMetric(other.localMetric),
+    localDataset(other.localDataset),
+    metric(other.metric),
+    distanceComps(other.distanceComps)
+{
+  // Set proper parent pointer.
+  for (size_t i = 0; i < children.size(); ++i)
+    children[i]->Parent() = this;
+
+  other.dataset = NULL;
+  other.point = 0;
+  other.scale = INT_MIN;
+  other.base = 0;
+  other.numDescendants = 0;
+  other.parent = NULL;
+  other.parentDistance = 0;
+  other.furthestDescendantDistance = 0;
+  other.localMetric = false;
+  other.localDataset = false;
+  other.metric = NULL;
+}
+
 // Construct from a boost::serialization archive.
 template<
     typename MetricType,

--- a/src/mlpack/core/tree/cover_tree/traits.hpp
+++ b/src/mlpack/core/tree/cover_tree/traits.hpp
@@ -33,6 +33,12 @@ class TreeTraits<CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>>
   static const bool HasOverlappingChildren = true;
 
   /**
+   * Cover trees do have self-children, so points can be included in more than
+   * one node.
+   */
+  static const bool HasDuplicatedPoints = true;
+
+  /**
    * Each cover tree node contains only one point, and that point is its
    * centroid.
    */

--- a/src/mlpack/core/tree/rectangle_tree/traits.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/traits.hpp
@@ -34,6 +34,11 @@ class TreeTraits<RectangleTree<MetricType, StatisticType, MatType, SplitType,
   static const bool HasOverlappingChildren = true;
 
   /**
+   * An R-tree node doesn't share points with another node.
+   */
+  static const bool HasDuplicatedPoints = false;
+
+  /**
    * There is no guarantee that the first point in a node is its centroid.
    */
   static const bool FirstPointIsCentroid = false;
@@ -86,6 +91,11 @@ class TreeTraits<RectangleTree<MetricType,
    * The R+/R++ tree can't have overlapping children.
    */
   static const bool HasOverlappingChildren = false;
+
+  /**
+   * An R-tree node doesn't share points with another node.
+   */
+  static const bool HasDuplicatedPoints = false;
 
   /**
    * There is no guarantee that the first point in a node is its centroid.

--- a/src/mlpack/core/tree/tree_traits.hpp
+++ b/src/mlpack/core/tree/tree_traits.hpp
@@ -79,6 +79,11 @@ class TreeTraits
   static const bool HasOverlappingChildren = true;
 
   /**
+   * This is true if a point can be included in more than one node.
+   */
+  static const bool HasDuplicatedPoints = false;
+
+  /**
    * This is true if the first point of each node is the centroid of its bound.
    */
   static const bool FirstPointIsCentroid = false;

--- a/src/mlpack/core/util/CMakeLists.txt
+++ b/src/mlpack/core/util/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
   cli_deleter.hpp
   cli_deleter.cpp
   cli_impl.hpp
+  deprecated.hpp
   log.hpp
   log.cpp
   nulloutstream.hpp

--- a/src/mlpack/core/util/deprecated.hpp
+++ b/src/mlpack/core/util/deprecated.hpp
@@ -1,0 +1,19 @@
+/**
+ * @file deprecated.hpp
+ * @author Marcos Pividori.
+ *
+ * Definition of the DEPRECATED macro.
+ */
+#ifndef MLPACK_CORE_UTIL_DEPRECATED_HPP
+#define MLPACK_CORE_UTIL_DEPRECATED_HPP
+
+#ifdef __GNUG__
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif
+
+#endif

--- a/src/mlpack/core/util/deprecated.hpp
+++ b/src/mlpack/core/util/deprecated.hpp
@@ -2,18 +2,19 @@
  * @file deprecated.hpp
  * @author Marcos Pividori.
  *
- * Definition of the DEPRECATED macro.
+ * Definition of the mlpack_deprecated macro.
  */
 #ifndef MLPACK_CORE_UTIL_DEPRECATED_HPP
 #define MLPACK_CORE_UTIL_DEPRECATED_HPP
 
 #ifdef __GNUG__
-#define DEPRECATED __attribute__((deprecated))
+#define mlpack_deprecated __attribute__((deprecated))
 #elif defined(_MSC_VER)
-#define DEPRECATED __declspec(deprecated)
+#define mlpack_deprecated __declspec(deprecated)
 #else
-#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-#define DEPRECATED
+#pragma message("WARNING: You need to implement mlpack_deprecated for this "
+    "compiler")
+#define mlpack_deprecated
 #endif
 
 #endif

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
@@ -101,16 +101,16 @@ double DualTreeKMeans<MetricType, MatType, TreeType>::Iterate(
   std::vector<size_t> oldFromNewCentroids;
   Tree* centroidTree = BuildTree<Tree>(centroids, oldFromNewCentroids);
 
+  // Find the nearest neighbors of each of the clusters.  We have to make our
+  // own TreeType, which is a little bit abuse, but we know for sure the
+  // TreeStatType we have will work.
+  neighbor::NeighborSearch<neighbor::NearestNeighborSort, MetricType, MatType,
+      NNSTreeType> nns(std::move(*centroidTree));
+
   // Reset information in the tree, if we need to.
   if (iteration > 0)
   {
     Timer::Start("knn");
-
-    // Find the nearest neighbors of each of the clusters.  We have to make our
-    // own TreeType, which is a little bit abuse, but we know for sure the
-    // TreeStatType we have will work.
-    neighbor::NeighborSearch<neighbor::NearestNeighborSort, MetricType, MatType,
-        NNSTreeType> nns(centroidTree);
 
     // If the tree maps points, we need an intermediate result matrix.
     arma::mat* interclusterDistancesTemp =
@@ -148,8 +148,9 @@ double DualTreeKMeans<MetricType, MatType, TreeType>::Iterate(
   // We won't use the KNN class here because we have our own set of rules.
   lastIterationCentroids = centroids;
   typedef DualTreeKMeansRules<MetricType, Tree> RuleType;
-  RuleType rules(centroidTree->Dataset(), dataset, assignments, upperBounds,
-      lowerBounds, metric, prunedPoints, oldFromNewCentroids, visited);
+  RuleType rules(nns.ReferenceTree().Dataset(), dataset, assignments,
+      upperBounds, lowerBounds, metric, prunedPoints, oldFromNewCentroids,
+      visited);
 
   typename Tree::template BreadthFirstDualTreeTraverser<RuleType>
       traverser(rules);
@@ -160,7 +161,7 @@ double DualTreeKMeans<MetricType, MatType, TreeType>::Iterate(
 
   // Set the number of pruned centroids in the root to 0.
   tree->Stat().Pruned() = 0;
-  traverser.Traverse(*tree, *centroidTree);
+  traverser.Traverse(*tree, nns.ReferenceTree());
   distanceCalculations += rules.BaseCases() + rules.Scores();
 
   Timer::Start("tree_mod");

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -134,9 +134,12 @@ class NeighborSearch
    * Additionally, an instantiated distance metric can be given, for cases where
    * the distance metric holds data.
    *
-   * There is no copying of the data matrices in this constructor (because
-   * tree-building is not necessary), so this is the constructor to use when
-   * copies absolutely must be avoided.
+   * This method is deprecated and will be removed in mlpack 3.0.0! Constructors
+   * taking a reference to the reference tree are prefered.
+   *
+   * This method won't take ownership of the given tree. There is no copying of
+   * the data matrices in this constructor (because  tree-building is not
+   * necessary).
    *
    * @note
    * Mapping the points of the matrix back to their original indices is not done
@@ -150,10 +153,10 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
-  NeighborSearch(Tree* referenceTree,
-                 const NeighborSearchMode mode = DUAL_TREE_MODE,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  DEPRECATED NeighborSearch(Tree* referenceTree,
+                            const NeighborSearchMode mode = DUAL_TREE_MODE,
+                            const double epsilon = 0,
+                            const MetricType metric = MetricType());
 
   /**
    * Create a NeighborSearch object without any reference data.  If Search() is
@@ -281,10 +284,10 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
-  NeighborSearch(Tree* referenceTree,
-                 const bool singleMode,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  DEPRECATED NeighborSearch(Tree* referenceTree,
+                            const bool singleMode,
+                            const double epsilon = 0,
+                            const MetricType metric = MetricType());
 
   /**
    * Initialize the NeighborSearch object with the given pre-constructed
@@ -364,9 +367,12 @@ class NeighborSearch
   /**
    * Set the reference tree to a new reference tree.
    *
+   * This method is deprecated and will be removed in mlpack 3.0.0! Train()
+   * methods taking a reference to the reference tree are prefered.
+   *
    * @param referenceTree Pre-built tree for reference points.
    */
-  void Train(Tree* referenceTree);
+  DEPRECATED void Train(Tree* referenceTree);
 
   /**
    * Set the reference tree as a copy of the given reference tree.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -127,39 +127,6 @@ class NeighborSearch
                  const MetricType metric = MetricType());
 
   /**
-   * Initialize the NeighborSearch object with the given pre-constructed
-   * reference tree (this is the tree built on the points that will be
-   * searched).  Optionally, perform the computation in a different mode.
-   * Naive mode is not available as an option for this constructor.
-   * Additionally, an instantiated distance metric can be given, for cases where
-   * the distance metric holds data.
-   *
-   * This method is deprecated and will be removed in mlpack 3.0.0! Constructors
-   * taking a reference to the reference tree are prefered.
-   *
-   * This method won't take ownership of the given tree. There is no copying of
-   * the data matrices in this constructor (because  tree-building is not
-   * necessary).
-   *
-   * @note
-   * Mapping the points of the matrix back to their original indices is not done
-   * when this constructor is used, so if the tree type you are using maps
-   * points (like BinarySpaceTree), then you will have to perform the re-mapping
-   * manually.
-   * @endnote
-   *
-   * @param referenceTree Pre-built tree for reference points.
-   * @param mode Neighbor search mode.
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric Instantiated distance metric.
-   */
-  mlpack_deprecated NeighborSearch(
-      Tree* referenceTree,
-      const NeighborSearchMode mode = DUAL_TREE_MODE,
-      const double epsilon = 0,
-      const MetricType metric = MetricType());
-
-  /**
    * Initialize the NeighborSearch object with a copy of the given
    * pre-constructed reference tree (this is the tree built on the points that
    * will be searched).  Optionally, choose to use single-tree mode.  Naive mode

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -194,11 +194,11 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric An optional instance of the MetricType class.
    */
-  NeighborSearch(const MatType& referenceSet,
-                 const bool naive,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(const MatType& referenceSet,
+                                   const bool naive,
+                                   const bool singleMode = false,
+                                   const double epsilon = 0,
+                                   const MetricType metric = MetricType());
 
   /**
    * Initialize the NeighborSearch object, taking ownership of the reference
@@ -222,11 +222,11 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric An optional instance of the MetricType class.
    */
-  NeighborSearch(MatType&& referenceSet,
-                 const bool naive,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(MatType&& referenceSet,
+                                   const bool naive,
+                                   const bool singleMode = false,
+                                   const double epsilon = 0,
+                                   const MetricType metric = MetricType());
 
   /**
    * Initialize the NeighborSearch object with a copy of the given
@@ -235,6 +235,8 @@ class NeighborSearch
    * is not available as an option for this constructor.  Additionally, an
    * instantiated distance metric can be given, for cases where the distance
    * metric holds data.
+   *
+   * Deprecated. Will be removed in mlpack 3.0.0.
    *
    * This method will copy the given tree.  You can avoid this copy by using the
    * construct that takes a rvalue reference to the tree.
@@ -252,10 +254,10 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
-  NeighborSearch(Tree& referenceTree,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(Tree& referenceTree,
+                                   const bool singleMode = false,
+                                   const double epsilon = 0,
+                                   const MetricType metric = MetricType());
 
   /**
    * Initialize the NeighborSearch object with the given pre-constructed
@@ -298,6 +300,8 @@ class NeighborSearch
    * distance metric can be given, for cases where the distance metric holds
    * data.
    *
+   * Deprecated. Will be removed in mlpack 3.0.0.
+   *
    * This method will take ownership of the given tree. There is no copying of
    * the data matrices (because tree-building is not necessary), so this is the
    * constructor to use when copies absolutely must be avoided.
@@ -315,10 +319,10 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
-  NeighborSearch(Tree&& referenceTree,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(Tree&& referenceTree,
+                                   const bool singleMode = false,
+                                   const double epsilon = 0,
+                                   const MetricType metric = MetricType());
 
   /**
    * Create a NeighborSearch object without any reference data.  If Search() is
@@ -333,10 +337,10 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated metric.
    */
-  NeighborSearch(const bool naive,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(const bool naive,
+                                   const bool singleMode = false,
+                                   const double epsilon = 0,
+                                   const MetricType metric = MetricType());
 
 
   /**
@@ -500,22 +504,25 @@ class NeighborSearch
   size_t Scores() const { return scores; }
 
   //! Access whether or not search is done in naive linear scan mode.
-  bool Naive() const { return naive; }
+  //! Deprecated. Will be removed in mlpack 3.0.0.
+  mlpack_deprecated bool Naive() const { return naive; }
   //! Modify whether or not search is done in naive linear scan mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  bool& Naive() { return naive; }
+  mlpack_deprecated bool& Naive() { return naive; }
 
   //! Access whether or not search is done in single-tree mode.
-  bool SingleMode() const { return singleMode; }
+  //! Deprecated. Will be removed in mlpack 3.0.0.
+  mlpack_deprecated bool SingleMode() const { return singleMode; }
   //! Modify whether or not search is done in single-tree mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  bool& SingleMode() { return singleMode; }
+  mlpack_deprecated bool& SingleMode() { return singleMode; }
 
   //! Access whether or not search is done in greedy mode.
-  bool Greedy() const { return greedy; }
+  //! Deprecated. Will be removed in mlpack 3.0.0.
+  mlpack_deprecated bool Greedy() const { return greedy; }
   //! Modify whether or not search is done in greedy mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  bool& Greedy() { return greedy; }
+  mlpack_deprecated bool& Greedy() { return greedy; }
 
   //! Access the relative error to be considered in approximate search.
   double Epsilon() const { return epsilon; }

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -234,9 +234,10 @@ class NeighborSearch
    *
    * Deprecated. Will be removed in mlpack 3.0.0.
    *
-   * There is no copying of the data matrices in this constructor (because
-   * tree-building is not necessary), so this is the constructor to use when
-   * copies absolutely must be avoided.
+   * This method won't take ownership of the given tree. There is no copying of
+   * the data matrices in this constructor (because  tree-building is not
+   * necessary), so this is the constructor to use when copies absolutely must
+   * be avoided.
    *
    * @note
    * Mapping the points of the matrix back to their original indices is not done
@@ -253,6 +254,36 @@ class NeighborSearch
    */
   NeighborSearch(Tree* referenceTree,
                  const bool singleMode,
+                 const double epsilon = 0,
+                 const MetricType metric = MetricType());
+
+  /**
+   * Initialize the NeighborSearch object with the given pre-constructed
+   * reference tree (this is the tree built on the points that will be
+   * searched).  Optionally, choose to use single-tree mode.  Naive mode is not
+   * available as an option for this constructor.  Additionally, an instantiated
+   * distance metric can be given, for cases where the distance metric holds
+   * data.
+   *
+   * This method will take ownership of the given tree. There is no copying of
+   * the data matrices (because tree-building is not necessary), so this is the
+   * constructor to use when copies absolutely must be avoided.
+   *
+   * @note
+   * Mapping the points of the matrix back to their original indices is not done
+   * when this constructor is used, so if the tree type you are using maps
+   * points (like BinarySpaceTree), then you will have to perform the re-mapping
+   * manually.
+   * @endnote
+   *
+   * @param referenceTree Pre-built tree for reference points.
+   * @param singleMode Whether single-tree computation should be used (as
+   *      opposed to dual-tree computation).
+   * @param epsilon Relative approximate error (non-negative).
+   * @param metric Instantiated distance metric.
+   */
+  NeighborSearch(Tree&& referenceTree,
+                 const bool singleMode = false,
                  const double epsilon = 0,
                  const MetricType metric = MetricType());
 
@@ -307,6 +338,15 @@ class NeighborSearch
    * @param referenceTree Pre-built tree for reference points.
    */
   void Train(Tree* referenceTree);
+
+  /**
+   * Set the reference tree to a new reference tree.
+   *
+   * This method will take ownership of the given tree.
+   *
+   * @param referenceTree Pre-built tree for reference points.
+   */
+  void Train(Tree&& referenceTree);
 
   /**
    * For each point in the query set, compute the nearest neighbors and store

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -528,6 +528,11 @@ class NeighborSearch
   //! Access the reference dataset.
   const MatType& ReferenceSet() const { return *referenceSet; }
 
+  //! Access the reference tree.
+  const Tree& ReferenceTree() const { return *referenceTree; }
+  //! Modify the reference tree.
+  Tree& ReferenceTree() { return *referenceTree; }
+
   //! Serialize the NeighborSearch model.
   template<typename Archive>
   void Serialize(Archive& ar, const unsigned int /* version */);

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -467,24 +467,30 @@ class NeighborSearch
   size_t Scores() const { return scores; }
 
   //! Access whether or not search is done in naive linear scan mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
+  //! Deprecated. Will be replaced in mlpack 3.0.0, by a new method:
+  //! NeighborSearchMode SearchMode().
   bool Naive() const { return naive; }
   //! Modify whether or not search is done in naive linear scan mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
+  //! Deprecated. Will be replaced in mlpack 3.0.0, by a new method:
+  //! NeighborSearchMode& SearchMode().
   bool& Naive() { return naive; }
 
   //! Access whether or not search is done in single-tree mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
+  //! Deprecated. Will be replaced in mlpack 3.0.0, by a new method:
+  //! NeighborSearchMode SearchMode().
   bool SingleMode() const { return singleMode; }
   //! Modify whether or not search is done in single-tree mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
+  //! Deprecated. Will be replaced in mlpack 3.0.0, by a new method:
+  //! NeighborSearchMode& SearchMode().
   bool& SingleMode() { return singleMode; }
 
   //! Access whether or not search is done in greedy mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
+  //! Deprecated. Will be replaced in mlpack 3.0.0, by a new method:
+  //! NeighborSearchMode SearchMode().
   bool Greedy() const { return greedy; }
   //! Modify whether or not search is done in greedy mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
+  //! Deprecated. Will be replaced in mlpack 3.0.0, by a new method:
+  //! NeighborSearchMode& SearchMode().
   bool& Greedy() { return greedy; }
 
   //! Access the relative error to be considered in approximate search.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -501,24 +501,24 @@ class NeighborSearch
 
   //! Access whether or not search is done in naive linear scan mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  mlpack_deprecated bool Naive() const { return naive; }
+  bool Naive() const { return naive; }
   //! Modify whether or not search is done in naive linear scan mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  mlpack_deprecated bool& Naive() { return naive; }
+  bool& Naive() { return naive; }
 
   //! Access whether or not search is done in single-tree mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  mlpack_deprecated bool SingleMode() const { return singleMode; }
+  bool SingleMode() const { return singleMode; }
   //! Modify whether or not search is done in single-tree mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  mlpack_deprecated bool& SingleMode() { return singleMode; }
+  bool& SingleMode() { return singleMode; }
 
   //! Access whether or not search is done in greedy mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  mlpack_deprecated bool Greedy() const { return greedy; }
+  bool Greedy() const { return greedy; }
   //! Modify whether or not search is done in greedy mode.
   //! Deprecated. Will be removed in mlpack 3.0.0.
-  mlpack_deprecated bool& Greedy() { return greedy; }
+  bool& Greedy() { return greedy; }
 
   //! Access the relative error to be considered in approximate search.
   double Epsilon() const { return epsilon; }

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -390,6 +390,9 @@ class NeighborSearch
    * number of points in the query dataset and k is the number of neighbors
    * being searched for.
    *
+   * This method is deprecated and will be removed in mlpack 3.0.0! The Search()
+   * method taking a reference to the query tree is prefered.
+   *
    * Note that if you are calling Search() multiple times with a single query
    * tree, you need to reset the bounds in the statistic of each query node,
    * otherwise the result may be wrong!  You can do this by calling
@@ -403,7 +406,33 @@ class NeighborSearch
    * @param sameSet Denotes whether or not the reference and query sets are the
    *      same.
    */
-  void Search(Tree* queryTree,
+  mlpack_deprecated void Search(Tree* queryTree,
+                                const size_t k,
+                                arma::Mat<size_t>& neighbors,
+                                arma::mat& distances,
+                                bool sameSet = false);
+
+  /**
+   * Given a pre-built query tree, search for the nearest neighbors of each
+   * point in the query tree, storing the output in the given matrices.  The
+   * matrices will be set to the size of n columns by k rows, where n is the
+   * number of points in the query dataset and k is the number of neighbors
+   * being searched for.
+   *
+   * Note that if you are calling Search() multiple times with a single query
+   * tree, you need to reset the bounds in the statistic of each query node,
+   * otherwise the result may be wrong!  You can do this by calling
+   * TreeType::Stat()::Reset() on each node in the query tree.
+   *
+   * @param queryTree Tree built on query points.
+   * @param k Number of neighbors to search for.
+   * @param neighbors Matrix storing lists of neighbors for each query point.
+   * @param distances Matrix storing distances of neighbors for each query
+   *      point.
+   * @param sameSet Denotes whether or not the reference and query sets are the
+   *      same.
+   */
+  void Search(Tree& queryTree,
               const size_t k,
               arma::Mat<size_t>& neighbors,
               arma::mat& distances,

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -246,7 +246,6 @@ class NeighborSearch
    * @endnote
    *
    * @param referenceTree Pre-built tree for reference points.
-   * @param referenceSet Set of reference points corresponding to referenceTree.
    * @param singleMode Whether single-tree computation should be used (as
    *      opposed to dual-tree computation).
    * @param epsilon Relative approximate error (non-negative).
@@ -304,6 +303,8 @@ class NeighborSearch
 
   /**
    * Set the reference tree to a new reference tree.
+   *
+   * @param referenceTree Pre-built tree for reference points.
    */
   void Train(Tree* referenceTree);
 

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -153,10 +153,11 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
-  DEPRECATED NeighborSearch(Tree* referenceTree,
-                            const NeighborSearchMode mode = DUAL_TREE_MODE,
-                            const double epsilon = 0,
-                            const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(
+      Tree* referenceTree,
+      const NeighborSearchMode mode = DUAL_TREE_MODE,
+      const double epsilon = 0,
+      const MetricType metric = MetricType());
 
   /**
    * Create a NeighborSearch object without any reference data.  If Search() is
@@ -284,10 +285,10 @@ class NeighborSearch
    * @param epsilon Relative approximate error (non-negative).
    * @param metric Instantiated distance metric.
    */
-  DEPRECATED NeighborSearch(Tree* referenceTree,
-                            const bool singleMode,
-                            const double epsilon = 0,
-                            const MetricType metric = MetricType());
+  mlpack_deprecated NeighborSearch(Tree* referenceTree,
+                                   const bool singleMode,
+                                   const double epsilon = 0,
+                                   const MetricType metric = MetricType());
 
   /**
    * Initialize the NeighborSearch object with the given pre-constructed
@@ -372,7 +373,7 @@ class NeighborSearch
    *
    * @param referenceTree Pre-built tree for reference points.
    */
-  DEPRECATED void Train(Tree* referenceTree);
+  mlpack_deprecated void Train(Tree* referenceTree);
 
   /**
    * Set the reference tree as a copy of the given reference tree.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -225,6 +225,35 @@ class NeighborSearch
                  const MetricType metric = MetricType());
 
   /**
+   * Initialize the NeighborSearch object with a copy of the given
+   * pre-constructed reference tree (this is the tree built on the points that
+   * will be searched).  Optionally, choose to use single-tree mode.  Naive mode
+   * is not available as an option for this constructor.  Additionally, an
+   * instantiated distance metric can be given, for cases where the distance
+   * metric holds data.
+   *
+   * This method will copy the given tree.  You can avoid this copy by using the
+   * construct that takes a rvalue reference to the tree.
+   *
+   * @note
+   * Mapping the points of the matrix back to their original indices is not done
+   * when this constructor is used, so if the tree type you are using maps
+   * points (like BinarySpaceTree), then you will have to perform the re-mapping
+   * manually.
+   * @endnote
+   *
+   * @param referenceTree Pre-built tree for reference points.
+   * @param singleMode Whether single-tree computation should be used (as
+   *      opposed to dual-tree computation).
+   * @param epsilon Relative approximate error (non-negative).
+   * @param metric Instantiated distance metric.
+   */
+  NeighborSearch(Tree& referenceTree,
+                 const bool singleMode = false,
+                 const double epsilon = 0,
+                 const MetricType metric = MetricType());
+
+  /**
    * Initialize the NeighborSearch object with the given pre-constructed
    * reference tree (this is the tree built on the points that will be
    * searched).  Optionally, choose to use single-tree mode.  Naive mode is not
@@ -338,6 +367,16 @@ class NeighborSearch
    * @param referenceTree Pre-built tree for reference points.
    */
   void Train(Tree* referenceTree);
+
+  /**
+   * Set the reference tree as a copy of the given reference tree.
+   *
+   * This method will copy the given tree.  You can avoid this copy by using the
+   * Train() method that takes a rvalue reference to the tree.
+   *
+   * @param referenceTree Pre-built tree for reference points.
+   */
+  void Train(Tree& referenceTree);
 
   /**
    * Set the reference tree to a new reference tree.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -183,7 +183,7 @@ class NeighborSearch
    * @param metric Instantiated distance metric.
    */
   NeighborSearch(
-      Tree& referenceTree,
+      const Tree& referenceTree,
       const NeighborSearchMode mode = DUAL_TREE_MODE,
       const double epsilon = 0,
       const MetricType metric = MetricType());
@@ -383,7 +383,7 @@ class NeighborSearch
    *
    * @param referenceTree Pre-built tree for reference points.
    */
-  void Train(Tree& referenceTree);
+  void Train(const Tree& referenceTree);
 
   /**
    * Set the reference tree to a new reference tree.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -160,6 +160,65 @@ class NeighborSearch
       const MetricType metric = MetricType());
 
   /**
+   * Initialize the NeighborSearch object with a copy of the given
+   * pre-constructed reference tree (this is the tree built on the points that
+   * will be searched).  Optionally, choose to use single-tree mode.  Naive mode
+   * is not available as an option for this constructor.  Additionally, an
+   * instantiated distance metric can be given, for cases where the distance
+   * metric holds data.
+   *
+   * This method will copy the given tree.  You can avoid this copy by using the
+   * construct that takes a rvalue reference to the tree.
+   *
+   * @note
+   * Mapping the points of the matrix back to their original indices is not done
+   * when this constructor is used, so if the tree type you are using maps
+   * points (like BinarySpaceTree), then you will have to perform the re-mapping
+   * manually.
+   * @endnote
+   *
+   * @param referenceTree Pre-built tree for reference points.
+   * @param mode Neighbor search mode.
+   * @param epsilon Relative approximate error (non-negative).
+   * @param metric Instantiated distance metric.
+   */
+  NeighborSearch(
+      Tree& referenceTree,
+      const NeighborSearchMode mode = DUAL_TREE_MODE,
+      const double epsilon = 0,
+      const MetricType metric = MetricType());
+
+  /**
+   * Initialize the NeighborSearch object with the given pre-constructed
+   * reference tree (this is the tree built on the points that will be
+   * searched).  Optionally, choose to use single-tree mode.  Naive mode is not
+   * available as an option for this constructor.  Additionally, an instantiated
+   * distance metric can be given, for cases where the distance metric holds
+   * data.
+   *
+   * This method will take ownership of the given tree. There is no copying of
+   * the data matrices (because tree-building is not necessary), so this is the
+   * constructor to use when copies absolutely must be avoided.
+   *
+   * @note
+   * Mapping the points of the matrix back to their original indices is not done
+   * when this constructor is used, so if the tree type you are using maps
+   * points (like BinarySpaceTree), then you will have to perform the re-mapping
+   * manually.
+   * @endnote
+   *
+   * @param referenceTree Pre-built tree for reference points.
+   * @param mode Neighbor search mode.
+   * @param epsilon Relative approximate error (non-negative).
+   * @param metric Instantiated distance metric.
+   */
+  NeighborSearch(
+      Tree&& referenceTree,
+      const NeighborSearchMode mode = DUAL_TREE_MODE,
+      const double epsilon = 0,
+      const MetricType metric = MetricType());
+
+  /**
    * Create a NeighborSearch object without any reference data.  If Search() is
    * called before a reference set is set with Train(), an exception will be
    * thrown.
@@ -229,37 +288,6 @@ class NeighborSearch
                                    const MetricType metric = MetricType());
 
   /**
-   * Initialize the NeighborSearch object with a copy of the given
-   * pre-constructed reference tree (this is the tree built on the points that
-   * will be searched).  Optionally, choose to use single-tree mode.  Naive mode
-   * is not available as an option for this constructor.  Additionally, an
-   * instantiated distance metric can be given, for cases where the distance
-   * metric holds data.
-   *
-   * Deprecated. Will be removed in mlpack 3.0.0.
-   *
-   * This method will copy the given tree.  You can avoid this copy by using the
-   * construct that takes a rvalue reference to the tree.
-   *
-   * @note
-   * Mapping the points of the matrix back to their original indices is not done
-   * when this constructor is used, so if the tree type you are using maps
-   * points (like BinarySpaceTree), then you will have to perform the re-mapping
-   * manually.
-   * @endnote
-   *
-   * @param referenceTree Pre-built tree for reference points.
-   * @param singleMode Whether single-tree computation should be used (as
-   *      opposed to dual-tree computation).
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric Instantiated distance metric.
-   */
-  mlpack_deprecated NeighborSearch(Tree& referenceTree,
-                                   const bool singleMode = false,
-                                   const double epsilon = 0,
-                                   const MetricType metric = MetricType());
-
-  /**
    * Initialize the NeighborSearch object with the given pre-constructed
    * reference tree (this is the tree built on the points that will be
    * searched).  Optionally, choose to use single-tree mode.  Naive mode is not
@@ -289,38 +317,6 @@ class NeighborSearch
    */
   mlpack_deprecated NeighborSearch(Tree* referenceTree,
                                    const bool singleMode,
-                                   const double epsilon = 0,
-                                   const MetricType metric = MetricType());
-
-  /**
-   * Initialize the NeighborSearch object with the given pre-constructed
-   * reference tree (this is the tree built on the points that will be
-   * searched).  Optionally, choose to use single-tree mode.  Naive mode is not
-   * available as an option for this constructor.  Additionally, an instantiated
-   * distance metric can be given, for cases where the distance metric holds
-   * data.
-   *
-   * Deprecated. Will be removed in mlpack 3.0.0.
-   *
-   * This method will take ownership of the given tree. There is no copying of
-   * the data matrices (because tree-building is not necessary), so this is the
-   * constructor to use when copies absolutely must be avoided.
-   *
-   * @note
-   * Mapping the points of the matrix back to their original indices is not done
-   * when this constructor is used, so if the tree type you are using maps
-   * points (like BinarySpaceTree), then you will have to perform the re-mapping
-   * manually.
-   * @endnote
-   *
-   * @param referenceTree Pre-built tree for reference points.
-   * @param singleMode Whether single-tree computation should be used (as
-   *      opposed to dual-tree computation).
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric Instantiated distance metric.
-   */
-  mlpack_deprecated NeighborSearch(Tree&& referenceTree,
-                                   const bool singleMode = false,
                                    const double epsilon = 0,
                                    const MetricType metric = MetricType());
 

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -834,6 +834,25 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
     arma::mat& distances,
     bool sameSet)
 {
+  Search(*queryTree, k, neighbors, distances, sameSet);
+}
+
+template<typename SortPolicy,
+         typename MetricType,
+         typename MatType,
+         template<typename TreeMetricType,
+                  typename TreeStatType,
+                  typename TreeMatType> class TreeType,
+         template<typename> class DualTreeTraversalType,
+         template<typename> class SingleTreeTraversalType>
+void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
+DualTreeTraversalType, SingleTreeTraversalType>::Search(
+    Tree& queryTree,
+    const size_t k,
+    arma::Mat<size_t>& neighbors,
+    arma::mat& distances,
+    bool sameSet)
+{
   // Update searchMode.
   UpdateSearchMode();
 
@@ -856,7 +875,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   scores = 0;
 
   // Get a reference to the query set.
-  const MatType& querySet = queryTree->Dataset();
+  const MatType& querySet = queryTree.Dataset();
 
   // We won't need to map query indices, but will we need to map distances?
   arma::Mat<size_t>* neighborPtr = &neighbors;
@@ -874,7 +893,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
 
   // Create the traverser.
   DualTreeTraversalType<RuleType> traverser(rules);
-  traverser.Traverse(*queryTree, *referenceTree);
+  traverser.Traverse(queryTree, *referenceTree);
 
   scores += rules.Scores();
   baseCases += rules.BaseCases();

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -314,6 +314,26 @@ SingleTreeTraversalType>::NeighborSearch(Tree* referenceTree,
     throw std::invalid_argument("epsilon must be non-negative");
 }
 
+// Construct the object.
+template<typename SortPolicy,
+         typename MetricType,
+         typename MatType,
+         template<typename TreeMetricType,
+                  typename TreeStatType,
+                  typename TreeMatType> class TreeType,
+         template<typename> class DualTreeTraversalType,
+         template<typename> class SingleTreeTraversalType>
+NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
+SingleTreeTraversalType>::NeighborSearch(Tree&& referenceTree,
+                                         const bool singleMode,
+                                         const double epsilon,
+                                         const MetricType metric) :
+    NeighborSearch(new Tree(std::move(referenceTree)), singleMode, epsilon,
+        metric)
+{
+  treeOwner = true;
+}
+
 // Construct the object without a reference dataset.
 template<typename SortPolicy,
          typename MetricType,
@@ -480,7 +500,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree* referenceTree)
     throw std::invalid_argument("cannot train on given reference tree when "
         "naive search (without trees) is desired");
 
-  if (treeOwner && referenceTree)
+  if (treeOwner && this->referenceTree)
     delete this->referenceTree;
   if (setOwner && referenceSet)
     delete this->referenceSet;
@@ -489,6 +509,21 @@ DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree* referenceTree)
   this->referenceSet = &referenceTree->Dataset();
   treeOwner = false;
   setOwner = false;
+}
+
+template<typename SortPolicy,
+         typename MetricType,
+         typename MatType,
+         template<typename TreeMetricType,
+                  typename TreeStatType,
+                  typename TreeMatType> class TreeType,
+         template<typename> class DualTreeTraversalType,
+         template<typename> class SingleTreeTraversalType>
+void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
+DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree&& referenceTree)
+{
+  Train(new Tree(std::move(referenceTree)));
+  treeOwner = true;
 }
 
 /**

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -324,6 +324,26 @@ template<typename SortPolicy,
          template<typename> class DualTreeTraversalType,
          template<typename> class SingleTreeTraversalType>
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
+SingleTreeTraversalType>::NeighborSearch(Tree& referenceTree,
+                                         const bool singleMode,
+                                         const double epsilon,
+                                         const MetricType metric) :
+    NeighborSearch(new Tree(referenceTree), singleMode, epsilon,
+        metric)
+{
+  treeOwner = true;
+}
+
+// Construct the object.
+template<typename SortPolicy,
+         typename MetricType,
+         typename MatType,
+         template<typename TreeMetricType,
+                  typename TreeStatType,
+                  typename TreeMatType> class TreeType,
+         template<typename> class DualTreeTraversalType,
+         template<typename> class SingleTreeTraversalType>
+NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
 SingleTreeTraversalType>::NeighborSearch(Tree&& referenceTree,
                                          const bool singleMode,
                                          const double epsilon,
@@ -509,6 +529,21 @@ DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree* referenceTree)
   this->referenceSet = &referenceTree->Dataset();
   treeOwner = false;
   setOwner = false;
+}
+
+template<typename SortPolicy,
+         typename MetricType,
+         typename MatType,
+         template<typename TreeMetricType,
+                  typename TreeStatType,
+                  typename TreeMatType> class TreeType,
+         template<typename> class DualTreeTraversalType,
+         template<typename> class SingleTreeTraversalType>
+void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
+DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree& referenceTree)
+{
+  Train(new Tree(referenceTree));
+  treeOwner = true;
 }
 
 template<typename SortPolicy,

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -177,7 +177,7 @@ template<typename SortPolicy,
          template<typename> class DualTreeTraversalType,
          template<typename> class SingleTreeTraversalType>
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
-SingleTreeTraversalType>::NeighborSearch(Tree& referenceTree,
+SingleTreeTraversalType>::NeighborSearch(const Tree& referenceTree,
                                          const NeighborSearchMode mode,
                                          const double epsilon,
                                          const MetricType metric) :
@@ -574,7 +574,8 @@ template<typename SortPolicy,
          template<typename> class DualTreeTraversalType,
          template<typename> class SingleTreeTraversalType>
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree& referenceTree)
+DualTreeTraversalType, SingleTreeTraversalType>::Train(
+    const Tree& referenceTree)
 {
   // Update searchMode according to naive, singleMode and greedy flags.
   UpdateSearchMode();

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -143,40 +143,6 @@ template<typename SortPolicy,
          template<typename> class DualTreeTraversalType,
          template<typename> class SingleTreeTraversalType>
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
-SingleTreeTraversalType>::NeighborSearch(Tree* referenceTree,
-                                         const NeighborSearchMode mode,
-                                         const double epsilon,
-                                         const MetricType metric) :
-    referenceTree(referenceTree),
-    referenceSet(&referenceTree->Dataset()),
-    treeOwner(false),
-    setOwner(false),
-    searchMode(mode),
-    epsilon(epsilon),
-    metric(metric),
-    baseCases(0),
-    scores(0),
-    treeNeedsReset(false)
-{
-  // Update naive, singleMode and greedy flags according to searchMode.
-  UpdateSearchModeFlags();
-
-  if (mode == NAIVE_MODE)
-    throw std::invalid_argument("invalid constructor for naive mode");
-  if (epsilon < 0)
-    throw std::invalid_argument("epsilon must be non-negative");
-}
-
-// Construct the object.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
 SingleTreeTraversalType>::NeighborSearch(const Tree& referenceTree,
                                          const NeighborSearchMode mode,
                                          const double epsilon,

--- a/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
@@ -87,7 +87,7 @@ void BiSearchVisitor<SortPolicy>::operator()(SpillKNN* ns) const
       // non overlapping (tau = 0).
       typename SpillKNN::Tree queryTree(std::move(querySet), 0 /* tau*/,
           leafSize, rho);
-      ns->Search(&queryTree, k, neighbors, distances);
+      ns->Search(queryTree, k, neighbors, distances);
     }
     else
       ns->Search(querySet, k, neighbors, distances);
@@ -109,7 +109,7 @@ void BiSearchVisitor<SortPolicy>::SearchLeaf(NSType* ns) const
 
     arma::Mat<size_t> neighborsOut;
     arma::mat distancesOut;
-    ns->Search(&queryTree, k, neighborsOut, distancesOut);
+    ns->Search(queryTree, k, neighborsOut, distancesOut);
 
     // Unmap the query points.
     distances.set_size(distancesOut.n_rows, distancesOut.n_cols);

--- a/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model_impl.hpp
@@ -176,11 +176,8 @@ void TrainVisitor<SortPolicy>::operator ()(SpillKNN* ns) const
       ns->Train(std::move(referenceSet));
     else
     {
-      typename SpillKNN::Tree* tree = new typename SpillKNN::Tree(
-          std::move(referenceSet), tau, leafSize, rho);
-      ns->Train(tree);
-      // Give the model ownership of the tree.
-      ns->treeOwner = true;
+      typename SpillKNN::Tree tree(std::move(referenceSet), tau, leafSize, rho);
+      ns->Train(std::move(tree));
     }
   }
   else
@@ -197,13 +194,10 @@ void TrainVisitor<SortPolicy>::TrainLeaf(NSType* ns) const
   else
   {
     std::vector<size_t> oldFromNewReferences;
-    typename NSType::Tree* tree =
-        new typename NSType::Tree(std::move(referenceSet),
+    typename NSType::Tree referenceTree(std::move(referenceSet),
         oldFromNewReferences, leafSize);
-    ns->Train(tree);
-
-    // Give the model ownership of the tree and the mappings.
-    ns->treeOwner = true;
+    ns->Train(std::move(referenceTree));
+    // Set the mappings.
     ns->oldFromNewReferences = std::move(oldFromNewReferences);
   }
 }

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
       arma::mat> tree(dataset);
 
   NeighborSearch<FurthestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
-      coverTreeSearch(&tree, SINGLE_TREE_MODE, 0.05);
+      coverTreeSearch(std::move(tree), SINGLE_TREE_MODE, 0.05);
 
   arma::Mat<size_t> neighborsCoverTree;
   arma::mat distancesCoverTree;
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
       arma::mat> referenceTree(dataset);
 
   NeighborSearch<FurthestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
-      coverTreeSearch(&referenceTree, DUAL_TREE_MODE, 0.05);
+      coverTreeSearch(std::move(referenceTree), DUAL_TREE_MODE, 0.05);
 
   arma::Mat<size_t> neighborsCoverTree;
   arma::mat distancesCoverTree;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -173,17 +173,12 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
   arma::mat distancesExact;
   exact.Search(dataset, 15, neighborsExact, distancesExact);
 
-  StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> referenceTree(dataset);
-
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> coverTreeSearch(std::move(referenceTree),
-      DUAL_TREE_MODE, 0.05);
+      StandardCoverTree> coverTreeSearch(dataset, DUAL_TREE_MODE, 0.05);
 
   arma::Mat<size_t> neighborsCoverTree;
   arma::mat distancesCoverTree;
-  coverTreeSearch.Search(&referenceTree, 15, neighborsCoverTree,
-      distancesCoverTree);
+  coverTreeSearch.Search(dataset, 15, neighborsCoverTree, distancesCoverTree);
 
   for (size_t i = 0; i < neighborsCoverTree.n_elem; ++i)
     REQUIRE_RELATIVE_ERR(distancesCoverTree[i], distancesExact[i], 0.05);

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(SingleSpillTreeTest)
       referenceTree(dataset, maxDist * 1.01 /* tau parameter */);
 
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat, SPTree>
-      spTreeSearch(&referenceTree, SINGLE_TREE_MODE, 0.05);
+      spTreeSearch(std::move(referenceTree), SINGLE_TREE_MODE, 0.05);
 
   arma::Mat<size_t> neighborsSPTree;
   arma::mat distancesSPTree;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
       arma::mat> tree(dataset);
 
   NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
-      coverTreeSearch(&tree, SINGLE_TREE_MODE, 0.05);
+      coverTreeSearch(std::move(tree), SINGLE_TREE_MODE, 0.05);
 
   arma::Mat<size_t> neighborsCoverTree;
   arma::mat distancesCoverTree;
@@ -177,7 +177,8 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
       arma::mat> referenceTree(dataset);
 
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> coverTreeSearch(&referenceTree, DUAL_TREE_MODE, 0.05);
+      StandardCoverTree> coverTreeSearch(std::move(referenceTree),
+      DUAL_TREE_MODE, 0.05);
 
   arma::Mat<size_t> neighborsCoverTree;
   arma::mat distancesCoverTree;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(TrainTreeTest)
 
   std::vector<size_t> oldFromNewReferences;
   KNN::Tree tree(dataset, oldFromNewReferences);
-  empty.Train(&tree);
+  empty.Train(std::move(tree));
 
   empty.Search(5, neighbors, distances);
   baseline.Search(5, baselineNeighbors, baselineDistances);
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(NaiveTrainTreeTest)
   arma::mat dataset = arma::randu<arma::mat>(5, 100);
   KNN::Tree tree(dataset);
 
-  BOOST_REQUIRE_THROW(empty.Train(&tree), std::invalid_argument);
+  BOOST_REQUIRE_THROW(empty.Train(std::move(tree)), std::invalid_argument);
 }
 
 /**
@@ -373,28 +373,32 @@ BOOST_AUTO_TEST_CASE(ExhaustiveSyntheticTest)
   // calculation.
   std::vector<size_t> oldFromNew;
   std::vector<size_t> newFromOld;
-  TreeType* tree = new TreeType(data, oldFromNew, newFromOld, 1);
+  TreeType tree(data, oldFromNew, newFromOld, 1);
+
+  KNN knn(std::move(tree));
+
   for (int i = 0; i < 3; i++)
   {
-    KNN* knn;
 
     switch (i)
     {
       case 0: // Use the dual-tree method.
-        knn = new KNN(tree, DUAL_TREE_MODE);
+        knn.Naive() = false;
+        knn.SingleMode() = false;
         break;
       case 1: // Use the single-tree method.
-        knn = new KNN(tree, SINGLE_TREE_MODE);
+        knn.Naive() = false;
+        knn.SingleMode() = true;
         break;
       case 2: // Use the naive method.
-        knn = new KNN(tree->Dataset(), NAIVE_MODE);
+        knn.Naive() = true;
         break;
     }
 
     // Now perform the actual calculation.
     arma::Mat<size_t> neighbors;
     arma::mat distances;
-    knn->Search(10, neighbors, distances);
+    knn.Search(10, neighbors, distances);
 
     // Now the exhaustive check for correctness.  This will be long.  We must
     // also remember that the distances returned are squared distances.  As a
@@ -643,12 +647,7 @@ BOOST_AUTO_TEST_CASE(ExhaustiveSyntheticTest)
     BOOST_REQUIRE_EQUAL(neighbors(9, newFromOld[10]), newFromOld[4]);
     BOOST_REQUIRE_CLOSE(distances(9, newFromOld[10]), 4.05, 1e-5);
 
-    // Clean the memory.
-    delete knn;
   }
-
-  // Delete the tree.
-  delete tree;
 }
 
 /**
@@ -769,7 +768,7 @@ BOOST_AUTO_TEST_CASE(SingleCoverTreeTest)
       arma::mat> tree(data);
 
   NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
-      coverTreeSearch(&tree, SINGLE_TREE_MODE);
+      coverTreeSearch(std::move(tree), SINGLE_TREE_MODE);
 
   KNN naive(data, NAIVE_MODE);
 
@@ -807,11 +806,11 @@ BOOST_AUTO_TEST_CASE(DualCoverTreeTest)
       arma::mat> referenceTree(dataset);
 
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> coverTreeSearch(&referenceTree);
+      StandardCoverTree> coverTreeSearch(std::move(referenceTree));
 
   arma::Mat<size_t> coverNeighbors;
   arma::mat coverDistances;
-  coverTreeSearch.Search(&referenceTree, 5, coverNeighbors, coverDistances);
+  coverTreeSearch.Search(dataset, 5, coverNeighbors, coverDistances);
 
   for (size_t i = 0; i < coverNeighbors.n_elem; ++i)
   {
@@ -835,14 +834,14 @@ BOOST_AUTO_TEST_CASE(SingleBallTreeTest)
       arma::mat> TreeType;
   TreeType tree(data);
 
+  KNN naive(tree.Dataset(), NAIVE_MODE);
+
   // BinarySpaceTree modifies data. Use modified data to maintain the
   // correspondance between points in the dataset for both methods. The order of
   // query points in both methods should be same.
 
   NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat, BallTree>
-      ballTreeSearch(&tree, SINGLE_TREE_MODE);
-
-  KNN naive(tree.Dataset(), NAIVE_MODE);
+      ballTreeSearch(std::move(tree), SINGLE_TREE_MODE);
 
   arma::Mat<size_t> ballTreeNeighbors;
   arma::mat ballTreeDistances;
@@ -1248,7 +1247,7 @@ BOOST_AUTO_TEST_CASE(NeighborPtrDeleteTest)
   // Build the tree ourselves.
   std::vector<size_t> oldFromNewReferences;
   KNN::Tree tree(dataset);
-  KNN knn(&tree);
+  KNN knn(std::move(tree));
 
   // Now make a query set.
   arma::mat queryset = arma::randu<arma::mat>(5, 50);

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -913,7 +913,7 @@ BOOST_AUTO_TEST_CASE(HybridSpillSearchTest)
   // neighbor of the query points, then we can be sure that we will get an exact
   // solution.
   SpillKNN::Tree referenceTree(dataset, maxDist * 1.01 /* tau parameter */);
-  SpillKNN spTreeSearch(&referenceTree);
+  SpillKNN spTreeSearch(std::move(referenceTree));
 
   for (size_t mode = 0; mode < 2; mode++)
   {
@@ -947,7 +947,7 @@ BOOST_AUTO_TEST_CASE(DuplicatedSpillSearchTest)
     double tau = test * 0.1;
 
     SpillKNN::Tree referenceTree(dataset, tau);
-    SpillKNN spTreeSearch(&referenceTree);
+    SpillKNN spTreeSearch(std::move(referenceTree));
 
     arma::Mat<size_t> neighborsSPTree;
     arma::mat distancesSPTree;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(EmptySearchTest)
       std::invalid_argument);
   BOOST_REQUIRE_THROW(empty.Search(5, neighbors, distances),
       std::invalid_argument);
-  BOOST_REQUIRE_THROW(empty.Search(&queryTree, 5, neighbors, distances),
+  BOOST_REQUIRE_THROW(empty.Search(queryTree, 5, neighbors, distances),
       std::invalid_argument);
 }
 

--- a/src/mlpack/tests/rectangle_tree_test.cpp
+++ b/src/mlpack/tests/rectangle_tree_test.cpp
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(PointDeletion)
 
   // Single-tree search.
   NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
-      RTree> knn1(&tree, SINGLE_TREE_MODE);
+      RTree> knn1(std::move(tree), SINGLE_TREE_MODE);
 
   arma::Mat<size_t> neighbors1;
   arma::mat distances1;
@@ -504,7 +504,7 @@ BOOST_AUTO_TEST_CASE(PointDynamicAdd)
 
   // Nearest neighbor search with the R tree.
   NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
-      RTree> knn1(&tree, SINGLE_TREE_MODE);
+      RTree> knn1(std::move(tree), SINGLE_TREE_MODE);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -535,16 +535,16 @@ BOOST_AUTO_TEST_CASE(SingleTreeTraverserTest)
       arma::mat> TreeType;
   TreeType rTree(dataset, 20, 6, 5, 2, 0);
 
-  // Nearest neighbor search with the R tree.
-  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
-      RStarTree> knn1(&rTree, SINGLE_TREE_MODE);
-
   BOOST_REQUIRE_EQUAL(rTree.NumDescendants(), 1000);
 
   CheckContainment(rTree);
   CheckExactContainment(rTree);
   CheckHierarchy(rTree);
   CheckNumDescendants(rTree);
+
+  // Nearest neighbor search with the R tree.
+  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
+      RStarTree> knn1(std::move(rTree), SINGLE_TREE_MODE);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -578,16 +578,16 @@ BOOST_AUTO_TEST_CASE(XTreeTraverserTest)
       arma::mat> TreeType;
   TreeType xTree(dataset, 20, 6, 5, 2, 0);
 
-  // Nearest neighbor search with the X tree.
-  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
-      XTree> knn1(&xTree, SINGLE_TREE_MODE);
-
   BOOST_REQUIRE_EQUAL(xTree.NumDescendants(), numP);
 
   CheckContainment(xTree);
   CheckExactContainment(xTree);
   CheckHierarchy(xTree);
   CheckNumDescendants(xTree);
+
+  // Nearest neighbor search with the X tree.
+  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
+      XTree> knn1(std::move(xTree), SINGLE_TREE_MODE);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -619,16 +619,16 @@ BOOST_AUTO_TEST_CASE(HilbertRTreeTraverserTest)
       NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
   TreeType hilbertRTree(dataset, 20, 6, 5, 2, 0);
 
-  // Nearest neighbor search with the Hilbert R tree.
-  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
-      HilbertRTree> knn1(&hilbertRTree, SINGLE_TREE_MODE);
-
   BOOST_REQUIRE_EQUAL(hilbertRTree.NumDescendants(), numP);
 
   CheckContainment(hilbertRTree);
   CheckExactContainment(hilbertRTree);
   CheckHierarchy(hilbertRTree);
   CheckNumDescendants(hilbertRTree);
+
+  // Nearest neighbor search with the Hilbert R tree.
+  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
+      HilbertRTree> knn1(std::move(hilbertRTree), SINGLE_TREE_MODE);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -1008,11 +1008,6 @@ BOOST_AUTO_TEST_CASE(RPlusTreeTraverserTest)
       arma::mat > TreeType;
   TreeType rPlusTree(dataset, 20, 6, 5, 2, 0);
 
-  // Nearest neighbor search with the R+ tree.
-
-  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
-      RPlusTree > knn1(&rPlusTree, SINGLE_TREE_MODE);
-
   BOOST_REQUIRE_EQUAL(rPlusTree.NumDescendants(), numP);
 
   CheckContainment(rPlusTree);
@@ -1020,6 +1015,10 @@ BOOST_AUTO_TEST_CASE(RPlusTreeTraverserTest)
   CheckHierarchy(rPlusTree);
   CheckOverlap(rPlusTree);
   CheckNumDescendants(rPlusTree);
+
+  // Nearest neighbor search with the R+ tree.
+  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>, arma::mat,
+      RPlusTree > knn1(std::move(rPlusTree), SINGLE_TREE_MODE);
 
   knn1.Search(5, neighbors1, distances1);
 
@@ -1139,11 +1138,6 @@ BOOST_AUTO_TEST_CASE(RPlusPlusTreeTraverserTest)
       NeighborSearchStat<NearestNeighborSort>, arma::mat > TreeType;
   TreeType rPlusPlusTree(dataset, 20, 6, 5, 2, 0);
 
-  // Nearest neighbor search with the R++ tree.
-
-  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>,
-      arma::mat, RPlusPlusTree > knn1(&rPlusPlusTree, SINGLE_TREE_MODE);
-
   BOOST_REQUIRE_EQUAL(rPlusPlusTree.NumDescendants(), numP);
 
   CheckContainment(rPlusPlusTree);
@@ -1151,6 +1145,11 @@ BOOST_AUTO_TEST_CASE(RPlusPlusTreeTraverserTest)
   CheckHierarchy(rPlusPlusTree);
   CheckRPlusPlusTreeBound(rPlusPlusTree);
   CheckNumDescendants(rPlusPlusTree);
+
+  // Nearest neighbor search with the R++ tree.
+  NeighborSearch<NearestNeighborSort, metric::LMetric<2, true>,
+      arma::mat, RPlusPlusTree > knn1(std::move(rPlusPlusTree),
+      SINGLE_TREE_MODE);
 
   knn1.Search(5, neighbors1, distances1);
 


### PR DESCRIPTION
@rcurtin 
I moved into a new branch, and I didn't realize this would close the PR. The previous PR was https://github.com/mlpack/mlpack/pull/743.
At this point everything is ready to merge. The only problem is that many warnings are shown when compiling because many methods use the deprecated constructors, passing a pointer to the reference tree.
It would take some time to update all that parts of the code.
Thanks