### PR TITLE
Named FFN

### DIFF
--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -160,12 +160,38 @@ class FFN
   template <class LayerType, class... Args>
   void Add(Args... args) { network.push_back(new LayerType(args...)); }
 
+  template <class LayerType, class... Args>
+  void AddNamed(std::string name, Args... args)
+  { 
+    network.push_back(new LayerType(args...));
+    // should raise error if duplicate
+    dictionary.insert(std::make_pair(name, new LayerType(args...)));
+  }
+
   /*
    * Add a new module to the model.
    *
    * @param layer The Layer to be added to the model.
    */
-  void Add(LayerTypes layer) { network.push_back(layer); }
+  void Add(LayerTypes layer, std::string name="")
+  { 
+    network.push_back(layer);
+    if(std::is_empty<std::string>(name))
+      dictionary["Layer" + network.size()] = layer;
+    else
+    {
+      // should raise error if duplicate
+      dictionary.insert(std::make_pair(name, layer));
+    }
+
+  }
+
+  std::vector<LayerTypes> Model(){return network;}
+
+  LayerTypes& getByName(std::string name)
+  {
+      return dictionary[name];
+  }
 
   //! Return the number of separable functions (the number of predictor points).
   size_t NumFunctions() const { return numFunctions; }
@@ -292,6 +318,9 @@ private:
 
   //! Locally-stored gradient parameter.
   arma::mat gradient;
+
+  //! Locally-stored dictionary.
+  std::map<std::string, LayerTypes> dictionary;
 }; // class FFN
 
 } // namespace ann

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -65,10 +65,8 @@ void BuildVanillaNetwork(MatType& trainData,
   model.Add<Linear<> >(trainData.n_rows, hiddenLayerSize);
   model.Add<SigmoidLayer<> >();
   model.Add<Linear<> >(hiddenLayerSize, outputSize);
-  model.AddNamed<LogSoftMax<> >("output");
-
-  std::cout << model.getByName("output") << std::endl;
-
+  model.Add<LogSoftMax<> >();
+  
   RMSprop<decltype(model)> opt(model, 0.01, 0.88, 1e-8,
       maxEpochs * trainData.n_cols, -1);
 
@@ -106,7 +104,6 @@ BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
   // Load the dataset.
   arma::mat dataset;
   data::Load("thyroid_train.csv", dataset, true);
-  std::cout << "hrere" << std::endl;
   arma::mat trainData = dataset.submat(0, 0, dataset.n_rows - 4,
       dataset.n_cols - 1);
 

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -15,6 +15,7 @@
 #include <mlpack/core/optimizers/rmsprop/rmsprop.hpp>
 #include <mlpack/methods/ann/layer/layer.hpp>
 #include <mlpack/methods/ann/ffn.hpp>
+#include <mlpack/methods/ann/visitor/weight_size_visitor.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"
@@ -64,7 +65,9 @@ void BuildVanillaNetwork(MatType& trainData,
   model.Add<Linear<> >(trainData.n_rows, hiddenLayerSize);
   model.Add<SigmoidLayer<> >();
   model.Add<Linear<> >(hiddenLayerSize, outputSize);
-  model.Add<LogSoftMax<> >();
+  model.AddNamed<LogSoftMax<> >("output");
+
+  std::cout << model.getByName("output") << std::endl;
 
   RMSprop<decltype(model)> opt(model, 0.01, 0.88, 1e-8,
       maxEpochs * trainData.n_cols, -1);
@@ -103,7 +106,7 @@ BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
   // Load the dataset.
   arma::mat dataset;
   data::Load("thyroid_train.csv", dataset, true);
-
+  std::cout << "hrere" << std::endl;
   arma::mat trainData = dataset.submat(0, 0, dataset.n_rows - 4,
       dataset.n_cols - 1);
 
@@ -408,6 +411,16 @@ BOOST_AUTO_TEST_CASE(DropConnectNetworkTest)
   // Vanilla neural net with logistic activation function.
   BuildDropConnectNetwork<>
       (dataset, labels, dataset, labels, 2, 10, 50, 0.2);
+}
+
+BOOST_AUTO_TEST_CASE(NamedNetworkTest)
+{
+  FFN<NegativeLogLikelihood<> > model;
+  model.AddNamed<LinearNoBias<> >("input", 4, 10);
+  model.Add<SigmoidLayer<> >();
+  model.Add<LinearNoBias<> >(10, 2);
+  model.Add<LogSoftMax<> >();
+  std::cout << boost::apply_visitor(WeightSizeVisitor(), model.getByName("input") ) << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This PR adds functionality of adding Layer Names to the Layer. This is really helpful in any layer by name in large networks.
typeid(object).name() this would not work as all linear layer types. would return the same thing.