### PR TITLE
Fix GMMTest comparisions

### DIFF
--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -111,17 +111,8 @@ BOOST_AUTO_TEST_CASE(GMMTrainEMOneGaussian)
     arma::mat actualCovar = ccov(data, 1 /* biased estimator */);
 
     // Check the model to see that it is correct.
-    BOOST_REQUIRE_CLOSE(gmm.Component(0).Mean()[0], actualMean(0), 1e-5);
-    BOOST_REQUIRE_CLOSE(gmm.Component(0).Mean()[1], actualMean(1), 1e-5);
-
-    BOOST_REQUIRE_CLOSE(gmm.Component(0).Covariance()(0, 0),
-        actualCovar(0, 0), 1e-5);
-    BOOST_REQUIRE_CLOSE(gmm.Component(0).Covariance()(0, 1),
-        actualCovar(0, 1), 1e-5);
-    BOOST_REQUIRE_CLOSE(gmm.Component(0).Covariance()(1, 0),
-        actualCovar(1, 0), 1e-5);
-    BOOST_REQUIRE_CLOSE(gmm.Component(0).Covariance()(1, 1),
-        actualCovar(1, 1), 1e-5);
+    CheckMatrices(gmm.Component(0).Mean(), actualMean);
+    CheckMatrices(gmm.Component(0).Covariance(), actualCovar);
 
     BOOST_REQUIRE_CLOSE(gmm.Weights()[0], 1.0, 1e-5);
   }
@@ -208,16 +199,10 @@ BOOST_AUTO_TEST_CASE(GMMTrainEMMultipleGaussians)
   for (size_t i = 0; i < gaussians; i++)
   {
     // Check the mean.
-    for (size_t j = 0; j < dims; j++)
-      BOOST_REQUIRE_CLOSE(gmm.Component(sortTry[i]).Mean()[j],
-          (means[sortRef[i]])[j], 0.001);
-
+    CheckMatrices(gmm.Component(sortTry[i]).Mean(), means[sortRef[i]], 1e-3);
     // Check the covariance.
-    for (size_t row = 0; row < dims; row++)
-      for (size_t col = 0; col < dims; col++)
-        BOOST_REQUIRE_CLOSE(gmm.Component(sortTry[i]).Covariance()(row, col),
-            (covars[sortRef[i]])(row, col), 0.05);
-
+    CheckMatrices(gmm.Component(sortTry[i]).Covariance(), covars[sortRef[i]],
+                  0.05);
     // Check the weight.
     BOOST_REQUIRE_CLOSE(gmm.Weights()[sortTry[i]], weights[sortRef[i]],
         0.001);

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -54,8 +54,8 @@ inline void CheckMatrices(const arma::mat& a, const arma::mat& b,
 
   for (size_t i = 0; i < a.n_elem; ++i)
   {
-    if (std::abs(a[i]) < 1e-5)
-      BOOST_REQUIRE_SMALL(b[i], 1e-5);
+    if (std::abs(a[i]) < tolerance / 2)
+      BOOST_REQUIRE_SMALL(b[i], tolerance / 2);
     else
       BOOST_REQUIRE_CLOSE(a[i], b[i], tolerance);
   }

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -46,7 +46,8 @@
     BOOST_REQUIRE_LE( std::abs((R) - (L)), (E) * std::abs(R))
 
 // Check the values of two matrices.
-inline void CheckMatrices(arma::mat& a, arma::mat& b)
+inline void CheckMatrices(const arma::mat& a, const arma::mat& b,
+                          double tolerance = 1e-5)
 {
   BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
   BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);
@@ -56,12 +57,12 @@ inline void CheckMatrices(arma::mat& a, arma::mat& b)
     if (std::abs(a[i]) < 1e-5)
       BOOST_REQUIRE_SMALL(b[i], 1e-5);
     else
-      BOOST_REQUIRE_CLOSE(a[i], b[i], 1e-5);
+      BOOST_REQUIRE_CLOSE(a[i], b[i], tolerance);
   }
 }
 
 // Check the values of two unsigned matrices.
-inline void CheckMatrices(arma::Mat<size_t>& a, arma::Mat<size_t>& b)
+inline void CheckMatrices(const arma::Mat<size_t>& a, const arma::Mat<size_t>& b)
 {
   BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
   BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);


### PR DESCRIPTION
Fixes #932.

I have changed the interface of `CheckMatrices` in test_tools.hpp to take tolerance values, with a default parameter to avoid changing existing code.