### PR TITLE
HMM initialization: don't use equal initial probabilities.

### DIFF
--- a/src/mlpack/methods/hmm/hmm_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_impl.hpp
@@ -29,11 +29,16 @@ HMM<Distribution>::HMM(const size_t states,
                        const Distribution emissions,
                        const double tolerance) :
     emission(states, /* default distribution */ emissions),
-    transition(arma::ones<arma::mat>(states, states) / (double) states),
-    initial(arma::ones<arma::vec>(states) / (double) states),
+    transition(arma::randu<arma::mat>(states, states)),
+    initial(arma::randu<arma::vec>(states) / (double) states),
     dimensionality(emissions.Dimensionality()),
     tolerance(tolerance)
-{ /* nothing to do */ }
+{
+  // Normalize the transition probabilities and initial state probabilities.
+  initial /= arma::accu(initial);
+  for (size_t i = 0; i < transition.n_cols; ++i)
+    transition.col(i) /= arma::accu(transition.col(i));
+}
 
 /**
  * Create the Hidden Markov Model with the given transition matrix and the given

--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -412,9 +412,10 @@ BOOST_AUTO_TEST_CASE(DiscreteHMMLabeledTrainTest)
 BOOST_AUTO_TEST_CASE(DiscreteHMMSimpleGenerateTest)
 {
   // Very simple HMM.  4 emissions with equal probability and 2 states with
-  // equal probability.  The default transition and emission matrices satisfy
-  // this property.
+  // equal probability.
   HMM<DiscreteDistribution> hmm(2, DiscreteDistribution(4));
+  hmm.Initial() = arma::ones<arma::vec>(2) / 2.0;
+  hmm.Transition() = arma::ones<arma::mat>(2, 2) / 2.0;
 
   // Now generate a really, really long sequence.
   arma::mat dataSeq;


### PR DESCRIPTION
That can cause training to fail sometimes.  Instead, optimization seems to perform better when using random intiialization.

This is a fix that came out of some debugging in the IRC channel.