### PR TITLE
issue #787 - Replace `MinDistance(TreeType*)` with `MinDistance(TreeType&)`

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -60,6 +60,7 @@ Copyright:
   Copyright 2016, Keon Kim <kwk236@gmail.com>
   Copyright 2016, Nilay Jain <nilayjain13@gmail.com>
   Copyright 2016, Peter Lehner <peter.lehner@dlr.de>
+  Copyright 2016, Anuraj Kanodia <akanuraj200@gmail.com>
 License: BSD-3-clause
   All rights reserved.
   .

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -194,7 +194,7 @@
  *   - Keon Kim <kwk236@gmail.com>
  *   - Nilay Jain <nilayjain13@gmail.com>
  *   - Peter Lehner <peter.lehner@dlr.de>
- *	 - Anuraj Kanodia <akanuraj200@gmail.com>
+ *  - Anuraj Kanodia <akanuraj200@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -194,7 +194,7 @@
  *   - Keon Kim <kwk236@gmail.com>
  *   - Nilay Jain <nilayjain13@gmail.com>
  *   - Peter Lehner <peter.lehner@dlr.de>
- *  - Anuraj Kanodia <akanuraj200@gmail.com>
+ *   - Anuraj Kanodia <akanuraj200@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -194,6 +194,7 @@
  *   - Keon Kim <kwk236@gmail.com>
  *   - Nilay Jain <nilayjain13@gmail.com>
  *   - Peter Lehner <peter.lehner@dlr.de>
+ *	 - Anuraj Kanodia <akanuraj200@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
@@ -428,21 +428,21 @@ class BinarySpaceTree
   size_t Point(const size_t index) const;
 
   //! Return the minimum distance to another node.
-  ElemType MinDistance(const BinarySpaceTree* other) const
+  ElemType MinDistance(const BinarySpaceTree& other) const
   {
-    return bound.MinDistance(other->Bound());
+    return bound.MinDistance(other.Bound());
   }
 
   //! Return the maximum distance to another node.
-  ElemType MaxDistance(const BinarySpaceTree* other) const
+  ElemType MaxDistance(const BinarySpaceTree& other) const
   {
-    return bound.MaxDistance(other->Bound());
+    return bound.MaxDistance(other.Bound());
   }
 
   //! Return the minimum and maximum distance to another node.
-  math::RangeType<ElemType> RangeDistance(const BinarySpaceTree* other) const
+  math::RangeType<ElemType> RangeDistance(const BinarySpaceTree& other) const
   {
-    return bound.RangeDistance(other->Bound());
+    return bound.RangeDistance(other.Bound());
   }
 
   //! Return the minimum distance to another point.

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
@@ -554,8 +554,8 @@ size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
   if (IsLeaf() || !left || !right)
     return 0;
 
-  ElemType leftDist = left->MinDistance(*queryNode);
-  ElemType rightDist = right->MinDistance(*queryNode);
+  ElemType leftDist = left->MinDistance(queryNode);
+  ElemType rightDist = right->MinDistance(queryNode);
   if (leftDist < rightDist)
     return 0;
   if (rightDist < leftDist)
@@ -579,8 +579,8 @@ size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
   if (IsLeaf() || !left || !right)
     return 0;
 
-  ElemType leftDist = left->MaxDistance(*queryNode);
-  ElemType rightDist = right->MaxDistance(*queryNode);
+  ElemType leftDist = left->MaxDistance(queryNode);
+  ElemType rightDist = right->MaxDistance(queryNode);
   if (leftDist > rightDist)
     return 0;
   if (rightDist > leftDist)

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
@@ -554,8 +554,8 @@ size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
   if (IsLeaf() || !left || !right)
     return 0;
 
-  ElemType leftDist = left->MinDistance(&queryNode);
-  ElemType rightDist = right->MinDistance(&queryNode);
+  ElemType leftDist = left->MinDistance(*queryNode);
+  ElemType rightDist = right->MinDistance(*queryNode);
   if (leftDist < rightDist)
     return 0;
   if (rightDist < leftDist)
@@ -579,8 +579,8 @@ size_t BinarySpaceTree<MetricType, StatisticType, MatType, BoundType,
   if (IsLeaf() || !left || !right)
     return 0;
 
-  ElemType leftDist = left->MaxDistance(&queryNode);
-  ElemType rightDist = right->MaxDistance(&queryNode);
+  ElemType leftDist = left->MaxDistance(*queryNode);
+  ElemType rightDist = right->MaxDistance(*queryNode);
   if (leftDist > rightDist)
     return 0;
   if (rightDist > leftDist)

--- a/src/mlpack/core/tree/cover_tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree.hpp
@@ -335,11 +335,11 @@ class CoverTree
   size_t GetFurthestChild(const CoverTree& queryNode);
 
   //! Return the minimum distance to another node.
-  ElemType MinDistance(const CoverTree* other) const;
+  ElemType MinDistance(const CoverTree& other) const;
 
   //! Return the minimum distance to another node given that the point-to-point
   //! distance has already been calculated.
-  ElemType MinDistance(const CoverTree* other, const ElemType distance) const;
+  ElemType MinDistance(const CoverTree& other, const ElemType distance) const;
 
   //! Return the minimum distance to another point.
   ElemType MinDistance(const arma::vec& other) const;
@@ -349,11 +349,11 @@ class CoverTree
   ElemType MinDistance(const arma::vec& other, const ElemType distance) const;
 
   //! Return the maximum distance to another node.
-  ElemType MaxDistance(const CoverTree* other) const;
+  ElemType MaxDistance(const CoverTree& other) const;
 
   //! Return the maximum distance to another node given that the point-to-point
   //! distance has already been calculated.
-  ElemType MaxDistance(const CoverTree* other, const ElemType distance) const;
+  ElemType MaxDistance(const CoverTree& other, const ElemType distance) const;
 
   //! Return the maximum distance to another point.
   ElemType MaxDistance(const arma::vec& other) const;
@@ -363,11 +363,11 @@ class CoverTree
   ElemType MaxDistance(const arma::vec& other, const ElemType distance) const;
 
   //! Return the minimum and maximum distance to another node.
-  math::RangeType<ElemType> RangeDistance(const CoverTree* other) const;
+  math::RangeType<ElemType> RangeDistance(const CoverTree& other) const;
 
   //! Return the minimum and maximum distance to another node given that the
   //! point-to-point distance has already been calculated.
-  math::RangeType<ElemType> RangeDistance(const CoverTree* other,
+  math::RangeType<ElemType> RangeDistance(const CoverTree& other,
                                           const ElemType distance) const;
 
   //! Return the minimum and maximum distance to another point.

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -724,7 +724,7 @@ size_t CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
   size_t bestIndex = 0;
   for (size_t i = 0; i < children.size(); ++i)
   {
-    ElemType distance = children[i]->MinDistance(&queryNode);
+    ElemType distance = children[i]->MinDistance(queryNode);
     if (distance <= bestDistance)
     {
       bestDistance = distance;
@@ -752,7 +752,7 @@ size_t CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
   size_t bestIndex = 0;
   for (size_t i = 0; i < children.size(); ++i)
   {
-    ElemType distance = children[i]->MaxDistance(&queryNode);
+    ElemType distance = children[i]->MaxDistance(queryNode);
     if (distance >= bestDistance)
     {
       bestDistance = distance;
@@ -771,12 +771,12 @@ template<
 typename CoverTree<MetricType, StatisticType, MatType,
     RootPointPolicy>::ElemType
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
-    MinDistance(const CoverTree* other) const
+    MinDistance(const CoverTree& other) const
 {
   // Every cover tree node will contain points up to base^(scale + 1) away.
   return std::max(metric->Evaluate(dataset->col(point),
-      other->Dataset().col(other->Point())) -
-      furthestDescendantDistance - other->FurthestDescendantDistance(), 0.0);
+      other.Dataset().col(other.Point())) -
+      furthestDescendantDistance - other.FurthestDescendantDistance(), 0.0);
 }
 
 template<
@@ -788,11 +788,11 @@ template<
 typename CoverTree<MetricType, StatisticType, MatType,
     RootPointPolicy>::ElemType
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
-    MinDistance(const CoverTree* other, const ElemType distance) const
+    MinDistance(const CoverTree& other, const ElemType distance) const
 {
   // We already have the distance as evaluated by the metric.
   return std::max(distance - furthestDescendantDistance -
-      other->FurthestDescendantDistance(), 0.0);
+      other.FurthestDescendantDistance(), 0.0);
 }
 
 template<
@@ -833,11 +833,11 @@ template<
 typename CoverTree<MetricType, StatisticType, MatType,
     RootPointPolicy>::ElemType
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
-    MaxDistance(const CoverTree* other) const
+    MaxDistance(const CoverTree& other) const
 {
   return metric->Evaluate(dataset->col(point),
-      other->Dataset().col(other->Point())) +
-      furthestDescendantDistance + other->FurthestDescendantDistance();
+      other.Dataset().col(other.Point())) +
+      furthestDescendantDistance + other.FurthestDescendantDistance();
 }
 
 template<
@@ -849,11 +849,11 @@ template<
 typename CoverTree<MetricType, StatisticType, MatType,
     RootPointPolicy>::ElemType
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
-    MaxDistance(const CoverTree* other, const ElemType distance) const
+    MaxDistance(const CoverTree& other, const ElemType distance) const
 {
   // We already have the distance as evaluated by the metric.
   return distance + furthestDescendantDistance +
-      other->FurthestDescendantDistance();
+      other.FurthestDescendantDistance();
 }
 
 template<
@@ -895,16 +895,16 @@ template<
 math::RangeType<typename
     CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::ElemType>
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
-    RangeDistance(const CoverTree* other) const
+    RangeDistance(const CoverTree& other) const
 {
   const ElemType distance = metric->Evaluate(dataset->col(point),
-      other->Dataset().col(other->Point()));
+      other.Dataset().col(other.Point()));
 
   math::RangeType<ElemType> result;
   result.Lo() = distance - furthestDescendantDistance -
-      other->FurthestDescendantDistance();
+      other.FurthestDescendantDistance();
   result.Hi() = distance + furthestDescendantDistance +
-      other->FurthestDescendantDistance();
+      other.FurthestDescendantDistance();
 
   return result;
 }
@@ -920,14 +920,14 @@ template<
 math::RangeType<typename
     CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::ElemType>
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
-    RangeDistance(const CoverTree* other,
+    RangeDistance(const CoverTree& other,
                   const ElemType distance) const
 {
   math::RangeType<ElemType> result;
   result.Lo() = distance - furthestDescendantDistance -
-      other->FurthestDescendantDistance();
+      other.FurthestDescendantDistance();
   result.Hi() = distance + furthestDescendantDistance +
-      other->FurthestDescendantDistance();
+      other.FurthestDescendantDistance();
 
   return result;
 }

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -463,21 +463,21 @@ class RectangleTree
   size_t& Point(const size_t index) { return points[index]; }
 
   //! Return the minimum distance to another node.
-  ElemType MinDistance(const RectangleTree* other) const
+  ElemType MinDistance(const RectangleTree& other) const
   {
-    return bound.MinDistance(other->Bound());
+    return bound.MinDistance(other.Bound());
   }
 
   //! Return the maximum distance to another node.
-  ElemType MaxDistance(const RectangleTree* other) const
+  ElemType MaxDistance(const RectangleTree& other) const
   {
-    return bound.MaxDistance(other->Bound());
+    return bound.MaxDistance(other.Bound());
   }
 
   //! Return the minimum and maximum distance to another node.
-  math::RangeType<ElemType> RangeDistance(const RectangleTree* other) const
+  math::RangeType<ElemType> RangeDistance(const RectangleTree& other) const
   {
-    return bound.RangeDistance(other->Bound());
+    return bound.RangeDistance(other.Bound());
   }
 
   //! Return the minimum distance to another point.

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree_impl.hpp
@@ -705,7 +705,7 @@ size_t RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
   size_t bestIndex = 0;
   for (size_t i = 0; i < NumChildren(); ++i)
   {
-    ElemType distance = Child(i).MinDistance(&queryNode);
+    ElemType distance = Child(i).MinDistance(queryNode);
     if (distance <= bestDistance)
     {
       bestDistance = distance;
@@ -735,7 +735,7 @@ size_t RectangleTree<MetricType, StatisticType, MatType, SplitType, DescentType,
   size_t bestIndex = 0;
   for (size_t i = 0; i < NumChildren(); ++i)
   {
-    ElemType distance = Child(i).MaxDistance(&queryNode);
+    ElemType distance = Child(i).MaxDistance(queryNode);
     if (distance >= bestDistance)
     {
       bestDistance = distance;

--- a/src/mlpack/core/tree/spill_tree/spill_tree.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree.hpp
@@ -368,21 +368,21 @@ class SpillTree
   size_t Point(const size_t index) const;
 
   //! Return the minimum distance to another node.
-  ElemType MinDistance(const SpillTree* other) const
+  ElemType MinDistance(const SpillTree& other) const
   {
-    return bound.MinDistance(other->Bound());
+    return bound.MinDistance(other.Bound());
   }
 
   //! Return the maximum distance to another node.
-  ElemType MaxDistance(const SpillTree* other) const
+  ElemType MaxDistance(const SpillTree& other) const
   {
-    return bound.MaxDistance(other->Bound());
+    return bound.MaxDistance(other.Bound());
   }
 
   //! Return the minimum and maximum distance to another node.
-  math::RangeType<ElemType> RangeDistance(const SpillTree* other) const
+  math::RangeType<ElemType> RangeDistance(const SpillTree& other) const
   {
-    return bound.RangeDistance(other->Bound());
+    return bound.RangeDistance(other.Bound());
   }
 
   //! Return the minimum distance to another point.

--- a/src/mlpack/methods/emst/dtb_rules_impl.hpp
+++ b/src/mlpack/methods/emst/dtb_rules_impl.hpp
@@ -115,7 +115,7 @@ double DTBRules<MetricType, TreeType>::Score(TreeType& queryNode,
     return DBL_MAX;
 
   ++scores;
-  const double distance = queryNode.MinDistance(&referenceNode);
+  const double distance = queryNode.MinDistance(referenceNode);
   const double bound = CalculateBound(queryNode);
 
   // If all the points in the reference node are farther than the candidate

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_rules_impl.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_rules_impl.hpp
@@ -216,7 +216,7 @@ inline double DualTreeKMeansRules<MetricType, TreeType>::Score(
       {
         // If this might affect the lower bound, make it more exact.
         queryNode.Stat().LowerBound() = std::min(queryNode.Stat().LowerBound(),
-            queryNode.MinDistance(&referenceNode));
+            queryNode.MinDistance(referenceNode));
         ++scores;
       }
 
@@ -228,7 +228,7 @@ inline double DualTreeKMeansRules<MetricType, TreeType>::Score(
   if (score != DBL_MAX)
   {
     // Get minimum and maximum distances.
-    const math::Range distances = queryNode.RangeDistance(&referenceNode);
+    const math::Range distances = queryNode.RangeDistance(referenceNode);
 
     score = distances.Lo();
     ++scores;

--- a/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort_impl.hpp
@@ -18,7 +18,7 @@ inline double FurthestNeighborSort::BestNodeToNodeDistance(
 {
   // This is not implemented yet for the general case because the trees do not
   // accept arbitrary distance metrics.
-  return queryNode->MaxDistance(referenceNode);
+  return queryNode->MaxDistance(*referenceNode);
 }
 
 template<typename TreeType>
@@ -27,7 +27,7 @@ inline double FurthestNeighborSort::BestNodeToNodeDistance(
     const TreeType* referenceNode,
     const double centerToCenterDistance)
 {
-  return queryNode->MaxDistance(referenceNode, centerToCenterDistance);
+  return queryNode->MaxDistance(*referenceNode, centerToCenterDistance);
 }
 
 template<typename TreeType>
@@ -37,7 +37,7 @@ inline double FurthestNeighborSort::BestNodeToNodeDistance(
     const TreeType* referenceChildNode,
     const double centerToCenterDistance)
 {
-  return queryNode->MaxDistance(referenceNode, centerToCenterDistance) +
+  return queryNode->MaxDistance(*referenceNode, centerToCenterDistance) +
       referenceChildNode->ParentDistance();
 }
 

--- a/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort_impl.hpp
@@ -18,7 +18,7 @@ inline double NearestNeighborSort::BestNodeToNodeDistance(
 {
   // This is not implemented yet for the general case because the trees do not
   // accept arbitrary distance metrics.
-  return queryNode->MinDistance(referenceNode);
+  return queryNode->MinDistance(*referenceNode);
 }
 
 template<typename TreeType>
@@ -27,7 +27,7 @@ inline double NearestNeighborSort::BestNodeToNodeDistance(
     const TreeType* referenceNode,
     const double centerToCenterDistance)
 {
-  return queryNode->MinDistance(referenceNode, centerToCenterDistance);
+  return queryNode->MinDistance(*referenceNode, centerToCenterDistance);
 }
 
 template<typename TreeType>
@@ -37,7 +37,7 @@ inline double NearestNeighborSort::BestNodeToNodeDistance(
     const TreeType* referenceChildNode,
     const double centerToCenterDistance)
 {
-  return queryNode->MinDistance(referenceChildNode, centerToCenterDistance) -
+  return queryNode->MinDistance(*referenceChildNode, centerToCenterDistance) -
       referenceChildNode->ParentDistance();
 }
 

--- a/src/mlpack/methods/range_search/range_search_rules_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_rules_impl.hpp
@@ -179,7 +179,7 @@ double RangeSearchRules<MetricType, TreeType>::Score(TreeType& queryNode,
   else
   {
     // Just perform the calculation.
-    distances = referenceNode.RangeDistance(&queryNode);
+    distances = referenceNode.RangeDistance(queryNode);
     ++scores;
   }
 


### PR DESCRIPTION
Changed functions in the Tree Type API to use references. Refactored all relevant files.
Functions changed:
```
ElemType MinDistance(const TreeType* other);
ElemType MaxDistance(const TreeType* other);
math::RangeType<ElemType> RangeDistance(const TreeType* other);
```

