### PR TITLE
Put all singletons in libmlpack.so

### DIFF
--- a/src/mlpack/core/util/CMakeLists.txt
+++ b/src/mlpack/core/util/CMakeLists.txt
@@ -21,6 +21,8 @@ set(SOURCES
   prefixedoutstream.cpp
   prefixedoutstream_impl.hpp
   sfinae_utility.hpp
+  singletons.hpp
+  singletons.cpp
   timers.hpp
   timers.cpp
   version.hpp

--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -15,8 +15,6 @@
 using namespace mlpack;
 using namespace mlpack::util;
 
-CLI* CLI::singleton = NULL;
-
 /* For clarity, we will alias boost's namespace. */
 namespace po = boost::program_options;
 

--- a/src/mlpack/core/util/cli_deleter.hpp
+++ b/src/mlpack/core/util/cli_deleter.hpp
@@ -24,10 +24,7 @@ class CLIDeleter
   ~CLIDeleter();
 };
 
-//! Declare the deleter.
-static CLIDeleter cliDeleter;
-
-} // namespace io
+} // namespace util
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/core/util/log.cpp
+++ b/src/mlpack/core/util/log.cpp
@@ -10,40 +10,8 @@
   #include "backtrace.hpp"
 #endif
 
-// Color code escape sequences -- but not on Windows.
-#ifndef _WIN32
-  #define BASH_RED "\033[0;31m"
-  #define BASH_GREEN "\033[0;32m"
-  #define BASH_YELLOW "\033[0;33m"
-  #define BASH_CYAN "\033[0;36m"
-  #define BASH_CLEAR "\033[0m"
-#else
-  #define BASH_RED ""
-  #define BASH_GREEN ""
-  #define BASH_YELLOW ""
-  #define BASH_CYAN ""
-  #define BASH_CLEAR ""
-#endif
-
 using namespace mlpack;
 using namespace mlpack::util;
-
-// Only output debugging output if in debug mode.
-#ifdef DEBUG
-PrefixedOutStream Log::Debug = PrefixedOutStream(std::cout,
-    BASH_CYAN "[DEBUG] " BASH_CLEAR);
-#else
-NullOutStream Log::Debug = NullOutStream();
-#endif
-
-PrefixedOutStream Log::Info = PrefixedOutStream(std::cout,
-    BASH_GREEN "[INFO ] " BASH_CLEAR, true /* unless --verbose */, false);
-PrefixedOutStream Log::Warn = PrefixedOutStream(std::cout,
-    BASH_YELLOW "[WARN ] " BASH_CLEAR, false, false);
-PrefixedOutStream Log::Fatal = PrefixedOutStream(std::cerr,
-    BASH_RED "[FATAL] " BASH_CLEAR, false, true /* fatal */);
-
-std::ostream& Log::cout = std::cout;
 
 // Only do anything for Assert() if in debugging mode.
 #ifdef DEBUG

--- a/src/mlpack/core/util/singletons.cpp
+++ b/src/mlpack/core/util/singletons.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file singletons.cpp
+ * @author Ryan Curtin
+ */
+#include "singletons.hpp"
+#include "log.hpp"
+#include "cli.hpp"
+
+using namespace mlpack;
+using namespace mlpack::util;
+
+// Color code escape sequences -- but not on Windows.
+#ifndef _WIN32
+  #define BASH_RED "\033[0;31m"
+  #define BASH_GREEN "\033[0;32m"
+  #define BASH_YELLOW "\033[0;33m"
+  #define BASH_CYAN "\033[0;36m"
+  #define BASH_CLEAR "\033[0m"
+#else
+  #define BASH_RED ""
+  #define BASH_GREEN ""
+  #define BASH_YELLOW ""
+  #define BASH_CYAN ""
+  #define BASH_CLEAR ""
+#endif
+
+CLI* CLI::singleton = NULL;
+
+// Only output debugging output if in debug mode.
+#ifdef DEBUG
+PrefixedOutStream Log::Debug = PrefixedOutStream(std::cout,
+    BASH_CYAN "[DEBUG] " BASH_CLEAR);
+#else
+NullOutStream Log::Debug = NullOutStream();
+#endif
+
+PrefixedOutStream Log::Info = PrefixedOutStream(std::cout,
+    BASH_GREEN "[INFO ] " BASH_CLEAR, true /* unless --verbose */, false);
+PrefixedOutStream Log::Warn = PrefixedOutStream(std::cout,
+    BASH_YELLOW "[WARN ] " BASH_CLEAR, false, false);
+PrefixedOutStream Log::Fatal = PrefixedOutStream(std::cerr,
+    BASH_RED "[FATAL] " BASH_CLEAR, false, true /* fatal */);
+
+/**
+ * This has to be last, so that the CLI object is destroyed before the Log
+ * output objects are destroyed.
+ */
+CLIDeleter cliDeleter;

--- a/src/mlpack/core/util/singletons.cpp
+++ b/src/mlpack/core/util/singletons.cpp
@@ -1,6 +1,8 @@
 /**
  * @file singletons.cpp
  * @author Ryan Curtin
+ *
+ * Declaration of singletons in libmlpack.so.
  */
 #include "singletons.hpp"
 #include "log.hpp"

--- a/src/mlpack/core/util/singletons.hpp
+++ b/src/mlpack/core/util/singletons.hpp
@@ -1,0 +1,21 @@
+/**
+ * @file singletons.hpp
+ * @author Ryan Curtin
+ *
+ * Definitions of singletons used by libmlpack.so.
+ */
+#ifndef MLPACK_CORE_UTIL_SINGLETONS_HPP
+#define MLPACK_CORE_UTIL_SINGLETONS_HPP
+
+#include "cli_deleter.hpp"
+#include <mlpack/mlpack_export.hpp>
+
+namespace mlpack {
+namespace util {
+
+extern MLPACK_EXPORT CLIDeleter cliDeleter;
+
+} // namespace util
+} // namespace mlpack
+
+#endif


### PR DESCRIPTION
This is a solution for #524.  It actually functions about the same as that solution but creates a separate file for singletons (`src/mlpack/core/singletons.cpp`).  As a result of this change it is possible to create a program that has `#include <mlpack/core.hpp>` without linking against libmlpack.so, if no mlpack symbols are used.  This was not possible before.

I'll leave this for a couple of days before I merge it.

@theSundayProgrammer: I know this took a very long time for me to get around to, but here is (finally) a solution.  Like I said it is essentially equivalent to yours, just arranged differently.