### PR TITLE
Turn VecType into an alias in NaiveBayesClassifier

### DIFF
--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
@@ -48,8 +48,8 @@ template<typename MatType = arma::mat>
 class NaiveBayesClassifier
 {
  public:
-   //! A short alias for the data point type.
-   using VecType = arma::Col<typename MatType::value_type>;
+  //! A short alias for the data point type.
+  using VecType = arma::Col<typename MatType::value_type>;
 
   /**
    * Initializes the classifier as per the input and then trains it by

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
@@ -48,6 +48,9 @@ template<typename MatType = arma::mat>
 class NaiveBayesClassifier
 {
  public:
+   //! A short alias for the data point type.
+   using VecType = arma::Col<typename MatType::value_type>;
+
   /**
    * Initializes the classifier as per the input and then trains it by
    * calculating the sample mean and variances.
@@ -107,7 +110,6 @@ class NaiveBayesClassifier
    * @param point Data point to train on.
    * @param label Label of data point.
    */
-  template<typename VecType>
   void Train(const VecType& point, const size_t label);
 
   /**
@@ -116,7 +118,6 @@ class NaiveBayesClassifier
    *
    * @param point Point to classify.
    */
-  template<typename VecType>
   size_t Classify(const VecType& point) const;
 
   /**
@@ -129,7 +130,6 @@ class NaiveBayesClassifier
    * @param probabilities This will be filled with class probabilities for the
    *      point.
    */
-  template<typename VecType>
   void Classify(const VecType& point,
                 size_t& prediction,
                 arma::vec& probabilities) const;
@@ -209,7 +209,6 @@ class NaiveBayesClassifier
    * @param point Data point to compute posterior log probability of.
    * @param logLikelihoods Vector to store log likelihoods in.
    */
-  template<typename VecType>
   void LogLikelihood(const VecType& point, arma::vec& logLikelihoods) const;
 
   /**

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -142,7 +142,6 @@ void NaiveBayesClassifier<MatType>::Train(const MatType& data,
 }
 
 template<typename MatType>
-template<typename VecType>
 void NaiveBayesClassifier<MatType>::Train(const VecType& point,
                                           const size_t label)
 {
@@ -163,7 +162,6 @@ void NaiveBayesClassifier<MatType>::Train(const VecType& point,
 }
 
 template<typename MatType>
-template<typename VecType>
 void NaiveBayesClassifier<MatType>::LogLikelihood(
     const VecType& point,
     arma::vec& logLikelihoods) const
@@ -208,7 +206,6 @@ void NaiveBayesClassifier<MatType>::LogLikelihood(
 }
 
 template<typename MatType>
-template<typename VecType>
 size_t NaiveBayesClassifier<MatType>::Classify(const VecType& point) const
 {
   // Find the label(class) with max log likelihood.
@@ -221,7 +218,6 @@ size_t NaiveBayesClassifier<MatType>::Classify(const VecType& point) const
 }
 
 template<typename MatType>
-template<typename VecType>
 void NaiveBayesClassifier<MatType>::Classify(const VecType& point,
                                              size_t& prediction,
                                              arma::vec& probabilities) const

--- a/src/mlpack/tests/nbc_test.cpp
+++ b/src/mlpack/tests/nbc_test.cpp
@@ -72,14 +72,22 @@ BOOST_AUTO_TEST_CASE(NaiveBayesClassifierTest)
 
   nbcTest.Classify(testData, calcVec, calcProbs);
 
-  for (size_t i = 0; i < testData.n_cols; i++)
-    BOOST_REQUIRE_EQUAL(testRes(i), calcVec(i));
+  size_t label;
+  arma::vec probsVec;
 
-  for (size_t i = 0; i < testResProbs.n_cols; ++i)
+  for (size_t i = 0; i < testData.n_cols; ++i)
   {
+    nbcTest.Classify(testData.col(i), label, probsVec);
+
+    BOOST_REQUIRE_EQUAL(testRes(i), calcVec(i));
+    BOOST_REQUIRE_EQUAL(testRes(i), label);
+    BOOST_REQUIRE_EQUAL(testRes(i), nbcTest.Classify(testData.col(i)));
+
     for (size_t j = 0; j < testResProbs.n_rows; ++j)
     {
       BOOST_REQUIRE_CLOSE(testResProbs(j, i) + 0.0001, calcProbs(j, i) + 0.0001,
+          0.01);
+      BOOST_REQUIRE_CLOSE(testResProbs(j, i) + 0.0001, probsVec(j) + 0.0001,
           0.01);
     }
   }
@@ -140,15 +148,25 @@ BOOST_AUTO_TEST_CASE(NaiveBayesClassifierIncrementalTest)
 
   nbcTest.Classify(testData, calcVec, calcProbs);
 
-  for (size_t i = 0; i < testData.n_cols; i++)
-    BOOST_REQUIRE_EQUAL(testRes(i), calcVec(i));
+  size_t label;
+  arma::vec probsVec;
 
-  for (size_t i = 0; i < testResProba.n_cols; ++i)
+  for (size_t i = 0; i < testData.n_cols; ++i)
+  {
+    nbcTest.Classify(testData.col(i), label, probsVec);
+
+    BOOST_REQUIRE_EQUAL(testRes(i), calcVec(i));
+    BOOST_REQUIRE_EQUAL(testRes(i), label);
+    BOOST_REQUIRE_EQUAL(testRes(i), nbcTest.Classify(testData.col(i)));
+
     for (size_t j = 0; j < testResProba.n_rows; ++j)
     {
       BOOST_REQUIRE_CLOSE(
           testResProba(j, i) + .00001, calcProbs(j, i) + .00001, 0.01);
+      BOOST_REQUIRE_CLOSE(
+          testResProba(j, i) + 0.0001, probsVec(j) + 0.0001, 0.01);
     }
+  }
 }
 
 /**

--- a/src/mlpack/tests/nbc_test.cpp
+++ b/src/mlpack/tests/nbc_test.cpp
@@ -147,14 +147,14 @@ BOOST_AUTO_TEST_CASE(NaiveBayesClassifierIncrementalTest)
 
   arma::mat testData;
   arma::Mat<size_t> testRes;
-  arma::mat testResProba;
+  arma::mat testResProbs;
   data::Load(testFilename, testData, true);
   data::Load(testResultFilename, testRes, true);
-  data::Load(testResultProbsFilename, testResProba, true);
+  data::Load(testResultProbsFilename, testResProbs, true);
 
   testData.shed_row(testData.n_rows - 1); // Remove the labels.
 
-  CheckLabelsAndProbabilities(testData, testRes, testResProba, nbcTest);
+  CheckLabelsAndProbabilities(testData, testRes, testResProbs, nbcTest);
 }
 
 /**

--- a/src/mlpack/tests/nbc_test.cpp
+++ b/src/mlpack/tests/nbc_test.cpp
@@ -45,7 +45,6 @@ void CheckLabelsAndProbabilities(const arma::mat& testData,
           0.01);
     }
   }
-
 }
 
 


### PR DESCRIPTION
Fix #1049 