### PR TITLE
Fix a bug in gaussian init

### DIFF
--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -51,7 +51,10 @@ class GaussianInitialization
                   const size_t rows,
                   const size_t cols)
   {
-    W = arma::mat(rows, cols);
+    if (W.is_empty())
+    {
+      W = arma::mat(rows, cols);
+    }
     W.imbue( [&]() { return arma::as_scalar(RandNormal(mean, variance)); } );
   }
 


### PR DESCRIPTION
Please find more discussions about this [here](https://github.com/mlpack/mlpack/pull/934).
Briefly speaking, it seems the init function goes wrong when the desired mat has pre-allocated memory. But I don't know why.