### PR TITLE
Trust Region Newton method.

### DIFF
--- a/src/mlpack/core/optimizers/CMakeLists.txt
+++ b/src/mlpack/core/optimizers/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DIRS
   sdp
   sgd
   smorms3
+  trust_region_newton
 )
 
 foreach(dir ${DIRS})

--- a/src/mlpack/core/optimizers/trust_region_newton/CMakeLists.txt
+++ b/src/mlpack/core/optimizers/trust_region_newton/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SOURCES
+  trust_region_newton.hpp
+  trust_region_newton_impl.hpp
+)
+
+set(DIR_SRCS)
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+
+set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)

--- a/src/mlpack/core/optimizers/trust_region_newton/trust_region_newton.hpp
+++ b/src/mlpack/core/optimizers/trust_region_newton/trust_region_newton.hpp
@@ -1,0 +1,200 @@
+/**
+ * @file trust_region_newton.hpp
+ * @author Marcus Edel
+ *
+ * Definition of the Trust Region Newton Method as described in
+ * "Trust Region Newton Method for Large-Scale Logistic Regression"
+ * by Chih-Jen Lin et al.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_OPTIMIZERS_TRUST_REGION_NEWTON_TRUST_REGION_NEWTON_HPP
+#define MLPACK_CORE_OPTIMIZERS_TRUST_REGION_NEWTON_TRUST_REGION_NEWTON_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace optimization {
+
+/**
+ * The Trust Region Newton optimizer, which uses approximate Newton steps in
+ * the beginning to maximize the log-likelihood. The parameters for the
+ * algorithm (maximum number of iterations, gradient norm and so forth)
+ * are all configurable via either the constructor or standalone modifier
+ * functions.
+ *
+ * For more information, please refer to:
+ *
+ * @code
+ * @inproceedings{Lin2007,
+ *   author = {Lin, Chih-Jen and Weng, Ruby C. and Keerthi, S. Sathiya},
+ *   title = {Trust Region Newton Methods for Large-scale Logistic Regression},
+ *   booktitle = {Proceedings of the 24th International Conference on Machine
+ *       Learning},
+ *   series = {ICML '07},
+ *   year = {2007},
+ *   pages = {561--568},
+ *   publisher = {ACM}
+ * }
+ * @endcode
+ *
+ * A function which can be optimized by this class must implement
+ * the following methods:
+ *
+ *  - a default constructor
+ *  - double Evaluate(const arma::mat& coordinates);
+ *  - void Gradient(const arma::mat& coordinates,
+ *                  arma::mat& gradient,
+ *                  arma::mat& derivative);
+ *  - void Hessian(const arma::mat& coordinates,
+ *                 const arma::mat& gradient,
+ *                 const arma::mat& derivative,
+ *                 arma::mat& hessian);
+ */
+template<typename FunctionType>
+class TrustRegionNewton
+{
+ public:
+  /**
+   * Construct the Trust Region Newton optimizer with the given function and
+   * parameters.  The defaults here are not necessarily good for the given
+   * problem, so it is suggested that the values used be tailored to the task
+   * at hand.
+   *
+   * @param function Function to be optimized (minimized).
+   * @param minGradientNorm Minimum gradient norm required to continue the
+   *        optimization.
+   * @param maxIterations Maximum number of iterations allowed (0 means no
+   *        limit).
+   * @param maxConjugateIterations Maximum number of iterations allowed for the
+   *        conjugate procedure  (0 means no limit).
+   * @param eta0 Positive constant to update the update rule select: such that
+   *        eta0 < eta1 < eta2 < 1.
+   * @param eta1 Positive constant to update the update rule select: such that
+   *        eta0 < eta1 < eta2 < 1.
+   * @param eta2 Positive constant to update the update rule select: such that
+   *        eta0 < eta1 < eta2 < 1.
+   * @param sigma1 Positive constant to update delta k select: such that
+   *        sigma1 < sigma2 < 1 < sigma3 (Default 0.25).
+   * @param sigma2 Positive constant to update delta k select: such that
+   *        sigma1 < sigma2 < 1 < sigma3 (Default 0.5).
+   * @param sigma3 Positive constant to update delta k select: such that
+   *        sigma1 < sigma2 < 1 < sigma3 (Default 4).
+   */
+  TrustRegionNewton(FunctionType& function,
+                    const double minGradientNorm = 1e-6,
+                    const size_t maxIterations = 20,
+                    const size_t maxConjugateIterations = 0,
+                    const double eta0 = 1e-4,
+                    const double eta1 = 0.25,
+                    const double eta2 = 0.75,
+                    const double sigma1 = 0.25,
+                    const double sigma2 = 0.5,
+                    const double sigma3 = 4);
+
+  /**
+   * Optimize the given function using the Trust Region Newton method. The given
+   * starting point will be modified to store the finishing point of the
+   * algorithm, and the final objective value is returned.
+   *
+   * @param function Function to optimize.
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(FunctionType& function, arma::mat& iterate);
+
+  /**
+   * Optimize the given function using the Trust Region Newton method. The given
+   * starting point will be modified to store the finishing point of the
+   * algorithm, and the final objective value is returned.
+   *
+   * @param iterate Starting point (will be modified).
+   * @return Objective value of the final point.
+   */
+  double Optimize(arma::mat& iterate)
+  {
+    return Optimize(this->function, iterate);
+  }
+
+  //! Get the instantiated function to be optimized.
+  const FunctionType& Function() const { return function; }
+  //! Modify the instantiated function.
+  FunctionType& Function() { return function; }
+
+  //! Get the min gradient norm.
+  double MinGradientNorm() const { return minGradientNorm; }
+  //! Modify the min gradient norm.
+  double& MinGradientNorm() { return minGradientNorm; }
+
+  //! Get the maximum number of iterations (0 indicates no limit).
+  size_t MaxIterations() const { return maxIterations; }
+  //! Modify the maximum number of iterations (0 indicates no limit).
+  size_t& MaxIterations() { return maxIterations; }
+
+ private:
+  /*
+   * Conjugate gradient procedure for approximately solving the trust region
+   * sub-problem.
+   *
+   * @param function Function to optimize.
+   * @param delta Scaling factor to use for the trust region sub-problem.
+   * @param iterate The initial point to begin with solving the trust region
+   *                sub-problem.
+   */
+  void ConjugateGradient(FunctionType& function,
+                         const double delta,
+                         const arma::mat& iterate);
+
+  //! The instantiated function.
+  FunctionType& function;
+
+  //! Minimum gradient norm required to continue the optimization.
+  double minGradientNorm;
+
+  //! The maximum number of allowed iterations.
+  size_t maxIterations;
+
+  //! The maximum number of allowed iterations for the conjugate procedure.
+  size_t maxConjugateIterations;
+
+  //! Update rule rate.
+  double eta0;
+
+  //! Update rule rate.
+  double eta1;
+
+  //! Update rule rate.
+  double eta2;
+
+  //! Scaling update factor.
+  double sigma1;
+
+  //! Scaling update factor.
+  double sigma2;
+
+  //! Scaling update factor.
+  double sigma3;
+
+  //! Scores the the update matrix s.
+  arma::mat s;
+
+  //! Scores the the update matrix r.
+  arma::mat r;
+
+  //! Internally stored derivative.
+  arma::mat derivative;
+
+  //! Internally stored gradient.
+  arma::mat gradient;
+};
+
+} // namespace optimization
+} // namespace mlpack
+
+// Include implementation.
+#include "trust_region_newton_impl.hpp"
+
+#endif

--- a/src/mlpack/core/optimizers/trust_region_newton/trust_region_newton_impl.hpp
+++ b/src/mlpack/core/optimizers/trust_region_newton/trust_region_newton_impl.hpp
@@ -1,0 +1,214 @@
+/**
+ * @file trust_region_newton_impl.hpp
+ * @author Marcus Edel
+ *
+ * Implementation of the Trust Region Newton Method.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_OPTIMIZERS_TRUST_REGION_NEWTON_TRUST_REGION_NEWTON_IMPL_HPP
+#define MLPACK_CORE_OPTIMIZERS_TRUST_REGION_NEWTON_TRUST_REGION_NEWTON_IMPL_HPP
+
+// In case it hasn't been included yet.
+#include "trust_region_newton.hpp"
+
+namespace mlpack {
+namespace optimization {
+
+template<typename FunctionType>
+TrustRegionNewton<FunctionType>::TrustRegionNewton(
+    FunctionType& function,
+    const double minGradientNorm,
+    const size_t maxIterations,
+    const size_t maxConjugateIterations,
+    const double eta0,
+    const double eta1,
+    const double eta2,
+    const double sigma1,
+    const double sigma2,
+    const double sigma3) :
+    function(function),
+    minGradientNorm(minGradientNorm),
+    maxIterations(maxIterations),
+    maxConjugateIterations(maxConjugateIterations),
+    eta0(eta0),
+    eta1(eta1),
+    eta2(eta2),
+    sigma1(sigma1),
+    sigma2(sigma2),
+    sigma3(sigma3)
+{ /* Nothing to do. */ }
+
+template<typename FunctionType>
+void TrustRegionNewton<FunctionType>::ConjugateGradient(
+    FunctionType& function,
+    const double delta,
+    const arma::mat& iterate)
+{
+  // The initial gradient values.
+  r = -gradient;
+  arma::mat d = r;
+  arma::mat hessian;
+
+  s.zeros();
+  double rTr = arma::dot(r, r);
+
+  // Whether to optimize until convergence.
+  const bool optimizeUntilConvergence = (maxConjugateIterations == 0);
+
+  const double minGradientNormConjugate = 0.5 * arma::norm(gradient, 2);
+  for (size_t itNum = 0; optimizeUntilConvergence ||
+      (itNum != maxConjugateIterations); ++itNum)
+  {
+    // If ||r^i|| <= e_k||detla f(w^k)|| then output sk =s^(i) and stop.
+    if (arma::norm(r, 2) <= minGradientNormConjugate)
+      break;
+
+    if (itNum > 0)
+    {
+      const double rTrUpdate = arma::dot(r, r);
+      d *= (rTrUpdate / rTr);
+      d += r;
+      rTr = rTrUpdate;
+    }
+
+    function.Hessian(iterate, d, derivative, hessian);
+
+    double alpha = rTr / arma::dot(d, hessian);
+    s += alpha * d;
+    if (arma::norm(s, 2) > delta)
+    {
+      // Compute tau such that ||s^(-i) + tau d^i|| = delta k.
+      s -= alpha * d;
+
+      const double std = arma::dot(s, d);
+      const double sts = arma::dot(s, s);
+      const double dtd = arma::dot(d, d);
+
+      const double deltaSq = delta * delta;
+      const double rad = std::sqrt(std * std + dtd * (deltaSq - sts));
+
+      if (std >= 0)
+        alpha = (deltaSq - sts) / (std + rad);
+      else
+        alpha = (rad - std) / dtd;
+
+      // Output sk = s^(i) + tau d^i and stop.
+      s += alpha * d;
+      r -= alpha * hessian;
+      break;
+    }
+
+    r -= alpha * hessian;
+    // break;
+  }
+}
+
+template<typename FunctionType>
+double TrustRegionNewton<FunctionType>::Optimize(
+    FunctionType& function, arma::mat& iterate)
+{
+  // The initial function value.
+  double functionValue = function.Evaluate(iterate);
+
+  // The initial gradient value.
+  function.Gradient(iterate, gradient, derivative);
+  double delta = arma::norm(gradient, 2);
+
+  // To keep track of where we are and how things are going.
+  size_t k = 0;
+  double alpha = 0;
+  s.set_size(gradient.n_rows, gradient.n_cols);
+
+  // Whether to optimize until convergence.
+  const bool optimizeUntilConvergence = (maxIterations == 0);
+
+  // The main optimization loop.
+  for (size_t itNum = 0; optimizeUntilConvergence || (itNum != maxIterations);
+       ++itNum)
+  {
+    // Break when the norm of the gradient becomes too small.
+    //
+    // But don't do this on the first iteration to ensure we always take at
+    // least one descent step.
+    if (itNum > 0 && arma::norm(gradient, 2) < minGradientNorm)
+    {
+      Log::Debug << "Trust Region Newton gradient norm too small "
+          << "(terminating successfully)." << std::endl;
+      std::cout << "okay\n";
+      break;
+    }
+
+    // Break if the objective is not a number.
+    if (std::isnan(functionValue))
+    {
+      Log::Warn << "Trust Region Newton terminated with objective "
+          << functionValue << "; " << "are the objective and gradient "
+          << "functions implemented correctly?" << std::endl;
+      break;
+    }
+
+    // Find an approximate solution s^k of the trust region sub-problem.
+    ConjugateGradient(function, delta, iterate);
+
+    // Save the old iterate before stepping.
+    arma::mat newIterate = s + iterate;
+
+    // It is possible that the difference between the two coordinates is zero.
+    // In this case we terminate successfully.
+    if (arma::accu(iterate != newIterate) == 0)
+    {
+      Log::Debug << "Trust Region Newton step size of 0 "
+          << "(terminating successfully)." << std::endl;
+      break;
+    }
+
+    double gs = arma::dot(gradient, s);
+    double denom = -0.5 * (gs - arma::dot(s, r));
+
+    const double newFunctionValue = function.Evaluate(newIterate);
+    const double nume = functionValue - newFunctionValue;
+    const double snorm = arma::norm(s, 2);
+
+    if (k == 1)
+      delta = std::min(delta, snorm);
+
+    if (newFunctionValue - functionValue - gs <= 0)
+    {
+      alpha = sigma3;
+    }
+    else
+    {
+      alpha = std::max(sigma1, -0.5 *
+          (gs / (newFunctionValue - functionValue - gs)));
+    }
+
+    if (nume < eta0 * denom)
+      delta = std::min(std::max(alpha, sigma1) * snorm, sigma2 * delta);
+    else if (nume < eta1 * denom)
+      delta = std::max(sigma1 * delta, std::min(alpha * snorm, sigma2 * delta));
+    else if (nume < eta2 * denom)
+      delta = std::max(sigma1 * delta, std::min(alpha * snorm, sigma3 * delta));
+    else
+      delta = std::max(delta, std::min(alpha * snorm, sigma3 * delta));
+
+    if (nume > eta0 * denom)
+    {
+      k += 1;
+      // Update the old iterate.
+      iterate = newIterate;
+      functionValue = newFunctionValue;
+      function.Gradient(iterate, gradient, derivative);
+    }
+  } // End of the optimization loop.
+
+  return function.Evaluate(iterate);
+}
+
+} // namespace optimization
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function.hpp
@@ -1,6 +1,7 @@
 /**
  * @file logistic_regression_function.hpp
  * @author Sumedh Ghaisas
+ * @author Marcus Edel
  *
  * Implementation of the logistic regression function, which is meant to be
  * optimized by a separate optimizer class that takes LogisticRegressionFunction
@@ -28,14 +29,33 @@ template<typename MatType = arma::mat>
 class LogisticRegressionFunction
 {
  public:
+  /**
+   * Construct the LogisticRegressionFunction class with the given labeled
+   * training data.  Optionally, specify lambda, which is the penalty parameter
+   * for L2-regularization.  If not specified, it is set to 1,
+   *
+   * @param predictors Input training variables.
+   * @param responses Outputs results from input training variables.
+   * @param lambda L2-regularization parameter.
+   */
   LogisticRegressionFunction(const MatType& predictors,
                              const arma::Row<size_t>& responses,
-                             const double lambda = 0);
+                             const double lambda = 1);
 
+  /**
+   * Construct the LogisticRegressionFunction class with the given labeled
+   * training data.  Optionally, specify lambda, which is the penalty parameter
+   * for L2-regularization.  If not specified, it is set to 1,
+   *
+   * @param predictors Input training variables.
+   * @param responses Outputs results from input training variables.
+   * @param initialPoint Initial model to train with.
+   * @param lambda L2-regularization parameter.
+   */
   LogisticRegressionFunction(const MatType& predictors,
                              const arma::Row<size_t>& responses,
                              const arma::vec& initialPoint,
-                             const double lambda = 0);
+                             const double lambda = 1);
 
   //! Return the initial point for the optimization.
   const arma::mat& InitialPoint() const { return initialPoint; }
@@ -104,6 +124,32 @@ class LogisticRegressionFunction
                 const size_t i,
                 arma::mat& gradient) const;
 
+  /**
+   * Evaluate the gradient of the logistic regression log-likelihood function
+   * with the given parameters.
+   *
+   * @param parameters Vector of logistic regression parameters.
+   * @param gradient Vector to output gradient into.
+   * @param derivative Vector to output derivative into.
+   */
+  void Gradient(const arma::mat& parameters,
+                arma::mat& gradient,
+                arma::mat& derivative);
+
+  /**
+   * Evaluate the hessian of the logistic regression log-likelihood function
+   * with the given gradient and derivative.
+   *
+   * @param parameters Vector of logistic regression parameters.
+   * @param gradient Vector of logistic regression gradient parameters.
+   * @param derivative Vector of logistic regression derivative parameters.
+   * @param hessian Vector to output hessian into.
+   */
+  void Hessian(const arma::mat& parameters,
+               const arma::mat& gradient,
+               const arma::mat& derivative,
+               arma::mat& hessian) const;
+
   //! Return the initial point for the optimization.
   const arma::mat& GetInitialPoint() const { return initialPoint; }
 
@@ -113,10 +159,13 @@ class LogisticRegressionFunction
  private:
   //! The initial point, from which to start the optimization.
   arma::mat initialPoint;
+
   //! The matrix of data points (predictors).
   const MatType& predictors;
+
   //! The vector of responses to the input data points.
   const arma::Row<size_t>& responses;
+
   //! The regularization parameter for L2-regularization.
   double lambda;
 };

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
@@ -206,7 +206,8 @@ void LogisticRegressionFunction<MatType>::Hessian(
 
   arma::mat hessianTemp = arma::mat(
       hessian.colptr(0) + 1, 1, gradient.n_elem - 1, false, true);
-  hessianTemp = (lambda * (gradient.col(0).subvec(1, parameters.n_elem - 1).t() *
+  hessianTemp = (lambda *
+      (gradient.col(0).subvec(1, parameters.n_elem - 1).t() *
       predictors % derivative)) * predictors.t() +
       gradient.col(0).subvec(1, parameters.n_elem - 1).t();
 }

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable(mlpack_test
   termination_policy_test.cpp
   tree_test.cpp
   tree_traits_test.cpp
+  trust_region_newton_test.cpp
   union_find_test.cpp
   svd_batch_test.cpp
   svd_incremental_test.cpp

--- a/src/mlpack/tests/trust_region_newton_test.cpp
+++ b/src/mlpack/tests/trust_region_newton_test.cpp
@@ -1,0 +1,78 @@
+/**
+ * @file trust_region_newton_test.cpp
+ * @author Marcus Edel
+ *
+ * Tests the Adam and AdaMax optimizer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+
+#include <mlpack/core/optimizers/trust_region_newton/trust_region_newton.hpp>
+#include <mlpack/methods/logistic_regression/logistic_regression.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include "test_tools.hpp"
+
+using namespace arma;
+using namespace mlpack::optimization;
+
+using namespace mlpack::distribution;
+using namespace mlpack::regression;
+
+using namespace mlpack;
+
+BOOST_AUTO_TEST_SUITE(TrustRegionNewtonTest);
+
+// Test training of logistic regression on two Gaussians and ensure it's
+// properly separable using the Trust Region Newton method.
+BOOST_AUTO_TEST_CASE(LogisticRegressionTrustRegionNewtonGaussianTest)
+{
+  // Generate a two-Gaussian dataset.
+  GaussianDistribution g1(arma::vec("1.0 1.0 1.0"), arma::eye<arma::mat>(3, 3));
+  GaussianDistribution g2(arma::vec("9.0 9.0 9.0"), arma::eye<arma::mat>(3, 3));
+
+  arma::mat data(3, 1000);
+  arma::Row<size_t> responses(1000);
+  for (size_t i = 0; i < 500; ++i)
+  {
+    data.col(i) = g1.Random();
+    responses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    data.col(i) = g2.Random();
+    responses[i] = 1;
+  }
+
+  // Now train a logistic regression object on it.
+  LogisticRegression<> lr(data.n_rows, 0.5);
+  lr.Train<TrustRegionNewton>(data, responses);
+
+  // Ensure that the error is close to zero.
+  const double acc = lr.ComputeAccuracy(data, responses);
+
+  BOOST_REQUIRE_CLOSE(acc, 100.0, 0.3); // 0.3% error tolerance.
+
+  // Create a test set.
+  for (size_t i = 0; i < 500; ++i)
+  {
+    data.col(i) = g1.Random();
+    responses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    data.col(i) = g2.Random();
+    responses[i] = 1;
+  }
+
+  // Ensure that the error is close to zero.
+  const double testAcc = lr.ComputeAccuracy(data, responses);
+
+  BOOST_REQUIRE_CLOSE(testAcc, 100.0, 0.6); // 0.6% error tolerance.
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Here is an implementation of the Trust Region Newton method as described in "Trust region Newton methods for large-scale logistic regression". Tested on the isolet dataset I get TrustRegionNewton: 326.386, L_BFGS: 464.662 ms. About to run benchmarks on all files mentioned in the paper, but this might take some time. It might also be interesting to look into: "A Study on Trust Region Update Rules in Newton Methods for Large-scale Linear Classification".