### PR TITLE
Search mode 3.0.0

### DIFF
--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
     data::Load(inputModelFile, "kfn_model", kfn, true); // Fatal on failure.
 
     // Adjust search mode.
-    kfn.SetSearchMode(searchMode);
+    kfn.SearchMode() = searchMode;
     kfn.Epsilon() = epsilon;
 
     // If leaf_size wasn't provided, let's consider the current value in the

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
     data::Load(inputModelFile, "knn_model", knn, true); // Fatal on failure.
 
     // Adjust search mode.
-    knn.SetSearchMode(searchMode);
+    knn.SearchMode() = searchMode;
     knn.Epsilon() = epsilon;
 
     // If leaf_size wasn't provided, let's consider the current value in the

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -169,114 +169,6 @@ class NeighborSearch
                  const MetricType metric = MetricType());
 
   /**
-   * Initialize the NeighborSearch object, passing a reference dataset (this is
-   * the dataset which is searched).  Optionally, perform the computation in
-   * naive mode or single-tree mode.  An initialized distance metric can be
-   * given, for cases where the metric has internal data (i.e. the
-   * distance::MahalanobisDistance class).
-   *
-   * Deprecated. Will be removed in mlpack 3.0.0.
-   *
-   * This method will copy the matrices to internal copies, which are rearranged
-   * during tree-building.  You can avoid this extra copy by pre-constructing
-   * the trees and passing them using a different constructor, or by using the
-   * construct that takes an rvalue reference to the dataset.
-   *
-   * @param referenceSet Set of reference points.
-   * @param naive If true, O(n^2) naive search will be used (as opposed to
-   *      dual-tree search).  This overrides singleMode (if it is set to true).
-   * @param singleMode If true, single-tree search will be used (as opposed to
-   *      dual-tree search).
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric An optional instance of the MetricType class.
-   */
-  NeighborSearch(const MatType& referenceSet,
-                 const bool naive,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
-
-  /**
-   * Initialize the NeighborSearch object, taking ownership of the reference
-   * dataset (this is the dataset which is searched).  Optionally, perform the
-   * computation in naive mode or single-tree mode.  An initialized distance
-   * metric can be given, for cases where the metric has internal data (i.e. the
-   * distance::MahalanobisDistance class).
-   *
-   * Deprecated. Will be removed in mlpack 3.0.0.
-   *
-   * This method will not copy the data matrix, but will take ownership of it,
-   * and depending on the type of tree used, may rearrange the points.  If you
-   * would rather a copy be made, consider using the constructor that takes a
-   * const reference to the data instead.
-   *
-   * @param referenceSet Set of reference points.
-   * @param naive If true, O(n^2) naive search will be used (as opposed to
-   *      dual-tree search).  This overrides singleMode (if it is set to true).
-   * @param singleMode If true, single-tree search will be used (as opposed to
-   *      dual-tree search).
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric An optional instance of the MetricType class.
-   */
-  NeighborSearch(MatType&& referenceSet,
-                 const bool naive,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
-
-  /**
-   * Initialize the NeighborSearch object with the given pre-constructed
-   * reference tree (this is the tree built on the points that will be
-   * searched).  Optionally, choose to use single-tree mode.  Naive mode is not
-   * available as an option for this constructor.  Additionally, an instantiated
-   * distance metric can be given, for cases where the distance metric holds
-   * data.
-   *
-   * Deprecated. Will be removed in mlpack 3.0.0.
-   *
-   * There is no copying of the data matrices in this constructor (because
-   * tree-building is not necessary), so this is the constructor to use when
-   * copies absolutely must be avoided.
-   *
-   * @note
-   * Mapping the points of the matrix back to their original indices is not done
-   * when this constructor is used, so if the tree type you are using maps
-   * points (like BinarySpaceTree), then you will have to perform the re-mapping
-   * manually.
-   * @endnote
-   *
-   * @param referenceTree Pre-built tree for reference points.
-   * @param referenceSet Set of reference points corresponding to referenceTree.
-   * @param singleMode Whether single-tree computation should be used (as
-   *      opposed to dual-tree computation).
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric Instantiated distance metric.
-   */
-  NeighborSearch(Tree* referenceTree,
-                 const bool singleMode,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
-
-  /**
-   * Create a NeighborSearch object without any reference data.  If Search() is
-   * called before a reference set is set with Train(), an exception will be
-   * thrown.
-   *
-   * Deprecated. Will be removed in mlpack 3.0.0.
-   *
-   * @param naive Whether to use naive search.
-   * @param singleMode Whether single-tree computation should be used (as
-   *      opposed to dual-tree computation).
-   * @param epsilon Relative approximate error (non-negative).
-   * @param metric Instantiated metric.
-   */
-  NeighborSearch(const bool naive,
-                 const bool singleMode = false,
-                 const double epsilon = 0,
-                 const MetricType metric = MetricType());
-
-
-  /**
    * Delete the NeighborSearch object. The tree is the only member we are
    * responsible for deleting.  The others will take care of themselves.
    */
@@ -412,23 +304,10 @@ class NeighborSearch
   //! Return the number of node combination scores during the last search.
   size_t Scores() const { return scores; }
 
-  //! Access whether or not search is done in naive linear scan mode.
-  bool Naive() const { return naive; }
-  //! Modify whether or not search is done in naive linear scan mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
-  bool& Naive() { return naive; }
-
-  //! Access whether or not search is done in single-tree mode.
-  bool SingleMode() const { return singleMode; }
-  //! Modify whether or not search is done in single-tree mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
-  bool& SingleMode() { return singleMode; }
-
-  //! Access whether or not search is done in greedy mode.
-  bool Greedy() const { return greedy; }
-  //! Modify whether or not search is done in greedy mode.
-  //! Deprecated. Will be removed in mlpack 3.0.0.
-  bool& Greedy() { return greedy; }
+  //! Access the search mode.
+  NeighborSearchMode SearchMode() const { return searchMode; }
+  //! Modify the search mode.
+  NeighborSearchMode& SearchMode() { return searchMode; }
 
   //! Access the relative error to be considered in approximate search.
   double Epsilon() const { return epsilon; }
@@ -457,12 +336,6 @@ class NeighborSearch
 
   //! Indicates the neighbor search mode.
   NeighborSearchMode searchMode;
-  //! Indicates if O(n^2) naive search is being used.
-  bool naive;
-  //! Indicates if single-tree search is being used (as opposed to dual-tree).
-  bool singleMode;
-  //! Indicates if greedy search is being used.
-  bool greedy;
   //! Indicates the relative error to be considered in approximate search.
   double epsilon;
 
@@ -477,16 +350,6 @@ class NeighborSearch
   //! If this is true, the reference tree bounds need to be reset on a call to
   //! Search() without a query set.
   bool treeNeedsReset;
-
-  //! Updates searchMode to be according to naive, singleMode and greedy
-  //! booleans.  This is only necessary until the modifiers Naive(),
-  //! SingleMode() and Greedy() are removed in mlpack 3.0.0.
-  void UpdateSearchMode();
-
-  //! Updates naive, singleMode and greedy flags according to searchMode.  This
-  //! is only necessary until the modifiers Naive(), SingleMode() and Greedy()
-  //! are removed in mlpack 3.0.0.
-  void UpdateSearchModeFlags();
 
   //! The NSModel class should have access to internal members.
   template<typename SortPol>

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -91,9 +91,6 @@ SingleTreeTraversalType>::NeighborSearch(const MatType& referenceSetIn,
     scores(0),
     treeNeedsReset(false)
 {
-  // Update naive, singleMode and greedy flags according to searchMode.
-  UpdateSearchModeFlags();
-
   if (epsilon < 0)
     throw std::invalid_argument("epsilon must be non-negative");
 }
@@ -126,9 +123,6 @@ SingleTreeTraversalType>::NeighborSearch(MatType&& referenceSetIn,
     scores(0),
     treeNeedsReset(false)
 {
-  // Update naive, singleMode and greedy flags according to searchMode.
-  UpdateSearchModeFlags();
-
   if (epsilon < 0)
     throw std::invalid_argument("epsilon must be non-negative");
 }
@@ -158,9 +152,6 @@ SingleTreeTraversalType>::NeighborSearch(Tree* referenceTree,
     scores(0),
     treeNeedsReset(false)
 {
-  // Update naive, singleMode and greedy flags according to searchMode.
-  UpdateSearchModeFlags();
-
   if (mode == NAIVE_MODE)
     throw std::invalid_argument("invalid constructor for naive mode");
   if (epsilon < 0)
@@ -191,164 +182,11 @@ SingleTreeTraversalType>::NeighborSearch(const NeighborSearchMode mode,
     scores(0),
     treeNeedsReset(false)
 {
-  // Update naive, singleMode and greedy flags according to searchMode.
-  UpdateSearchModeFlags();
-
   if (epsilon < 0)
     throw std::invalid_argument("epsilon must be non-negative");
 
   // Build the tree on the empty dataset, if necessary.
   if (mode != NAIVE_MODE)
-  {
-    referenceTree = BuildTree<MatType, Tree>(*referenceSet,
-        oldFromNewReferences);
-    treeOwner = true;
-  }
-}
-
-// Construct the object.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
-SingleTreeTraversalType>::NeighborSearch(const MatType& referenceSetIn,
-                                         const bool naive,
-                                         const bool singleMode,
-                                         const double epsilon,
-                                         const MetricType metric) :
-    referenceTree(naive ? NULL :
-        BuildTree<MatType, Tree>(referenceSetIn, oldFromNewReferences)),
-    referenceSet(naive ? &referenceSetIn : &referenceTree->Dataset()),
-    treeOwner(!naive), // False if a tree was passed.  If naive, then no trees.
-    setOwner(false),
-    naive(naive),
-    singleMode(!naive && singleMode), // No single mode if naive.
-    greedy(false),
-    epsilon(epsilon),
-    metric(metric),
-    baseCases(0),
-    scores(0),
-    treeNeedsReset(false)
-{
-  // Update searchMode according to naive, singleMode and greedy flags.
-  UpdateSearchMode();
-
-  if (epsilon < 0)
-    throw std::invalid_argument("epsilon must be non-negative");
-}
-
-// Construct the object.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
-SingleTreeTraversalType>::NeighborSearch(MatType&& referenceSetIn,
-                                         const bool naive,
-                                         const bool singleMode,
-                                         const double epsilon,
-                                         const MetricType metric) :
-    referenceTree(naive ? NULL :
-        BuildTree<MatType, Tree>(std::move(referenceSetIn),
-                                 oldFromNewReferences)),
-    referenceSet(naive ? new MatType(std::move(referenceSetIn)) :
-        &referenceTree->Dataset()),
-    treeOwner(!naive),
-    setOwner(naive),
-    naive(naive),
-    singleMode(!naive && singleMode),
-    greedy(false),
-    epsilon(epsilon),
-    metric(metric),
-    baseCases(0),
-    scores(0),
-    treeNeedsReset(false)
-{
-  // Update searchMode according to naive, singleMode and greedy flags.
-  UpdateSearchMode();
-
-  if (epsilon < 0)
-    throw std::invalid_argument("epsilon must be non-negative");
-}
-
-// Construct the object.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
-SingleTreeTraversalType>::NeighborSearch(Tree* referenceTree,
-                                         const bool singleMode,
-                                         const double epsilon,
-                                         const MetricType metric) :
-    referenceTree(referenceTree),
-    referenceSet(&referenceTree->Dataset()),
-    treeOwner(false),
-    setOwner(false),
-    naive(false),
-    singleMode(singleMode),
-    greedy(false),
-    epsilon(epsilon),
-    metric(metric),
-    baseCases(0),
-    scores(0),
-    treeNeedsReset(false)
-{
-  // Update searchMode according to naive, singleMode and greedy flags.
-  UpdateSearchMode();
-
-  if (epsilon < 0)
-    throw std::invalid_argument("epsilon must be non-negative");
-}
-
-// Construct the object without a reference dataset.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
-SingleTreeTraversalType>::NeighborSearch(const bool naive,
-                                         const bool singleMode,
-                                         const double epsilon,
-                                         const MetricType metric) :
-    referenceTree(NULL),
-    referenceSet(new MatType()), // Empty matrix.
-    treeOwner(false),
-    setOwner(true),
-    naive(naive),
-    singleMode(singleMode),
-    greedy(false),
-    epsilon(epsilon),
-    metric(metric),
-    baseCases(0),
-    scores(0),
-    treeNeedsReset(false)
-{
-  // Update searchMode according to naive, singleMode and greedy flags.
-  UpdateSearchMode();
-
-  if (epsilon < 0)
-    throw std::invalid_argument("epsilon must be non-negative");
-
-  // Build the tree on the empty dataset, if necessary.
-  if (!naive)
   {
     referenceTree = BuildTree<MatType, Tree>(*referenceSet,
         oldFromNewReferences);
@@ -386,9 +224,6 @@ void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
 DualTreeTraversalType, SingleTreeTraversalType>::Train(
     const MatType& referenceSet)
 {
-  // Update searchMode.
-  UpdateSearchMode();
-
   // Clean up the old tree, if we built one.
   if (treeOwner && referenceTree)
     delete referenceTree;
@@ -427,9 +262,6 @@ template<typename SortPolicy,
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
 DualTreeTraversalType, SingleTreeTraversalType>::Train(MatType&& referenceSetIn)
 {
-  // Update searchMode.
-  UpdateSearchMode();
-
   // Clean up the old tree, if we built one.
   if (treeOwner && referenceTree)
     delete referenceTree;
@@ -473,9 +305,6 @@ template<typename SortPolicy,
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
 DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree* referenceTree)
 {
-  // Update searchMode.
-  UpdateSearchMode();
-
   if (searchMode == NAIVE_MODE)
     throw std::invalid_argument("cannot train on given reference tree when "
         "naive search (without trees) is desired");
@@ -510,9 +339,6 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
     arma::Mat<size_t>& neighbors,
     arma::mat& distances)
 {
-  // Update searchMode.
-  UpdateSearchMode();
-
   if (k > referenceSet->n_cols)
   {
     std::stringstream ss;
@@ -727,9 +553,6 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
     arma::mat& distances,
     bool sameSet)
 {
-  // Update searchMode.
-  UpdateSearchMode();
-
   if (k > referenceSet->n_cols)
   {
     std::stringstream ss;
@@ -811,9 +634,6 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
     arma::Mat<size_t>& neighbors,
     arma::mat& distances)
 {
-  // Update searchMode.
-  UpdateSearchMode();
-
   if (k > referenceSet->n_cols)
   {
     std::stringstream ss;
@@ -1060,13 +880,8 @@ DualTreeTraversalType, SingleTreeTraversalType>::Serialize(
 {
   using data::CreateNVP;
 
-  // Update searchMode.
-  UpdateSearchMode();
-
   // Serialize preferences for search.
   ar & CreateNVP(searchMode, "searchMode");
-  ar & CreateNVP(naive, "naive");
-  ar & CreateNVP(singleMode, "singleMode");
   ar & CreateNVP(treeNeedsReset, "treeNeedsReset");
 
   // If we are doing naive search, we serialize the dataset.  Otherwise we
@@ -1130,69 +945,6 @@ DualTreeTraversalType, SingleTreeTraversalType>::Serialize(
     baseCases = 0;
     scores = 0;
   }
-}
-
-//! Updates naive, singleMode and greedy flags according to searchMode.  This is
-//! only necessary until the modifiers Naive(), SingleMode() and Greedy() are
-//! removed in mlpack 3.0.0.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::UpdateSearchModeFlags()
-{
-  switch (searchMode)
-  {
-    case NAIVE_MODE:
-      naive = true;
-      singleMode = false;
-      greedy = false;
-      break;
-    case SINGLE_TREE_MODE:
-      naive = false;
-      singleMode = true;
-      greedy = false;
-      break;
-    case DUAL_TREE_MODE:
-      naive = false;
-      singleMode = false;
-      greedy = false;
-      break;
-    case GREEDY_SINGLE_TREE_MODE:
-      naive = false;
-      singleMode = true;
-      greedy = true;
-      break;
-  }
-}
-
-//! Updates searchMode to be according to naive, singleMode and greedy booleans.
-//! This is only necessary until the modifiers Naive(), SingleMode() and
-//! Greedy() are removed in mlpack 3.0.0.
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::UpdateSearchMode()
-{
-  if (naive)
-    searchMode = NAIVE_MODE;
-  else if (singleMode && greedy)
-    searchMode = GREEDY_SINGLE_TREE_MODE;
-  else if (singleMode)
-    searchMode = SINGLE_TREE_MODE;
-  else
-    searchMode = DUAL_TREE_MODE;
 }
 
 } // namespace neighbor

--- a/src/mlpack/methods/neighbor_search/ns_model.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model.hpp
@@ -199,29 +199,12 @@ class TrainVisitor : public boost::static_visitor<void>
 /**
  * SearchModeVisitor exposes the SearchMode() method of the given NSType.
  */
-class SearchModeVisitor : public boost::static_visitor<NeighborSearchMode>
+class SearchModeVisitor : public boost::static_visitor<NeighborSearchMode&>
 {
  public:
   //! Return the search mode.
   template<typename NSType>
-  NeighborSearchMode operator()(NSType* ns) const;
-};
-
-/**
- * SetSearchModeVisitor modifies the SearchMode method of the given NSType.
- */
-class SetSearchModeVisitor : public boost::static_visitor<void>
-{
-  NeighborSearchMode searchMode;
- public:
-  //! Construct the SetSearchModeVisitor object with the given mode.
-  SetSearchModeVisitor(const NeighborSearchMode searchMode) :
-      searchMode(searchMode)
-  {};
-
-  //! Set the search mode.
-  template<typename NSType>
-  void operator()(NSType* ns) const;
+  NeighborSearchMode& operator()(NSType* ns) const;
 };
 
 /**
@@ -342,10 +325,9 @@ class NSModel
   //! Expose the dataset.
   const arma::mat& Dataset() const;
 
-  //! Access the search mode.
+  //! Expose SearchMode.
   NeighborSearchMode SearchMode() const;
-  //! Modify the search mode.
-  void SetSearchMode(const NeighborSearchMode mode);
+  NeighborSearchMode& SearchMode();
 
   //! Expose Epsilon.
   double Epsilon() const;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(MoveTrainTest)
   BOOST_REQUIRE_EQUAL(distances.n_cols, 200);
 
   dataset = arma::randu<arma::mat>(3, 300);
-  knn.Naive() = true;
+  knn.SearchMode() = NAIVE_MODE;
   knn.Train(std::move(dataset));
   knn.Search(1, neighbors, distances);
 
@@ -918,7 +918,8 @@ BOOST_AUTO_TEST_CASE(HybridSpillSearchTest)
 
   for (size_t mode = 0; mode < 2; mode++)
   {
-    spTreeSearch.SingleMode() = (mode == 0);
+    if (mode)
+      spTreeSearch.SearchMode() = SINGLE_TREE_MODE;
 
     arma::Mat<size_t> neighborsSPTree;
     arma::mat distancesSPTree;
@@ -955,7 +956,8 @@ BOOST_AUTO_TEST_CASE(DuplicatedSpillSearchTest)
 
     for (size_t mode = 0; mode < 2; mode++)
     {
-      spTreeSearch.SingleMode() = (mode == 0);
+      if (mode)
+        spTreeSearch.SearchMode() = SINGLE_TREE_MODE;
 
       spTreeSearch.Search(dataset, k, neighborsSPTree, distancesSPTree);
 

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -1131,11 +1131,11 @@ BOOST_AUTO_TEST_CASE(RASearchTest)
   // Find nearest neighbors in the top 10, with accuracy 0.95.  So 95% of the
   // results we get (at least) should fall into the top 10 of the true nearest
   // neighbors.
-  AllkRANN allkrann(dataset, DUAL_TREE_MODE, 5, 0.95);
+  AllkRANN allkrann(dataset, false, false, 5, 0.95);
 
-  AllkRANN krannXml(otherDataset, DUAL_TREE_MODE);
-  AllkRANN krannText(otherDataset, NAIVE_MODE);
-  AllkRANN krannBinary(otherDataset, NAIVE_MODE);
+  AllkRANN krannXml(otherDataset, false, false);
+  AllkRANN krannText(otherDataset, true, false);
+  AllkRANN krannBinary(otherDataset, true, true);
 
   SerializeObjectAll(allkrann, krannXml, krannText, krannBinary);
 

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -1131,11 +1131,11 @@ BOOST_AUTO_TEST_CASE(RASearchTest)
   // Find nearest neighbors in the top 10, with accuracy 0.95.  So 95% of the
   // results we get (at least) should fall into the top 10 of the true nearest
   // neighbors.
-  AllkRANN allkrann(dataset, false, false, 5, 0.95);
+  AllkRANN allkrann(dataset, DUAL_TREE_MODE, 5, 0.95);
 
-  AllkRANN krannXml(otherDataset, false, false);
-  AllkRANN krannText(otherDataset, true, false);
-  AllkRANN krannBinary(otherDataset, true, true);
+  AllkRANN krannXml(otherDataset, DUAL_TREE_MODE);
+  AllkRANN krannText(otherDataset, NAIVE_MODE);
+  AllkRANN krannBinary(otherDataset, NAIVE_MODE);
 
   SerializeObjectAll(allkrann, krannXml, krannText, krannBinary);
 


### PR DESCRIPTION
@rcurtin 
This PR removes the reverse compatibility code inside `NeighborSearch` class.
This is intended to be merged for version 3.0.0.
The only difference with the PR https://github.com/mlpack/mlpack/pull/762  is the last commit.
I will rebase on top of master when https://github.com/mlpack/mlpack/pull/762 is merged, so it will be clearer.
Thanks!
Marcos
