### PR TITLE
#include "add_merge.hpp" instead of #include "add_merge_impl.hpp" in add_merge_impl.hpp

### DIFF
--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -14,7 +14,7 @@
 #define MLPACK_METHODS_ANN_LAYER_ADD_MERGE_IMPL_HPP
 
 // In case it hasn't yet been included.
-#include "add_merge_impl.hpp"
+#include "add_merge.hpp"
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {


### PR DESCRIPTION
Hey,

While going through the NN layers code, came across this small typo, which is harmless. But just for mlpack's sake!