### PR TITLE
Correct minor typo in ffn.hpp

### DIFF
--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -204,7 +204,7 @@ private:
   void Gradient();
 
   /**
-   * Reset the module infomration (weights/parameters).
+   * Reset the module information (weights/parameters).
    */
   void ResetParameters();
 


### PR DESCRIPTION
This is a small pull request that restores balance to the universe by changing '_infomration_' to '_information_'. 

Thanks Marcus for sharing that tweet! :) 