### PR TITLE
Uniform interface for Softmax and Logistic Regression

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -73,6 +73,7 @@ Copyright:
   Copyright 2017, Lakshya Agrawal <zeeshan.lakshya@gmail.com>
   Copyright 2017, Praveen Ch <chvsp972911@gmail.com>
   Copyright 2017, Kirill Mishchenko <ki.mishchenko@gmail.com>
+  Copyright 2017, Sagar B Hathwar <sagarbhathwar@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -214,6 +214,7 @@
  *   - Vivek Pal <vivekpal.dtu@gmail.com>
  *   - Praveen Ch <chvsp972911@gmail.com>
  *   - Kirill Mishchenko <ki.mishchenko@gmail.com>
+ *   - Sagar B Hathwar <sagarbhathwar@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -145,9 +145,11 @@ class SoftmaxRegression
   size_t Classify(const VecType& point) const;
 
   /**
-   * Classify the given points. The class probabilities for each point is computed.
-   * For each point, the class with the highest probability among all is chosen.
-   * The class labels and class probabilities for each point are returned.
+   * Classify the given points, returning class probabilities and predicted
+   * class label for each point.
+   * The function calculates the probabilities for every class, given a data
+   * point. It then chooses the class which has the highest probability among
+   * all.
    *
    * @param dataset Matrix of data points to be classified.
    * @param labels Predicted labels for each point.
@@ -157,7 +159,7 @@ class SoftmaxRegression
                  arma::mat& probabilites) const;
 
   /**
-   * Classify the given points. The class probabilities for each point is returned.
+   * Classify the given points, returning class probabilities for each point.
    *
    * @param dataset Matrix of data points to be classified.
    * @param probabilities Class probabilities for each point.

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -134,23 +134,33 @@ class SoftmaxRegression
   void Classify(const arma::mat& dataset, arma::Row<size_t>& labels) const;
 
   /**
-   * Classify the given point. The predicted class label is retured
+   * Classify the given point. The predicted class label is returned.
    * The function calculates the probabilites for every class, given the point.
-   * It then chooses the class which has the highest probability among all
+   * It then chooses the class which has the highest probability among all.
    *
-   * @param point Point to be classified
-   * @return Predicted class label of the point
+   * @param point Point to be classified.
+   * @return Predicted class label of the point.
    */
   template<typename VecType>
   size_t Classify(const VecType& point) const;
 
   /**
-   * Classify the given points. The predicted label is returned
-   * The function calculates the probabilities for every class, given a data point.
-   * It then chooses the class which has the highest probability among all
+   * Classify the given points. The class probabilities for each point is computed.
+   * For each point, the class with the highest probability among all is chosen.
+   * The class labels and class probabilities for each point are returned.
    *
-   * @param dataset Matrix of data points for which are to be classified
-   * @param probabilities Class probabilities for each point
+   * @param dataset Matrix of data points to be classified.
+   * @param labels Predicted labels for each point.
+   * @param probabilities Class probabilities for each point.
+   */
+   void Classify(const arma::mat& dataset, arma::Row<size_t>& labels,
+                 arma::mat& probabilites) const;
+
+  /**
+   * Classify the given points. The class probabilities for each point is returned.
+   *
+   * @param dataset Matrix of data points to be classified.
+   * @param probabilities Class probabilities for each point.
    */
   void Classify(const arma::mat& dataset,
                 arma::mat& probabilities) const;

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -134,6 +134,28 @@ class SoftmaxRegression
   void Classify(const arma::mat& dataset, arma::Row<size_t>& labels) const;
 
   /**
+   * Classify the given point. The predicted class label is retured
+   * The function calculates the probabilites for every class, given the point.
+   * It then chooses the class which has the highest probability among all
+   *
+   * @param point Point to be classified
+   * @return Predicted class label of the point
+   */
+  template<typename VecType>
+  size_t Classify(const VecType& point) const;
+
+  /**
+   * Classify the given points. The predicted label is returned
+   * The function calculates the probabilities for every class, given a data point.
+   * It then chooses the class which has the highest probability among all
+   *
+   * @param dataset Matrix of data points for which are to be classified
+   * @param probabilities Class probabilities for each point
+   */
+  void Classify(const arma::mat& dataset,
+                arma::mat& probabilities) const;
+
+  /**
    * Computes accuracy of the learned model given the feature data and the
    * labels associated with each data point. Predictions are made using the
    * provided data and are compared with the actual labels.
@@ -161,7 +183,7 @@ class SoftmaxRegression
    * @param numClasses Number of classes for classification.
    * @return Objective value of the final point.
    */
-  double Train(const arma::mat &data, const arma::Row<size_t>& labels,
+  double Train(const arma::mat& data, const arma::Row<size_t>& labels,
                const size_t numClasses);
 
   //! Sets the number of classes.

--- a/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
@@ -112,6 +112,24 @@ size_t SoftmaxRegression<OptimizerType>::Classify(const VecType& point) const
 
 template<template<typename> class OptimizerType>
 void SoftmaxRegression<OptimizerType>::Classify(const arma::mat& dataset,
+                                                arma::Row<size_t>& labels,
+                                                arma::mat& probabilites)
+    const
+{
+  Classify(dataset, probabilites);
+
+  // Initialize each label to 0.
+  labels.zeros(dataset.n_cols);
+
+  // For each column, choose the class with the highest probability
+  for(size_t i = 0; i < dataset.n_cols; i++)
+  {
+    labels(i) = probabilites.col(i).index_max();
+  }
+}
+
+template<template<typename> class OptimizerType>
+void SoftmaxRegression<OptimizerType>::Classify(const arma::mat& dataset,
                                                 arma::mat& probabilities)
     const
 {

--- a/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
@@ -113,18 +113,31 @@ size_t SoftmaxRegression<OptimizerType>::Classify(const VecType& point) const
 template<template<typename> class OptimizerType>
 void SoftmaxRegression<OptimizerType>::Classify(const arma::mat& dataset,
                                                 arma::Row<size_t>& labels,
-                                                arma::mat& probabilites)
+                                                arma::mat& probabilities)
     const
 {
-  Classify(dataset, probabilites);
+  Classify(dataset, probabilities);
 
-  // Initialize each label to 0.
+  // Prepare necessary data.
   labels.zeros(dataset.n_cols);
+  double maxProbability = 0;
 
-  // For each column, choose the class with the highest probability
-  for(size_t i = 0; i < dataset.n_cols; i++)
+  // For each test input.
+  for (size_t i = 0; i < dataset.n_cols; i++)
   {
-    labels(i) = probabilites.col(i).index_max();
+    // For each class.
+    for (size_t j = 0; j < numClasses; j++)
+    {
+      // If a higher class probability is encountered, change prediction.
+      if (probabilities(j, i) > maxProbability)
+      {
+        maxProbability = probabilities(j, i);
+        labels(i) = j;
+      }
+    }
+
+    // Set maximum probability to zero for the next input.
+    maxProbability = 0;
   }
 }
 

--- a/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
@@ -75,35 +75,8 @@ void SoftmaxRegression<OptimizerType>::Classify(const arma::mat& dataset,
                                                 arma::Row<size_t>& labels)
     const
 {
-  if (dataset.n_rows != FeatureSize())
-  {
-    std::ostringstream oss;
-    oss << "SoftmaxRegression::Classify(): dataset has " << dataset.n_rows
-        << " dimensions, but model has " << FeatureSize() << "dimensions";
-    throw std::invalid_argument(oss.str());
-  }
-
-  // Calculate the probabilities for each test input.
-  arma::mat hypothesis, probabilities;
-  if (fitIntercept)
-  {
-    // In order to add the intercept term, we should compute following matrix:
-    //     [1; data] = arma::join_cols(ones(1, data.n_cols), data)
-    //     hypothesis = arma::exp(parameters * [1; data]).
-    //
-    // Since the cost of join maybe high due to the copy of original data,
-    // split the hypothesis computation to two components.
-    hypothesis = arma::exp(
-      arma::repmat(parameters.col(0), 1, dataset.n_cols) +
-      parameters.cols(1, parameters.n_cols - 1) * dataset);
-  }
-  else
-  {
-    hypothesis = arma::exp(parameters * dataset);
-  }
-
-  probabilities = hypothesis / arma::repmat(arma::sum(hypothesis, 0),
-                                            numClasses, 1);
+  arma::mat probabilities;
+  Classify(dataset, probabilities);
 
   // Prepare necessary data.
   labels.zeros(dataset.n_cols);
@@ -126,6 +99,51 @@ void SoftmaxRegression<OptimizerType>::Classify(const arma::mat& dataset,
     // Set maximum probability to zero for the next input.
     maxProbability = 0;
   }
+}
+
+template<template<typename> class OptimizerType>
+template<typename VecType>
+size_t SoftmaxRegression<OptimizerType>::Classify(const VecType& point) const
+{
+  arma::Row<size_t> label(1);
+  Classify(point, label);
+  return size_t(label(0));
+}
+
+template<template<typename> class OptimizerType>
+void SoftmaxRegression<OptimizerType>::Classify(const arma::mat& dataset,
+                                                arma::mat& probabilities)
+    const
+{
+  if (dataset.n_rows != FeatureSize())
+  {
+    std::ostringstream oss;
+    oss << "SoftmaxRegression::Classify(): dataset has " << dataset.n_rows
+        << " dimensions, but model has " << FeatureSize() << "dimensions";
+    throw std::invalid_argument(oss.str());
+  }
+
+  // Calculate the probabilities for each test input.
+  arma::mat hypothesis;
+  if (fitIntercept)
+  {
+    // In order to add the intercept term, we should compute following matrix:
+    //     [1; data] = arma::join_cols(ones(1, data.n_cols), data)
+    //     hypothesis = arma::exp(parameters * [1; data]).
+    //
+    // Since the cost of join maybe high due to the copy of original data,
+    // split the hypothesis computation to two components.
+    hypothesis = arma::exp(
+      arma::repmat(parameters.col(0), 1, dataset.n_cols) +
+      parameters.cols(1, parameters.n_cols - 1) * dataset);
+  }
+  else
+  {
+    hypothesis = arma::exp(parameters * dataset);
+  }
+
+  probabilities = hypothesis / arma::repmat(arma::sum(hypothesis, 0),
+                                            numClasses, 1);
 }
 
 template<template<typename> class OptimizerType>

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -413,4 +413,172 @@ BOOST_AUTO_TEST_CASE(SoftmaxRegressionOptimizerTrainTest)
   }
 }
 
+BOOST_AUTO_TEST_CASE(SoftmaxRegressionClassifySinglePointTest)
+{
+  const size_t points = 5000;
+  const size_t inputSize = 5;
+  const size_t numClasses = 5;
+  const double lambda = 0.5;
+
+  // Generate five-Gaussian dataset.
+  arma::mat identity = arma::eye<arma::mat>(5, 5);
+  GaussianDistribution g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
+  GaussianDistribution g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
+  GaussianDistribution g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
+  GaussianDistribution g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
+  GaussianDistribution g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
+
+  arma::mat data(inputSize, points);
+  arma::Row<size_t> labels(points);
+
+  for (size_t i = 0; i < points / 5; i++)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; i++)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; i++)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; i++)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; i++)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+
+  // Train softmax regression object.
+  SoftmaxRegression<> sr(data, labels, numClasses, lambda);
+
+  // Create test dataset.
+  for (size_t i = 0; i < points / 5; i++)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; i++)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; i++)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; i++)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; i++)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+
+  sr.Classify(data, labels);
+
+  for(size_t i = 0; i < data.n_cols; ++i)
+  {
+    BOOST_REQUIRE_EQUAL(sr.Classify(data.col(i)), labels(i));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SoftmaxRegressionComputeProbabilitiesTest)
+{
+  const size_t points = 5000;
+  const size_t inputSize = 5;
+  const size_t numClasses = 5;
+  const double lambda = 0.5;
+
+  // Generate five-Gaussian dataset.
+  arma::mat identity = arma::eye<arma::mat>(5, 5);
+  GaussianDistribution g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
+  GaussianDistribution g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
+  GaussianDistribution g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
+  GaussianDistribution g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
+  GaussianDistribution g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
+
+  arma::mat data(inputSize, points);
+  arma::Row<size_t> labels(points);
+
+  for (size_t i = 0; i < points / 5; i++)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; i++)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; i++)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; i++)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; i++)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+
+  // Train softmax regression object.
+  SoftmaxRegression<> sr(data, labels, numClasses, lambda);
+
+  // Create test dataset.
+  for (size_t i = 0; i < points / 5; i++)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; i++)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; i++)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; i++)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; i++)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+
+  arma::mat probabilities;
+  sr.Classify(data, probabilities);
+
+  BOOST_REQUIRE_EQUAL(probabilities.n_cols, data.n_cols);
+  BOOST_REQUIRE_EQUAL(probabilities.n_rows, sr.NumClasses());
+
+  for(size_t i = 0; i < data.n_cols; ++i)
+  {
+    BOOST_REQUIRE_CLOSE(arma::sum(probabilities.col(i)), 1.0, 1e-5);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -581,4 +581,94 @@ BOOST_AUTO_TEST_CASE(SoftmaxRegressionComputeProbabilitiesTest)
   }
 }
 
+BOOST_AUTO_TEST_CASE(SoftmaxRegressionComputeProbabilitiesAndLabelsTest)
+{
+  const size_t points = 5000;
+  const size_t inputSize = 5;
+  const size_t numClasses = 5;
+  const double lambda = 0.5;
+
+  // Generate five-Gaussian dataset.
+  arma::mat identity = arma::eye<arma::mat>(5, 5);
+  GaussianDistribution g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
+  GaussianDistribution g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
+  GaussianDistribution g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
+  GaussianDistribution g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
+  GaussianDistribution g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
+
+  arma::mat data(inputSize, points);
+  arma::Row<size_t> labels(points);
+
+  for (size_t i = 0; i < points / 5; i++)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; i++)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; i++)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; i++)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; i++)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+
+  // Train softmax regression object.
+  SoftmaxRegression<> sr(data, labels, numClasses, lambda);
+
+  // Create test dataset.
+  for (size_t i = 0; i < points / 5; i++)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; i++)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; i++)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; i++)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; i++)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+
+  arma::mat probabilities;
+  arma::Row<size_t> testLabels;
+
+  sr.Classify(data, labels);
+  sr.Classify(data, testLabels, probabilities);
+
+  BOOST_REQUIRE_EQUAL(probabilities.n_cols, data.n_cols);
+  BOOST_REQUIRE_EQUAL(probabilities.n_rows, sr.NumClasses());
+
+  for(size_t i = 0; i < data.n_cols; ++i)
+  {
+    BOOST_REQUIRE_CLOSE(arma::sum(probabilities.col(i)), 1.0, 1e-5);
+    BOOST_REQUIRE_EQUAL(testLabels(i), labels(i));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Added a few overloads to Classify method is softmax regression and the tests for them, so that Softmax and Logistic regression have a uniform interface

Noticed two failed tests. Unable to verify if these are due to anything that I have changed
`load_save_test.cpp(683): fatal error: in "LoadSaveTest/LoadHDF5Test": critical check test.n_rows == 4 has failed [2 != 4]`

`nmf_test.cpp(95): fatal error: in "NMFTest/NMFRandomDivTest": absolute value of arma::norm(v - wh, "fro") / arma::norm(v, "fro"){0.071824514847599066} exceeds 0.014999999999999999`

Please verify and comment on any changes to be made

Thank you