### PR TITLE
Use omp_get_thread_num and omp_set_num_threads only if OpenMP supported.

### DIFF
--- a/src/mlpack/core/optimizers/parallel_sgd/parallel_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/parallel_sgd/parallel_sgd_impl.hpp
@@ -82,16 +82,21 @@ double ParallelSGD<DecayPolicyType>::Optimize(
     double stepSize = decayPolicy.StepSize(i);
 
     // Shuffle for uniform sampling of functions by each thread.
-
-    if (shuffle) // Determine order of visitation.
+    if (shuffle)
+    {
+      // Determine order of visitation.
       std::shuffle(visitationOrder.begin(), visitationOrder.end(),
           mlpack::math::randGen);
+    }
 
     #pragma omp parallel
     {
       // Each processor gets a subset of the instances.
-      // Each subset is of size threadShareSize.
-      size_t threadId = omp_get_thread_num();
+      // Each subset is of size threadShareSize
+      size_t threadId = 0;
+      #ifdef HAS_OPENMP
+        threadId = omp_get_thread_num();
+      #endif
 
       for (size_t j = threadId * threadShareSize;
           j < (threadId + 1) * threadShareSize && j < visitationOrder.n_elem;
@@ -119,6 +124,7 @@ double ParallelSGD<DecayPolicyType>::Optimize(
       }
     }
   }
+
   Log::Info << "\n Parallel SGD terminated with objective : "
     << overallObjective << std::endl;
   return overallObjective;

--- a/src/mlpack/methods/regularized_svd/regularized_svd_function_impl.hpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd_function_impl.hpp
@@ -279,7 +279,10 @@ inline double ParallelSGD<ExponentialBackoff>::Optimize(
     {
       // Each processor gets a subset of the instances.
       // Each subset is of size threadShareSize.
-      size_t threadId = omp_get_thread_num();
+      size_t threadId = 0;
+      #ifdef HAS_OPENMP
+        threadId = omp_get_thread_num();
+      #endif
 
       for (size_t j = threadId * threadShareSize;
           j < (threadId + 1) * threadShareSize && j < visitationOrder.n_elem;

--- a/src/mlpack/tests/parallel_sgd_test.cpp
+++ b/src/mlpack/tests/parallel_sgd_test.cpp
@@ -30,6 +30,11 @@ using namespace mlpack::optimization::test;
 
 BOOST_AUTO_TEST_SUITE(ParallelSGDTest);
 
+
+// These tests are only compiled if the user has specified OpenMP to be
+// used.
+#ifdef HAS_OPENMP
+
 /**
  * Test the correctness of the Parallel SGD implementation using a specified
  * sparse test function, with guaranteed disjoint updates between different
@@ -96,6 +101,8 @@ BOOST_AUTO_TEST_CASE(GeneralizedRosenbrockTest)
       BOOST_REQUIRE_CLOSE(coordinates[j], (double) 1.0, 0.01);
   }
 }
+
+#endif
 
 /**
  * Test the correctness of the Exponential backoff stepsize decay policy.

--- a/src/mlpack/tests/regularized_svd_test.cpp
+++ b/src/mlpack/tests/regularized_svd_test.cpp
@@ -251,6 +251,10 @@ BOOST_AUTO_TEST_CASE(RegularizedSVDFunctionOptimize)
   BOOST_REQUIRE_SMALL(relativeError, 1e-2);
 }
 
+// The test is only compiled if the user has specified OpenMP to be
+// used.
+#ifdef HAS_OPENMP
+
 // Test Regularized SVD with parallel SGD.
 BOOST_AUTO_TEST_CASE(RegularizedSVDFunctionOptimizeHOGWILD)
 {
@@ -311,5 +315,7 @@ BOOST_AUTO_TEST_CASE(RegularizedSVDFunctionOptimizeHOGWILD)
   // Relative error should be small.
   BOOST_REQUIRE_SMALL(relativeError, 1e-2);
 }
+
+#endif
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
I was thinking how we could easily prevent such an issue, and I think we could configure travis to build with and without OpenMP support. I think using jenkins to test regular PR's might also be an option.