### PR TITLE
Removed Unncessary Headers - PR for issue #722

### DIFF
--- a/src/mlpack/methods/det/det_main.cpp
+++ b/src/mlpack/methods/det/det_main.cpp
@@ -10,7 +10,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include <mlpack/prereqs.hpp>
-#include <mlpack/core/util/cli.hpp>
+
 #include "dt_utils.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/det/det_main.cpp
+++ b/src/mlpack/methods/det/det_main.cpp
@@ -9,8 +9,7 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/prereqs.hpp>
-
+#include <mlpack/core/util/cli.hpp>
 #include "dt_utils.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/det/dt_utils.hpp
+++ b/src/mlpack/methods/det/dt_utils.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_DET_DT_UTILS_HPP
 #define MLPACK_METHODS_DET_DT_UTILS_HPP
 
-#include <mlpack/prereqs.hpp>
+
 #include "dtree.hpp"
 
 namespace mlpack {

--- a/src/mlpack/methods/emst/edge_pair.hpp
+++ b/src/mlpack/methods/emst/edge_pair.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_EMST_EDGE_PAIR_HPP
 #define MLPACK_METHODS_EMST_EDGE_PAIR_HPP
 
-#include <mlpack/prereqs.hpp>
+
 
 #include "union_find.hpp"
 

--- a/src/mlpack/methods/emst/emst_main.cpp
+++ b/src/mlpack/methods/emst/emst_main.cpp
@@ -26,7 +26,7 @@
  */
 #include "dtb.hpp"
 
-#include <mlpack/prereqs.hpp>
+
 #include <mlpack/core/util/cli.hpp>
 
 PROGRAM_INFO("Fast Euclidean Minimum Spanning Tree", "This program can compute "

--- a/src/mlpack/methods/emst/union_find.hpp
+++ b/src/mlpack/methods/emst/union_find.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_METHODS_EMST_UNION_FIND_HPP
 #define MLPACK_METHODS_EMST_UNION_FIND_HPP
 
-#include <mlpack/prereqs.hpp>
+
 
 namespace mlpack {
 namespace emst {

--- a/src/mlpack/methods/emst/union_find.hpp
+++ b/src/mlpack/methods/emst/union_find.hpp
@@ -15,7 +15,7 @@
 #ifndef MLPACK_METHODS_EMST_UNION_FIND_HPP
 #define MLPACK_METHODS_EMST_UNION_FIND_HPP
 
-
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 namespace emst {

--- a/src/mlpack/methods/kernel_pca/kernel_pca.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca.hpp
@@ -14,7 +14,7 @@
 #ifndef MLPACK_METHODS_KERNEL_PCA_KERNEL_PCA_HPP
 #define MLPACK_METHODS_KERNEL_PCA_KERNEL_PCA_HPP
 
-#include <mlpack/prereqs.hpp>
+
 #include <mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -12,6 +12,7 @@
 
 #include <mlpack/core/util/cli.hpp>
 #include <mlpack/core/math/random.hpp>
+#include <mlpack/core/kernels/kernel_traits.hpp>
 #include <mlpack/core/kernels/linear_kernel.hpp>
 #include <mlpack/core/kernels/polynomial_kernel.hpp>
 #include <mlpack/core/kernels/cosine_distance.hpp>

--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -9,10 +9,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#include <mlpack/prereqs.hpp>
+
 #include <mlpack/core/util/cli.hpp>
 #include <mlpack/core/math/random.hpp>
-#include <mlpack/core/kernels/kernel_traits.hpp>
 #include <mlpack/core/kernels/linear_kernel.hpp>
 #include <mlpack/core/kernels/polynomial_kernel.hpp>
 #include <mlpack/core/kernels/cosine_distance.hpp>

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_KERNEL_PCA_NAIVE_METHOD_HPP
 #define MLPACK_METHODS_KERNEL_PCA_NAIVE_METHOD_HPP
 
-#include <mlpack/prereqs.hpp>
+
 
 namespace mlpack {
 namespace kpca {

--- a/src/mlpack/methods/kernel_pca/kernel_rules/nystroem_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/nystroem_method.hpp
@@ -13,7 +13,7 @@
 #ifndef MLPACK_METHODS_KERNEL_PCA_NYSTROEM_METHOD_HPP
 #define MLPACK_METHODS_KERNEL_PCA_NYSTROEM_METHOD_HPP
 
-#include <mlpack/prereqs.hpp>
+
 #include <mlpack/methods/nystroem_method/kmeans_selection.hpp>
 #include <mlpack/methods/nystroem_method/nystroem_method.hpp>
 


### PR DESCRIPTION
Referencing issue #722 , I have removed the headers in the following files:

- det_main.cpp

- dt_utils.hpp

- edge_pair.hpp

- emst_main.cpp

- kernel_pca.hpp

- kernel_pca_main.cpp

- kernel_pca_main.cpp

- kernel_rules/naive_method.hpp

- kernel_rules/nystroem_method.hpp

I have ran the tests on their respective modules and found that they have passed the tests. Please do tell me if I have done anything wrong! 