### PR TITLE
Refactor NaiveBayesClassifier to have templated Train() functions.

### DIFF
--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
@@ -43,11 +43,20 @@ namespace naive_bayes /** The Naive Bayes Classifier. */ {
  *
  * nbc.Classify(testing_data, results);
  * @endcode
+ *
+ * The ModelMatType template parameter specifies the internal matrix type that
+ * NaiveBayesClassifier will use to hold the model.  This can be arma::mat,
+ * arma::fmat, or any other Armadillo (or Armadillo-compatible) object.
+ *
+ * @tparam ModelMatType Internal matrix type to use to store the model.
  */
-template<typename MatType = arma::mat>
+template<typename ModelMatType = arma::mat>
 class NaiveBayesClassifier
 {
  public:
+  // Convenience typedef.
+  typedef typename ModelMatType::elem_type ElemType;
+
   /**
    * Initializes the classifier as per the input and then trains it by
    * calculating the sample mean and variances.
@@ -66,6 +75,7 @@ class NaiveBayesClassifier
    *     calculate the variance; this can prevent loss of precision in some
    *     cases, but will be somewhat slower to calculate.
    */
+  template<typename MatType>
   NaiveBayesClassifier(const MatType& data,
                        const arma::Row<size_t>& labels,
                        const size_t classes,
@@ -95,6 +105,7 @@ class NaiveBayesClassifier
    * @param incremental Whether or not to use the incremental algorithm for
    *      training.
    */
+  template<typename MatType>
   void Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const bool incremental = true);
@@ -111,8 +122,8 @@ class NaiveBayesClassifier
   void Train(const VecType& point, const size_t label);
 
   /**
-   * Classify the given point, using the training GaussianNB model. The predicted label is
-   * returned.
+   * Classify the given point, using the trained NaiveBayesClassifier model. The
+   * predicted label is returned.
    *
    * @param point Point to classify.
    */
@@ -120,22 +131,22 @@ class NaiveBayesClassifier
   size_t Classify(const VecType& point) const;
 
   /**
-   * Classify the given point using the training GaussianNB model
-   * and also return estimates of the probability for
-   * each class in the given vector.
+   * Classify the given point using the trained NaiveBayesClassifier model and
+   * also return estimates of the probability for each class in the given
+   * vector.
    *
    * @param point Point to classify.
    * @param prediction This will be set to the predicted class of the point.
    * @param probabilities This will be filled with class probabilities for the
    *      point.
    */
-  template<typename VecType>
+  template<typename VecType, typename ProbabilitiesVecType>
   void Classify(const VecType& point,
                 size_t& prediction,
-                arma::vec& probabilities) const;
+                ProbabilitiesVecType& probabilities) const;
 
   /**
-   * Classify the given points using the training GaussianNB model.
+   * Classify the given points using the trained NaiveBayesClassifier model.
    * The predicted labels for each point are stored in the given vector.
    *
    * @code
@@ -148,13 +159,15 @@ class NaiveBayesClassifier
    * @param data List of data points.
    * @param predictions Vector that class predictions will be placed into.
    */
+  template<typename MatType>
   void Classify(const MatType& data,
                 arma::Row<size_t>& predictions) const;
 
   /**
-   * Classify the given points using the training GaussianNB model
-   * and also return estimates of the probabilities for each class in the given matrix.
-   * The predicted labels for each point are stored in the given vector.
+   * Classify the given points using the trained NaiveBayesClassifier model and
+   * also return estimates of the probabilities for each class in the given
+   * matrix.  The predicted labels for each point are stored in the given
+   * vector.
    *
    * @code
    * arma::mat test_data; // each column is a test point
@@ -169,24 +182,25 @@ class NaiveBayesClassifier
    * @param probabilities This will be filled with class probabilities for each
    *      point. Each row represents a point.
    */
+  template<typename MatType>
   void Classify(const MatType& data,
                 arma::Row<size_t>& predictions,
-                arma::mat& probabilities) const;
+                ModelMatType& probabilities) const;
 
   //! Get the sample means for each class.
-  const MatType& Means() const { return means; }
+  const ModelMatType& Means() const { return means; }
   //! Modify the sample means for each class.
-  MatType& Means() { return means; }
+  ModelMatType& Means() { return means; }
 
   //! Get the sample variances for each class.
-  const MatType& Variances() const { return variances; }
+  const ModelMatType& Variances() const { return variances; }
   //! Modify the sample variances for each class.
-  MatType& Variances() { return variances; }
+  ModelMatType& Variances() { return variances; }
 
   //! Get the prior probabilities for each class.
-  const arma::vec& Probabilities() const { return probabilities; }
+  const ModelMatType& Probabilities() const { return probabilities; }
   //! Modify the prior probabilities for each class.
-  arma::vec& Probabilities() { return probabilities; }
+  ModelMatType& Probabilities() { return probabilities; }
 
   //! Serialize the classifier.
   template<typename Archive>
@@ -194,23 +208,13 @@ class NaiveBayesClassifier
 
  private:
   //! Sample mean for each class.
-  MatType means;
+  ModelMatType means;
   //! Sample variances for each class.
-  MatType variances;
-  //! Class probabilities.
-  arma::vec probabilities;
+  ModelMatType variances;
+  //! Class probabilities; this has the shape of a column vector.
+  ModelMatType probabilities;
   //! Number of training points seen so far.
   size_t trainingPoints;
-
-  /**
-   * Compute the unnormalized posterior log probability (log likelihood) of
-   * given point.
-   *
-   * @param point Data point to compute posterior log probability of.
-   * @param logLikelihoods Vector to store log likelihoods in.
-   */
-  template<typename VecType>
-  void LogLikelihood(const VecType& point, arma::vec& logLikelihoods) const;
 
   /**
    * Compute the unnormalized posterior log probability of given points (log
@@ -220,8 +224,9 @@ class NaiveBayesClassifier
    * @param data Set of points to compute posterior log probability for.
    * @param logLikelihoods Matrix to store log likelihoods in.
    */
+  template<typename MatType>
   void LogLikelihood(const MatType& data,
-                     arma::mat& logLikelihoods) const;
+                     ModelMatType& logLikelihoods) const;
 };
 
 } // namespace naive_bayes

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -25,14 +25,19 @@
 namespace mlpack {
 namespace naive_bayes {
 
+template<typename ModelMatType>
 template<typename MatType>
-NaiveBayesClassifier<MatType>::NaiveBayesClassifier(
+NaiveBayesClassifier<ModelMatType>::NaiveBayesClassifier(
     const MatType& data,
     const arma::Row<size_t>& labels,
     const size_t classes,
     const bool incremental) :
     trainingPoints(0) // Set when we call Train().
 {
+  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   const size_t dimensionality = data.n_rows;
 
   // Perform training, after initializing the model to 0 (that is, if Train()
@@ -53,9 +58,10 @@ NaiveBayesClassifier<MatType>::NaiveBayesClassifier(
   Train(data, labels, incremental);
 }
 
-template<typename MatType>
-NaiveBayesClassifier<MatType>::NaiveBayesClassifier(const size_t dimensionality,
-                                                    const size_t classes) :
+template<typename ModelMatType>
+NaiveBayesClassifier<ModelMatType>::NaiveBayesClassifier(
+    const size_t dimensionality,
+    const size_t classes) :
     trainingPoints(0)
 {
   // Initialize model to 0.
@@ -64,11 +70,17 @@ NaiveBayesClassifier<MatType>::NaiveBayesClassifier(const size_t dimensionality,
   variances.zeros(dimensionality, classes);
 }
 
+template<typename ModelMatType>
 template<typename MatType>
-void NaiveBayesClassifier<MatType>::Train(const MatType& data,
-                                          const arma::Row<size_t>& labels,
-                                          const bool incremental)
+void NaiveBayesClassifier<ModelMatType>::Train(
+    const MatType& data,
+    const arma::Row<size_t>& labels,
+    const bool incremental)
 {
+  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   // Calculate the class probabilities as well as the sample mean and variance
   // for each of the features with respect to each of the labels.
   if (incremental)
@@ -141,11 +153,15 @@ void NaiveBayesClassifier<MatType>::Train(const MatType& data,
   trainingPoints += data.n_cols;
 }
 
-template<typename MatType>
+template<typename ModelMatType>
 template<typename VecType>
-void NaiveBayesClassifier<MatType>::Train(const VecType& point,
-                                          const size_t label)
+void NaiveBayesClassifier<ModelMatType>::Train(const VecType& point,
+                                               const size_t label)
 {
+  static_assert(std::is_same<ElemType, typename VecType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   // We must use the incremental algorithm here.
   probabilities *= trainingPoints;
   probabilities[label]++;
@@ -162,18 +178,18 @@ void NaiveBayesClassifier<MatType>::Train(const VecType& point,
   probabilities /= trainingPoints;
 }
 
+template<typename ModelMatType>
 template<typename MatType>
-template<typename VecType>
-void NaiveBayesClassifier<MatType>::LogLikelihood(
-    const VecType& point,
-    arma::vec& logLikelihoods) const
+void NaiveBayesClassifier<ModelMatType>::LogLikelihood(
+    const MatType& data,
+    ModelMatType& logLikelihoods) const
 {
-  // Check that the number of features in the test data is same as in the
-  // training data.
-  Log::Assert(point.n_rows == means.n_rows);
+  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
 
-  logLikelihoods = arma::log(probabilities);
-  arma::mat invVar = 1.0 / variances;
+  logLikelihoods = arma::log(arma::repmat(probabilities, 1, data.n_cols));
+  ModelMatType invVar = 1.0 / variances;
 
   // Calculate the joint log likelihood of point for each of the
   // means.n_cols.
@@ -183,36 +199,25 @@ void NaiveBayesClassifier<MatType>::LogLikelihood(
   {
     // This is an adaptation of gmm::phi() for the case where the covariance is
     // a diagonal matrix.
-    arma::vec diffs = point - means.col(i);
-    arma::vec rhs = -0.5 * arma::diagmat(invVar.col(i)) * diffs;
-    double exponent = arma::accu(diffs % rhs); // log(exp(value)) == value
+    ModelMatType diffs = data - arma::repmat(means.col(i), 1, data.n_cols);
+    ModelMatType rhs = -0.5 * arma::diagmat(invVar.col(i)) * diffs;
+    arma::Col<ElemType> exponents = arma::sum(diffs % rhs, 0);
 
-    // Calculate point log likelihood as sum of logs to decrease floating point
-    // errors.
-    logLikelihoods(i) += (point.n_rows / -2.0 * log(2 * M_PI) - 0.5 *
-        log(arma::det(arma::diagmat(variances.col(i)))) + exponent);
+    logLikelihoods.row(i) += (data.n_rows / -2.0 * log(2 * M_PI) - 0.5 *
+        std::log(arma::det(arma::diagmat(variances.col(i)))) + exponents);
   }
 }
 
-template<typename MatType>
-void NaiveBayesClassifier<MatType>::LogLikelihood(
-    const MatType& data,
-    arma::mat& logLikelihoods) const
-{
-  logLikelihoods.set_size(means.n_cols, data.n_cols);
-  for (size_t i = 0; i < data.n_cols; ++i)
-  {
-    arma::vec v = logLikelihoods.unsafe_col(i);
-    LogLikelihood(data.col(i), v);
-  }
-}
-
-template<typename MatType>
+template<typename ModelMatType>
 template<typename VecType>
-size_t NaiveBayesClassifier<MatType>::Classify(const VecType& point) const
+size_t NaiveBayesClassifier<ModelMatType>::Classify(const VecType& point) const
 {
+  static_assert(std::is_same<ElemType, typename VecType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   // Find the label(class) with max log likelihood.
-  arma::vec logLikelihoods;
+  ModelMatType logLikelihoods;
   LogLikelihood(point, logLikelihoods);
 
   arma::uword maxIndex = 0;
@@ -220,17 +225,22 @@ size_t NaiveBayesClassifier<MatType>::Classify(const VecType& point) const
   return maxIndex;
 }
 
-template<typename MatType>
-template<typename VecType>
-void NaiveBayesClassifier<MatType>::Classify(const VecType& point,
-                                             size_t& prediction,
-                                             arma::vec& probabilities) const
+template<typename ModelMatType>
+template<typename VecType, typename ProbabilitiesVecType>
+void NaiveBayesClassifier<ModelMatType>::Classify(
+    const VecType& point,
+    size_t& prediction,
+    ProbabilitiesVecType& probabilities) const
 {
+  static_assert(std::is_same<ElemType, typename VecType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   // log(Prob(Y|X)) = Log(Prob(X|Y)) + Log(Prob(Y)) - Log(Prob(X));
   // But LogLikelihood() gives us the unnormalized log likelihood which is
   // Log(Prob(X|Y)) + Log(Prob(Y)) so we need to subtract the normalization
   // term.
-  arma::vec logLikelihoods;
+  ModelMatType logLikelihoods;
   LogLikelihood(point, logLikelihoods);
   const double logProbX = log(arma::accu(exp(logLikelihoods))); // Log(Prob(X)).
   logLikelihoods -= logProbX;
@@ -241,14 +251,19 @@ void NaiveBayesClassifier<MatType>::Classify(const VecType& point,
   probabilities = exp(logLikelihoods); // log(exp(value)) == value.
 }
 
+template<typename ModelMatType>
 template<typename MatType>
-void NaiveBayesClassifier<MatType>::Classify(
+void NaiveBayesClassifier<ModelMatType>::Classify(
     const MatType& data,
     arma::Row<size_t>& predictions) const
 {
+  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   predictions.set_size(data.n_cols);
 
-  arma::mat logLikelihoods;
+  ModelMatType logLikelihoods;
   LogLikelihood(data, logLikelihoods);
 
   for (size_t i = 0; i < data.n_cols; ++i)
@@ -259,18 +274,24 @@ void NaiveBayesClassifier<MatType>::Classify(
   }
 }
 
+template<typename ModelMatType>
 template<typename MatType>
-void NaiveBayesClassifier<MatType>::Classify(
+void NaiveBayesClassifier<ModelMatType>::Classify(
     const MatType& data,
     arma::Row<size_t>& predictions,
-    arma::mat& predictionProbs) const
+    ModelMatType& predictionProbs) const
 {
+  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+      "NaiveBayesClassifier: element type of given data must match the element "
+      "type of the model!");
+
   predictions.set_size(data.n_cols);
 
-  arma::mat logLikelihoods;
+  ModelMatType logLikelihoods;
   LogLikelihood(data, logLikelihoods);
 
-  arma::vec logProbX(data.n_cols); // log(Prob(X)) for each point.
+  // This will hold log(Prob(X)) for each point.
+  arma::Col<ElemType> logProbX(data.n_cols);
   for (size_t j = 0; j < data.n_cols; ++j)
   {
     logProbX(j) = log(arma::accu(exp(logLikelihoods.col(j))));
@@ -288,10 +309,11 @@ void NaiveBayesClassifier<MatType>::Classify(
   }
 }
 
-template<typename MatType>
+template<typename ModelMatType>
 template<typename Archive>
-void NaiveBayesClassifier<MatType>::Serialize(Archive& ar,
-                                              const unsigned int /* version */)
+void NaiveBayesClassifier<ModelMatType>::Serialize(
+    Archive& ar,
+    const unsigned int /* version */)
 {
   ar & data::CreateNVP(means, "means");
   ar & data::CreateNVP(variances, "variances");


### PR DESCRIPTION
This is an alternate solution to #1051.  It actually allows more flexibility---now I can pass in subviews, etc. to `NaiveBayesClassifier::Train()`, and I can still use `NaiveBayesClassifier` with non-double types (i.e. `NaiveBayesClassifier<float>`.  Since all overloads of `Train()` are templatized, this should satisfy the conditions needed for the hyper-parameter tuner.

@micyril: what do you think?  Is this an acceptable alternate approach?