### PR TITLE
CodeAi fixed 4 null pointer dereferences in hoeffding_tree_model.cpp

### DIFF
--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.cpp
@@ -68,13 +68,13 @@ HoeffdingTreeModel& HoeffdingTreeModel::operator=(
 
   // Create the right tree.
   type = other.type;
-  if (type == GINI_HOEFFDING)
+  if (other.giniHoeffdingTree && (type == GINI_HOEFFDING))
     giniHoeffdingTree = new GiniHoeffdingTreeType(*other.giniHoeffdingTree);
-  else if (type == GINI_BINARY)
+  else if (other.giniBinaryTree && (type == GINI_BINARY))
     giniBinaryTree = new GiniBinaryTreeType(*other.giniBinaryTree);
-  else if (type == INFO_HOEFFDING)
+  else if (other.infoHoeffdingTree && (type == INFO_HOEFFDING))
     infoHoeffdingTree = new InfoHoeffdingTreeType(*other.infoHoeffdingTree);
-  else if (type == INFO_BINARY)
+  else if (other.infoBinaryTree && (type == INFO_BINARY))
     infoBinaryTree = new InfoBinaryTreeType(*other.infoBinaryTree);
 
   return *this;


### PR DESCRIPTION
Potential null dereferences of other.giniHoeffdingTree, other.giniBinaryTree, other.infoHoeffdingTree, other.infoBinaryTree on lines 72, 74, 76, and 78 respectively.  CodeAi fixes these issues by tightening the if condition to verify that each pointer variable is not null before use in the constructor.  

See the bug reports below for more information:

[CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_78.pdf](https://github.com/mlpack/mlpack/files/917104/CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_78.pdf)
[CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_76.pdf](https://github.com/mlpack/mlpack/files/917101/CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_76.pdf)
[CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_74.pdf](https://github.com/mlpack/mlpack/files/917102/CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_74.pdf)
[CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_72.pdf](https://github.com/mlpack/mlpack/files/917103/CodeAiBugReport_mlpack_src_mlpack_methods_hoeffding_trees_hoeffding_tree_model_cpp_72.pdf)