### PR TITLE
Fix support for printing arma objects with custom precision 

### DIFF
--- a/src/mlpack/core/util/backtrace.cpp
+++ b/src/mlpack/core/util/backtrace.cpp
@@ -42,7 +42,6 @@
   #include <dlfcn.h>
 #endif
 
-#include "prefixedoutstream.hpp"
 #include "backtrace.hpp"
 #include "log.hpp"
 

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -22,12 +22,13 @@
 #include <boost/any.hpp>
 #include <boost/program_options.hpp>
 
+#include <mlpack/prereqs.hpp>
+
 #include "timers.hpp"
 #include "cli_deleter.hpp" // To make sure we can delete the singleton.
 #include "version.hpp"
 #include "param.hpp"
 
-#include <mlpack/prereqs.hpp>
 
 #include "param_data.hpp"
 #include "print_param.hpp"

--- a/src/mlpack/core/util/prefixedoutstream.cpp
+++ b/src/mlpack/core/util/prefixedoutstream.cpp
@@ -10,11 +10,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <string>
-#include <iostream>
-#include <streambuf>
-#include <string.h>
-#include <stdlib.h>
+#include <mlpack/prereqs.hpp>
 
 #include "prefixedoutstream.hpp"
 

--- a/src/mlpack/core/util/prefixedoutstream.hpp
+++ b/src/mlpack/core/util/prefixedoutstream.hpp
@@ -13,13 +13,7 @@
 #ifndef MLPACK_CORE_UTIL_PREFIXEDOUTSTREAM_HPP
 #define MLPACK_CORE_UTIL_PREFIXEDOUTSTREAM_HPP
 
-#include <iostream>
-#include <iomanip>
-#include <string>
-#include <streambuf>
-#include <stdexcept>
-
-#include <mlpack/core/arma_extend/arma_extend.hpp> // Includes Armadillo
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace util {

--- a/src/mlpack/core/util/prefixedoutstream.hpp
+++ b/src/mlpack/core/util/prefixedoutstream.hpp
@@ -19,7 +19,7 @@
 #include <streambuf>
 #include <stdexcept>
 
-#include <mlpack/core/util/sfinae_utility.hpp>
+#include <mlpack/core/arma_extend/arma_extend.hpp> // Includes Armadillo
 
 namespace mlpack {
 namespace util {
@@ -124,11 +124,19 @@ class PrefixedOutStream
    * Conducts the base logic required in all the operator << overloads.  Mostly
    * just a good idea to reduce copy-pasta.
    *
+   * Calls 2 different overloads to be able to output arma objects with custom
+   * precision
+   *
    * @tparam T The type of the data to output.
    * @param val The The data to be output.
    */
   template<typename T>
-  void BaseLogic(const T& val);
+  typename std::enable_if<!arma::is_arma_type<T>::value, void>::type
+  BaseLogic(const T& val);
+
+  template<typename T>
+  typename std::enable_if<arma::is_arma_type<T>::value, void>::type
+  BaseLogic(const T& val);
 
   /**
    * Output the prefix, but only if we need to and if we are allowed to.

--- a/src/mlpack/core/util/prefixedoutstream.hpp
+++ b/src/mlpack/core/util/prefixedoutstream.hpp
@@ -125,11 +125,11 @@ class PrefixedOutStream
    * @param val The The data to be output.
    */
   template<typename T>
-  typename std::enable_if<!arma::is_arma_type<T>::value, void>::type
+  typename std::enable_if<!arma::is_arma_type<T>::value>::type
   BaseLogic(const T& val);
 
   template<typename T>
-  typename std::enable_if<arma::is_arma_type<T>::value, void>::type
+  typename std::enable_if<arma::is_arma_type<T>::value>::type
   BaseLogic(const T& val);
 
   /**

--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -153,18 +153,30 @@ PrefixedOutStream::BaseLogic(const T& val)
   PrefixIfNeeded();
 
   std::ostringstream convert;
-  // Sync flags and precision with destination stream
-  convert.setf(destination.flags());
-  convert.precision(destination.precision());
 
   // Check if the stream is in the default state
-  if(convert.flags() == 4098 && convert.precision() == 6)
+  if(destination.flags() == convert.flags() && 
+     destination.precision() == convert.precision())
   {
     convert << val;
   }
   else
   {
-    val.raw_print(convert);
+    // Sync flags and precision with destination stream
+    convert.setf(destination.flags());
+    convert.precision(destination.precision());
+
+    // Set width of the convert stream
+    double maxVal = arma::abs(val).max();
+    if(maxVal == 0.f) {
+        maxVal = 1;
+    }
+    int maxLog = log10(maxVal);
+    maxLog = (maxLog > 0) ? floor(maxLog) + 1 : 1;
+
+    const int padding = 4;
+    convert.width(convert.precision() + maxLog + padding);
+    arma::arma_ostream::print(convert, val, false);
   }
 
   if (convert.fail())

--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -144,6 +144,9 @@ template<typename T>
 typename std::enable_if<arma::is_arma_type<T>::value, void>::type
 PrefixedOutStream::BaseLogic(const T& val)
 {
+
+  // Extract printable object from the input
+  auto printVal = arma::unwrap<T>(val).M;
   // We will use this to track whether or not we need to terminate at the end of
   // this call (only for streams which terminate after a newline).
   bool newlined = false;
@@ -158,7 +161,7 @@ PrefixedOutStream::BaseLogic(const T& val)
   if(destination.flags() == convert.flags() && 
      destination.precision() == convert.precision())
   {
-    convert << val;
+    arma::arma_ostream::print(convert, printVal, true);
   }
   else
   {
@@ -167,16 +170,16 @@ PrefixedOutStream::BaseLogic(const T& val)
     convert.precision(destination.precision());
 
     // Set width of the convert stream
-    double maxVal = arma::abs(val).max();
-    if(maxVal == 0.f) {
+    double maxVal = arma::abs(printVal).max();
+    if(maxVal == 0.f)
+    {
         maxVal = 1;
     }
     int maxLog = log10(maxVal);
     maxLog = (maxLog > 0) ? floor(maxLog) + 1 : 1;
-
     const int padding = 4;
     convert.width(convert.precision() + maxLog + padding);
-    arma::arma_ostream::print(convert, val, false);
+    arma::arma_ostream::print(convert, printVal, false);
   }
 
   if (convert.fail())

--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -34,7 +34,8 @@ PrefixedOutStream& PrefixedOutStream::operator<<(const T& s)
 }
 
 template<typename T>
-void PrefixedOutStream::BaseLogic(const T& val)
+typename std::enable_if<!arma::is_arma_type<T>::value, void>::type
+PrefixedOutStream::BaseLogic(const T& val)
 {
   // We will use this to track whether or not we need to terminate at the end of
   // this call (only for streams which terminate after a newline).
@@ -49,6 +50,122 @@ void PrefixedOutStream::BaseLogic(const T& val)
   convert.setf(destination.flags());
   convert.precision(destination.precision());
   convert << val;
+
+  if (convert.fail())
+  {
+    PrefixIfNeeded();
+    if (!ignoreInput)
+    {
+      destination << "Failed type conversion to string for output; output not "
+          "shown." << std::endl;
+      newlined = true;
+    }
+  }
+  else
+  {
+    line = convert.str();
+
+    // If the length of the casted thing was 0, it may have been a stream
+    // manipulator, so send it directly to the stream and don't ask questions.
+    if (line.length() == 0)
+    {
+      // The prefix cannot be necessary at this point.
+      if (!ignoreInput) // Only if the user wants it.
+        destination << val;
+
+      return;
+    }
+
+    // Now, we need to check for newlines in the output and print it.
+    size_t nl;
+    size_t pos = 0;
+    while ((nl = line.find('\n', pos)) != std::string::npos)
+    {
+      PrefixIfNeeded();
+
+      // Only output if the user wants it.
+      if (!ignoreInput)
+      {
+        destination << line.substr(pos, nl - pos);
+        destination << std::endl;
+      }
+
+      newlined = true; // Ensure this is set for the fatal exception if needed.
+      carriageReturned = true; // Regardless of whether or not we display it.
+
+      pos = nl + 1;
+    }
+
+    if (pos != line.length()) // We need to display the rest.
+    {
+      PrefixIfNeeded();
+      if (!ignoreInput)
+        destination << line.substr(pos);
+    }
+  }
+
+  // If we displayed a newline and we need to throw afterwards, do that.
+  if (fatal && newlined)
+  {
+    if (!ignoreInput)
+      destination << std::endl;
+
+    // Print a backtrace, if we can.
+#ifdef HAS_BFD_DL
+    if (fatal && !ignoreInput)
+    {
+      size_t nl;
+      size_t pos = 0;
+
+      Backtrace bt;
+      std::string btLine = bt.ToString();
+      while ((nl = btLine.find('\n', pos)) != std::string::npos)
+      {
+        PrefixIfNeeded();
+
+        if (!ignoreInput)
+        {
+          destination << btLine.substr(pos, nl - pos);
+          destination << std::endl;
+        }
+
+        carriageReturned = true; // Regardless of whether or not we display it.
+
+        pos = nl + 1;
+      }
+    }
+#endif
+
+    throw std::runtime_error("fatal error; see Log::Fatal output");
+  }
+}
+
+template<typename T>
+typename std::enable_if<arma::is_arma_type<T>::value, void>::type
+PrefixedOutStream::BaseLogic(const T& val)
+{
+  // We will use this to track whether or not we need to terminate at the end of
+  // this call (only for streams which terminate after a newline).
+  bool newlined = false;
+  std::string line;
+
+  // If we need to, output the prefix.
+  PrefixIfNeeded();
+
+  std::ostringstream convert;
+  // Sync flags and precision with destination stream
+  convert.setf(destination.flags());
+  convert.precision(destination.precision());
+
+  // Check if the stream is in the default state
+  if(convert.flags() == 4098 && convert.precision() == 6)
+  {
+    convert << val;
+  }
+  else
+  {
+    val.raw_print(convert);
+  }
 
   if (convert.fail())
   {

--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -170,7 +170,9 @@ PrefixedOutStream::BaseLogic(const T& val)
     convert.precision(destination.precision());
 
     // Set width of the convert stream
-    double maxVal = arma::abs(printVal).max();
+    auto absVal = arma::abs(printVal).P.Q;
+    double maxVal = absVal.max();
+
     if(maxVal == 0.f)
     {
         maxVal = 1;

--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -34,7 +34,7 @@ PrefixedOutStream& PrefixedOutStream::operator<<(const T& s)
 }
 
 template<typename T>
-typename std::enable_if<!arma::is_arma_type<T>::value, void>::type
+typename std::enable_if<!arma::is_arma_type<T>::value>::type
 PrefixedOutStream::BaseLogic(const T& val)
 {
   // We will use this to track whether or not we need to terminate at the end of
@@ -141,7 +141,7 @@ PrefixedOutStream::BaseLogic(const T& val)
 }
 
 template<typename T>
-typename std::enable_if<arma::is_arma_type<T>::value, void>::type
+typename std::enable_if<arma::is_arma_type<T>::value>::type
 PrefixedOutStream::BaseLogic(const T& val)
 {
 

--- a/src/mlpack/core/util/singletons.cpp
+++ b/src/mlpack/core/util/singletons.cpp
@@ -9,9 +9,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include "singletons.hpp"
-#include "log.hpp"
 #include "cli.hpp"
+#include "log.hpp"
+#include "singletons.hpp"
 
 using namespace mlpack;
 using namespace mlpack::util;

--- a/src/mlpack/core/util/singletons.hpp
+++ b/src/mlpack/core/util/singletons.hpp
@@ -12,8 +12,8 @@
 #ifndef MLPACK_CORE_UTIL_SINGLETONS_HPP
 #define MLPACK_CORE_UTIL_SINGLETONS_HPP
 
-#include "cli_deleter.hpp"
 #include <mlpack/mlpack_export.hpp>
+#include "cli_deleter.hpp"
 
 namespace mlpack {
 namespace util {

--- a/src/mlpack/tests/mlpack_test.cpp
+++ b/src/mlpack/tests/mlpack_test.cpp
@@ -12,8 +12,6 @@
  */
 #define BOOST_TEST_MODULE mlpackTest
 
-#include <mlpack/core/util/log.hpp>
-
 #include <boost/version.hpp>
 
 // We only need to do this for old Boost versions.

--- a/src/mlpack/tests/prefixedoutstream_test.cpp
+++ b/src/mlpack/tests/prefixedoutstream_test.cpp
@@ -81,12 +81,12 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
       BASH_GREEN "[INFO ] " BASH_CLEAR "   3.5000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   4.0000\n");
 
-  // TODO: Make Op types printable on logs?
-  //ss.str("");
-  //pss << trans(test);
-  //// This should result in there being stuff on the line.
-  //BOOST_REQUIRE_EQUAL(ss.str(), BASH_GREEN "[INFO ] " BASH_CLEAR
-      //"   1.0000   1.5000   2.0000   2.5000   3.0000   3.5000   4.0000\n");
+  ss.str("");
+  pss << trans(test);
+
+  // This should result in there being stuff on the line.
+  BOOST_REQUIRE_EQUAL(ss.str(), BASH_GREEN "[INFO ] " BASH_CLEAR
+      "   1.0000   1.5000   2.0000   2.5000   3.0000   3.5000   4.0000\n");
 
   arma::mat test2("1.0 1.5 2.0; 2.5 3.0 3.5; 4.0 4.5 4.99999");
   ss.str("");
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
 
   pss << test;
 
-  BOOST_REQUIRE_EQUAL(ss.str(), 
+  BOOST_REQUIRE_EQUAL(ss.str(),
       BASH_GREEN "[INFO ] " BASH_CLEAR "   1.000000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   1.500000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   2.000000\n"
@@ -122,6 +122,15 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
       BASH_GREEN "[INFO ] " BASH_CLEAR "   3.500000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   4.000000\n");
 
+  ss.str("");
+
+  pss << trans(test);
+
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR
+      "   1.000000   1.500000   2.000000   2.500000"
+      "   3.000000   3.500000   4.000000\n");
+
   // Try printing a matrix, with higher precision
   ss << std::setprecision(8);
   ss.str("");
@@ -129,25 +138,25 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
   pss << test2;
 
   BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      BASH_GREEN "[INFO ] " BASH_CLEAR
       "   1.00000000   1.50000000   2.00000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      BASH_GREEN "[INFO ] " BASH_CLEAR
       "   2.50000000   3.00000000   3.50000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      BASH_GREEN "[INFO ] " BASH_CLEAR
       "   4.00000000   4.50000000   4.99999000\n");
 
   // Try alignment with larger values
   test2.at(2) = 40;
   ss.str("");
-  pss << test2;
+  pss << trans(test2);
 
   BOOST_REQUIRE_EQUAL(ss.str(),
       BASH_GREEN "[INFO ] " BASH_CLEAR 
-      "    1.00000000    1.50000000    2.00000000\n"
+      "    1.00000000    2.50000000   40.00000000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR 
-      "    2.50000000    3.00000000    3.50000000\n"
+      "    1.50000000    3.00000000    4.50000000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR 
-      "   40.00000000    4.50000000    4.99999000\n");
+      "    2.00000000    3.50000000    4.99999000\n");
 
   // Test stream after reset
   test2.at(2) = 4;

--- a/src/mlpack/tests/prefixedoutstream_test.cpp
+++ b/src/mlpack/tests/prefixedoutstream_test.cpp
@@ -104,6 +104,43 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
       BASH_GREEN "[INFO ] " BASH_CLEAR "hello   1.0000   1.5000   2.0000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   2.5000   3.0000   3.5000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   4.0000   4.5000   5.0000\n");
+
+  // Try to print armadillo objects with custom precision
+  ss << std::fixed;
+  ss << std::setprecision(6);
+  ss.str("");
+
+  pss << test;
+
+  BOOST_REQUIRE_EQUAL(ss.str(), BASH_GREEN "[INFO ] " BASH_CLEAR "1.000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "1.500000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "2.000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "2.500000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "3.000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "3.500000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "4.000000\n");
+
+  // Try printing a matrix, with higher precision
+  ss << std::setprecision(8);
+  ss.str("");
+
+  pss << test2;
+
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR "1.00000000 1.50000000 2.00000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "2.50000000 3.00000000 3.50000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "4.00000000 4.50000000 4.99999000\n");
+
+  // Test stream after reset
+  ss << std::setprecision(6);
+  ss.unsetf(std::ios::floatfield);
+  ss.str("");
+
+  pss << test2;
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   1.0000   1.5000   2.0000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   2.5000   3.0000   3.5000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   4.0000   4.5000   5.0000\n");
 }
 
 /**

--- a/src/mlpack/tests/prefixedoutstream_test.cpp
+++ b/src/mlpack/tests/prefixedoutstream_test.cpp
@@ -106,6 +106,75 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
       BASH_GREEN "[INFO ] " BASH_CLEAR "   2.5000   3.0000   3.5000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   4.0000   4.5000   5.0000\n");
 
+}
+
+/**
+ * Test that we can correctly output things in general.
+ */
+BOOST_AUTO_TEST_CASE(TestPrefixedOutStream)
+{
+  std::stringstream ss;
+  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ] " BASH_CLEAR);
+
+  pss << "hello world I am ";
+  pss << 7;
+
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR "hello world I am 7");
+
+  pss << std::endl;
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR "hello world I am 7\n");
+
+  ss.str("");
+  pss << std::endl;
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR "\n");
+}
+
+/**
+ * Test format modifiers.
+ */
+BOOST_AUTO_TEST_CASE(TestPrefixedOutStreamModifiers)
+{
+  std::stringstream ss;
+  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ] " BASH_CLEAR);
+
+  pss << "I have a precise number which is ";
+  pss << std::setw(6) << std::setfill('0') << (int)156;
+
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR
+      "I have a precise number which is 000156");
+}
+
+/**
+ * Test formatted floating-point output.
+ */
+BOOST_AUTO_TEST_CASE(TestFormattedOutput)
+{
+  std::stringstream ss;
+  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ]" BASH_CLEAR);
+
+  const double pi = std::acos(-1.0);
+  pss << std::setprecision(10) << pi;
+
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ]" BASH_CLEAR "3.141592654");
+}
+
+/**
+ * Test custom precision output of arma objects.
+ */
+BOOST_AUTO_TEST_CASE(TestArmaCustomPrecision)
+{
+  std::stringstream ss;
+  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ] " BASH_CLEAR);
+  // The vector to be tested
+  arma::vec test("1.0 1.5 2.0 2.5 3.0 3.5 4.0");
+  // The matrix to be tested
+  arma::mat test2("1.0 1.5 2.0; 2.5 3.0 3.5; 4.0 4.5 4.99999");
+
   // Try to print armadillo objects with custom precision
   ss << std::fixed;
   ss << std::setprecision(6);
@@ -169,61 +238,6 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
       BASH_GREEN "[INFO ] " BASH_CLEAR "   1.0000   1.5000   2.0000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   2.5000   3.0000   3.5000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   4.0000   4.5000   5.0000\n");
-}
-
-/**
- * Test that we can correctly output things in general.
- */
-BOOST_AUTO_TEST_CASE(TestPrefixedOutStream)
-{
-  std::stringstream ss;
-  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ] " BASH_CLEAR);
-
-  pss << "hello world I am ";
-  pss << 7;
-
-  BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ] " BASH_CLEAR "hello world I am 7");
-
-  pss << std::endl;
-  BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ] " BASH_CLEAR "hello world I am 7\n");
-
-  ss.str("");
-  pss << std::endl;
-  BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ] " BASH_CLEAR "\n");
-}
-
-/**
- * Test format modifiers.
- */
-BOOST_AUTO_TEST_CASE(TestPrefixedOutStreamModifiers)
-{
-  std::stringstream ss;
-  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ] " BASH_CLEAR);
-
-  pss << "I have a precise number which is ";
-  pss << std::setw(6) << std::setfill('0') << (int)156;
-
-  BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ] " BASH_CLEAR
-      "I have a precise number which is 000156");
-}
-
-/**
- * Test formatted floating-point output.
- */
-BOOST_AUTO_TEST_CASE(TestFormattedOutput)
-{
-  std::stringstream ss;
-  PrefixedOutStream pss(ss, BASH_GREEN "[INFO ]" BASH_CLEAR);
-
-  const double pi = std::acos(-1.0);
-  pss << std::setprecision(10) << pi;
-
-  BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ]" BASH_CLEAR "3.141592654");
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/prefixedoutstream_test.cpp
+++ b/src/mlpack/tests/prefixedoutstream_test.cpp
@@ -81,11 +81,12 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
       BASH_GREEN "[INFO ] " BASH_CLEAR "   3.5000\n"
       BASH_GREEN "[INFO ] " BASH_CLEAR "   4.0000\n");
 
-  ss.str("");
-  pss << trans(test);
-  // This should result in there being stuff on the line.
-  BOOST_REQUIRE_EQUAL(ss.str(), BASH_GREEN "[INFO ] " BASH_CLEAR
-      "   1.0000   1.5000   2.0000   2.5000   3.0000   3.5000   4.0000\n");
+  // TODO: Make Op types printable on logs?
+  //ss.str("");
+  //pss << trans(test);
+  //// This should result in there being stuff on the line.
+  //BOOST_REQUIRE_EQUAL(ss.str(), BASH_GREEN "[INFO ] " BASH_CLEAR
+      //"   1.0000   1.5000   2.0000   2.5000   3.0000   3.5000   4.0000\n");
 
   arma::mat test2("1.0 1.5 2.0; 2.5 3.0 3.5; 4.0 4.5 4.99999");
   ss.str("");
@@ -112,13 +113,14 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
 
   pss << test;
 
-  BOOST_REQUIRE_EQUAL(ss.str(), BASH_GREEN "[INFO ] " BASH_CLEAR "1.000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "1.500000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "2.000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "2.500000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "3.000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "3.500000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "4.000000\n");
+  BOOST_REQUIRE_EQUAL(ss.str(), 
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   1.000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   1.500000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   2.000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   2.500000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   3.000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   3.500000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR "   4.000000\n");
 
   // Try printing a matrix, with higher precision
   ss << std::setprecision(8);
@@ -127,11 +129,28 @@ BOOST_AUTO_TEST_CASE(TestArmadilloPrefixedOutStream)
   pss << test2;
 
   BOOST_REQUIRE_EQUAL(ss.str(),
-      BASH_GREEN "[INFO ] " BASH_CLEAR "1.00000000 1.50000000 2.00000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "2.50000000 3.00000000 3.50000000\n"
-      BASH_GREEN "[INFO ] " BASH_CLEAR "4.00000000 4.50000000 4.99999000\n");
+      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      "   1.00000000   1.50000000   2.00000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      "   2.50000000   3.00000000   3.50000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      "   4.00000000   4.50000000   4.99999000\n");
+
+  // Try alignment with larger values
+  test2.at(2) = 40;
+  ss.str("");
+  pss << test2;
+
+  BOOST_REQUIRE_EQUAL(ss.str(),
+      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      "    1.00000000    1.50000000    2.00000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      "    2.50000000    3.00000000    3.50000000\n"
+      BASH_GREEN "[INFO ] " BASH_CLEAR 
+      "   40.00000000    4.50000000    4.99999000\n");
 
   // Test stream after reset
+  test2.at(2) = 4;
   ss << std::setprecision(6);
   ss.unsetf(std::ios::floatfield);
   ss.str("");


### PR DESCRIPTION
Relevant issue : #755 

A few issues : 
 * After the user sets up custom flags, `arma` objects are printed with the set precision, but the stream does not align matrix elements.
 * During build, a `pragma` message appears

> In file included from /home/shikhar/Documents/dev/mlpack-fork/src/mlpack/../mlpack/core.hpp:217:0,
                 from /home/shikhar/Documents/dev/mlpack-fork/src/mlpack/tests/test_tools.hpp:15,
                 from /home/shikhar/Documents/dev/mlpack-fork/src/mlpack/tests/mlpack_test.cpp:25:
/home/shikhar/Documents/dev/mlpack-fork/src/mlpack/../mlpack/prereqs.hpp:20:17: note: #pragma message: Armadillo was included before mlpack; this can sometimes cause prob
lems.  It should only be necessary to include <mlpack/core.hpp> and not <armadillo>.
 #pragma message "Armadillo was included before mlpack; this can sometimes cause\

because of the need to include `arma` in `prefixedoutstream.hpp`

