### PR TITLE
Faster build times

### DIFF
--- a/src/mlpack/core/boost_backport/policy.hpp
+++ b/src/mlpack/core/boost_backport/policy.hpp
@@ -6,6 +6,7 @@
 #ifndef BOOST_MATH_POLICY_HPP
 #define BOOST_MATH_POLICY_HPP
 
+#include <mlpack/core.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/contains.hpp>
 #include <boost/mpl/if.hpp>
@@ -20,6 +21,8 @@
 #include <boost/static_assert.hpp>
 #include <boost/assert.hpp>
 #include <boost/math/tools/config.hpp>
+//#include <boost/math/policies/policy.hpp>
+//#include <boost/math/tools/precision.hpp>
 #include <limits>
 // Sadly we do need the .h versions of these to be sure of getting
 // FLT_MANT_DIG etc.

--- a/src/mlpack/core/data/binarize.hpp
+++ b/src/mlpack/core/data/binarize.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_DATA_BINARIZE_HPP
 #define MLPACK_CORE_DATA_BINARIZE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/dataset_mapper.hpp
+++ b/src/mlpack/core/data/dataset_mapper.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_DATA_DATASET_INFO_HPP
 #define MLPACK_CORE_DATA_DATASET_INFO_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <unordered_map>
 #include <boost/bimap.hpp>
 

--- a/src/mlpack/core/data/imputation_methods/custom_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/custom_imputation.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DATA_IMPUTE_STRATEGIES_CUSTOM_IMPUTATION_HPP
 #define MLPACK_CORE_DATA_IMPUTE_STRATEGIES_CUSTOM_IMPUTATION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/imputation_methods/listwise_deletion.hpp
+++ b/src/mlpack/core/data/imputation_methods/listwise_deletion.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DATA_IMPUTE_STRATEGIES_LISTWISE_DELETION_HPP
 #define MLPACK_CORE_DATA_IMPUTE_STRATEGIES_LISTWISE_DELETION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/imputation_methods/mean_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/mean_imputation.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MEAN_IMPUTATION_HPP
 #define MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MEAN_IMPUTATION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/imputation_methods/median_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/median_imputation.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MEDIAN_IMPUTATION_HPP
 #define MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MEDIAN_IMPUTATION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_DATA_IMPUTER_HPP
 #define MLPACK_CORE_DATA_IMPUTER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "dataset_mapper.hpp"
 #include "map_policies/missing_policy.hpp"
 #include "map_policies/increment_policy.hpp"

--- a/src/mlpack/core/data/map_policies/datatype.hpp
+++ b/src/mlpack/core/data/map_policies/datatype.hpp
@@ -11,7 +11,7 @@
 #ifndef MLPACK_CORE_DATA_MAP_POLICIES_DATATYPE_HPP
 #define MLPACK_CORE_DATA_MAP_POLICIES_DATATYPE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/map_policies/increment_policy.hpp
+++ b/src/mlpack/core/data/map_policies/increment_policy.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DATA_MAP_POLICIES_INCREMENT_POLICY_HPP
 #define MLPACK_CORE_DATA_MAP_POLICIES_INCREMENT_POLICY_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <unordered_map>
 #include <boost/bimap.hpp>
 #include <mlpack/core/data/map_policies/datatype.hpp>

--- a/src/mlpack/core/data/map_policies/missing_policy.hpp
+++ b/src/mlpack/core/data/map_policies/missing_policy.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DATA_MAP_POLICIES_MISSING_POLICY_HPP
 #define MLPACK_CORE_DATA_MAP_POLICIES_MISSING_POLICY_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <unordered_map>
 #include <boost/bimap.hpp>
 #include <mlpack/core/data/map_policies/datatype.hpp>

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_DATA_SPLIT_DATA_HPP
 #define MLPACK_CORE_DATA_SPLIT_DATA_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/dists/discrete_distribution.hpp
+++ b/src/mlpack/core/dists/discrete_distribution.hpp
@@ -13,7 +13,9 @@
 #ifndef MLPACK_CORE_DISTRIBUTIONS_DISCRETE_DISTRIBUTION_HPP
 #define MLPACK_CORE_DISTRIBUTIONS_DISCRETE_DISTRIBUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/log.hpp>
+#include <mlpack/core/math/random.hpp>
 
 namespace mlpack {
 namespace distribution /** Probability distributions. */ {

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -18,7 +18,9 @@
 #ifndef _MLPACK_CORE_DISTRIBUTIONS_GAMMA_DISTRIBUTION_HPP
 #define _MLPACK_CORE_DISTRIBUTIONS_GAMMA_DISTRIBUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
+#include <boost/program_options.hpp>
 
 namespace mlpack {
 namespace distribution {

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_DISTRIBUTIONS_GAUSSIAN_DISTRIBUTION_HPP
 #define MLPACK_CORE_DISTRIBUTIONS_GAUSSIAN_DISTRIBUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace distribution {

--- a/src/mlpack/core/dists/laplace_distribution.cpp
+++ b/src/mlpack/core/dists/laplace_distribution.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "laplace_distribution.hpp"
 

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_DISTRIBUTIONS_REGRESSION_DISTRIBUTION_HPP
 #define MLPACK_CORE_DISTRIBUTIONS_REGRESSION_DISTRIBUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/dists/gaussian_distribution.hpp>
 #include <mlpack/methods/linear_regression/linear_regression.hpp>
 

--- a/src/mlpack/core/kernels/cosine_distance.hpp
+++ b/src/mlpack/core/kernels/cosine_distance.hpp
@@ -13,7 +13,8 @@
 #ifndef MLPACK_CORE_KERNELS_COSINE_DISTANCE_HPP
 #define MLPACK_CORE_KERNELS_COSINE_DISTANCE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/kernels/kernel_traits.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/epanechnikov_kernel.hpp
+++ b/src/mlpack/core/kernels/epanechnikov_kernel.hpp
@@ -12,7 +12,8 @@
 #ifndef MLPACK_CORE_KERNELS_EPANECHNIKOV_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_EPANECHNIKOV_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/kernels/kernel_traits.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/epanechnikov_kernel_impl.hpp
+++ b/src/mlpack/core/kernels/epanechnikov_kernel_impl.hpp
@@ -14,6 +14,7 @@
 
 // In case it hasn't already been included.
 #include "epanechnikov_kernel.hpp"
+#include <mlpack/core/util/log.hpp>
 
 #include <mlpack/core/metrics/lmetric.hpp>
 

--- a/src/mlpack/core/kernels/example_kernel.hpp
+++ b/src/mlpack/core/kernels/example_kernel.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_KERNELS_EXAMPLE_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_EXAMPLE_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 

--- a/src/mlpack/core/kernels/gaussian_kernel.hpp
+++ b/src/mlpack/core/kernels/gaussian_kernel.hpp
@@ -14,8 +14,9 @@
 #ifndef MLPACK_CORE_KERNELS_GAUSSIAN_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_GAUSSIAN_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
+#include <mlpack/core/kernels/kernel_traits.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/hyperbolic_tangent_kernel.hpp
+++ b/src/mlpack/core/kernels/hyperbolic_tangent_kernel.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_KERNELS_HYPERBOLIC_TANGENT_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_HYPERBOLIC_TANGENT_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/laplacian_kernel.hpp
+++ b/src/mlpack/core/kernels/laplacian_kernel.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_KERNELS_LAPLACIAN_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_LAPLACIAN_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/linear_kernel.hpp
+++ b/src/mlpack/core/kernels/linear_kernel.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_KERNELS_LINEAR_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_LINEAR_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/polynomial_kernel.hpp
+++ b/src/mlpack/core/kernels/polynomial_kernel.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_KERNELS_POLYNOMIAL_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_POLYNOMIAL_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/pspectrum_string_kernel.hpp
+++ b/src/mlpack/core/kernels/pspectrum_string_kernel.hpp
@@ -20,7 +20,8 @@
 #include <string>
 #include <vector>
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/log.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/spherical_kernel.hpp
+++ b/src/mlpack/core/kernels/spherical_kernel.hpp
@@ -10,7 +10,8 @@
 #ifndef MLPACK_CORE_KERNELS_SPHERICAL_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_SPHERICAL_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <boost/math/special_functions/gamma.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/core/kernels/triangular_kernel.hpp
+++ b/src/mlpack/core/kernels/triangular_kernel.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_KERNELS_TRIANGULAR_KERNEL_HPP
 #define MLPACK_CORE_KERNELS_TRIANGULAR_KERNEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 
 namespace mlpack {

--- a/src/mlpack/core/math/columns_to_blocks.hpp
+++ b/src/mlpack/core/math/columns_to_blocks.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NN_COLUMNS_TO_BLOCKS_HPP
 #define MLPACK_METHODS_NN_COLUMNS_TO_BLOCKS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace math {

--- a/src/mlpack/core/math/lin_alg.cpp
+++ b/src/mlpack/core/math/lin_alg.cpp
@@ -10,7 +10,8 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "lin_alg.hpp"
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
 
 using namespace mlpack;
 using namespace math;

--- a/src/mlpack/core/metrics/lmetric.hpp
+++ b/src/mlpack/core/metrics/lmetric.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_METRICS_LMETRIC_HPP
 #define MLPACK_CORE_METRICS_LMETRIC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace metric {

--- a/src/mlpack/core/metrics/mahalanobis_distance.hpp
+++ b/src/mlpack/core/metrics/mahalanobis_distance.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_METRICS_MAHALANOBIS_DISTANCE_HPP
 #define MLPACK_CORE_METRICS_MAHALANOBIS_DISTANCE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace metric {

--- a/src/mlpack/core/optimizers/adadelta/ada_delta.hpp
+++ b/src/mlpack/core/optimizers/adadelta/ada_delta.hpp
@@ -15,7 +15,7 @@
 #ifndef __MLPACK_CORE_OPTIMIZERS_ADADELTA_ADA_DELTA_HPP
 #define __MLPACK_CORE_OPTIMIZERS_ADADELTA_ADA_DELTA_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/adam/adam.hpp
+++ b/src/mlpack/core/optimizers/adam/adam.hpp
@@ -16,7 +16,7 @@
 #ifndef __MLPACK_CORE_OPTIMIZERS_ADAM_ADAM_HPP
 #define __MLPACK_CORE_OPTIMIZERS_ADAM_ADAM_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian.hpp
+++ b/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_AUG_LAGRANGIAN_HPP
 #define MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_AUG_LAGRANGIAN_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
 
 #include "aug_lagrangian_function.hpp"

--- a/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_function.hpp
+++ b/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_AUG_LAGRANGIAN_FUNCTION_HPP
 #define MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_AUG_LAGRANGIAN_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_test_functions.hpp
+++ b/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_test_functions.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_TEST_FUNCTIONS_HPP
 #define MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_TEST_FUNCTIONS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/gradient_descent/gradient_descent.hpp
+++ b/src/mlpack/core/optimizers/gradient_descent/gradient_descent.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_GRADIENT_DESCENT_GRADIENT_DESCENT_HPP
 #define MLPACK_CORE_OPTIMIZERS_GRADIENT_DESCENT_GRADIENT_DESCENT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/gradient_descent/test_function.hpp
+++ b/src/mlpack/core/optimizers/gradient_descent/test_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_GD_TEST_FUNCTION_HPP
 #define MLPACK_CORE_OPTIMIZERS_GD_TEST_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/lbfgs/lbfgs.hpp
+++ b/src/mlpack/core/optimizers/lbfgs/lbfgs.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_LBFGS_LBFGS_HPP
 #define MLPACK_CORE_OPTIMIZERS_LBFGS_LBFGS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/lbfgs/test_functions.hpp
+++ b/src/mlpack/core/optimizers/lbfgs/test_functions.hpp
@@ -18,7 +18,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_LBFGS_TEST_FUNCTIONS_HPP
 #define MLPACK_CORE_OPTIMIZERS_LBFGS_TEST_FUNCTIONS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 // To fulfill the template policy class 'FunctionType', we must implement
 // the following:

--- a/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd.hpp
+++ b/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_MINIBATCH_SGD_MINIBATCH_SGD_HPP
 #define MLPACK_CORE_OPTIMIZERS_MINIBATCH_SGD_MINIBATCH_SGD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/rmsprop/rmsprop.hpp
+++ b/src/mlpack/core/optimizers/rmsprop/rmsprop.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_RMSPROP_RMSPROP_HPP
 #define MLPACK_CORE_OPTIMIZERS_RMSPROP_RMSPROP_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/sdp/lrsdp.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_SDP_LRSDP_HPP
 #define MLPACK_CORE_OPTIMIZERS_SDP_LRSDP_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/aug_lagrangian/aug_lagrangian.hpp>
 
 #include "lrsdp_function.hpp"

--- a/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_SDP_LRSDP_FUNCTION_HPP
 #define MLPACK_CORE_OPTIMIZERS_SDP_LRSDP_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/aug_lagrangian/aug_lagrangian.hpp>
 #include <mlpack/core/optimizers/sdp/sdp.hpp>
 

--- a/src/mlpack/core/optimizers/sdp/primal_dual.hpp
+++ b/src/mlpack/core/optimizers/sdp/primal_dual.hpp
@@ -11,7 +11,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_SDP_PRIMAL_DUAL_HPP
 #define MLPACK_CORE_OPTIMIZERS_SDP_PRIMAL_DUAL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/sdp/sdp.hpp>
 
 namespace mlpack {

--- a/src/mlpack/core/optimizers/sdp/sdp.hpp
+++ b/src/mlpack/core/optimizers/sdp/sdp.hpp
@@ -11,7 +11,8 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_SDP_SDP_HPP
 #define MLPACK_CORE_OPTIMIZERS_SDP_SDP_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/lin_alg.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/sgd/sgd.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_SGD_SGD_HPP
 #define MLPACK_CORE_OPTIMIZERS_SGD_SGD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/sgd/test_function.hpp
+++ b/src/mlpack/core/optimizers/sgd/test_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_OPTIMIZERS_SGD_TEST_FUNCTION_HPP
 #define MLPACK_CORE_OPTIMIZERS_SGD_TEST_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/tree/ballbound.hpp
+++ b/src/mlpack/core/tree/ballbound.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_BALLBOUND_HPP
 #define MLPACK_CORE_TREE_BALLBOUND_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include "bound_traits.hpp"
 

--- a/src/mlpack/core/tree/ballbound_impl.hpp
+++ b/src/mlpack/core/tree/ballbound_impl.hpp
@@ -14,6 +14,7 @@
 
 // In case it hasn't been included already.
 #include "ballbound.hpp"
+#include <mlpack/core/math/clamp.hpp>
 
 #include <string>
 

--- a/src/mlpack/core/tree/binary_space_tree.hpp
+++ b/src/mlpack/core/tree/binary_space_tree.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "bounds.hpp"
 #include "binary_space_tree/midpoint_split.hpp"
 #include "binary_space_tree/mean_split.hpp"

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
@@ -11,7 +11,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_BINARY_SPACE_TREE_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_BINARY_SPACE_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "../statistic.hpp"
 #include "midpoint_split.hpp"

--- a/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_BREADTH_FIRST_DUAL_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_BREADTH_FIRST_DUAL_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <queue>
 
 #include "../binary_space_tree.hpp"

--- a/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_DUAL_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_DUAL_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "binary_space_tree.hpp"
 

--- a/src/mlpack/core/tree/binary_space_tree/mean_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/mean_split.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_MEAN_SPLIT_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_MEAN_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/perform_split.hpp>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/binary_space_tree/midpoint_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/midpoint_split.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_MIDPOINT_SPLIT_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_MIDPOINT_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/perform_split.hpp>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/binary_space_tree/rp_tree_max_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/rp_tree_max_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_RP_TREE_MAX_SPLIT_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_RP_TREE_MAX_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/perform_split.hpp>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/binary_space_tree/rp_tree_mean_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/rp_tree_mean_split.hpp
@@ -13,9 +13,10 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_RP_TREE_MEAN_SPLIT_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_RP_TREE_MEAN_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "rp_tree_max_split.hpp"
 #include <mlpack/core/tree/perform_split.hpp>
+#include <mlpack/core/math/lin_alg.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/binary_space_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/single_tree_traverser.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_SINGLE_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_SINGLE_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "binary_space_tree.hpp"
 

--- a/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_UB_TREE_SPLIT_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_UB_TREE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "../address.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/binary_space_tree/vantage_point_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/vantage_point_split.hpp
@@ -13,8 +13,9 @@
 #ifndef MLPACK_CORE_TREE_BINARY_SPACE_TREE_VANTAGE_POINT_SPLIT_HPP
 #define MLPACK_CORE_TREE_BINARY_SPACE_TREE_VANTAGE_POINT_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/perform_split.hpp>
+#include <mlpack/core/math/random.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/cellbound.hpp
+++ b/src/mlpack/core/tree/cellbound.hpp
@@ -34,7 +34,7 @@
 #ifndef MLPACK_CORE_TREE_CELLBOUND_HPP
 #define MLPACK_CORE_TREE_CELLBOUND_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/math/range.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include "bound_traits.hpp"

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
@@ -10,6 +10,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "cosine_tree.hpp"
+#include <mlpack/core/util/log.hpp>
 
 #include <boost/math/distributions/normal.hpp>
 

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_COSINE_TREE_COSINE_TREE_HPP
 #define MLPACK_CORE_TREE_COSINE_TREE_COSINE_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <boost/heap/priority_queue.hpp>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_COVER_TREE_HPP
 #define MLPACK_CORE_TREE_COVER_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "cover_tree/first_point_is_root.hpp"
 #include "cover_tree/cover_tree.hpp"
 #include "cover_tree/single_tree_traverser.hpp"

--- a/src/mlpack/core/tree/cover_tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree.hpp
@@ -12,7 +12,8 @@
 #ifndef MLPACK_CORE_TREE_COVER_TREE_COVER_TREE_HPP
 #define MLPACK_CORE_TREE_COVER_TREE_COVER_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/range.hpp>
 
 #include "../statistic.hpp"
 #include "first_point_is_root.hpp"

--- a/src/mlpack/core/tree/cover_tree/dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/cover_tree/dual_tree_traverser.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_COVER_TREE_DUAL_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_COVER_TREE_DUAL_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <queue>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/cover_tree/dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/dual_tree_traverser_impl.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_COVER_TREE_DUAL_TREE_TRAVERSER_IMPL_HPP
 #define MLPACK_CORE_TREE_COVER_TREE_DUAL_TREE_TRAVERSER_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <queue>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/cover_tree/first_point_is_root.hpp
+++ b/src/mlpack/core/tree/cover_tree/first_point_is_root.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_FIRST_POINT_IS_ROOT_HPP
 #define MLPACK_CORE_TREE_FIRST_POINT_IS_ROOT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_COVER_TREE_SINGLE_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_COVER_TREE_SINGLE_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "cover_tree.hpp"
 

--- a/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_GREEDY_SINGLE_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_GREEDY_SINGLE_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/hollow_ball_bound.hpp
+++ b/src/mlpack/core/tree/hollow_ball_bound.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_HOLLOW_BALL_BOUND_HPP
 #define MLPACK_CORE_TREE_HOLLOW_BALL_BOUND_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include "bound_traits.hpp"
 

--- a/src/mlpack/core/tree/hrectbound.hpp
+++ b/src/mlpack/core/tree/hrectbound.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_HRECTBOUND_HPP
 #define MLPACK_CORE_TREE_HRECTBOUND_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/math/range.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include "bound_traits.hpp"

--- a/src/mlpack/core/tree/octree.hpp
+++ b/src/mlpack/core/tree/octree.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_OCTREE_HPP
 #define MLPACK_CORE_TREE_OCTREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "bounds.hpp"
 #include "octree/octree.hpp"
 #include "octree/traits.hpp"

--- a/src/mlpack/core/tree/octree/dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/octree/dual_tree_traverser.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_OCTREE_DUAL_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_OCTREE_DUAL_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "octree.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/octree/octree.hpp
+++ b/src/mlpack/core/tree/octree/octree.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_OCTREE_OCTREE_HPP
 #define MLPACK_CORE_TREE_OCTREE_OCTREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "../hrectbound.hpp"
 #include "../statistic.hpp"
 

--- a/src/mlpack/core/tree/octree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/octree/single_tree_traverser.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_OCTREE_SINGLE_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_OCTREE_SINGLE_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "octree.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_DISCRETE_HILBERT_VALUE_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_DISCRETE_HILBERT_VALUE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/rectangle_tree/dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/dual_tree_traverser.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_DUAL_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_DUAL_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "rectangle_tree.hpp"
 

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_descent_heuristic.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_descent_heuristic.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_HILBERT_R_TREE_DESCENT_HEURISTIC_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_HILBERT_R_TREE_DESCENT_HEURISTIC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_HILBERT_R_TREE_SPLIT_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_HILBERT_R_TREE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_PLUS_TREE_AUXILIARY_INFORMATION_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_PLUS_TREE_AUXILIARY_INFORMATION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "../hrectbound.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_descent_heuristic.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_descent_heuristic.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_PLUS_TREE_DESCENT_HEURISTIC_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_PLUS_TREE_DESCENT_HEURISTIC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_descent_heuristic.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_descent_heuristic.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_TREE_DESCENT_HEURISTIC_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_TREE_DESCENT_HEURISTIC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_TREE_SPLIT_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_TREE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_descent_heuristic.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_descent_heuristic.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_STAR_TREE_DESCENT_HEURISTIC_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_STAR_TREE_DESCENT_HEURISTIC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_STAR_TREE_SPLIT_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_STAR_TREE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_descent_heuristic.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_descent_heuristic.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_TREE_DESCENT_HEURISTIC_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_TREE_DESCENT_HEURISTIC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_R_TREE_SPLIT_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_TREE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_RECTANGLE_TREE_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_RECTANGLE_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "../hrectbound.hpp"
 #include "../statistic.hpp"

--- a/src/mlpack/core/tree/rectangle_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/single_tree_traverser.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_SINGLE_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_SINGLE_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "rectangle_tree.hpp"
 

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_CORE_TREE_RECTANGLE_TREE_X_TREE_SPLIT_HPP
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_X_TREE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree /** Trees and tree-building procedures. */ {

--- a/src/mlpack/core/tree/space_split/hyperplane.hpp
+++ b/src/mlpack/core/tree/space_split/hyperplane.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_HYPERPLANE_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_HYPERPLANE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "projection_vector.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/space_split/mean_space_split.hpp
+++ b/src/mlpack/core/tree/space_split/mean_space_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_MEAN_SPACE_SPLIT_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_MEAN_SPACE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "hyperplane.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/space_split/midpoint_space_split.hpp
+++ b/src/mlpack/core/tree/space_split/midpoint_space_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_MIDPOINT_SPACE_SPLIT_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_MIDPOINT_SPACE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "hyperplane.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/space_split/projection_vector.hpp
+++ b/src/mlpack/core/tree/space_split/projection_vector.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_PROJECTION_VECTOR_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_PROJECTION_VECTOR_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "../bounds.hpp"
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/core/tree/space_split/space_split.hpp
+++ b/src/mlpack/core/tree/space_split/space_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_SPACE_SPLIT_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_SPACE_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "hyperplane.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/tree/spill_tree.hpp
+++ b/src/mlpack/core/tree/spill_tree.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "bounds.hpp"
 #include "spill_tree/is_spill_tree.hpp"
 #include "spill_tree/spill_tree.hpp"

--- a/src/mlpack/core/tree/spill_tree/spill_dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_dual_tree_traverser.hpp
@@ -18,7 +18,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_SPILL_DUAL_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_SPILL_DUAL_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "spill_tree.hpp"
 

--- a/src/mlpack/core/tree/spill_tree/spill_single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_single_tree_traverser.hpp
@@ -17,7 +17,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_SPILL_SINGLE_TREE_TRAVERSER_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_SPILL_SINGLE_TREE_TRAVERSER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "spill_tree.hpp"
 

--- a/src/mlpack/core/tree/spill_tree/spill_tree.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree.hpp
@@ -11,7 +11,7 @@
 #ifndef MLPACK_CORE_TREE_SPILL_TREE_SPILL_TREE_HPP
 #define MLPACK_CORE_TREE_SPILL_TREE_SPILL_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "../space_split/midpoint_space_split.hpp"
 #include "../statistic.hpp"
 

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -15,6 +15,8 @@
 #ifndef MLPACK_CORE_UTIL_PARAM_HPP
 #define MLPACK_CORE_UTIL_PARAM_HPP
 
+#include <mlpack/core/util/cli.hpp>
+
 /**
  * Document an executable.  Only one instance of this macro should be
  * present in your program!  Therefore, use it in the main.cpp

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -28,7 +28,7 @@
 #ifndef MLPACK_METHODS_ADABOOST_ADABOOST_HPP
 #define MLPACK_METHODS_ADABOOST_ADABOOST_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/perceptron/perceptron.hpp>
 #include <mlpack/methods/decision_stump/decision_stump.hpp>
 

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -32,7 +32,9 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/data/normalize_labels.hpp>
 #include "adaboost.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/amf/amf.hpp
+++ b/src/mlpack/methods/amf/amf.hpp
@@ -18,7 +18,7 @@
 #ifndef MLPACK_METHODS_AMF_AMF_HPP
 #define MLPACK_METHODS_AMF_AMF_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/methods/amf/update_rules/nmf_mult_dist.hpp>
 #include <mlpack/methods/amf/update_rules/nmf_als.hpp>

--- a/src/mlpack/methods/amf/init_rules/average_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/average_init.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_AMF_AVERAGE_INIT_HPP
 #define MLPACK_METHODS_AMF_AVERAGE_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/init_rules/given_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/given_init.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_AMF_INIT_RULES_GIVEN_INIT_HPP
 #define MLPACK_METHODS_AMF_INIT_RULES_GIVEN_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/init_rules/random_acol_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/random_acol_init.hpp
@@ -12,7 +12,8 @@
 #ifndef MLPACK_METHODS_LMF_RANDOM_ACOL_INIT_HPP
 #define MLPACK_METHODS_LMF_RANDOM_ACOL_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/init_rules/random_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/random_init.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_LMF_RANDOM_INIT_HPP
 #define MLPACK_METHODS_LMF_RANDOM_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/termination_policies/incomplete_incremental_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/incomplete_incremental_termination.hpp
@@ -12,7 +12,7 @@
 #ifndef _MLPACK_METHODS_AMF_INCOMPLETE_INCREMENTAL_TERMINATION_HPP
 #define _MLPACK_METHODS_AMF_INCOMPLETE_INCREMENTAL_TERMINATION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -12,7 +12,7 @@
 #ifndef _MLPACK_METHODS_AMF_SIMPLERESIDUETERMINATION_HPP_INCLUDED
 #define _MLPACK_METHODS_AMF_SIMPLERESIDUETERMINATION_HPP_INCLUDED
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/termination_policies/simple_tolerance_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_tolerance_termination.hpp
@@ -12,7 +12,7 @@
 #ifndef _MLPACK_METHODS_AMF_SIMPLE_TOLERANCE_TERMINATION_HPP_INCLUDED
 #define _MLPACK_METHODS_AMF_SIMPLE_TOLERANCE_TERMINATION_HPP_INCLUDED
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/termination_policies/validation_RMSE_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/validation_RMSE_termination.hpp
@@ -12,7 +12,7 @@
 #ifndef _MLPACK_METHODS_AMF_VALIDATIONRMSETERMINATION_HPP_INCLUDED
 #define _MLPACK_METHODS_AMF_VALIDATIONRMSETERMINATION_HPP_INCLUDED
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack
 {

--- a/src/mlpack/methods/amf/update_rules/nmf_als.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_als.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_LMF_UPDATE_RULES_NMF_ALS_HPP
 #define MLPACK_METHODS_LMF_UPDATE_RULES_NMF_ALS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/update_rules/nmf_mult_dist.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_mult_dist.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_LMF_UPDATE_RULES_NMF_MULT_DIST_UPDATE_RULES_HPP
 #define MLPACK_METHODS_LMF_UPDATE_RULES_NMF_MULT_DIST_UPDATE_RULES_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/update_rules/nmf_mult_div.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_mult_div.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_LMF_UPDATE_RULES_NMF_MULT_DIV_HPP
 #define MLPACK_METHODS_LMF_UPDATE_RULES_NMF_MULT_DIV_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/update_rules/svd_batch_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_batch_learning.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_AMF_UPDATE_RULES_SVD_BATCH_LEARNING_HPP
 #define MLPACK_METHODS_AMF_UPDATE_RULES_SVD_BATCH_LEARNING_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace amf {

--- a/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_AMF_SVD_COMPLETE_INCREMENTAL_LEARNING_HPP
 #define MLPACK_METHODS_AMF_SVD_COMPLETE_INCREMENTAL_LEARNING_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack
 {

--- a/src/mlpack/methods/ann/activation_functions/identity_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/identity_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_IDENTITY_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_IDENTITY_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/activation_functions/logistic_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/logistic_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_LOGISTIC_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_LOGISTIC_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/activation_functions/rectifier_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/rectifier_function.hpp
@@ -23,7 +23,7 @@
 #ifndef MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_RECTIFIER_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_RECTIFIER_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <algorithm>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/activation_functions/softsign_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softsign_function.hpp
@@ -25,7 +25,7 @@
 #ifndef MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_SOFTSIGN_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_SOFTSIGN_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/activation_functions/tanh_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/tanh_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_TANH_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_ACTIVATION_FUNCTIONS_TANH_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/cnn.hpp
+++ b/src/mlpack/methods/ann/cnn.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_CNN_HPP
 #define MLPACK_METHODS_ANN_CNN_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/methods/ann/network_util.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>

--- a/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_CONVOLUTION_RULES_FFT_CONVOLUTION_HPP
 #define MLPACK_METHODS_ANN_CONVOLUTION_RULES_FFT_CONVOLUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "border_modes.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_CONVOLUTION_RULES_NAIVE_CONVOLUTION_HPP
 #define MLPACK_METHODS_ANN_CONVOLUTION_RULES_NAIVE_CONVOLUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "border_modes.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/convolution_rules/svd_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/svd_convolution.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_CONVOLUTION_RULES_SVD_CONVOLUTION_HPP
 #define MLPACK_METHODS_ANN_CONVOLUTION_RULES_SVD_CONVOLUTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "border_modes.hpp"
 #include "fft_convolution.hpp"
 #include "naive_convolution.hpp"

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_FFN_HPP
 #define MLPACK_METHODS_ANN_FFN_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/methods/ann/network_util.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>

--- a/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
@@ -27,7 +27,7 @@
 #ifndef MLPACK_METHODS_ANN_INIT_RULES_KATHIRVALAVAKUMAR_SUBAVATHI_INIT_HPP
 #define MLPACK_METHODS_ANN_INIT_RULES_KATHIRVALAVAKUMAR_SUBAVATHI_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/activation_functions/logistic_function.hpp>
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
 #include <iostream>

--- a/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
@@ -26,7 +26,7 @@
 #ifndef MLPACK_METHODS_ANN_INIT_RULES_NGUYEN_WIDROW_INIT_HPP
 #define MLPACK_METHODS_ANN_INIT_RULES_NGUYEN_WIDROW_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "random_init.hpp"
 

--- a/src/mlpack/methods/ann/init_rules/oivs_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/oivs_init.hpp
@@ -27,7 +27,7 @@
 #ifndef MLPACK_METHODS_ANN_INIT_RULES_OIVS_INIT_HPP
 #define MLPACK_METHODS_ANN_INIT_RULES_OIVS_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/activation_functions/logistic_function.hpp>
 
 #include "random_init.hpp"

--- a/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_INIT_RULES_ORTHOGONAL_INIT_HPP
 #define MLPACK_METHODS_ANN_INIT_RULES_ORTHOGONAL_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/init_rules/random_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/random_init.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_INIT_RULES_RANDOM_INIT_HPP
 #define MLPACK_METHODS_ANN_INIT_RULES_RANDOM_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/init_rules/zero_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/zero_init.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_INIT_RULES_ZERO_INIT_HPP
 #define MLPACK_METHODS_ANN_INIT_RULES_ZERO_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/base_layer.hpp
+++ b/src/mlpack/methods/ann/layer/base_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_BASE_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_BASE_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/activation_functions/logistic_function.hpp>
 #include <mlpack/methods/ann/activation_functions/identity_function.hpp>
 #include <mlpack/methods/ann/activation_functions/rectifier_function.hpp>

--- a/src/mlpack/methods/ann/layer/bias_layer.hpp
+++ b/src/mlpack/methods/ann/layer/bias_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_BIAS_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_BIAS_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/binary_classification_layer.hpp
+++ b/src/mlpack/methods/ann/layer/binary_classification_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_BINARY_CLASSIFICATION_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_BINARY_CLASSIFICATION_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/constant_layer.hpp
+++ b/src/mlpack/methods/ann/layer/constant_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_CONSTANT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_CONSTANT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/conv_layer.hpp
+++ b/src/mlpack/methods/ann/layer/conv_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_CONV_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_CONV_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 #include <mlpack/methods/ann/convolution_rules/border_modes.hpp>
 #include <mlpack/methods/ann/convolution_rules/naive_convolution.hpp>

--- a/src/mlpack/methods/ann/layer/dropconnect_layer.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_DROPCONNECT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_DROPCONNECT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "empty_layer.hpp"
 #include <mlpack/methods/ann/network_util.hpp>

--- a/src/mlpack/methods/ann/layer/dropout_layer.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_DROPOUT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_DROPOUT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/glimpse_layer.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse_layer.hpp
@@ -26,7 +26,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_GLIMPSE_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_GLIMPSE_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/pooling_rules/mean_pooling.hpp>
 #include <algorithm>
 

--- a/src/mlpack/methods/ann/layer/hard_tanh_layer.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_HARD_TANH_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_HARD_TANH_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/leaky_relu_layer.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu_layer.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_LEAKYRELU_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_LEAKYRELU_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/linear_layer.hpp
+++ b/src/mlpack/methods/ann/layer/linear_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_LINEAR_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_LINEAR_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/log_softmax_layer.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_LOG_SOFTMAX_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_LOG_SOFTMAX_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/lstm_layer.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_LSTM_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_LSTM_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/multiclass_classification_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multiclass_classification_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_MULTICLASS_CLASSIFICATION_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_MULTICLASS_CLASSIFICATION_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/multiply_constant_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_MULTIPLY_CONSTANT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_MULTIPLY_CONSTANT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/negative_log_likelihood_layer.hpp
+++ b/src/mlpack/methods/ann/layer/negative_log_likelihood_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_NEGATIVE_LOG_LIKELIHOOD_Layer_HPP
 #define MLPACK_METHODS_ANN_LAYER_NEGATIVE_LOG_LIKELIHOOD_Layer_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/one_hot_layer.hpp
+++ b/src/mlpack/methods/ann/layer/one_hot_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_ONE_HOT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_ONE_HOT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/pooling_layer.hpp
+++ b/src/mlpack/methods/ann/layer/pooling_layer.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_POOLING_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_POOLING_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/pooling_rules/mean_pooling.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 

--- a/src/mlpack/methods/ann/layer/recurrent_layer.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_RECURRENT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_RECURRENT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/reinforce_normal_layer.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_REINFORCE_NORMAL_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_REINFORCE_NORMAL_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/softmax_layer.hpp
+++ b/src/mlpack/methods/ann/layer/softmax_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_SOFTMAX_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_SOFTMAX_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/layer/sparse_bias_layer.hpp
+++ b/src/mlpack/methods/ann/layer/sparse_bias_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_SPARSE_BIAS_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_SPARSE_BIAS_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/sparse_input_layer.hpp
+++ b/src/mlpack/methods/ann/layer/sparse_input_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_SPARSE_INPUT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_SPARSE_INPUT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 #include <type_traits>

--- a/src/mlpack/methods/ann/layer/sparse_output_layer.hpp
+++ b/src/mlpack/methods/ann/layer/sparse_output_layer.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_SPARSE_OUTPUT_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_SPARSE_OUTPUT_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/ann/layer/vr_class_reward_layer.hpp
+++ b/src/mlpack/methods/ann/layer/vr_class_reward_layer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_LAYER_VR_CLASS_REWARD_LAYER_HPP
 #define MLPACK_METHODS_ANN_LAYER_VR_CLASS_REWARD_LAYER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/network_util.hpp
+++ b/src/mlpack/methods/ann/network_util.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_NETWORK_UTIL_HPP
 #define MLPACK_METHODS_ANN_NETWORK_UTIL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 

--- a/src/mlpack/methods/ann/performance_functions/cee_function.hpp
+++ b/src/mlpack/methods/ann/performance_functions/cee_function.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_CEE_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_CEE_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/ann/layer/linear_layer.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>
 

--- a/src/mlpack/methods/ann/performance_functions/mse_function.hpp
+++ b/src/mlpack/methods/ann/performance_functions/mse_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_MSE_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_MSE_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/performance_functions/sparse_function.hpp
+++ b/src/mlpack/methods/ann/performance_functions/sparse_function.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_SPARSE_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_SPARSE_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/performance_functions/sse_function.hpp
+++ b/src/mlpack/methods/ann/performance_functions/sse_function.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_SSE_FUNCTION_HPP
 #define MLPACK_METHODS_ANN_PERFORMANCE_FUNCTIONS_SSE_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/pooling_rules/max_pooling.hpp
+++ b/src/mlpack/methods/ann/pooling_rules/max_pooling.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_POOLING_RULES_MAX_POOLING_HPP
 #define MLPACK_METHODS_ANN_POOLING_RULES_MAX_POOLING_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/pooling_rules/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/pooling_rules/mean_pooling.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_POOLING_RULES_MEAN_POOLING_HPP
 #define MLPACK_METHODS_ANN_POOLING_RULES_MEAN_POOLING_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_ANN_RNN_HPP
 #define MLPACK_METHODS_ANN_RNN_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <boost/ptr_container/ptr_vector.hpp>
 

--- a/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
+++ b/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 #include "drusilla_select.hpp"
 #include "qdafn.hpp"

--- a/src/mlpack/methods/approx_kfn/drusilla_select.hpp
+++ b/src/mlpack/methods/approx_kfn/drusilla_select.hpp
@@ -30,7 +30,7 @@
 #ifndef MLPACK_METHODS_APPROX_KFN_DRUSILLA_SELECT_HPP
 #define MLPACK_METHODS_APPROX_KFN_DRUSILLA_SELECT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/approx_kfn/qdafn.hpp
+++ b/src/mlpack/methods/approx_kfn/qdafn.hpp
@@ -24,7 +24,8 @@
 #ifndef MLPACK_METHODS_APPROX_KFN_QDAFN_HPP
 #define MLPACK_METHODS_APPROX_KFN_QDAFN_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/dists/gaussian_distribution.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/cf/cf.hpp
+++ b/src/mlpack/methods/cf/cf.hpp
@@ -16,7 +16,7 @@
 #ifndef MLPACK_METHODS_CF_CF_HPP
 #define MLPACK_METHODS_CF_CF_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 #include <mlpack/methods/amf/amf.hpp>
 #include <mlpack/methods/amf/update_rules/nmf_als.hpp>

--- a/src/mlpack/methods/cf/cf_main.cpp
+++ b/src/mlpack/methods/cf/cf_main.cpp
@@ -10,8 +10,8 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#include <mlpack/core.hpp>
-
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
 #include <mlpack/methods/amf/amf.hpp>
 #include <mlpack/methods/regularized_svd/regularized_svd.hpp>
 #include <mlpack/methods/amf/termination_policies/max_iteration_termination.hpp>

--- a/src/mlpack/methods/cf/svd_wrapper.hpp
+++ b/src/mlpack/methods/cf/svd_wrapper.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_SVDWRAPPER_HPP
 #define MLPACK_METHODS_SVDWRAPPER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack
 {

--- a/src/mlpack/methods/decision_stump/decision_stump.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_DECISION_STUMP_DECISION_STUMP_HPP
 #define MLPACK_METHODS_DECISION_STUMP_DECISION_STUMP_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace decision_stump {

--- a/src/mlpack/methods/decision_stump/decision_stump_main.cpp
+++ b/src/mlpack/methods/decision_stump/decision_stump_main.cpp
@@ -9,7 +9,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/data/normalize_labels.hpp>
 #include "decision_stump.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/det/det_main.cpp
+++ b/src/mlpack/methods/det/det_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include "dt_utils.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/det/dt_utils.hpp
+++ b/src/mlpack/methods/det/dt_utils.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_DET_DT_UTILS_HPP
 #define MLPACK_METHODS_DET_DT_UTILS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "dtree.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/det/dtree.hpp
+++ b/src/mlpack/methods/det/dtree.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_DET_DTREE_HPP
 #define MLPACK_METHODS_DET_DTREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace det /** Density Estimation Trees */ {

--- a/src/mlpack/methods/emst/dtb.hpp
+++ b/src/mlpack/methods/emst/dtb.hpp
@@ -28,7 +28,7 @@
 #include "dtb_stat.hpp"
 #include "edge_pair.hpp"
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 
 #include <mlpack/core/tree/binary_space_tree.hpp>

--- a/src/mlpack/methods/emst/dtb_rules.hpp
+++ b/src/mlpack/methods/emst/dtb_rules.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_EMST_DTB_RULES_HPP
 #define MLPACK_METHODS_EMST_DTB_RULES_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/core/tree/traversal_info.hpp>
 

--- a/src/mlpack/methods/emst/dtb_stat.hpp
+++ b/src/mlpack/methods/emst/dtb_stat.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_EMST_DTB_STAT_HPP
 #define MLPACK_METHODS_EMST_DTB_STAT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace emst {

--- a/src/mlpack/methods/emst/edge_pair.hpp
+++ b/src/mlpack/methods/emst/edge_pair.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_EMST_EDGE_PAIR_HPP
 #define MLPACK_METHODS_EMST_EDGE_PAIR_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "union_find.hpp"
 

--- a/src/mlpack/methods/emst/emst_main.cpp
+++ b/src/mlpack/methods/emst/emst_main.cpp
@@ -26,7 +26,7 @@
  */
 #include "dtb.hpp"
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 PROGRAM_INFO("Fast Euclidean Minimum Spanning Tree", "This program can compute "
     "the Euclidean minimum spanning tree of a set of input points using the "

--- a/src/mlpack/methods/emst/union_find.hpp
+++ b/src/mlpack/methods/emst/union_find.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_METHODS_EMST_UNION_FIND_HPP
 #define MLPACK_METHODS_EMST_UNION_FIND_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace emst {

--- a/src/mlpack/methods/fastmks/fastmks.hpp
+++ b/src/mlpack/methods/fastmks/fastmks.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_FASTMKS_FASTMKS_HPP
 #define MLPACK_METHODS_FASTMKS_FASTMKS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/ip_metric.hpp>
 #include "fastmks_stat.hpp"
 #include <mlpack/core/tree/cover_tree.hpp>

--- a/src/mlpack/methods/fastmks/fastmks_main.cpp
+++ b/src/mlpack/methods/fastmks/fastmks_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 
 #include "fastmks.hpp"
 #include "fastmks_model.hpp"

--- a/src/mlpack/methods/fastmks/fastmks_model.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_model.hpp
@@ -12,8 +12,19 @@
 #ifndef MLPACK_METHODS_FASTMKS_FASTMKS_MODEL_HPP
 #define MLPACK_METHODS_FASTMKS_FASTMKS_MODEL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "fastmks.hpp"
+#include <mlpack/core/kernels/kernel_traits.hpp>
+#include <mlpack/core/kernels/linear_kernel.hpp>
+#include <mlpack/core/kernels/polynomial_kernel.hpp>
+#include <mlpack/core/kernels/cosine_distance.hpp>
+#include <mlpack/core/kernels/gaussian_kernel.hpp>
+#include <mlpack/core/kernels/epanechnikov_kernel.hpp>
+#include <mlpack/core/kernels/hyperbolic_tangent_kernel.hpp>
+#include <mlpack/core/kernels/laplacian_kernel.hpp>
+#include <mlpack/core/kernels/pspectrum_string_kernel.hpp>
+#include <mlpack/core/kernels/spherical_kernel.hpp>
+#include <mlpack/core/kernels/triangular_kernel.hpp>
 
 namespace mlpack {
 namespace fastmks {

--- a/src/mlpack/methods/fastmks/fastmks_rules.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_rules.hpp
@@ -12,7 +12,8 @@
 #ifndef MLPACK_METHODS_FASTMKS_FASTMKS_RULES_HPP
 #define MLPACK_METHODS_FASTMKS_FASTMKS_RULES_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/kernels/kernel_traits.hpp>
 #include <mlpack/core/tree/cover_tree/cover_tree.hpp>
 #include <mlpack/core/tree/traversal_info.hpp>
 #include <boost/heap/priority_queue.hpp>

--- a/src/mlpack/methods/fastmks/fastmks_stat.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_stat.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_FASTMKS_FASTMKS_STAT_HPP
 #define MLPACK_METHODS_FASTMKS_FASTMKS_STAT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/tree_traits.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/gmm/diagonal_constraint.hpp
+++ b/src/mlpack/methods/gmm/diagonal_constraint.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_GMM_DIAGONAL_CONSTRAINT_HPP
 #define MLPACK_METHODS_GMM_DIAGONAL_CONSTRAINT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace gmm {

--- a/src/mlpack/methods/gmm/eigenvalue_ratio_constraint.hpp
+++ b/src/mlpack/methods/gmm/eigenvalue_ratio_constraint.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_GMM_EIGENVALUE_RATIO_CONSTRAINT_HPP
 #define MLPACK_METHODS_GMM_EIGENVALUE_RATIO_CONSTRAINT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace gmm {

--- a/src/mlpack/methods/gmm/em_fit.hpp
+++ b/src/mlpack/methods/gmm/em_fit.hpp
@@ -14,7 +14,8 @@
 #ifndef MLPACK_METHODS_GMM_EM_FIT_HPP
 #define MLPACK_METHODS_GMM_EM_FIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/dists/gaussian_distribution.hpp>
 
 // Default clustering mechanism.
 #include <mlpack/methods/kmeans/kmeans.hpp>

--- a/src/mlpack/methods/gmm/gmm.hpp
+++ b/src/mlpack/methods/gmm/gmm.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_MOG_MOG_EM_HPP
 #define MLPACK_METHODS_MOG_MOG_EM_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 // This is the default fitting method class.
 #include "em_fit.hpp"

--- a/src/mlpack/methods/gmm/gmm_generate_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_generate_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "gmm.hpp"
 
 using namespace std;

--- a/src/mlpack/methods/gmm/gmm_probability_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_probability_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "gmm.hpp"
 
 using namespace std;

--- a/src/mlpack/methods/gmm/gmm_train_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_train_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "gmm.hpp"
 #include "no_constraint.hpp"

--- a/src/mlpack/methods/gmm/no_constraint.hpp
+++ b/src/mlpack/methods/gmm/no_constraint.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_GMM_NO_CONSTRAINT_HPP
 #define MLPACK_METHODS_GMM_NO_CONSTRAINT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace gmm {

--- a/src/mlpack/methods/gmm/positive_definite_constraint.hpp
+++ b/src/mlpack/methods/gmm/positive_definite_constraint.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_GMM_POSITIVE_DEFINITE_CONSTRAINT_HPP
 #define MLPACK_METHODS_GMM_POSITIVE_DEFINITE_CONSTRAINT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace gmm {

--- a/src/mlpack/methods/hmm/hmm.hpp
+++ b/src/mlpack/methods/hmm/hmm.hpp
@@ -14,7 +14,8 @@
 #ifndef MLPACK_METHODS_HMM_HMM_HPP
 #define MLPACK_METHODS_HMM_HMM_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/dists/discrete_distribution.hpp>
 
 namespace mlpack {
 namespace hmm /** Hidden Markov Models. */ {

--- a/src/mlpack/methods/hmm/hmm_generate_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_generate_main.cpp
@@ -11,7 +11,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "hmm.hpp"
 #include "hmm_util.hpp"

--- a/src/mlpack/methods/hmm/hmm_loglik_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_loglik_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "hmm.hpp"
 #include "hmm_util.hpp"

--- a/src/mlpack/methods/hmm/hmm_regression.hpp
+++ b/src/mlpack/methods/hmm/hmm_regression.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_HMM_HMM_REGRESSION_HPP
 #define MLPACK_METHODS_HMM_HMM_REGRESSION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/dists/regression_distribution.hpp>
 #include "hmm.hpp"
 

--- a/src/mlpack/methods/hmm/hmm_train_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_train_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "hmm.hpp"
 #include "hmm_util.hpp"

--- a/src/mlpack/methods/hmm/hmm_util.hpp
+++ b/src/mlpack/methods/hmm/hmm_util.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_HMM_HMM_UTIL_HPP
 #define MLPACK_METHODS_HMM_HMM_UTIL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace hmm {

--- a/src/mlpack/methods/hmm/hmm_util_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_util_impl.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_HMM_HMM_UTIL_IMPL_HPP
 #define MLPACK_METHODS_HMM_HMM_UTIL_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/methods/hmm/hmm.hpp>
 #include <mlpack/methods/gmm/gmm.hpp>

--- a/src/mlpack/methods/hmm/hmm_viterbi_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_viterbi_main.cpp
@@ -10,7 +10,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "hmm.hpp"
 #include "hmm_util.hpp"

--- a/src/mlpack/methods/hoeffding_trees/binary_numeric_split_info.hpp
+++ b/src/mlpack/methods/hoeffding_trees/binary_numeric_split_info.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_BINARY_NUMERIC_SPLIT_INFO_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_BINARY_NUMERIC_SPLIT_INFO_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/methods/hoeffding_trees/categorical_split_info.hpp
+++ b/src/mlpack/methods/hoeffding_trees/categorical_split_info.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_CATEGORICAL_SPLIT_INFO_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_CATEGORICAL_SPLIT_INFO_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/methods/hoeffding_trees/gini_impurity.hpp
+++ b/src/mlpack/methods/hoeffding_trees/gini_impurity.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_GINI_INDEX_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_GINI_INDEX_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_categorical_split.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_categorical_split.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_HOEFFDING_CATEGORICAL_SPLIT_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_HOEFFDING_CATEGORICAL_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "categorical_split_info.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_numeric_split.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_numeric_split.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_HOEFFDING_NUMERIC_SPLIT_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_HOEFFDING_NUMERIC_SPLIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "numeric_split_info.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
@@ -13,7 +13,8 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_HOEFFDING_TREE_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_HOEFFDING_TREE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/data/dataset_mapper.hpp>
 #include "gini_impurity.hpp"
 #include "hoeffding_numeric_split.hpp"
 #include "hoeffding_categorical_split.hpp"

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include <mlpack/methods/hoeffding_trees/hoeffding_tree.hpp>
 #include <mlpack/methods/hoeffding_trees/binary_numeric_split.hpp>
 #include <mlpack/methods/hoeffding_trees/information_gain.hpp>

--- a/src/mlpack/methods/hoeffding_trees/numeric_split_info.hpp
+++ b/src/mlpack/methods/hoeffding_trees/numeric_split_info.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_HOEFFDING_TREES_NUMERIC_SPLIT_INFO_HPP
 #define MLPACK_METHODS_HOEFFDING_TREES_NUMERIC_SPLIT_INFO_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/methods/kernel_pca/kernel_pca.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_KERNEL_PCA_KERNEL_PCA_HPP
 #define MLPACK_METHODS_KERNEL_PCA_KERNEL_PCA_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -9,7 +9,21 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/math/random.hpp>
+#include <mlpack/core/kernels/kernel_traits.hpp>
+#include <mlpack/core/kernels/linear_kernel.hpp>
+#include <mlpack/core/kernels/polynomial_kernel.hpp>
+#include <mlpack/core/kernels/cosine_distance.hpp>
+#include <mlpack/core/kernels/gaussian_kernel.hpp>
+#include <mlpack/core/kernels/epanechnikov_kernel.hpp>
+#include <mlpack/core/kernels/hyperbolic_tangent_kernel.hpp>
+#include <mlpack/core/kernels/laplacian_kernel.hpp>
+#include <mlpack/core/kernels/pspectrum_string_kernel.hpp>
+#include <mlpack/core/kernels/spherical_kernel.hpp>
+#include <mlpack/core/kernels/triangular_kernel.hpp>
+#include <mlpack/methods/hoeffding_trees/hoeffding_tree.hpp>
 #include <mlpack/methods/nystroem_method/ordered_selection.hpp>
 #include <mlpack/methods/nystroem_method/random_selection.hpp>
 #include <mlpack/methods/nystroem_method/kmeans_selection.hpp>

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_KERNEL_PCA_NAIVE_METHOD_HPP
 #define MLPACK_METHODS_KERNEL_PCA_NAIVE_METHOD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kpca {

--- a/src/mlpack/methods/kernel_pca/kernel_rules/nystroem_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/nystroem_method.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_KERNEL_PCA_NYSTROEM_METHOD_HPP
 #define MLPACK_METHODS_KERNEL_PCA_NYSTROEM_METHOD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/nystroem_method/kmeans_selection.hpp>
 #include <mlpack/methods/nystroem_method/nystroem_method.hpp>
 

--- a/src/mlpack/methods/kmeans/allow_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/allow_empty_clusters.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_KMEANS_ALLOW_EMPTY_CLUSTERS_HPP
 #define MLPACK_METHODS_KMEANS_ALLOW_EMPTY_CLUSTERS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kmeans {

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -13,7 +13,7 @@
 #ifndef __MLPACK_METHODS_KMEANS_KILL_EMPTY_CLUSTERS_HPP
 #define __MLPACK_METHODS_KMEANS_KILL_EMPTY_CLUSTERS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kmeans {

--- a/src/mlpack/methods/kmeans/kmeans.hpp
+++ b/src/mlpack/methods/kmeans/kmeans.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_KMEANS_KMEANS_HPP
 #define MLPACK_METHODS_KMEANS_KMEANS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/core/metrics/lmetric.hpp>
 #include "sample_initialization.hpp"

--- a/src/mlpack/methods/kmeans/kmeans_main.cpp
+++ b/src/mlpack/methods/kmeans/kmeans_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "kmeans.hpp"
 #include "allow_empty_clusters.hpp"

--- a/src/mlpack/methods/kmeans/max_variance_new_cluster.hpp
+++ b/src/mlpack/methods/kmeans/max_variance_new_cluster.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_KMEANS_MAX_VARIANCE_NEW_CLUSTER_HPP
 #define MLPACK_METHODS_KMEANS_MAX_VARIANCE_NEW_CLUSTER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kmeans {

--- a/src/mlpack/methods/kmeans/random_partition.hpp
+++ b/src/mlpack/methods/kmeans/random_partition.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_KMEANS_RANDOM_PARTITION_HPP
 #define MLPACK_METHODS_KMEANS_RANDOM_PARTITION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kmeans {

--- a/src/mlpack/methods/kmeans/refined_start.hpp
+++ b/src/mlpack/methods/kmeans/refined_start.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_KMEANS_REFINED_START_HPP
 #define MLPACK_METHODS_KMEANS_REFINED_START_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kmeans {

--- a/src/mlpack/methods/kmeans/sample_initialization.hpp
+++ b/src/mlpack/methods/kmeans/sample_initialization.hpp
@@ -14,7 +14,8 @@
 #ifndef __MLPACK_METHODS_KMEANS_SAMPLE_INITIALIZATION_HPP
 #define __MLPACK_METHODS_KMEANS_SAMPLE_INITIALIZATION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
 
 namespace mlpack {
 namespace kmeans {

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -10,6 +10,8 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "lars.hpp"
+#include <mlpack/core/util/log.hpp>
+#include <mlpack/core/util/timers.hpp>
 
 using namespace mlpack;
 using namespace mlpack::regression;

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -24,7 +24,7 @@
 #ifndef MLPACK_METHODS_LARS_LARS_HPP
 #define MLPACK_METHODS_LARS_LARS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace regression {

--- a/src/mlpack/methods/lars/lars_main.cpp
+++ b/src/mlpack/methods/lars/lars_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 
 #include "lars.hpp"
 

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -11,6 +11,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "linear_regression.hpp"
+#include <mlpack/core/util/log.hpp>
 
 using namespace mlpack;
 using namespace mlpack::regression;

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_LINEAR_REGRESSION_LINEAR_REGRESSION_HPP
 #define MLPACK_METHODS_LINEAR_REGRESSION_LINEAR_REGRESSION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace regression /** Regression methods. */ {

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include "linear_regression.hpp"
 
 PROGRAM_INFO("Simple Linear Regression and Prediction",

--- a/src/mlpack/methods/local_coordinate_coding/lcc.cpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.cpp
@@ -10,6 +10,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "lcc.hpp"
+#include <mlpack/core/math/lin_alg.hpp>
 
 namespace mlpack {
 namespace lcc {

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_LOCAL_COORDINATE_CODING_LCC_HPP
 #define MLPACK_METHODS_LOCAL_COORDINATE_CODING_LCC_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/lars/lars.hpp>
 
 // Include three simple dictionary initializers from sparse coding.

--- a/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
+++ b/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include "lcc.hpp"
 
 PROGRAM_INFO("Local Coordinate Coding",

--- a/src/mlpack/methods/logistic_regression/logistic_regression.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_LOGISTIC_REGRESSION_LOGISTIC_REGRESSION_HPP
 #define MLPACK_METHODS_LOGISTIC_REGRESSION_LOGISTIC_REGRESSION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
 
 #include "logistic_regression_function.hpp"

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_LOGISTIC_REGRESSION_LOGISTIC_REGRESSION_FUNCTION_HPP
 #define MLPACK_METHODS_LOGISTIC_REGRESSION_LOGISTIC_REGRESSION_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace regression {

--- a/src/mlpack/methods/logistic_regression/logistic_regression_main.cpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include "logistic_regression.hpp"
 
 #include <mlpack/core/optimizers/sgd/sgd.hpp>

--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -10,7 +10,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 
 #include "lsh_search.hpp"

--- a/src/mlpack/methods/lsh/lsh_search.hpp
+++ b/src/mlpack/methods/lsh/lsh_search.hpp
@@ -43,7 +43,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_LSH_SEARCH_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_LSH_SEARCH_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp>

--- a/src/mlpack/methods/lsh/lsh_search_impl.hpp
+++ b/src/mlpack/methods/lsh/lsh_search_impl.hpp
@@ -12,7 +12,8 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_LSH_SEARCH_IMPL_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_LSH_SEARCH_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/mean_shift/mean_shift.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_MEAN_SHIFT_MEAN_SHIFT_HPP
 #define MLPACK_METHODS_MEAN_SHIFT_MEAN_SHIFT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/kernels/gaussian_kernel.hpp>
 #include <mlpack/core/kernels/kernel_traits.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>

--- a/src/mlpack/methods/mean_shift/mean_shift_main.cpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_main.cpp
@@ -9,7 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/kernels/gaussian_kernel.hpp>
 #include "mean_shift.hpp"
 

--- a/src/mlpack/methods/mvu/mvu.hpp
+++ b/src/mlpack/methods/mvu/mvu.hpp
@@ -17,7 +17,7 @@
 #ifndef MLPACK_METHODS_MVU_MVU_HPP
 #define MLPACK_METHODS_MVU_MVU_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace mvu {

--- a/src/mlpack/methods/mvu/mvu_main.cpp
+++ b/src/mlpack/methods/mvu/mvu_main.cpp
@@ -11,7 +11,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "mvu.hpp"
 
 PROGRAM_INFO("Maximum Variance Unfolding (MVU)", "This program implements "

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_NAIVE_BAYES_NAIVE_BAYES_CLASSIFIER_HPP
 #define MLPACK_METHODS_NAIVE_BAYES_NAIVE_BAYES_CLASSIFIER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace naive_bayes /** The Naive Bayes Classifier. */ {

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -16,7 +16,7 @@
 #ifndef MLPACK_METHODS_NAIVE_BAYES_NAIVE_BAYES_CLASSIFIER_IMPL_HPP
 #define MLPACK_METHODS_NAIVE_BAYES_NAIVE_BAYES_CLASSIFIER_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 // In case it hasn't been included already.
 #include "naive_bayes_classifier.hpp"

--- a/src/mlpack/methods/naive_bayes/nbc_main.cpp
+++ b/src/mlpack/methods/naive_bayes/nbc_main.cpp
@@ -12,7 +12,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/data/normalize_labels.hpp>
 
 #include "naive_bayes_classifier.hpp"
 

--- a/src/mlpack/methods/nca/nca.hpp
+++ b/src/mlpack/methods/nca/nca.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_NCA_NCA_HPP
 #define MLPACK_METHODS_NCA_NCA_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/optimizers/sgd/sgd.hpp>
 

--- a/src/mlpack/methods/nca/nca_main.cpp
+++ b/src/mlpack/methods/nca/nca_main.cpp
@@ -9,7 +9,10 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/data/normalize_labels.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 
 #include "nca.hpp"

--- a/src/mlpack/methods/nca/nca_softmax_error_function.hpp
+++ b/src/mlpack/methods/nca/nca_softmax_error_function.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NCA_NCA_SOFTMAX_ERROR_FUNCTION_HPP
 #define MLPACK_METHODS_NCA_NCA_SOFTMAX_ERROR_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace nca {

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -10,7 +10,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <string>
 #include <fstream>

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -10,7 +10,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/tree/cover_tree.hpp>
 
 #include <string>

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_NEIGHBOR_SEARCH_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_NEIGHBOR_SEARCH_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <vector>
 #include <string>
 
@@ -21,7 +21,6 @@
 #include <mlpack/core/tree/rectangle_tree.hpp>
 #include <mlpack/core/tree/binary_space_tree/binary_space_tree.hpp>
 
-#include <mlpack/core/metrics/lmetric.hpp>
 #include "neighbor_search_stat.hpp"
 #include "sort_policies/nearest_neighbor_sort.hpp"
 #include "neighbor_search_rules.hpp"

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_NEIGHBOR_SEARCH_IMPL_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_NEIGHBOR_SEARCH_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/greedy_single_tree_traverser.hpp>
 #include "neighbor_search_rules.hpp"
 #include <mlpack/core/tree/spill_tree/is_spill_tree.hpp>

--- a/src/mlpack/methods/neighbor_search/neighbor_search_stat.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_stat.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_NEIGHBOR_SEARCH_STAT_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_NEIGHBOR_SEARCH_STAT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/furthest_neighbor_sort.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_FURTHEST_NEIGHBOR_SORT_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_FURTHEST_NEIGHBOR_SORT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp
+++ b/src/mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_NEAREST_NEIGHBOR_SORT_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_NEAREST_NEIGHBOR_SORT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/neighbor_search/unmap.hpp
+++ b/src/mlpack/methods/neighbor_search/unmap.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_NEIGHBOR_SEARCH_UNMAP_HPP
 #define MLPACK_METHODS_NEIGHBOR_SEARCH_UNMAP_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/nmf/nmf_main.cpp
+++ b/src/mlpack/methods/nmf/nmf_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 
 #include <mlpack/methods/amf/amf.hpp>
 

--- a/src/mlpack/methods/nystroem_method/kmeans_selection.hpp
+++ b/src/mlpack/methods/nystroem_method/kmeans_selection.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_NYSTROEM_METHOD_KMEANS_SELECTION_HPP
 #define MLPACK_METHODS_NYSTROEM_METHOD_KMEANS_SELECTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/kmeans/kmeans.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/nystroem_method/nystroem_method.hpp
+++ b/src/mlpack/methods/nystroem_method/nystroem_method.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_METHODS_NYSTROEM_METHOD_NYSTROEM_METHOD_HPP
 #define MLPACK_METHODS_NYSTROEM_METHOD_NYSTROEM_METHOD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include "kmeans_selection.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/nystroem_method/ordered_selection.hpp
+++ b/src/mlpack/methods/nystroem_method/ordered_selection.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_NYSTROEM_METHOD_ORDERED_SELECTION_HPP
 #define MLPACK_METHODS_NYSTROEM_METHOD_ORDERED_SELECTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/methods/nystroem_method/random_selection.hpp
+++ b/src/mlpack/methods/nystroem_method/random_selection.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_NYSTROEM_METHOD_RANDOM_SELECTION_HPP
 #define MLPACK_METHODS_NYSTROEM_METHOD_RANDOM_SELECTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace kernel {

--- a/src/mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp
@@ -16,7 +16,7 @@
 #ifndef MLPACK_METHODS_PCA_DECOMPOSITION_POLICIES_EXACT_SVD_METHOD_HPP
 #define MLPACK_METHODS_PCA_DECOMPOSITION_POLICIES_EXACT_SVD_METHOD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace pca {

--- a/src/mlpack/methods/pca/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/quic_svd_method.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_PCA_DECOMPOSITION_POLICIES_QUIC_SVD_METHOD_HPP
 #define MLPACK_METHODS_PCA_DECOMPOSITION_POLICIES_QUIC_SVD_METHOD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/quic_svd/quic_svd.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/pca/decomposition_policies/randomized_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/randomized_svd_method.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_PCA_DECOMPOSITION_POLICIES_RANDOMIZED_SVD_METHOD_HPP
 #define MLPACK_METHODS_PCA_DECOMPOSITION_POLICIES_RANDOMIZED_SVD_METHOD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/randomized_svd/randomized_svd.hpp>
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
 

--- a/src/mlpack/methods/pca/pca.hpp
+++ b/src/mlpack/methods/pca/pca.hpp
@@ -16,7 +16,7 @@
 #ifndef MLPACK_METHODS_PCA_PCA_HPP
 #define MLPACK_METHODS_PCA_PCA_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -16,7 +16,8 @@
 #ifndef MLPACK_METHODS_PCA_PCA_IMPL_HPP
 #define MLPACK_METHODS_PCA_PCA_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/lin_alg.hpp>
 #include "pca.hpp"
 
 using namespace std;

--- a/src/mlpack/methods/pca/pca_main.cpp
+++ b/src/mlpack/methods/pca/pca_main.cpp
@@ -10,7 +10,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 
 #include "pca.hpp"
 #include <mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp>

--- a/src/mlpack/methods/perceptron/initialization_methods/random_init.hpp
+++ b/src/mlpack/methods/perceptron/initialization_methods/random_init.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_PERCEPTRON_INITIALIZATION_METHODS_RANDOM_INIT_HPP
 #define MLPACK_METHODS_PERCEPTRON_INITIALIZATION_METHODS_RANDOM_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace perceptron {

--- a/src/mlpack/methods/perceptron/initialization_methods/zero_init.hpp
+++ b/src/mlpack/methods/perceptron/initialization_methods/zero_init.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_PERCEPTRON_INITIALIZATION_METHODS_ZERO_INIT_HPP
 #define MLPACK_METHODS_PERCEPTRON_INITIALIZATION_METHODS_ZERO_INIT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace perceptron {

--- a/src/mlpack/methods/perceptron/learning_policies/simple_weight_update.hpp
+++ b/src/mlpack/methods/perceptron/learning_policies/simple_weight_update.hpp
@@ -12,7 +12,7 @@
 #ifndef _MLPACK_METHODS_PERCEPTRON_LEARNING_POLICIES_SIMPLE_WEIGHT_UPDATE_HPP
 #define _MLPACK_METHODS_PERCEPTRON_LEARNING_POLICIES_SIMPLE_WEIGHT_UPDATE_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 /**
  * This class is used to update the weightVectors matrix according to the simple

--- a/src/mlpack/methods/perceptron/perceptron.hpp
+++ b/src/mlpack/methods/perceptron/perceptron.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_PERCEPTRON_PERCEPTRON_HPP
 #define MLPACK_METHODS_PERCEPTRON_PERCEPTRON_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "initialization_methods/zero_init.hpp"
 #include "initialization_methods/random_init.hpp"

--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -13,7 +13,9 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/data/normalize_labels.hpp>
 #include "perceptron.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/preprocess/preprocess_binarize_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_binarize_main.cpp
@@ -9,8 +9,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/data/binarize.hpp>
+#include <mlpack/core/util/param.hpp>
 
 PROGRAM_INFO("Binarize Data", "This utility takes a dataset and binarizes the "
     "variables into either 0 or 1 given threshold. User can apply binarization "

--- a/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
@@ -10,7 +10,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include <mlpack/core/data/imputer.hpp>
 #include <mlpack/core/data/dataset_mapper.hpp>
 #include <mlpack/core/data/map_policies/increment_policy.hpp>

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include <mlpack/core/data/split_data.hpp>
 
 PROGRAM_INFO("Split Data", "This utility takes a dataset and optionally labels "

--- a/src/mlpack/methods/quic_svd/quic_svd.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_QUIC_SVD_QUIC_SVD_HPP
 #define MLPACK_METHODS_QUIC_SVD_QUIC_SVD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/tree/cosine_tree/cosine_tree.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/radical/radical.cpp
+++ b/src/mlpack/methods/radical/radical.cpp
@@ -11,6 +11,8 @@
  */
 
 #include "radical.hpp"
+#include <mlpack/core/util/log.hpp>
+#include <mlpack/core/util/timers.hpp>
 
 using namespace std;
 using namespace arma;

--- a/src/mlpack/methods/radical/radical.hpp
+++ b/src/mlpack/methods/radical/radical.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_RADICAL_RADICAL_HPP
 #define MLPACK_METHODS_RADICAL_RADICAL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace radical {

--- a/src/mlpack/methods/radical/radical_main.cpp
+++ b/src/mlpack/methods/radical/radical_main.cpp
@@ -10,7 +10,9 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
+#include <mlpack/core/math/random.hpp>
 #include "radical.hpp"
 
 PROGRAM_INFO("RADICAL", "An implementation of RADICAL, a method for independent"

--- a/src/mlpack/methods/randomized_svd/randomized_svd.hpp
+++ b/src/mlpack/methods/randomized_svd/randomized_svd.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_RANDOMIZED_SVD_RANDOMIZED_SVD_HPP
 #define MLPACK_METHODS_RANDOMIZED_SVD_RANDOMIZED_SVD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace svd {

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_RANGE_SEARCH_RANGE_SEARCH_HPP
 #define MLPACK_METHODS_RANGE_SEARCH_RANGE_SEARCH_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/tree/binary_space_tree.hpp>
 #include "range_search_stat.hpp"

--- a/src/mlpack/methods/range_search/range_search_main.cpp
+++ b/src/mlpack/methods/range_search/range_search_main.cpp
@@ -11,7 +11,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/tree/cover_tree.hpp>
 

--- a/src/mlpack/methods/range_search/range_search_stat.hpp
+++ b/src/mlpack/methods/range_search/range_search_stat.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_RANGE_SEARCH_RANGE_SEARCH_STAT_HPP
 #define MLPACK_METHODS_RANGE_SEARCH_RANGE_SEARCH_STAT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace range {

--- a/src/mlpack/methods/range_search/rs_model.cpp
+++ b/src/mlpack/methods/range_search/rs_model.cpp
@@ -10,6 +10,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "rs_model.hpp"
+#include <mlpack/core/math/random_basis.hpp>
 
 using namespace std;
 using namespace mlpack;

--- a/src/mlpack/methods/rann/krann_main.cpp
+++ b/src/mlpack/methods/rann/krann_main.cpp
@@ -10,7 +10,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "ra_search.hpp"
 #include "ra_model.hpp"

--- a/src/mlpack/methods/rann/ra_model_impl.hpp
+++ b/src/mlpack/methods/rann/ra_model_impl.hpp
@@ -14,6 +14,7 @@
 
 // In case it hasn't been included yet.
 #include "ra_model.hpp"
+#include <mlpack/core/math/random_basis.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/rann/ra_query_stat.hpp
+++ b/src/mlpack/methods/rann/ra_query_stat.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_RANN_RA_QUERY_STAT_HPP
 #define MLPACK_METHODS_RANN_RA_QUERY_STAT_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/core/tree/binary_space_tree.hpp>
 

--- a/src/mlpack/methods/rann/ra_search.hpp
+++ b/src/mlpack/methods/rann/ra_search.hpp
@@ -23,7 +23,7 @@
 #ifndef MLPACK_METHODS_RANN_RA_SEARCH_HPP
 #define MLPACK_METHODS_RANN_RA_SEARCH_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/core/tree/binary_space_tree.hpp>
 

--- a/src/mlpack/methods/rann/ra_search_impl.hpp
+++ b/src/mlpack/methods/rann/ra_search_impl.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_RANN_RA_SEARCH_IMPL_HPP
 #define MLPACK_METHODS_RANN_RA_SEARCH_IMPL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include "ra_search_rules.hpp"
 

--- a/src/mlpack/methods/rann/ra_util.hpp
+++ b/src/mlpack/methods/rann/ra_util.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_RANN_RA_UTIL_HPP
 #define MLPACK_METHODS_RANN_RA_UTIL_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace neighbor {

--- a/src/mlpack/methods/regularized_svd/regularized_svd.hpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_REGULARIZED_SVD_REGULARIZED_SVD_HPP
 #define MLPACK_METHODS_REGULARIZED_SVD_REGULARIZED_SVD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/sgd/sgd.hpp>
 #include <mlpack/methods/cf/cf.hpp>
 

--- a/src/mlpack/methods/regularized_svd/regularized_svd_function.hpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd_function.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_REGULARIZED_SVD_REGULARIZED_FUNCTION_SVD_HPP
 #define MLPACK_METHODS_REGULARIZED_SVD_REGULARIZED_FUNCTION_SVD_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/sgd/sgd.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/rmva/rmva.hpp
+++ b/src/mlpack/methods/rmva/rmva.hpp
@@ -13,7 +13,7 @@
 #ifndef __MLPACK_METHODS_RMVA_RMVA_HPP
 #define __MLPACK_METHODS_RMVA_RMVA_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 #include <mlpack/methods/ann/network_util.hpp>
 #include <mlpack/methods/ann/layer/layer_traits.hpp>

--- a/src/mlpack/methods/rmva/rmva_main.cpp
+++ b/src/mlpack/methods/rmva/rmva_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 
 #include "rmva.hpp"
 

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_SOFTMAX_REGRESSION_SOFTMAX_REGRESSION_HPP
 #define MLPACK_METHODS_SOFTMAX_REGRESSION_SOFTMAX_REGRESSION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
 
 #include "softmax_regression_function.hpp"

--- a/src/mlpack/methods/softmax_regression/softmax_regression_function.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_function.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_SOFTMAX_REGRESSION_SOFTMAX_REGRESSION_FUNCTION_HPP
 #define MLPACK_METHODS_SOFTMAX_REGRESSION_SOFTMAX_REGRESSION_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace regression {

--- a/src/mlpack/methods/softmax_regression/softmax_regression_main.cpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_main.cpp
@@ -8,7 +8,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include <mlpack/methods/softmax_regression/softmax_regression.hpp>
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
 

--- a/src/mlpack/methods/sparse_autoencoder/maximal_inputs.hpp
+++ b/src/mlpack/methods/sparse_autoencoder/maximal_inputs.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_NN_MAXIMAL_INPUTS_HPP
 #define MLPACK_METHODS_NN_MAXIMAL_INPUTS_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace nn {

--- a/src/mlpack/methods/sparse_autoencoder/sparse_autoencoder.hpp
+++ b/src/mlpack/methods/sparse_autoencoder/sparse_autoencoder.hpp
@@ -12,7 +12,7 @@
 #ifndef MLPACK_METHODS_SPARSE_AUTOENCODER_SPARSE_AUTOENCODER_HPP
 #define MLPACK_METHODS_SPARSE_AUTOENCODER_SPARSE_AUTOENCODER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
 
 #include "sparse_autoencoder_function.hpp"

--- a/src/mlpack/methods/sparse_autoencoder/sparse_autoencoder_function.hpp
+++ b/src/mlpack/methods/sparse_autoencoder/sparse_autoencoder_function.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_SPARSE_AUTOENCODER_SPARSE_AUTOENCODER_FUNCTION_HPP
 #define MLPACK_METHODS_SPARSE_AUTOENCODER_SPARSE_AUTOENCODER_FUNCTION_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace nn {

--- a/src/mlpack/methods/sparse_coding/data_dependent_random_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/data_dependent_random_initializer.hpp
@@ -12,7 +12,8 @@
 #ifndef MLPACK_METHODS_SPARSE_CODING_DATA_DEPENDENT_RANDOM_INITIALIZER_HPP
 #define MLPACK_METHODS_SPARSE_CODING_DATA_DEPENDENT_RANDOM_INITIALIZER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
 
 namespace mlpack {
 namespace sparse_coding {

--- a/src/mlpack/methods/sparse_coding/nothing_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/nothing_initializer.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_SPARSE_CODING_NOTHING_INITIALIZER_HPP
 #define MLPACK_METHODS_SPARSE_CODING_NOTHING_INITIALIZER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace sparse_coding {

--- a/src/mlpack/methods/sparse_coding/random_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/random_initializer.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_SPARSE_CODING_RANDOM_INITIALIZER_HPP
 #define MLPACK_METHODS_SPARSE_CODING_RANDOM_INITIALIZER_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace sparse_coding {

--- a/src/mlpack/methods/sparse_coding/sparse_coding.cpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.cpp
@@ -11,6 +11,8 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "sparse_coding.hpp"
+#include <mlpack/core/math/lin_alg.hpp>
+#include <mlpack/core/util/param.hpp>
 
 namespace mlpack {
 namespace sparse_coding {

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_SPARSE_CODING_SPARSE_CODING_HPP
 #define MLPACK_METHODS_SPARSE_CODING_SPARSE_CODING_HPP
 
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
 #include <mlpack/methods/lars/lars.hpp>
 
 // Include our three simple dictionary initializers.

--- a/src/mlpack/methods/sparse_coding/sparse_coding_main.cpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding_main.cpp
@@ -9,7 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/core.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/param.hpp>
 #include "sparse_coding.hpp"
 
 PROGRAM_INFO("Sparse Coding", "An implementation of Sparse Coding with "

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -82,10 +82,15 @@ using enable_if_t = typename enable_if<B, T>::type;
 
 // Now include Armadillo through the special mlpack extensions.
 #include <mlpack/core/arma_extend/arma_extend.hpp>
+#include <mlpack/core/util/arma_traits.hpp>
 
 // Ensure that the user isn't doing something stupid with their Armadillo
 // defines.
 #include <mlpack/core/util/arma_config_check.hpp>
+
+// All code should have access to logging
+#include <mlpack/core/util/log.hpp>
+#include <mlpack/core/util/timers.hpp>
 
 // On Visual Studio, disable C4519 (default arguments for function templates)
 // since it's by default an error, which doesn't even make any sense because

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -11,6 +11,10 @@
 #ifndef MLPACK_PREREQS_HPP
 #define MLPACK_PREREQS_HPP
 
+// Defining _USE_MATH_DEFINES should set M_PI.
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 // First, check if Armadillo was included before, warning if so.
 #ifdef ARMA_INCLUDES
 #pragma message "Armadillo was included before mlpack; this can sometimes cause\
@@ -30,10 +34,6 @@
 #include <stdexcept>
 #include <tuple>
 #include <queue>
-
-// Defining _USE_MATH_DEFINES should set M_PI.
-#define _USE_MATH_DEFINES
-#include <cmath>
 
 // But if it's not defined, we'll do it.
 #ifndef M_PI

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -13,6 +13,7 @@
 // Note: We don't use BOOST_REQUIRE_CLOSE in the code below because we need
 // to use FPC_WEAK, and it's not at all intuitive how to do that.
 #include <mlpack/methods/lars/lars.hpp>
+#include <mlpack/core/data/load.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"


### PR DESCRIPTION
Replaced all instances of `#include <mlpack/core.hpp>` with `#include <mlpack/prereqs.hpp>`.  This doesn't affect build times when building the whole project, but it greatly reduces build times after modifying only a few files.