### PR TITLE
Suppressing Warning from unit test

### DIFF
--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -28,10 +28,7 @@ BOOST_AUTO_TEST_SUITE(LoadSaveTest);
 BOOST_AUTO_TEST_CASE(NoExtensionLoad)
 {
   arma::mat out;
-  bool lflag = Log::Warn.ignoreInput;
-  Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("noextension", out) == false);
-  Log::Warn.ignoreInput = lflag;
 }
 
 /**
@@ -40,10 +37,7 @@ BOOST_AUTO_TEST_CASE(NoExtensionLoad)
 BOOST_AUTO_TEST_CASE(NoExtensionSave)
 {
   arma::mat out;
-  bool lflag = Log::Warn.ignoreInput;
-  Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Save("noextension", out) == false);
-  Log::Warn.ignoreInput = lflag;
 }
 
 /**
@@ -52,10 +46,7 @@ BOOST_AUTO_TEST_CASE(NoExtensionSave)
 BOOST_AUTO_TEST_CASE(NotExistLoad)
 {
   arma::mat out;
-  bool lflag = Log::Warn.ignoreInput;
-  Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("nonexistentfile_______________.csv", out) == false);
-  Log::Warn.ignoreInput = lflag;
 }
 
 /**
@@ -460,10 +451,7 @@ BOOST_AUTO_TEST_CASE(LoadRawBinaryTest)
       == true);
 
   // Now reload through our interface.
-  bool lflag = Log::Warn.ignoreInput;
-  Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("test_file.bin", test) == true);
-  Log::Warn.ignoreInput = lflag;
 
   BOOST_REQUIRE_EQUAL(test.n_rows, 1);
   BOOST_REQUIRE_EQUAL(test.n_cols, 8);
@@ -656,13 +644,10 @@ BOOST_AUTO_TEST_CASE(NoHDF5Test)
   test.randu(5, 5);
 
   // Stop warnings.
-  bool lflag = Log::Warn.ignoreInput;
-  Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Save("test_file.h5", test) == false);
   BOOST_REQUIRE(data::Save("test_file.hdf5", test) == false);
   BOOST_REQUIRE(data::Save("test_file.hdf", test) == false);
   BOOST_REQUIRE(data::Save("test_file.he5", test) == false);
-  Log::Warn.ignoreInput = lflag;
 }
 #endif
 

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -28,9 +28,10 @@ BOOST_AUTO_TEST_SUITE(LoadSaveTest);
 BOOST_AUTO_TEST_CASE(NoExtensionLoad)
 {
   arma::mat out;
+  bool lflag = Log::Warn.ignoreInput;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("noextension", out) == false);
-//  Log::Warn.ignoreInput = false;
+  Log::Warn.ignoreInput = lflag;
 }
 
 /**
@@ -39,9 +40,10 @@ BOOST_AUTO_TEST_CASE(NoExtensionLoad)
 BOOST_AUTO_TEST_CASE(NoExtensionSave)
 {
   arma::mat out;
+  bool lflag = Log::Warn.ignoreInput;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Save("noextension", out) == false);
- // Log::Warn.ignoreInput = false;
+  Log::Warn.ignoreInput = lflag;
 }
 
 /**
@@ -50,9 +52,10 @@ BOOST_AUTO_TEST_CASE(NoExtensionSave)
 BOOST_AUTO_TEST_CASE(NotExistLoad)
 {
   arma::mat out;
+  bool lflag = Log::Warn.ignoreInput;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("nonexistentfile_______________.csv", out) == false);
-  //Log::Warn.ignoreInput = false;
+  Log::Warn.ignoreInput = lflag;
 }
 
 /**
@@ -457,9 +460,10 @@ BOOST_AUTO_TEST_CASE(LoadRawBinaryTest)
       == true);
 
   // Now reload through our interface.
+  bool lflag = Log::Warn.ignoreInput;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("test_file.bin", test) == true);
-//  Log::Warn.ignoreInput = false;
+  Log::Warn.ignoreInput = lflag;
 
   BOOST_REQUIRE_EQUAL(test.n_rows, 1);
   BOOST_REQUIRE_EQUAL(test.n_cols, 8);
@@ -652,12 +656,13 @@ BOOST_AUTO_TEST_CASE(NoHDF5Test)
   test.randu(5, 5);
 
   // Stop warnings.
+  bool lflag = Log::Warn.ignoreInput;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Save("test_file.h5", test) == false);
   BOOST_REQUIRE(data::Save("test_file.hdf5", test) == false);
   BOOST_REQUIRE(data::Save("test_file.hdf", test) == false);
   BOOST_REQUIRE(data::Save("test_file.he5", test) == false);
-//  Log::Warn.ignoreInput = false;
+  Log::Warn.ignoreInput = lflag;
 }
 #endif
 

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(NoExtensionLoad)
   arma::mat out;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("noextension", out) == false);
-  Log::Warn.ignoreInput = false;
+//  Log::Warn.ignoreInput = false;
 }
 
 /**
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(NoExtensionSave)
   arma::mat out;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Save("noextension", out) == false);
-  Log::Warn.ignoreInput = false;
+ // Log::Warn.ignoreInput = false;
 }
 
 /**
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(NotExistLoad)
   arma::mat out;
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("nonexistentfile_______________.csv", out) == false);
-  Log::Warn.ignoreInput = false;
+  //Log::Warn.ignoreInput = false;
 }
 
 /**
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(LoadRawBinaryTest)
   // Now reload through our interface.
   Log::Warn.ignoreInput = true;
   BOOST_REQUIRE(data::Load("test_file.bin", test) == true);
-  Log::Warn.ignoreInput = false;
+//  Log::Warn.ignoreInput = false;
 
   BOOST_REQUIRE_EQUAL(test.n_rows, 1);
   BOOST_REQUIRE_EQUAL(test.n_cols, 8);
@@ -657,7 +657,7 @@ BOOST_AUTO_TEST_CASE(NoHDF5Test)
   BOOST_REQUIRE(data::Save("test_file.hdf5", test) == false);
   BOOST_REQUIRE(data::Save("test_file.hdf", test) == false);
   BOOST_REQUIRE(data::Save("test_file.he5", test) == false);
-  Log::Warn.ignoreInput = false;
+//  Log::Warn.ignoreInput = false;
 }
 #endif
 


### PR DESCRIPTION
The file load_save_test.cpp generate warnings that were not suppressed when using mlpack_test to run unit tests. A guard has been added for all test invocations, that sets Log::Warn.ignoreInput to true temporarily while tests are run, and resets to its earlier value. 

The earlier setting set Log::Warn.ignoreInput to false at the end of a test, this caused subsequent files to pick up this flag and output warnings. 