### PR TITLE
Use unique filenames in Serialization tests

### DIFF
--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -158,7 +158,6 @@ void TestArmadilloSerialization(MatType& x)
         BOOST_REQUIRE_SMALL(double(x(j, i)), 1e-8);
       else
         BOOST_REQUIRE_CLOSE(double(orig(j, i)), double(x(j, i)), 1e-8);
-
 }
 
 // Test all serialization strategies.

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -33,6 +33,7 @@ template<typename CubeType,
 void TestArmadilloSerialization(arma::Cube<CubeType>& x)
 {
   // First save it.
+  // Use type_info name to get unique file name for serialization test files.
   std::string fileName = FilterFileName(typeid(IArchiveType).name());
   std::ofstream ofs(fileName, std::ios::binary);
   OArchiveType o(ofs);

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -33,7 +33,8 @@ template<typename CubeType,
 void TestArmadilloSerialization(arma::Cube<CubeType>& x)
 {
   // First save it.
-  std::ofstream ofs("test", std::ios::binary);
+  std::string fileName = FilterFileName(typeid(IArchiveType).name());
+  std::ofstream ofs(fileName, std::ios::binary);
   OArchiveType o(ofs);
 
   bool success = true;
@@ -52,7 +53,7 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   // Now load it.
   arma::Cube<CubeType> orig(x);
   success = true;
-  std::ifstream ifs("test", std::ios::binary);
+  std::ifstream ifs(fileName, std::ios::binary);
   IArchiveType i(ifs);
 
   try
@@ -63,6 +64,8 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   {
     success = false;
   }
+
+  remove(fileName.c_str());
 
   BOOST_REQUIRE_EQUAL(success, true);
 
@@ -88,8 +91,6 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
       }
     }
   }
-
-  remove("test");
 }
 
 // Test all serialization strategies.
@@ -111,7 +112,8 @@ template<typename MatType,
 void TestArmadilloSerialization(MatType& x)
 {
   // First save it.
-  std::ofstream ofs("test", std::ios::binary);
+  std::string fileName = FilterFileName(typeid(IArchiveType).name());
+  std::ofstream ofs(fileName, std::ios::binary);
   OArchiveType o(ofs);
 
   bool success = true;
@@ -130,7 +132,7 @@ void TestArmadilloSerialization(MatType& x)
   // Now load it.
   MatType orig(x);
   success = true;
-  std::ifstream ifs("test", std::ios::binary);
+  std::ifstream ifs(fileName, std::ios::binary);
   IArchiveType i(ifs);
 
   try
@@ -141,6 +143,8 @@ void TestArmadilloSerialization(MatType& x)
   {
     success = false;
   }
+
+  remove(fileName.c_str());
 
   BOOST_REQUIRE_EQUAL(success, true);
 
@@ -155,7 +159,6 @@ void TestArmadilloSerialization(MatType& x)
       else
         BOOST_REQUIRE_CLOSE(double(orig(j, i)), double(x(j, i)), 1e-8);
 
-  remove("test");
 }
 
 // Test all serialization strategies.
@@ -175,7 +178,8 @@ void TestAllArmadilloSerialization(MatType& x)
 template<typename T, typename IArchiveType, typename OArchiveType>
 void SerializeObject(T& t, T& newT)
 {
-  std::ofstream ofs("test", std::ios::binary);
+  std::string fileName = FilterFileName(typeid(T).name());
+  std::ofstream ofs(fileName, std::ios::binary);
   OArchiveType o(ofs);
 
   bool success = true;
@@ -191,7 +195,7 @@ void SerializeObject(T& t, T& newT)
 
   BOOST_REQUIRE_EQUAL(success, true);
 
-  std::ifstream ifs("test", std::ios::binary);
+  std::ifstream ifs(fileName, std::ios::binary);
   IArchiveType i(ifs);
 
   try
@@ -203,6 +207,8 @@ void SerializeObject(T& t, T& newT)
     success = false;
   }
   ifs.close();
+
+  remove(fileName.c_str());
 
   BOOST_REQUIRE_EQUAL(success, true);
 }
@@ -223,7 +229,8 @@ void SerializeObjectAll(T& t, T& xmlT, T& textT, T& binaryT)
 template<typename T, typename IArchiveType, typename OArchiveType>
 void SerializePointerObject(T* t, T*& newT)
 {
-  std::ofstream ofs("test", std::ios::binary);
+  std::string fileName = FilterFileName(typeid(T).name());
+  std::ofstream ofs(fileName, std::ios::binary);
   OArchiveType o(ofs);
 
   bool success = true;
@@ -239,7 +246,7 @@ void SerializePointerObject(T* t, T*& newT)
 
   BOOST_REQUIRE_EQUAL(success, true);
 
-  std::ifstream ifs("test", std::ios::binary);
+  std::ifstream ifs(fileName, std::ios::binary);
   IArchiveType i(ifs);
 
   try
@@ -251,6 +258,8 @@ void SerializePointerObject(T* t, T*& newT)
     success = false;
   }
   ifs.close();
+
+  remove(fileName.c_str());
 
   BOOST_REQUIRE_EQUAL(success, true);
 }

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -48,4 +48,18 @@ inline void CheckMatrices(const arma::Mat<size_t>& a,
     BOOST_REQUIRE_EQUAL(a[i], b[i]);
 }
 
+inline std::string FilterFileName(const std::string& inputString)
+{
+  // Take the last valid 32 characters for the filename.
+  std::string fileName;
+  for(auto it = inputString.rbegin(); it != inputString.rend() &&
+      fileName.size() != 32; ++it)
+  {
+    if(std::isalnum(*it))
+      fileName.push_back(*it);
+  }
+
+  return fileName;
+}
+
 #endif

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -52,10 +52,10 @@ inline std::string FilterFileName(const std::string& inputString)
 {
   // Take the last valid 32 characters for the filename.
   std::string fileName;
-  for(auto it = inputString.rbegin(); it != inputString.rend() &&
+  for (auto it = inputString.rbegin(); it != inputString.rend() &&
       fileName.size() != 32; ++it)
   {
-    if(std::isalnum(*it))
+    if (std::isalnum(*it))
       fileName.push_back(*it);
   }
 

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -48,6 +48,7 @@ inline void CheckMatrices(const arma::Mat<size_t>& a,
     BOOST_REQUIRE_EQUAL(a[i], b[i]);
 }
 
+// Filter typeinfo string to generate unique filenames for serialization tests.
 inline std::string FilterFileName(const std::string& inputString)
 {
   // Take the last valid 32 characters for the filename.


### PR DESCRIPTION
Fix for #1052 

`FilterFileName()` does not handle the corner case of `inputString` being empty, but I think it should be fine here.