### PR TITLE
Adaboost error fix

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -135,14 +135,20 @@ void AdaBoost<WeakLearnerType, MatType>::Train(
     if ((i > 0) && (std::abs(rt - crt) < tolerance))
       break;
 
+    // Check if model has converged.
+    if ((rt >= 1))
+    {
+      // Save the weak learner and terminate.
+      alpha.push_back(1.0);
+      wl.push_back(w);
+      break;
+    }
+
     crt = rt;
 
     // Our goal is to find alphat which mizimizes or approximately minimizes the
     // value of Z as a function of alpha.
-    if (rt >= 1)
-      alphat = 0.5 * log(DBL_MAX);
-    else
-      alphat = 0.5 * log((1 + rt) / (1 - rt));
+    alphat = 0.5 * log((1 + rt) / (1 - rt));
 
     alpha.push_back(alphat);
     wl.push_back(w);

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -139,7 +139,10 @@ void AdaBoost<WeakLearnerType, MatType>::Train(
 
     // Our goal is to find alphat which mizimizes or approximately minimizes the
     // value of Z as a function of alpha.
-    alphat = 0.5 * log((1 + rt) / (1 - rt));
+    if (rt >= 1)
+      alphat = 0.5 * log(DBL_MAX);
+    else
+      alphat = 0.5 * log((1 + rt) / (1 - rt));
 
     alpha.push_back(alphat);
     wl.push_back(w);


### PR DESCRIPTION
A fix for issue in #821. The problem was that for the given training set, ```rt``` value was a very small value greater than ```1``` which caused the calculation of log of a negative value. Hence the additional check of the value of ```rt```. If the value of ```rt = 1``` then the denominator in the calculation of ```alphat``` is zero. ```DBL_MAX``` is introduced to avoid calculating log of ```inf```.

After this change
- The reported crash is fixed. 
- The adaboost algorithm now converges in one iteration on the given dataset. 
- The problem with serializing and deserializing ```nan``` is behind the curtains. I'll look into it next.