### PR TITLE
Fix VanillaNetworkTest

### DIFF
--- a/src/mlpack/tests/convolutional_network_test.cpp
+++ b/src/mlpack/tests/convolutional_network_test.cpp
@@ -1,6 +1,7 @@
 /**
  * @file convolutional_network_test.cpp
  * @author Marcus Edel
+ * @author Abhinav Moudgil
  *
  * Tests the convolutional neural network.
  *
@@ -22,7 +23,6 @@
 using namespace mlpack;
 using namespace mlpack::ann;
 using namespace mlpack::optimization;
-
 
 BOOST_AUTO_TEST_SUITE(ConvolutionalNetworkTest);
 
@@ -47,11 +47,13 @@ BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
   {
     if (i < nPoints / 2)
     {
-      Y(i) = 4;
+      // class 1 - digit = 4
+      Y(i) = 1;
     }
     else
     {
-      Y(i) = 9;
+      // class 2 - digit = 9
+      Y(i) = 2;
     }
   }
 
@@ -73,60 +75,46 @@ BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
    * +---+        +---+        +---+        +---+        +---+    +---+
    */
 
-  // It isn't guaranteed that the network will converge in the specified number
-  // of iterations using random weights. If this works 1 of 5 times, I'm fine
-  // with that. All I want to know is that the network is able to escape from
-  // local minima and to solve the task.
-  size_t successes = 0;
-  for (size_t trial = 0; trial < 5; ++trial)
+  FFN<NegativeLogLikelihood<>, RandomInitialization> model;
+
+  model.Add<Convolution<> >(1, 8, 5, 5, 1, 1, 0, 0, 28, 28);
+  model.Add<ReLULayer<> >();
+  model.Add<MaxPooling<> >(8, 8, 2, 2);
+  model.Add<Convolution<> >(8, 12, 2, 2);
+  model.Add<ReLULayer<> >();
+  model.Add<MaxPooling<> >(2, 2, 2, 2);
+  model.Add<Linear<> >(192, 20);
+  model.Add<ReLULayer<> >();
+  model.Add<Linear<> >(20, 10);
+  model.Add<ReLULayer<> >();
+  model.Add<Linear<> >(10, 2);
+  model.Add<LogSoftMax<> >();
+
+  RMSprop<decltype(model)> opt(model, 0.001, 0.88, 1e-8, 5000, -1);
+
+  model.Train(std::move(X), std::move(Y), opt);
+
+  arma::mat predictionTemp;
+  model.Predict(X, predictionTemp);
+  arma::mat prediction = arma::zeros<arma::mat>(1, predictionTemp.n_cols);
+
+  for (size_t i = 0; i < predictionTemp.n_cols; ++i)
   {
-    FFN<NegativeLogLikelihood<>, GaussianInitialization> model;
-
-    model.Add<Convolution<> >(1, 8, 5, 5, 1, 1, 0, 0, 28, 28);
-    model.Add<ReLULayer<> >();
-    model.Add<MaxPooling<> >(8, 8, 2, 2);
-    model.Add<Convolution<> >(8, 12, 2, 2);
-    model.Add<ReLULayer<> >();
-    model.Add<MaxPooling<> >(2, 2, 2, 2);
-    model.Add<Linear<> >(192, 20);
-    model.Add<ReLULayer<> >();
-    model.Add<Linear<> >(20, 30);
-    model.Add<ReLULayer<> >();
-    model.Add<Linear<> >(30, 10);
-    model.Add<LogSoftMax<> >();
-
-    RMSprop<decltype(model)> opt(model, 0.01, 0.88, 1e-8, 5000, -1);
-
-    model.Train(std::move(X), std::move(Y), opt);
-
-    arma::mat predictionTemp;
-    model.Predict(X, predictionTemp);
-    arma::mat prediction = arma::zeros<arma::mat>(1, predictionTemp.n_cols);
-
-    for (size_t i = 0; i < predictionTemp.n_cols; ++i)
-    {
-      prediction(i) = arma::as_scalar(arma::find(
+    prediction(i) = arma::as_scalar(arma::find(
           arma::max(predictionTemp.col(i)) == predictionTemp.col(i), 1)) + 1;
-    }
+  }
 
-    size_t error = 0;
-    for (size_t i = 0; i < X.n_cols; i++)
+  size_t correct = 0;
+  for (size_t i = 0; i < X.n_cols; i++)
+  {
+    if (prediction(i) == Y(i))
     {
-      if (prediction(i) == Y(i))
-      {
-        error++;
-      }
-    }
-
-    double classificationError = 1 - double(error) / X.n_cols;
-    if (classificationError <= 0.2)
-    {
-      ++successes;
-      break;
+      correct++;
     }
   }
 
-  BOOST_REQUIRE_GE(successes, 1);
+  double classificationError = 1 - double(correct) / X.n_cols;
+  BOOST_REQUIRE_LE(classificationError, 0.2);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/convolutional_network_test.cpp
+++ b/src/mlpack/tests/convolutional_network_test.cpp
@@ -47,12 +47,12 @@ BOOST_AUTO_TEST_CASE(VanillaNetworkTest)
   {
     if (i < nPoints / 2)
     {
-      // class 1 - digit = 4
+      // Assign label "1" to all samples with digit = 4
       Y(i) = 1;
     }
     else
     {
-      // class 2 - digit = 9
+      // Assign label "2" to all samples with digit = 9
       Y(i) = 2;
     }
   }


### PR DESCRIPTION
### Issue
CNN used to get stuck in local minima and couldn't converge in the given number of iterations. #922

### Hyperparameter Tuning
* Since the network is performing only binary classification task of recognizing 4 and 9, so number of output units in the CNN network has been updated to 2. This reduces the number of parameters in the network, hence avoiding wrong classification due to weights which could not be trained in the given number of iterations.
* Reduced number of units in full connected layers to reduce number of trainable parameters. 
* Reduced learning rate of optimizer to converge easily in given number of iterations. 

### Updates in PR
* Removed loop which performs the same test five times, hence reducing the testing time. 
* Renamed `error` variable as `correct` for more clarity because it counts the number of correct predictions by the network.
* Did Hyperparameter tuning as explained above.

### Results
Test was run for 75 times with `math::RandomSeed(std::time(NULL))` added to the top. Mean classification error over the runs was around `0.03` (rough estimate). Console log (with `classificationError` printed in each run) can be viewed [here](https://pastebin.com/1vBsHv3U). Please let me know if you are able to reproduce similar results.