### PR TITLE
Adding dummy Evaluate function to FNN and RNN modules

### DIFF
--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -313,6 +313,9 @@ class FFN
   
   //! Cost achieved in the last Forward call
   double currentCost = -1;
+  
+  //! Objective function index used for the last evaluation call
+  size_t currentFunctionIndex = 0;
 
   //! THe current input of the forward/backward pass.
   arma::mat currentInput;

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -159,6 +159,11 @@ class FFN
    * and with respect to only one point in the dataset. This is useful for
    * optimizers such as SGD, which require a separable objective function.
    *
+   * Its a dummy Evaluate function for the optimizer to save an extra Forward
+   * pass while optimizing. Function returns previously stored result. 
+   * The actual forward pass is done by function 'ForwardCall', called while 
+   * computing Gradient.
+   *
    * @param parameters Matrix of the model parameters to be optimized.
    * @param i Index of points to use for objective function gradient evaluation.
    * @param gradient Matrix to output gradient into.
@@ -210,6 +215,20 @@ class FFN
   void Serialize(Archive& ar, const unsigned int /* version */);
 
  private:
+  /**
+   * Evaluate the feedforward network with the given parameters. This function
+   * is usually called by the optimizer to train the model.
+   *
+   * @param parameters Matrix model parameters.
+   * @param i Index of point to use for objective function evaluation.
+   * @param deterministic Whether or not to train or test the model. Note some
+   *        layer act differently in training or testing mode.
+   */
+  double ForwardCall(const arma::mat& parameters,
+                     const size_t i,
+                     const bool deterministic = true);
+  
+ 
   // Helper functions.
   /**
    * The Forward algorithm (part of the Forward-Backward algorithm).  Computes
@@ -291,6 +310,9 @@ class FFN
 
   //! The current error for the backward pass.
   arma::mat error;
+  
+  //! Cost achieved in the last Forward call
+  double currentCost = -1;
 
   //! THe current input of the forward/backward pass.
   arma::mat currentInput;

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -169,6 +169,7 @@ template<typename OutputLayerType, typename InitializationRuleType>
 double FFN<OutputLayerType, InitializationRuleType>::ForwardCall(
     const arma::mat& /* parameters */, const size_t i, const bool deterministic)
 {
+  currentFunctionIndex = i;
   if (parameter.is_empty())
   {
     ResetParameters();
@@ -194,7 +195,7 @@ template<typename OutputLayerType, typename InitializationRuleType>
 double FFN<OutputLayerType, InitializationRuleType>::Evaluate(
     const arma::mat& parameters, const size_t i, const bool deterministic)
 {
-  if (currentCost == -1)
+  if (numFunctions == 1 || currentCost == -1 || currentFunctionIndex != i)
   {
     return ForwardCall(parameters, i, deterministic);
   }

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -303,6 +303,9 @@ class RNN
   
   //! Cost achieved in the last Forward call
   double currentCost = -1;
+  
+  //! Objective function index used for the last evaluation call
+  size_t currentFunctionIndex = 0;
 
   //! THe current input of the forward/backward pass.
   arma::mat currentInput;

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -201,6 +201,20 @@ class RNN
  private:
   // Helper functions.
   /**
+   * Evaluate the recurrent neural network with the given parameters. This
+   * function is usually called by the optimizer to train the model.
+   *
+   * @param parameters Matrix model parameters.
+   * @param i Index of point to use for objective function evaluation.
+   * @param deterministic Whether or not to train or test the model. Note some
+   *        layer act differently in training or testing mode.
+   */
+  double ForwardCall(const arma::mat& /* parameters */,
+                     const size_t i,
+                     const bool deterministic = true);
+
+  
+  /**
    * The Forward algorithm (part of the Forward-Backward algorithm).  Computes
    * forward probabilities for each module.
    *
@@ -286,6 +300,9 @@ class RNN
 
   //! The current error for the backward pass.
   arma::mat error;
+  
+  //! Cost achieved in the last Forward call
+  double currentCost = -1;
 
   //! THe current input of the forward/backward pass.
   arma::mat currentInput;

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -187,6 +187,8 @@ template<typename OutputLayerType, typename InitializationRuleType>
 double RNN<OutputLayerType, InitializationRuleType>::ForwardCall(
     const arma::mat& /* parameters */, const size_t i, const bool deterministic)
 {
+  currentFunctionIndex = i;
+  
   if (parameter.is_empty())
   {
     ResetParameters();
@@ -245,7 +247,7 @@ template<typename OutputLayerType, typename InitializationRuleType>
 double RNN<OutputLayerType, InitializationRuleType>::Evaluate(
     const arma::mat& parameters, const size_t i, const bool deterministic)
 {
-  if (currentCost == -1)
+  if (currentCost == -1 || numFunctions == 1 || currentFunctionIndex != i)
   {
     return ForwardCall(parameters, i, deterministic);
   }


### PR DESCRIPTION
 The dummy functions are added to avoid an extra Forward pass. The dummy functions will be called from the optimizer. The dummy functions will return the cost computed by the forward pass done in Gradient call.