### PR TITLE
SGD with momentum update.

### DIFF
--- a/src/mlpack/core/optimizers/momentum_sgd/CMakeLists.txt
+++ b/src/mlpack/core/optimizers/momentum_sgd/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SOURCES
+  momentum_sgd.hpp
+  momentum_sgd_impl.hpp
+)
+
+set(DIR_SRCS)
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+
+set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)

--- a/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp
+++ b/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp
@@ -1,0 +1,178 @@
+/**
+ * @file momentum_sgd.hpp
+ * @author Ryan Curtin
+ * @author Arun Reddy
+ *
+ * Stochastic Gradient Descent(SGD) with Momentum update (MomentumSGD) is an approach
+ * that enjoys accelerated convergence rates compared to vanilla SGD.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_OPTIMIZERS_MOMENTUM_SGD_MOMENTUM_SGD_HPP
+#define MLPACK_CORE_OPTIMIZERS_MOMENTUM_SGD_MOMENTUM_SGD_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace optimization {
+
+/**
+ * Learning with SGD can sometimes be slow. Using momentum update for parameter
+ * learning can accelerate the rate of convergence in cases the surface curves
+ * much more steeply(a steep hilly terrain with high curvature). The momentum
+ * algorithm introduces a new velocity vector \f$ v \f$ with the same dimension
+ * as the paramater \f$ A \f$. Also it introduces a new hyperparameter momentum
+ * \f$ mu \in (0,1] \f$. Common values of \f$ mu \f$ include 0.5, 0.9 and 0.99.
+ * Typically it begins with a small value and later raised.
+ *
+ * SGD is a technique for minimizing a function which can be expressed as a
+ * sum of other functions.  That is, suppose we have
+ *
+ * \f[
+ * f(A) = \sum_{i = 0}^{n} f_i(A)
+ * \f]
+ *
+ * and our task is to minimize \f$ A \f$.  Unlike SGD which directly uses the
+ * gradient of the function \f$ A \f$ , SGD with momentum update iterates over
+ * each function \f$ f_i(A) \f$, producing the following update scheme:
+ *
+ * \f[
+ * v = mu*v - \alpha \nabla f_i(A)
+ * A_{j + 1} = A_j + v
+ * \f]
+ *
+ * where \f$ \alpha \f$ is a parameter which specifies the step size.  \f$ i \f$
+ * is chosen according to \f$ j \f$ (the iteration number).  The MomentumSGD class
+ * supports either scanning through each of the \f$ n \f$ functions \f$ f_i(A)
+ * \f$ linearly, or in a random sequence.  The algorithm continues until \f$ j
+ * \f$ reaches the maximum number of iterations---or when a full sequence of
+ * updates through each of the \f$ n \f$ functions \f$ f_i(A) \f$ produces an
+ * improvement within a certain tolerance \f$ \epsilon \f$.  That is,
+ *
+ * \f[
+ * | f(A_{j + n}) - f(A_j) | < \epsilon.
+ * \f]
+ *
+ * The parameter \f$\epsilon\f$ is specified by the tolerance parameter to the
+ * constructor; \f$n\f$ is specified by the maxIterations parameter.
+ *
+ * This class is useful for data-dependent functions whose objective function
+ * can be expressed as a sum of objective functions operating on an individual
+ * point.  Then, MomentumSGD considers the gradient of the objective function operating
+ * on an individual point in its update of \f$ A \f$.
+ *
+ * For MomentumSGD to work, a DecomposableFunctionType template parameter is required.
+ * This class must implement the following function:
+ *
+ *   size_t NumFunctions();
+ *   double Evaluate(const arma::mat& coordinates, const size_t i);
+ *   void Gradient(const arma::mat& coordinates,
+ *                 const size_t i,
+ *                 arma::mat& gradient);
+ *
+ * NumFunctions() should return the number of functions (\f$n\f$), and in the
+ * other two functions, the parameter i refers to which individual function (or
+ * gradient) is being evaluated.  So, for the case of a data-dependent function,
+ * such as NCA (see mlpack::nca::NCA), NumFunctions() should return the number
+ * of points in the dataset, and Evaluate(coordinates, 0) will evaluate the
+ * objective function on the first point in the dataset (presumably, the dataset
+ * is held internally in the DecomposableFunctionType).
+ *
+ * @tparam DecomposableFunctionType Decomposable objective function type to be
+ *     minimized.
+ */
+template<typename DecomposableFunctionType>
+class MomentumSGD
+{
+ public:
+  /**
+   * Construct the MomentumSGD optimizer with the given function and parameters.  The
+   * defaults here are not necessarily good for the given problem, so it is
+   * suggested that the values used be tailored to the task at hand.  The
+   * maximum number of iterations refers to the maximum number of points that
+   * are processed (i.e., one iteration equals one point; one iteration does not
+   * equal one pass over the dataset). Typically the momentum paramter is often
+   * initialized with small value like 0.5 and later raised.
+   *
+   * @param function Function to be optimized (minimized).
+   * @param stepSize Step size for each iteration.
+   * @param maxIterations Maximum number of iterations allowed (0 means no
+   *     limit).
+   * @param tolerance Maximum absolute tolerance to terminate algorithm.
+   * @param momentum The momentum hyperparameter
+   * @param shuffle If true, the function order is shuffled; otherwise, each
+   *     function is visited in linear order.
+   */
+  MomentumSGD(DecomposableFunctionType& function,
+      const double stepSize = 0.01,
+      const size_t maxIterations = 100000,
+      const double tolerance = 1e-5,
+      const double momentum = 0.5,
+      const bool shuffle = true);
+
+  /**
+   * Optimize the given function using stochastic gradient descent.  The given
+   * starting point will be modified to store the finishing point of the
+   * algorithm, and the final objective value is returned.
+   *
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(arma::mat& iterate);
+
+  //! Get the instantiated function to be optimized.
+  const DecomposableFunctionType& Function() const { return function; }
+  //! Modify the instantiated function.
+  DecomposableFunctionType& Function() { return function; }
+
+  //! Get the step size.
+  double StepSize() const { return stepSize; }
+  //! Modify the step size.
+  double& StepSize() { return stepSize; }
+
+  //! Get the maximum number of iterations (0 indicates no limit).
+  size_t MaxIterations() const { return maxIterations; }
+  //! Modify the maximum number of iterations (0 indicates no limit).
+  size_t& MaxIterations() { return maxIterations; }
+
+  //! Get the tolerance for termination.
+  double Tolerance() const { return tolerance; }
+  //! Modify the tolerance for termination.
+  double& Tolerance() { return tolerance; }
+
+  //! Get whether or not the individual functions are shuffled.
+  bool Shuffle() const { return shuffle; }
+  //! Modify whether or not the individual functions are shuffled.
+  bool& Shuffle() { return shuffle; }
+
+ private:
+  //! The instantiated function.
+  DecomposableFunctionType& function;
+
+  //! The step size for each example.
+  double stepSize;
+
+  //! The maximum number of allowed iterations.
+  size_t maxIterations;
+
+  //! The tolerance for termination.
+  double tolerance;
+
+  //! The momentum hyperparameter
+  double momentum;
+
+  //! Controls whether or not the individual functions are shuffled when
+  //! iterating.
+  bool shuffle;
+};
+
+} // namespace optimization
+} // namespace mlpack
+
+// Include implementation.
+#include "momentum_sgd_impl.hpp"
+
+#endif

--- a/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp
+++ b/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp
@@ -28,6 +28,17 @@ namespace optimization {
  * momentum \f$ mu \in (0,1] \f$. Common values of \f$ mu \f$ include 0.5, 0.9 and 0.99.
  * Typically it begins with a small value and later raised.
  *
+ * For more information, please refer to the Section 8.3.2 of the following book
+ *
+ * @code
+ * @book{Goodfellow-et-al-2016,
+ *  title={Deep Learning},
+ *  author={Ian Goodfellow and Yoshua Bengio and Aaron Courville},
+ *  publisher={MIT Press},
+ *  note={\url{http://www.deeplearningbook.org}},
+ *  year={2016}
+ * }
+ *
  * SGD is a technique for minimizing a function which can be expressed as a
  * sum of other functions.  That is, suppose we have
  *

--- a/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp
+++ b/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp
@@ -3,7 +3,7 @@
  * @author Ryan Curtin
  * @author Arun Reddy
  *
- * Stochastic Gradient Descent(SGD) with Momentum update (MomentumSGD) is an approach
+ * Stochastic Gradient Descent(SGD) with Momentum update(MomentumSGD) is an approach
  * that enjoys accelerated convergence rates compared to vanilla SGD.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
@@ -21,11 +21,11 @@ namespace optimization {
 
 /**
  * Learning with SGD can sometimes be slow. Using momentum update for parameter
- * learning can accelerate the rate of convergence in cases the surface curves
- * much more steeply(a steep hilly terrain with high curvature). The momentum
- * algorithm introduces a new velocity vector \f$ v \f$ with the same dimension
- * as the paramater \f$ A \f$. Also it introduces a new hyperparameter momentum
- * \f$ mu \in (0,1] \f$. Common values of \f$ mu \f$ include 0.5, 0.9 and 0.99.
+ * learning can accelerate the rate of convergence, specifically in the cases
+ * where the surface curves much more steeply(a steep hilly terrain with high curvature)
+ * . The momentum algorithm introduces a new velocity vector \f$ v \f$ with the
+ * same dimension as the paramater \f$ A \f$. Also it introduces a new hyperparameter
+ * momentum \f$ mu \in (0,1] \f$. Common values of \f$ mu \f$ include 0.5, 0.9 and 0.99.
  * Typically it begins with a small value and later raised.
  *
  * SGD is a technique for minimizing a function which can be expressed as a

--- a/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/momentum_sgd/momentum_sgd_impl.hpp
@@ -1,0 +1,128 @@
+/**
+ * @file sgd_impl.hpp
+ * @author Ryan Curtin
+ * @author Arun Reddy
+ *
+ * Implementation of stochastic gradient descent with momentum.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_OPTIMIZERS_MOMENTUM_SGD_MOMENTUM_SGD_IMPL_HPP
+#define MLPACK_CORE_OPTIMIZERS_MOMENTUM_SGD_MOMENTUM_SGD_IMPL_HPP
+
+#include <mlpack/methods/regularized_svd/regularized_svd_function.hpp>
+// In case it hasn't been included yet.
+#include "momentum_sgd.hpp"
+
+namespace mlpack {
+namespace optimization {
+
+template<typename DecomposableFunctionType>
+MomentumSGD<DecomposableFunctionType>::MomentumSGD(DecomposableFunctionType& function,
+                                   const double stepSize,
+                                   const size_t maxIterations,
+                                   const double tolerance,
+                                   const double momentum,
+                                   const bool shuffle) :
+    function(function),
+    stepSize(stepSize),
+    maxIterations(maxIterations),
+    tolerance(tolerance),
+    momentum(momentum),
+    shuffle(shuffle)
+{ /* Nothing to do. */ }
+
+//! Optimize the function (minimize).
+template<typename DecomposableFunctionType>
+double MomentumSGD<DecomposableFunctionType>::Optimize(arma::mat& iterate)
+{
+  // Find the number of functions to use.
+  const size_t numFunctions = function.NumFunctions();
+
+  // This is used only if shuffle is true.
+  arma::Col<size_t> visitationOrder;
+  if (shuffle)
+    visitationOrder = arma::shuffle(arma::linspace<arma::Col<size_t>>(0,
+        (numFunctions - 1), numFunctions));
+
+  // To keep track of where we are and how things are going.
+  size_t currentFunction = 0;
+  double overallObjective = 0;
+  double lastObjective = DBL_MAX;
+
+  // Calculate the first objective function.
+  for (size_t i = 0; i < numFunctions; ++i)
+    overallObjective += function.Evaluate(iterate, i);
+
+  // Now iterate!
+  arma::mat gradient(iterate.n_rows, iterate.n_cols);
+
+  //
+  arma::mat v = arma::zeros<arma::mat>(iterate.n_rows, iterate.n_cols);
+
+  for (size_t i = 1; i != maxIterations; ++i, ++currentFunction)
+  {
+    // Is this iteration the start of a sequence?
+    if ((currentFunction % numFunctions) == 0)
+    {
+      // Output current objective function.
+      Log::Info << "MomentumSGD: iteration " << i << ", objective " << overallObjective
+          << "." << std::endl;
+
+      if (std::isnan(overallObjective) || std::isinf(overallObjective))
+      {
+        Log::Warn << "MomentumSGD: converged to " << overallObjective << "; terminating"
+            << " with failure.  Try a smaller step size?" << std::endl;
+        return overallObjective;
+      }
+
+      if (std::abs(lastObjective - overallObjective) < tolerance)
+      {
+        Log::Info << "MomentumSGD: minimized within tolerance " << tolerance << "; "
+            << "terminating optimization." << std::endl;
+        return overallObjective;
+      }
+
+      // Reset the counter variables.
+      lastObjective = overallObjective;
+      overallObjective = 0;
+      currentFunction = 0;
+
+      if (shuffle) // Determine order of visitation.
+        visitationOrder = arma::shuffle(visitationOrder);
+    }
+
+    // Evaluate the gradient for this iteration.
+    if (shuffle)
+      function.Gradient(iterate, visitationOrder[currentFunction], gradient);
+    else
+      function.Gradient(iterate, currentFunction, gradient);
+
+    // And update the iterate.
+    v = momentum*v - stepSize * gradient;
+    iterate += v;
+
+    // Now add that to the overall objective function.
+    if (shuffle)
+      overallObjective += function.Evaluate(iterate,
+          visitationOrder[currentFunction]);
+    else
+      overallObjective += function.Evaluate(iterate, currentFunction);
+  }
+
+  Log::Info << "MomentumSGD: maximum iterations (" << maxIterations << ") reached; "
+      << "terminating optimization." << std::endl;
+  // Calculate final objective.
+  overallObjective = 0;
+  for (size_t i = 0; i < numFunctions; ++i)
+    overallObjective += function.Evaluate(iterate, i);
+  return overallObjective;
+}
+
+} // namespace optimization
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(mlpack_test
   metric_test.cpp
   minibatch_sgd_test.cpp
   mlpack_test.cpp
+  momentum_sgd_test.cpp
   nbc_test.cpp
   nca_test.cpp
   nmf_test.cpp

--- a/src/mlpack/tests/momentum_sgd_test.cpp
+++ b/src/mlpack/tests/momentum_sgd_test.cpp
@@ -1,0 +1,110 @@
+/**
+ * @file momentum_sgd_test.cpp
+ * @author Marcus Edel
+ * @author Arun Reddy
+ *
+ * Tests the MomentumSGD optimizer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+
+#include <mlpack/core/optimizers/momentum_sgd/momentum_sgd.hpp>
+#include <mlpack/core/optimizers/sgd/test_function.hpp>
+
+#include <mlpack/methods/logistic_regression/logistic_regression.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include "test_tools.hpp"
+
+using namespace arma;
+using namespace mlpack;
+using namespace mlpack::optimization;
+using namespace mlpack::optimization::test;
+
+using namespace mlpack::distribution;
+using namespace mlpack::regression;
+
+BOOST_AUTO_TEST_SUITE(MomentumSGDTest);
+
+/**
+ * Tests the RMSprop optimizer using a simple test function.
+ */
+BOOST_AUTO_TEST_CASE(SimpleMomentumSGDTestFunction)
+{
+  SGDTestFunction f;
+  MomentumSGD<SGDTestFunction> optimizer(f, 1e-3, 5000000, 1e-9, 0.9, true);
+
+  arma::mat coordinates = f.GetInitialPoint();
+  optimizer.Optimize(coordinates);
+
+  BOOST_REQUIRE_SMALL(coordinates[0], 0.1);
+  BOOST_REQUIRE_SMALL(coordinates[1], 0.1);
+  BOOST_REQUIRE_SMALL(coordinates[2], 0.1);
+}
+
+/**
+ * Run RMSprop on logistic regression and make sure the results are acceptable.
+ */
+BOOST_AUTO_TEST_CASE(LogisticRegressionTest)
+{
+  // Generate a two-Gaussian dataset.
+  GaussianDistribution g1(arma::vec("1.0 1.0 1.0"), arma::eye<arma::mat>(3, 3));
+  GaussianDistribution g2(arma::vec("9.0 9.0 9.0"), arma::eye<arma::mat>(3, 3));
+
+  arma::mat data(3, 1000);
+  arma::Row<size_t> responses(1000);
+  for (size_t i = 0; i < 500; ++i)
+  {
+    data.col(i) = g1.Random();
+    responses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    data.col(i) = g2.Random();
+    responses[i] = 1;
+  }
+
+  // Shuffle the dataset.
+  arma::uvec indices = arma::shuffle(arma::linspace<arma::uvec>(0,
+                                                                data.n_cols - 1, data.n_cols));
+  arma::mat shuffledData(3, 1000);
+  arma::Row<size_t> shuffledResponses(1000);
+  for (size_t i = 0; i < data.n_cols; ++i)
+  {
+    shuffledData.col(i) = data.col(indices[i]);
+    shuffledResponses[i] = responses[indices[i]];
+  }
+
+  // Create a test set.
+  arma::mat testData(3, 1000);
+  arma::Row<size_t> testResponses(1000);
+  for (size_t i = 0; i < 500; ++i)
+  {
+    testData.col(i) = g1.Random();
+    testResponses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    testData.col(i) = g2.Random();
+    testResponses[i] = 1;
+  }
+
+  LogisticRegression<> lr(shuffledData.n_rows, 0.5);
+
+  LogisticRegressionFunction<> lrf(shuffledData, shuffledResponses, 0.5);
+  MomentumSGD<LogisticRegressionFunction<> > momentum_sgd(lrf);
+  lr.Train(momentum_sgd);
+
+  // Ensure that the error is close to zero.
+  const double acc = lr.ComputeAccuracy(data, responses);
+  BOOST_REQUIRE_CLOSE(acc, 100.0, 0.3); // 0.3% error tolerance.
+
+  const double testAcc = lr.ComputeAccuracy(testData, testResponses);
+  BOOST_REQUIRE_CLOSE(testAcc, 100.0, 0.6); // 0.6% error tolerance.
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Implemented SGD with the momentum update towards  #893.

1. Implemented based on the sgd momentum algorithm from Deep learning book (http://www.deeplearningbook.org/) - Section 8.3.2
2. Added a hyperparamter `momentum` and set the default value to 0.5.
3. Added a test case similar to other optimizer test cases.