### PR TITLE
Add new API for some optimizers

### DIFF
--- a/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
+++ b/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
@@ -97,6 +97,20 @@ class AdaDelta
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
+   * @param function Function to optimize.
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
+  {
+    return optimizer.Optimize(function, iterate);
+  }
+
+  /**
+   * Optimize the given function using AdaDelta. The given starting point will
+   * be modified to store the finishing point of the algorithm, and the final
+   * objective value is returned.
+   *
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */

--- a/src/mlpack/core/optimizers/ada_grad/ada_grad.hpp
+++ b/src/mlpack/core/optimizers/ada_grad/ada_grad.hpp
@@ -93,6 +93,20 @@ class AdaGrad
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
+   * @param function Function to optimize.
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
+  {
+    return optimizer.Optimize(function, iterate);
+  }
+
+  /**
+   * Optimize the given function using AdaGrad. The given starting point will
+   * be modified to store the finishing point of the algorithm, and the final
+   * objective value is returned.
+   *
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */

--- a/src/mlpack/core/optimizers/adam/adam.hpp
+++ b/src/mlpack/core/optimizers/adam/adam.hpp
@@ -108,6 +108,20 @@ class AdamType
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
+   * @param function Function to optimize.
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
+  {
+    return optimizer.Optimize(function, iterate);
+  }
+
+  /**
+   * Optimize the given function using Adam. The given starting point will be
+   * modified to store the finishing point of the algorithm, and the final
+   * objective value is returned.
+   *
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */

--- a/src/mlpack/core/optimizers/gradient_descent/gradient_descent.hpp
+++ b/src/mlpack/core/optimizers/gradient_descent/gradient_descent.hpp
@@ -75,10 +75,24 @@ class GradientDescent
    * point will be modified to store the finishing point of the algorithm, and
    * the final objective value is returned.
    *
+   * @param function Function to optimize.
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */
-  double Optimize(arma::mat& iterate);
+  double Optimize(FunctionType& function, arma::mat& iterate);
+
+  /**
+   * Optimize the given function using gradient descent.  The given starting
+   * point will be modified to store the finishing point of the algorithm, and
+   * the final objective value is returned.
+   *
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(arma::mat& iterate)
+  {
+    return Optimize(this->function, iterate);
+  }
 
   //! Get the instantiated function to be optimized.
   const FunctionType& Function() const { return function; }

--- a/src/mlpack/core/optimizers/gradient_descent/gradient_descent_impl.hpp
+++ b/src/mlpack/core/optimizers/gradient_descent/gradient_descent_impl.hpp
@@ -33,7 +33,7 @@ GradientDescent<FunctionType>::GradientDescent(
 //! Optimize the function (minimize).
 template<typename FunctionType>
 double GradientDescent<FunctionType>::Optimize(
-    arma::mat& iterate)
+    FunctionType& function, arma::mat& iterate)
 {
   // To keep track of where we are and how things are going.
   double overallObjective = function.Evaluate(iterate);

--- a/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd.hpp
+++ b/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd.hpp
@@ -122,10 +122,24 @@ class MiniBatchSGDType
    * will be modified to store the finishing point of the algorithm, and the
    * final objective value is returned.
    *
+   * @param function Function to optimize.
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */
-  double Optimize(arma::mat& iterate);
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate);
+
+  /**
+   * Optimize the given function using mini-batch SGD.  The given starting point
+   * will be modified to store the finishing point of the algorithm, and the
+   * final objective value is returned.
+   *
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(arma::mat& iterate)
+  {
+    return Optimize(this->function, iterate);
+  }
 
   //! Get the instantiated function to be optimized.
   const DecomposableFunctionType& Function() const { return function; }

--- a/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd_impl.hpp
@@ -55,7 +55,7 @@ double MiniBatchSGDType<
     DecomposableFunctionType,
     UpdatePolicyType,
     DecayPolicyType
->::Optimize(arma::mat& iterate)
+>::Optimize(DecomposableFunctionType& function, arma::mat& iterate)
 {
   // Find the number of functions.
   const size_t numFunctions = function.NumFunctions();

--- a/src/mlpack/core/optimizers/rmsprop/rmsprop.hpp
+++ b/src/mlpack/core/optimizers/rmsprop/rmsprop.hpp
@@ -100,6 +100,20 @@ class RMSProp
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
+   * @param function Function to optimize.
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
+  {
+    return optimizer.Optimize(function, iterate);
+  }
+
+  /**
+   * Optimize the given function using RMSProp. The given starting point will be
+   * modified to store the finishing point of the algorithm, and the final
+   * objective value is returned.
+   *
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */

--- a/src/mlpack/core/optimizers/sgd/sgd.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd.hpp
@@ -109,10 +109,24 @@ class SGD
    * starting point will be modified to store the finishing point of the
    * algorithm, and the final objective value is returned.
    *
+   * @param function Function to optimize.
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */
-  double Optimize(arma::mat& iterate);
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate);
+
+  /**
+   * Optimize the given function using stochastic gradient descent.  The given
+   * starting point will be modified to store the finishing point of the
+   * algorithm, and the final objective value is returned.
+   *
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(arma::mat& iterate)
+  {
+    return Optimize(this->function, iterate);
+  }
 
   //! Get the instantiated function to be optimized.
   const DecomposableFunctionType& Function() const { return function; }

--- a/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
@@ -42,6 +42,7 @@ SGD<DecomposableFunctionType, UpdatePolicyType>::SGD(
 //! Optimize the function (minimize).
 template<typename DecomposableFunctionType, typename UpdatePolicyType>
 double SGD<DecomposableFunctionType, UpdatePolicyType>::Optimize(
+    DecomposableFunctionType& function,
     arma::mat& iterate)
 {
   // Find the number of functions to use.

--- a/src/mlpack/core/optimizers/smorms3/smorms3.hpp
+++ b/src/mlpack/core/optimizers/smorms3/smorms3.hpp
@@ -93,6 +93,20 @@ class SMORMS3
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
+   * @param function Function to optimize.
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
+  {
+    return optimizer.Optimize(function, iterate);
+  }
+
+  /**
+   * Optimize the given function using SMORMS3. The given starting point will
+   * be modified to store the finishing point of the algorithm, and the final
+   * objective value is returned.
+   *
    * @param iterate Starting point (will be modified).
    * @return Objective value of the final point.
    */

--- a/src/mlpack/methods/regularized_svd/regularized_svd_function.cpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd_function.cpp
@@ -131,6 +131,7 @@ namespace optimization {
 
 template<>
 double StandardSGD<mlpack::svd::RegularizedSVDFunction>::Optimize(
+    mlpack::svd::RegularizedSVDFunction& function,
     arma::mat& parameters)
 {
   // Find the number of functions to use.

--- a/src/mlpack/methods/regularized_svd/regularized_svd_function.hpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd_function.hpp
@@ -111,6 +111,7 @@ namespace optimization {
    */
   template<>
   double StandardSGD<mlpack::svd::RegularizedSVDFunction>::Optimize(
+      mlpack::svd::RegularizedSVDFunction& function,
       arma::mat& parameters);
 
 } // namespace optimization


### PR DESCRIPTION
As discussed here https://github.com/mlpack/mlpack/pull/1014, I added some new APIs for some optimizers.(`ada_delta`, `ada_grad`, `adam`, `gradient_descent`, `minibatch_sgd`, `rmsprop`, `sgd`, `smorms3`) I just added the new API as @zoq suggested and didn't delete the old one. So even this PR is merged, all the optimizers will still have consistent API to some extent. We need to continue refactoring all the optimizers and finally delete the old API. Maybe @rcurtin , @micyril and I can work on this together in the future. But I think now it's necessary to merge this PR so I can go further in the DQN PR and async RL methods.