### PR TITLE
switch last (!) remaining std::cout to destination

### DIFF
--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -103,7 +103,7 @@ void PrefixedOutStream::BaseLogic(const T& val)
   if (fatal && newlined)
   {
     if (!ignoreInput)
-      std::cout << std::endl;
+      destination << std::endl;
 
     // Print a backtrace, if we can.
 #ifdef HAS_BFD_DL


### PR DESCRIPTION
so I looked into why R was complaining that `std::cout` was referenced when linking against mlpack -- and it turns out that the (sole !!) remaining use of `std::cout` appears to be an instance that ought to have been converted to `destination`

this PR does that

no Travis build on my side; I just used to have a clone rather than fork and did not have Travis set up to build when I just committed this but it should work out just fine