### PR TITLE
Reduce compilation time - PR for #722

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -79,6 +79,7 @@ Copyright:
   Copyright 2017, Nishanth Hegde <hegde.nishanth@gmail.com>
   Copyright 2017, Parminder Singh <parmsingh101@gmail.com>
   Copyright 2017, CodeAi <benjamin.bales@assrc.us>
+  Copyright 2017, Franciszek Stokowacki <franek.stokowacki@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -220,6 +220,7 @@
  *   - Nishanth Hegde <hegde.nishanth@gmail.com>
  *   - Parminder Singh <parmsingh101@gmail.com>
  *   - CodeAi (deep learning bug detector) <benjamin.bales@assrc.us>
+ *   - Franciszek Stokowacki <franek.stokowacki@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -15,6 +15,7 @@
 // In case it hasn't already been included.
 #include "cover_tree.hpp"
 
+#include <queue>
 #include <string>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split_impl.hpp
@@ -13,7 +13,6 @@
 #define MLPACK_CORE_TREE_RECTANGLE_TREE_R_PLUS_TREE_SPLIT_IMPL_HPP
 
 #include "r_plus_tree_split.hpp"
-#include "rectangle_tree.hpp"
 #include "r_plus_plus_tree_auxiliary_information.hpp"
 #include "r_plus_tree_split_policy.hpp"
 #include "r_plus_plus_tree_split_policy.hpp"

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -14,6 +14,8 @@
 // In case it wasn't included already for some reason.
 #include "spill_tree.hpp"
 
+#include <queue>
+
 namespace mlpack {
 namespace tree {
 

--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -17,6 +17,9 @@
 #include "cli.hpp"
 #include "log.hpp"
 
+#include "cli_deleter.hpp" // To make sure we can delete the singleton.
+#include "version.hpp"
+
 #include <mlpack/core/data/load.hpp>
 #include <mlpack/core/data/save.hpp>
 

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -25,8 +25,6 @@
 #include <mlpack/prereqs.hpp>
 
 #include "timers.hpp"
-#include "cli_deleter.hpp" // To make sure we can delete the singleton.
-#include "version.hpp"
 #include "param.hpp"
 
 

--- a/src/mlpack/core/util/output_param_impl.hpp
+++ b/src/mlpack/core/util/output_param_impl.hpp
@@ -9,6 +9,7 @@
 
 #include "output_param.hpp"
 #include <mlpack/core/data/save.hpp>
+#include <iostream>
 
 namespace mlpack {
 namespace util {

--- a/src/mlpack/core/util/singletons.cpp
+++ b/src/mlpack/core/util/singletons.cpp
@@ -12,6 +12,7 @@
 #include "cli.hpp"
 #include "log.hpp"
 #include "singletons.hpp"
+#include <iostream>
 
 using namespace mlpack;
 using namespace mlpack::util;

--- a/src/mlpack/methods/adaboost/adaboost_model.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_model.cpp
@@ -4,6 +4,7 @@
  *
  * A serializable AdaBoost model, used by the main program.
  */
+#include "adaboost.hpp"
 #include "adaboost_model.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/adaboost/adaboost_model.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_model.hpp
@@ -9,6 +9,7 @@
 
 #include <mlpack/core.hpp>
 
+// Use forward declaration instead of include to accelerate compilation.
 class AdaBoost;
 
 namespace mlpack {

--- a/src/mlpack/methods/adaboost/adaboost_model.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_model.hpp
@@ -8,7 +8,8 @@
 #define MLPACK_METHODS_ADABOOST_ADABOOST_MODEL_HPP
 
 #include <mlpack/core.hpp>
-#include "adaboost.hpp"
+
+class AdaBoost;
 
 namespace mlpack {
 namespace adaboost {

--- a/src/mlpack/methods/cf/cf.cpp
+++ b/src/mlpack/methods/cf/cf.cpp
@@ -15,6 +15,8 @@
  */
 #include "cf.hpp"
 
+#include <queue>
+
 namespace mlpack {
 namespace cf {
 

--- a/src/mlpack/methods/fastmks/fastmks.hpp
+++ b/src/mlpack/methods/fastmks/fastmks.hpp
@@ -17,6 +17,7 @@
 #include <mlpack/core/metrics/ip_metric.hpp>
 #include "fastmks_stat.hpp"
 #include <mlpack/core/tree/cover_tree.hpp>
+#include <queue>
 
 namespace mlpack {
 namespace fastmks /** Fast max-kernel search. */ {

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.cpp
@@ -6,6 +6,8 @@
  */
 #include "hoeffding_tree_model.hpp"
 
+#include <queue>
+
 using namespace mlpack;
 using namespace mlpack::tree;
 

--- a/src/mlpack/methods/lsh/lsh_search.hpp
+++ b/src/mlpack/methods/lsh/lsh_search.hpp
@@ -48,6 +48,8 @@
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/methods/neighbor_search/sort_policies/nearest_neighbor_sort.hpp>
 
+#include <queue>
+
 namespace mlpack {
 namespace neighbor {
 

--- a/src/mlpack/methods/neighbor_search/neighbor_search_rules.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_rules.hpp
@@ -15,6 +15,8 @@
 
 #include <mlpack/core/tree/traversal_info.hpp>
 
+#include <queue>
+
 namespace mlpack {
 namespace neighbor {
 

--- a/src/mlpack/methods/rann/ra_search_rules.hpp
+++ b/src/mlpack/methods/rann/ra_search_rules.hpp
@@ -16,6 +16,8 @@
 
 #include <mlpack/core/tree/traversal_info.hpp>
 
+#include <queue>
+
 namespace mlpack {
 namespace neighbor {
 

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -30,10 +30,8 @@
 #include <climits>
 #include <cfloat>
 #include <cstdint>
-#include <iostream>
 #include <stdexcept>
 #include <tuple>
-#include <queue>
 #include <utility>
 
 // But if it's not defined, we'll do it.

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -22,6 +22,7 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
+#include "test_tools.hpp"
 
 namespace mlpack {
 

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -22,7 +22,6 @@
 #include <mlpack/core.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include "test_tools.hpp"
 
 namespace mlpack {
 

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -15,31 +15,6 @@
 #include <mlpack/core.hpp>
 #include <boost/version.hpp>
 
-// This is only necessary for pre-1.36 Boost.Test.
-#if BOOST_VERSION < 103600
-
-#include <boost/test/floating_point_comparison.hpp>
-#include <boost/test/auto_unit_test.hpp>
-
-// This depends on other macros.  Probably not a great idea... but it works, and
-// we only need it for ancient Boost versions.
-#define BOOST_REQUIRE_GE( L, R ) \
-    BOOST_REQUIRE_EQUAL( (L >= R), true )
-
-#define BOOST_REQUIRE_NE( L, R ) \
-    BOOST_REQUIRE_EQUAL( (L != R), true )
-
-#define BOOST_REQUIRE_LE( L, R ) \
-    BOOST_REQUIRE_EQUAL( (L <= R), true )
-
-#define BOOST_REQUIRE_LT( L, R ) \
-    BOOST_REQUIRE_EQUAL( (L < R), true )
-
-#define BOOST_REQUIRE_GT( L, R ) \
-    BOOST_REQUIRE_EQUAL( (L > R), true )
-
-#endif
-
 // Require the approximation L to be within a relative error of E respect to the
 // actual value R.
 #define REQUIRE_RELATIVE_ERR( L, R, E ) \


### PR DESCRIPTION
Change some includes to reduce compilation time. 
PR for issue #722

* Remove #include \<queue\> and \<iostream\> from prereqs.hpp. Add includes in files that need them. 
* Use AdaBoost forward declaration in adaboost_model
* Move some includes from header to cpp file in util/cli.cpp
* Remove unnecessary includes in some other files