### PR TITLE
Implementation of AdaMax optimizer.

### DIFF
--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -211,6 +211,7 @@
  *   - Dinesh Raj <dinu.iota@gmail.com>
  *   - Prasanna Patil <prasannapatil08@gmail.com>
  *   - Lakshya Agrawal <zeeshan.lakshya@gmail.com>
+ *   - Vivek Pal <vivekpal.dtu@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core/optimizers/adam/adam.hpp
+++ b/src/mlpack/core/optimizers/adam/adam.hpp
@@ -5,9 +5,10 @@
  * @author Marcus Edel
  * @author Vivek Pal
  *
- * Adam optimizer. Adam is an an algorithm for first-order gradient-based
- * optimization of stochastic objective functions, based on adaptive estimates
- * of lower-order moments.
+ * Adam and AdaMax optimizer. Adam is an an algorithm for first-order gradient-
+ * -based optimization of stochastic objective functions, based on adaptive
+ * estimates of lower-order moments. AdaMax is simply a variant of Adam based
+ * on the infinity norm.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -25,7 +26,8 @@ namespace optimization {
 /**
  * Adam is an optimizer that computes individual adaptive learning rates for
  * different parameters from estimates of first and second moments of the
- * gradients.
+ * gradients. AdaMax is a variant of Adam based on the infinity norm as given
+ * in the section 7 of the following paper.
  *
  * For more information, see the following.
  *
@@ -39,8 +41,8 @@ namespace optimization {
  * @endcode
  *
  *
- * For Adam to work, a DecomposableFunctionType template parameter is required.
- * This class must implement the following function:
+ * For Adam and AdaMax to work, a DecomposableFunctionType template parameter
+ * is required. This class must implement the following function:
  *
  *   size_t NumFunctions();
  *   double Evaluate(const arma::mat& coordinates, const size_t i);
@@ -82,6 +84,8 @@ class Adam
    * @param tolerance Maximum absolute tolerance to terminate algorithm.
    * @param shuffle If true, the function order is shuffled; otherwise, each
    *        function is visited in linear order.
+   * @param adaMax If true, then the AdaMax optimizer is used; otherwise, by
+   *        default the Adam optimizer is used.
    */
   Adam(DecomposableFunctionType& function,
       const double stepSize = 0.001,

--- a/src/mlpack/core/optimizers/adam/adam.hpp
+++ b/src/mlpack/core/optimizers/adam/adam.hpp
@@ -3,6 +3,7 @@
  * @author Ryan Curtin
  * @author Vasanth Kalingeri
  * @author Marcus Edel
+ * @author Vivek Pal
  *
  * Adam optimizer. Adam is an an algorithm for first-order gradient-based
  * optimization of stochastic objective functions, based on adaptive estimates
@@ -89,7 +90,8 @@ class Adam
       const double eps = 1e-8,
       const size_t maxIterations = 100000,
       const double tolerance = 1e-5,
-      const bool shuffle = true);
+      const bool shuffle = true,
+      const bool adaMax = false);
 
   /**
    * Optimize the given function using Adam. The given starting point will be
@@ -141,6 +143,11 @@ class Adam
   //! Modify whether or not the individual functions are shuffled.
   bool& Shuffle() { return shuffle; }
 
+  //! Get whether or not the AdaMax optimizer is specified.
+  bool AdaMax() const { return adaMax; }
+  //! Modify wehther or not the AdaMax optimizer is to be used.
+  bool& AdaMax() { return adaMax; }
+
  private:
   //! The instantiated function.
   DecomposableFunctionType& function;
@@ -166,6 +173,9 @@ class Adam
   //! Controls whether or not the individual functions are shuffled when
   //! iterating.
   bool shuffle;
+
+  //! Specifies whether or not the AdaMax optimizer is to be used.
+  bool adaMax;
 };
 
 } // namespace optimization

--- a/src/mlpack/core/optimizers/adam/adam_impl.hpp
+++ b/src/mlpack/core/optimizers/adam/adam_impl.hpp
@@ -137,7 +137,7 @@ double Adam<DecomposableFunctionType>::Optimize(arma::mat& iterate)
     if (adaMax)
     {
       if (biasCorrection1 != 0.0)
-        iterate -= ((stepSize / biasCorrection1) * (m / (u + eps)));
+        iterate -= (stepSize / biasCorrection1 * m / (u + eps));
     }
     else
     {

--- a/src/mlpack/core/optimizers/adam/adam_impl.hpp
+++ b/src/mlpack/core/optimizers/adam/adam_impl.hpp
@@ -121,17 +121,9 @@ double Adam<DecomposableFunctionType>::Optimize(arma::mat& iterate)
 
     if (adaMax)
     {
-      u *= beta2;
-      arma::mat absGradient = arma::abs(gradient);
       // Update the exponentially weighted infinity norm.
-      for (size_t row = 0; row != iterate.n_rows; ++row)
-      {
-        for (size_t col = 0; col != iterate.n_cols; ++col)
-        {
-          if (u.at(row, col) < absGradient.at(row, col))
-            u.at(row, col) = absGradient.at(row, col);
-        }
-      }
+      u *= beta2;
+      u = arma::max(u, arma::abs(gradient));
     }
     else
     {

--- a/src/mlpack/core/optimizers/adam/adam_impl.hpp
+++ b/src/mlpack/core/optimizers/adam/adam_impl.hpp
@@ -70,11 +70,20 @@ double Adam<DecomposableFunctionType>::Optimize(arma::mat& iterate)
   // Exponential moving average of gradient values.
   arma::mat m = arma::zeros<arma::mat>(iterate.n_rows, iterate.n_cols);
 
-  // Initialize the exponentially weighted infinity norm for AdaMax optimizer.
-  arma::mat u = arma::zeros<arma::mat>(iterate.n_rows, iterate.n_cols);
-
-  // Exponential moving average of squared gradient values.
-  arma::mat v = arma::zeros<arma::mat>(iterate.n_rows, iterate.n_cols);
+  /**
+   * Initialize  either the exponentially weighted infinity norm for AdaMax
+   * optimizer (u) or exponential moving average of squared gradient values
+   * for Adam optimizer (v).
+   */
+  arma::mat u, v;
+  if (adaMax)
+  {
+    u = arma::zeros<arma::mat>(iterate.n_rows, iterate.n_cols);
+  }
+  else
+  {
+    v = arma::zeros<arma::mat>(iterate.n_rows, iterate.n_cols);
+  }
 
   for (size_t i = 1; i != maxIterations; ++i, ++currentFunction)
   {

--- a/src/mlpack/core/optimizers/adam/adam_impl.hpp
+++ b/src/mlpack/core/optimizers/adam/adam_impl.hpp
@@ -145,7 +145,7 @@ double Adam<DecomposableFunctionType>::Optimize(arma::mat& iterate)
     if (adaMax)
     {
       if (biasCorrection1 != 0.0)
-        iterate -= ((stepSize / biasCorrection1) * (m / u));
+        iterate -= ((stepSize / biasCorrection1) * (m / (u + eps)));
     }
     else
     {

--- a/src/mlpack/tests/adam_test.cpp
+++ b/src/mlpack/tests/adam_test.cpp
@@ -1,8 +1,9 @@
 /**
  * @file adam_test.cpp
  * @author Vasanth Kalingeri
+ * @author Vivek Pal
  *
- * Tests the Adam optimizer.
+ * Tests the Adam and AdaMax optimizer.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -46,9 +47,26 @@ BOOST_AUTO_TEST_CASE(SimpleAdamTestFunction)
 }
 
 /**
+ * Tests the AdaMax optimizer using a simple test function.
+ */
+BOOST_AUTO_TEST_CASE(SimpleAdaMaxTestFunction)
+{
+  SGDTestFunction f;
+  Adam<SGDTestFunction> optimizer(f, 2e-3, 0.9, 0.999, 1e-8, 5000000, 1e-9, true
+                                  ,true);
+
+  arma::mat coordinates = f.GetInitialPoint();
+  optimizer.Optimize(coordinates);
+
+  BOOST_REQUIRE_SMALL(coordinates[0], 0.1);
+  BOOST_REQUIRE_SMALL(coordinates[1], 0.1);
+  BOOST_REQUIRE_SMALL(coordinates[2], 0.1);
+}
+
+/**
  * Run Adam on logistic regression and make sure the results are acceptable.
  */
-BOOST_AUTO_TEST_CASE(LogisticRegressionTest)
+BOOST_AUTO_TEST_CASE(AdamLogisticRegressionTest)
 {
   // Generate a two-Gaussian dataset.
   GaussianDistribution g1(arma::vec("1.0 1.0 1.0"), arma::eye<arma::mat>(3, 3));
@@ -97,6 +115,68 @@ BOOST_AUTO_TEST_CASE(LogisticRegressionTest)
   LogisticRegressionFunction<> lrf(shuffledData, shuffledResponses, 0.5);
   Adam<LogisticRegressionFunction<> > adam(lrf);
   lr.Train(adam);
+
+  // Ensure that the error is close to zero.
+  const double acc = lr.ComputeAccuracy(data, responses);
+  BOOST_REQUIRE_CLOSE(acc, 100.0, 0.3); // 0.3% error tolerance.
+
+  const double testAcc = lr.ComputeAccuracy(testData, testResponses);
+  BOOST_REQUIRE_CLOSE(testAcc, 100.0, 0.6); // 0.6% error tolerance.
+}
+
+/**
+ * Run AdaMax on logistic regression and make sure the results are acceptable.
+ */
+BOOST_AUTO_TEST_CASE(AdaMaxLogisticRegressionTest)
+{
+  // Generate a two-Gaussian dataset.
+  GaussianDistribution g1(arma::vec("1.0 1.0 1.0"), arma::eye<arma::mat>(3, 3));
+  GaussianDistribution g2(arma::vec("9.0 9.0 9.0"), arma::eye<arma::mat>(3, 3));
+
+  arma::mat data(3, 1000);
+  arma::Row<size_t> responses(1000);
+  for (size_t i = 0; i < 500; ++i)
+  {
+    data.col(i) = g1.Random();
+    responses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    data.col(i) = g2.Random();
+    responses[i] = 1;
+  }
+
+  // Shuffle the dataset.
+  arma::uvec indices = arma::shuffle(arma::linspace<arma::uvec>(0,
+      data.n_cols - 1, data.n_cols));
+  arma::mat shuffledData(3, 1000);
+  arma::Row<size_t> shuffledResponses(1000);
+  for (size_t i = 0; i < data.n_cols; ++i)
+  {
+    shuffledData.col(i) = data.col(indices[i]);
+    shuffledResponses[i] = responses[indices[i]];
+  }
+
+  // Create a test set.
+  arma::mat testData(3, 1000);
+  arma::Row<size_t> testResponses(1000);
+  for (size_t i = 0; i < 500; ++i)
+  {
+    testData.col(i) = g1.Random();
+    testResponses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    testData.col(i) = g2.Random();
+    testResponses[i] = 1;
+  }
+
+  LogisticRegression<> lr(shuffledData.n_rows, 0.5);
+
+  LogisticRegressionFunction<> lrf(shuffledData, shuffledResponses, 0.5);
+  Adam<LogisticRegressionFunction<> > adamax(lrf, 1e-3, 0.9, 0.999, 1e-8, 5000000,
+                                             1e-9, true, true);
+  lr.Train(adamax);
 
   // Ensure that the error is close to zero.
   const double acc = lr.ComputeAccuracy(data, responses);


### PR DESCRIPTION
`SimpleAdaMaxTestFunction` test is currently failing with values of `coordinates` vector as `[-nan; -45.59; -nan]` after optimization. For our context, the original values were `[6; -45.6; 6.2]` to begin with.

So as it appears, Optimize function is reducing positive values to `-nan` which might be the case due to `0 / 0` (I'm suspecting somewhere during the iterations atleast one of the elements of `u` and `m` at the same index become zero) and minimal change seen on negative values.