### PR TITLE
Serialize the network for ANNs

### DIFF
--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -392,7 +392,11 @@ void FFN<OutputLayerType, InitializationRuleType>::Serialize(
 
   // Be sure to clear other layers before loading.
   if (Archive::is_loading::value)
+  {
+    std::for_each(network.begin(), network.end(),
+        boost::apply_visitor(deleteVisitor));
     network.clear();
+  }
 
   ar & BOOST_SERIALIZATION_NVP(network);
 
@@ -412,7 +416,6 @@ void FFN<OutputLayerType, InitializationRuleType>::Serialize(
 
     deterministic = true;
     ResetDeterministic();
-    reset = true;
   }
 }
 

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -134,7 +134,9 @@ void FFN<OutputLayerType, InitializationRuleType>::Forward(
     arma::mat inputs, arma::mat& results)
 {
   if (parameter.is_empty())
+  {
     ResetParameters();
+  }
 
   if (!deterministic)
   {
@@ -387,6 +389,11 @@ void FFN<OutputLayerType, InitializationRuleType>::Serialize(
   ar & data::CreateNVP(height, "height");
   ar & data::CreateNVP(currentInput, "currentInput");
   ar & data::CreateNVP(currentTarget, "currentTarget");
+
+  // Be sure to clear other layers before loading.
+  if (Archive::is_loading::value)
+    network.clear();
+
   ar & BOOST_SERIALIZATION_NVP(network);
 
   // If we are loading, we need to initialize the weights.
@@ -402,6 +409,10 @@ void FFN<OutputLayerType, InitializationRuleType>::Serialize(
 
       boost::apply_visitor(resetVisitor, network[i]);
     }
+
+    deterministic = true;
+    ResetDeterministic();
+    reset = true;
   }
 }
 

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -23,6 +23,8 @@
 #include "visitor/set_input_height_visitor.hpp"
 #include "visitor/set_input_width_visitor.hpp"
 
+#include <boost/serialization/variant.hpp>
+
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
@@ -385,6 +387,7 @@ void FFN<OutputLayerType, InitializationRuleType>::Serialize(
   ar & data::CreateNVP(height, "height");
   ar & data::CreateNVP(currentInput, "currentInput");
   ar & data::CreateNVP(currentTarget, "currentTarget");
+  ar & BOOST_SERIALIZATION_NVP(network);
 
   // If we are loading, we need to initialize the weights.
   if (Archive::is_loading::value)

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -36,7 +36,9 @@ FFN<OutputLayerType, InitializationRuleType>::FFN(
     initializeRule(std::move(initializeRule)),
     width(0),
     height(0),
-    reset(false)
+    reset(false),
+    numFunctions(0),
+    deterministic(true)
 {
   /* Nothing to do here */
 }

--- a/src/mlpack/methods/ann/layer/add.hpp
+++ b/src/mlpack/methods/ann/layer/add.hpp
@@ -39,7 +39,7 @@ class Add
    *
    * @param outSize The number of output units.
    */
-  Add(const size_t outSize);
+  Add(const size_t outSize = 0);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/add.hpp
+++ b/src/mlpack/methods/ann/layer/add.hpp
@@ -106,7 +106,7 @@ class Add
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of output units.

--- a/src/mlpack/methods/ann/layer/add_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_impl.hpp
@@ -60,7 +60,10 @@ template<typename Archive>
 void Add<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  // Nothing to serialize.
+  ar & BOOST_SERIALIZATION_NVP(outSize);
+
+  if (Archive::is_loading::value)
+    weights.set_size(outSize, 1);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/add_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_impl.hpp
@@ -60,7 +60,7 @@ template<typename Archive>
 void Add<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(weights, "weights");
+  // Nothing to serialize.
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/add_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_impl.hpp
@@ -57,7 +57,7 @@ void Add<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Add<InputDataType, OutputDataType>::Serialize(
+void Add<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(weights, "weights");

--- a/src/mlpack/methods/ann/layer/add_merge.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge.hpp
@@ -109,7 +109,7 @@ class AddMerge
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   std::vector<LayerTypes> network;

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -52,7 +52,7 @@ template<typename Archive>
 void AddMerge<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(network, "network");
+  ar & BOOST_SERIALIZATION_NVP(network);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -52,6 +52,9 @@ template<typename Archive>
 void AddMerge<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
+  if (Archive::is_loading::value)
+    network.clear();
+
   ar & BOOST_SERIALIZATION_NVP(network);
 }
 

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -49,7 +49,7 @@ void AddMerge<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void AddMerge<InputDataType, OutputDataType>::Serialize(
+void AddMerge<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(network, "network");

--- a/src/mlpack/methods/ann/layer/base_layer.hpp
+++ b/src/mlpack/methods/ann/layer/base_layer.hpp
@@ -106,7 +106,7 @@ class BaseLayer
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */)
+  void serialize(Archive& /* ar */, const unsigned int /* version */)
   {
     /* Nothing to do here */
   }

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -148,7 +148,7 @@ class Concat
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Parameter which indicates if the modules should be exposed.

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -51,6 +51,11 @@ class Concat
   Concat(const bool model = true, const bool same = true);
 
   /**
+   * Destroy the layers held by the model.
+   */
+  ~Concat();
+
+  /**
    * Ordinary feed forward pass of a neural network, evaluating the function
    * f(x) by propagating the activity forward through f.
    *

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -30,6 +30,14 @@ Concat<InputDataType, OutputDataType>::Concat(
 }
 
 template<typename InputDataType, typename OutputDataType>
+Concat<InputDataType, OutputDataType>::~Concat()
+{
+  // Clear memory.
+  std::for_each(network.begin(), network.end(),
+      boost::apply_visitor(deleteVisitor));
+}
+
+template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Concat<InputDataType, OutputDataType>::Forward(
     arma::Mat<eT>&& input, arma::Mat<eT>&& output)
@@ -151,9 +159,23 @@ void Concat<InputDataType, OutputDataType>::Gradient(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void Concat<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */, const unsigned int /* version */)
+    Archive& ar, const unsigned int /* version */)
 {
-  // Nothing to do here.
+  ar & BOOST_SERIALIZATION_NVP(model);
+  ar & BOOST_SERIALIZATION_NVP(same);
+
+  // Do we have to load or save a model?
+  if (model)
+  {
+    // Clear memory first, if needed.
+    if (Archive::is_loading::value)
+    {
+      std::for_each(network.begin(), network.end(),
+          boost::apply_visitor(deleteVisitor));
+    }
+
+    ar & BOOST_SERIALIZATION_NVP(network);
+  }
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -150,7 +150,7 @@ void Concat<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Concat<InputDataType, OutputDataType>::Serialize(
+void Concat<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */, const unsigned int /* version */)
 {
   // Nothing to do here.

--- a/src/mlpack/methods/ann/layer/concat_performance.hpp
+++ b/src/mlpack/methods/ann/layer/concat_performance.hpp
@@ -91,7 +91,7 @@ class ConcatPerformance
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of inputs.

--- a/src/mlpack/methods/ann/layer/concat_performance.hpp
+++ b/src/mlpack/methods/ann/layer/concat_performance.hpp
@@ -45,7 +45,7 @@ class ConcatPerformance
    * @param inSize The number of inputs.
    * @param outputLayer Output layer used to evaluate the network.
    */
-  ConcatPerformance(const size_t inSize,
+  ConcatPerformance(const size_t inSize = 0,
                     OutputLayerType&& outputLayer = OutputLayerType());
 
   /*

--- a/src/mlpack/methods/ann/layer/concat_performance_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_performance_impl.hpp
@@ -104,7 +104,7 @@ void ConcatPerformance<
     OutputLayerType,
     InputDataType,
     OutputDataType
->::Serialize(Archive& /* ar */, const unsigned int /* version */)
+>::serialize(Archive& /* ar */, const unsigned int /* version */)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/constant.hpp
+++ b/src/mlpack/methods/ann/layer/constant.hpp
@@ -41,7 +41,7 @@ class Constant
    * @param outSize The number of output units.
    * @param scalar The constant value used to create the constant output.
    */
-  Constant(const size_t outSize, const double scalar);
+  Constant(const size_t outSize = 0, const double scalar = 0.0);
 
   /**
    * Ordinary feed forward pass of a neural network. The forward pass fills the

--- a/src/mlpack/methods/ann/layer/constant.hpp
+++ b/src/mlpack/methods/ann/layer/constant.hpp
@@ -85,7 +85,7 @@ class Constant
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input units.

--- a/src/mlpack/methods/ann/layer/constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/constant_impl.hpp
@@ -53,7 +53,7 @@ void Constant<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Constant<InputDataType, OutputDataType>::Serialize(
+void Constant<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(constantOutput, "constantOutput");

--- a/src/mlpack/methods/ann/layer/constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/constant_impl.hpp
@@ -56,7 +56,7 @@ template<typename Archive>
 void Constant<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(constantOutput, "constantOutput");
+  ar & BOOST_SERIALIZATION_NVP(constantOutput);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -165,7 +165,7 @@ class Convolution
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /*

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -320,6 +320,9 @@ void Convolution<
   ar & BOOST_SERIALIZATION_NVP(inputHeight);
   ar & BOOST_SERIALIZATION_NVP(outputWidth);
   ar & BOOST_SERIALIZATION_NVP(outputHeight);
+
+  if (Archive::is_loading::value)
+    weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -316,7 +316,6 @@ void Convolution<
   ar & data::CreateNVP(dH, "dH");
   ar & data::CreateNVP(padW, "padW");
   ar & data::CreateNVP(padH, "padH");
-  ar & data::CreateNVP(weights, "weights");
   ar & data::CreateNVP(inputWidth, "inputWidth");
   ar & data::CreateNVP(inputHeight, "inputHeight");
   ar & data::CreateNVP(outputWidth, "outputWidth");

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -308,18 +308,18 @@ void Convolution<
 >::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(outSize, "outSize");
-  ar & data::CreateNVP(kW, "kW");
-  ar & data::CreateNVP(kH, "kH");
-  ar & data::CreateNVP(dW, "dW");
-  ar & data::CreateNVP(dH, "dH");
-  ar & data::CreateNVP(padW, "padW");
-  ar & data::CreateNVP(padH, "padH");
-  ar & data::CreateNVP(inputWidth, "inputWidth");
-  ar & data::CreateNVP(inputHeight, "inputHeight");
-  ar & data::CreateNVP(outputWidth, "outputWidth");
-  ar & data::CreateNVP(outputHeight, "outputHeight");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
+  ar & BOOST_SERIALIZATION_NVP(kW);
+  ar & BOOST_SERIALIZATION_NVP(kH);
+  ar & BOOST_SERIALIZATION_NVP(dW);
+  ar & BOOST_SERIALIZATION_NVP(dH);
+  ar & BOOST_SERIALIZATION_NVP(padW);
+  ar & BOOST_SERIALIZATION_NVP(padH);
+  ar & BOOST_SERIALIZATION_NVP(inputWidth);
+  ar & BOOST_SERIALIZATION_NVP(inputHeight);
+  ar & BOOST_SERIALIZATION_NVP(outputWidth);
+  ar & BOOST_SERIALIZATION_NVP(outputHeight);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -305,7 +305,7 @@ void Convolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->::Serialize(
+>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(inSize, "inSize");

--- a/src/mlpack/methods/ann/layer/cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/layer/cross_entropy_error.hpp
@@ -86,7 +86,7 @@ class CrossEntropyError
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/layer/cross_entropy_error_impl.hpp
@@ -46,7 +46,7 @@ void CrossEntropyError<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void CrossEntropyError<InputDataType, OutputDataType>::Serialize(
+void CrossEntropyError<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/layer/cross_entropy_error_impl.hpp
@@ -50,7 +50,7 @@ void CrossEntropyError<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(eps, "eps");
+  ar & BOOST_SERIALIZATION_NVP(eps);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/dropconnect.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect.hpp
@@ -160,7 +160,7 @@ class DropConnect
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! The probability of setting a value to zero.

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -115,8 +115,8 @@ void DropConnect<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(ratio, "ratio");
-  ar & data::CreateNVP(scale, "scale");
+  ar & BOOST_SERIALIZATION_NVP(ratio);
+  ar & BOOST_SERIALIZATION_NVP(scale);
 }
 
 }  // namespace ann

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -115,9 +115,21 @@ void DropConnect<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
+  // Delete the old network first, if needed.
+  if (Archive::is_loading::value)
+  {
+    boost::apply_visitor(DeleteVisitor(), baseLayer);
+  }
+
   ar & BOOST_SERIALIZATION_NVP(ratio);
   ar & BOOST_SERIALIZATION_NVP(scale);
-  ar & BOOST_SERIALIZATION_NVP(network);
+  ar & BOOST_SERIALIZATION_NVP(baseLayer);
+
+  if (Archive::is_loading::value)
+  {
+    network.clear();
+    network.push_back(baseLayer);
+  }
 }
 
 }  // namespace ann

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -117,6 +117,7 @@ void DropConnect<InputDataType, OutputDataType>::serialize(
 {
   ar & BOOST_SERIALIZATION_NVP(ratio);
   ar & BOOST_SERIALIZATION_NVP(scale);
+  ar & BOOST_SERIALIZATION_NVP(network);
 }
 
 }  // namespace ann

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -28,7 +28,10 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-DropConnect<InputDataType, OutputDataType>::DropConnect()
+DropConnect<InputDataType, OutputDataType>::DropConnect() :
+    ratio(0.5),
+    scale(2.0),
+    deterministic(true)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -111,7 +111,7 @@ void DropConnect<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void DropConnect<InputDataType, OutputDataType>::Serialize(
+void DropConnect<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -123,7 +123,7 @@ class Dropout
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -74,8 +74,8 @@ void Dropout<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(ratio, "ratio");
-  ar & data::CreateNVP(rescale, "rescale");
+  ar & BOOST_SERIALIZATION_NVP(ratio);
+  ar & BOOST_SERIALIZATION_NVP(rescale);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -24,6 +24,7 @@ Dropout<InputDataType, OutputDataType>::Dropout(
     const double ratio, const bool rescale) :
     ratio(ratio),
     scale(1.0 / (1.0 - ratio)),
+    deterministic(true),
     rescale(rescale)
 {
   // Nothing to do here.

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -76,6 +76,9 @@ void Dropout<InputDataType, OutputDataType>::serialize(
 {
   ar & BOOST_SERIALIZATION_NVP(ratio);
   ar & BOOST_SERIALIZATION_NVP(rescale);
+
+  // Reset scale.
+  scale = 1.0 / (1.0 - ratio);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -70,7 +70,7 @@ void Dropout<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Dropout<InputDataType, OutputDataType>::Serialize(
+void Dropout<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/elu.hpp
+++ b/src/mlpack/methods/ann/layer/elu.hpp
@@ -116,7 +116,7 @@ class ELU
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /**

--- a/src/mlpack/methods/ann/layer/elu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/elu_impl.hpp
@@ -50,7 +50,7 @@ void ELU<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(alpha, "alpha");
+  ar & BOOST_SERIALIZATION_NVP(alpha);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/elu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/elu_impl.hpp
@@ -46,7 +46,7 @@ void ELU<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void ELU<InputDataType, OutputDataType>::Serialize(
+void ELU<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/glimpse.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse.hpp
@@ -94,8 +94,8 @@ class Glimpse
    * @param inputWidth The input width of the given input data.
    * @param inputHeight The input height of the given input data.
    */
-  Glimpse(const size_t inSize,
-          const size_t size,
+  Glimpse(const size_t inSize = 0,
+          const size_t size = 0,
           const size_t depth = 3,
           const size_t scale = 2,
           const size_t inputWidth = 0,

--- a/src/mlpack/methods/ann/layer/glimpse.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse.hpp
@@ -173,7 +173,7 @@ class Glimpse
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /*

--- a/src/mlpack/methods/ann/layer/glimpse_impl.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse_impl.hpp
@@ -28,7 +28,11 @@ Glimpse<InputDataType, OutputDataType>::Glimpse(
     depth(depth),
     scale(scale),
     inputWidth(inputWidth),
-    inputHeight(inputHeight)
+    inputHeight(inputHeight),
+    outputWidth(size),
+    outputHeight(size),
+    inputDepth(0),
+    deterministic(true)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/glimpse_impl.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse_impl.hpp
@@ -207,7 +207,7 @@ void Glimpse<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Glimpse<InputDataType, OutputDataType>::Serialize(
+void Glimpse<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(inSize, "inSize");

--- a/src/mlpack/methods/ann/layer/glimpse_impl.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse_impl.hpp
@@ -210,12 +210,12 @@ template<typename Archive>
 void Glimpse<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(size, "size");
-  ar & data::CreateNVP(depth, "depth");
-  ar & data::CreateNVP(scale, "scale");
-  ar & data::CreateNVP(inputWidth, "inputWidth");
-  ar & data::CreateNVP(location, "location");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(size);
+  ar & BOOST_SERIALIZATION_NVP(depth);
+  ar & BOOST_SERIALIZATION_NVP(scale);
+  ar & BOOST_SERIALIZATION_NVP(inputWidth);
+  ar & BOOST_SERIALIZATION_NVP(location);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/gru.hpp
+++ b/src/mlpack/methods/ann/layer/gru.hpp
@@ -67,8 +67,14 @@ class GRU
    * @param outSize The number of output units.
    * @param rho Maximum number of steps to backpropagate through time (BPTT).
    */
-  GRU(const size_t inSize, const size_t outSize, const size_t rho =
-      std::numeric_limits<size_t>::max());
+  GRU(const size_t inSize,
+      const size_t outSize,
+      const size_t rho = std::numeric_limits<size_t>::max());
+
+  /**
+   * Delete the GRU and the layers it holds.
+   */
+  ~GRU();
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -195,6 +201,9 @@ class GRU
 
   //! Locally-stored delta visitor.
   DeltaVisitor deltaVisitor;
+
+  //! Locally-stored delete visitor.
+  DeleteVisitor deleteVisitor;
 
   //! Locally-stored list of network modules.
   std::vector<LayerTypes> network;

--- a/src/mlpack/methods/ann/layer/gru.hpp
+++ b/src/mlpack/methods/ann/layer/gru.hpp
@@ -154,7 +154,7 @@ class GRU
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input units.

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -330,9 +330,9 @@ template<typename Archive>
 void GRU<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(outSize, "outSize");
-  ar & data::CreateNVP(rho, "rho");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
+  ar & BOOST_SERIALIZATION_NVP(rho);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -77,6 +77,17 @@ GRU<InputDataType, OutputDataType>::GRU(
 }
 
 template<typename InputDataType, typename OutputDataType>
+GRU<InputDataType, OutputDataType>::~GRU()
+{
+  boost::apply_visitor(deleteVisitor, input2GateModule);
+  boost::apply_visitor(deleteVisitor, output2GateModule);
+  boost::apply_visitor(deleteVisitor, outputHidden2GateModule);
+  boost::apply_visitor(deleteVisitor, inputGateModule);
+  boost::apply_visitor(deleteVisitor, forgetGateModule);
+  boost::apply_visitor(deleteVisitor, hiddenStateModule);
+}
+
+template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void GRU<InputDataType, OutputDataType>::Forward(
     arma::Mat<eT>&& input, arma::Mat<eT>&& output)
@@ -330,9 +341,27 @@ template<typename Archive>
 void GRU<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
+  // If necessary, clean memory from the old model.
+  if (Archive::is_loading::value)
+  {
+    boost::apply_visitor(deleteVisitor, input2GateModule);
+    boost::apply_visitor(deleteVisitor, output2GateModule);
+    boost::apply_visitor(deleteVisitor, outputHidden2GateModule);
+    boost::apply_visitor(deleteVisitor, inputGateModule);
+    boost::apply_visitor(deleteVisitor, forgetGateModule);
+    boost::apply_visitor(deleteVisitor, hiddenStateModule);
+  }
+
   ar & BOOST_SERIALIZATION_NVP(inSize);
   ar & BOOST_SERIALIZATION_NVP(outSize);
   ar & BOOST_SERIALIZATION_NVP(rho);
+
+  ar & BOOST_SERIALIZATION_NVP(input2GateModule);
+  ar & BOOST_SERIALIZATION_NVP(output2GateModule);
+  ar & BOOST_SERIALIZATION_NVP(outputHidden2GateModule);
+  ar & BOOST_SERIALIZATION_NVP(inputGateModule);
+  ar & BOOST_SERIALIZATION_NVP(forgetGateModule);
+  ar & BOOST_SERIALIZATION_NVP(hiddenStateModule);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -327,7 +327,7 @@ void GRU<InputDataType, OutputDataType>::ResetCell()
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void GRU<InputDataType, OutputDataType>::Serialize(
+void GRU<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(weights, "weights");

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -330,7 +330,6 @@ template<typename Archive>
 void GRU<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(weights, "weights");
   ar & data::CreateNVP(inSize, "inSize");
   ar & data::CreateNVP(outSize, "outSize");
   ar & data::CreateNVP(rho, "rho");

--- a/src/mlpack/methods/ann/layer/hard_tanh.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh.hpp
@@ -112,7 +112,7 @@ class HardTanH
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/hard_tanh_impl.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh_impl.hpp
@@ -58,7 +58,7 @@ void HardTanH<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void HardTanH<InputDataType, OutputDataType>::Serialize(
+void HardTanH<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/hard_tanh_impl.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh_impl.hpp
@@ -62,8 +62,8 @@ void HardTanH<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(maxValue, "maxValue");
-  ar & data::CreateNVP(minValue, "minValue");
+  ar & BOOST_SERIALIZATION_NVP(maxValue);
+  ar & BOOST_SERIALIZATION_NVP(minValue);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/join.hpp
+++ b/src/mlpack/methods/ann/layer/join.hpp
@@ -79,7 +79,7 @@ class Join
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input rows.

--- a/src/mlpack/methods/ann/layer/join_impl.hpp
+++ b/src/mlpack/methods/ann/layer/join_impl.hpp
@@ -50,8 +50,8 @@ void Join<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSizeRows, "inSizeRows");
-  ar & data::CreateNVP(inSizeCols, "inSizeCols");
+  ar & BOOST_SERIALIZATION_NVP(inSizeRows);
+  ar & BOOST_SERIALIZATION_NVP(inSizeCols);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/join_impl.hpp
+++ b/src/mlpack/methods/ann/layer/join_impl.hpp
@@ -19,7 +19,9 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-Join<InputDataType, OutputDataType>::Join()
+Join<InputDataType, OutputDataType>::Join() :
+    inSizeRows(0),
+    inSizeCols(0)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/join_impl.hpp
+++ b/src/mlpack/methods/ann/layer/join_impl.hpp
@@ -46,7 +46,7 @@ void Join<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Join<InputDataType, OutputDataType>::Serialize(
+void Join<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/leaky_relu.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu.hpp
@@ -99,7 +99,7 @@ class LeakyReLU
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /**

--- a/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
@@ -47,7 +47,7 @@ void LeakyReLU<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void LeakyReLU<InputDataType, OutputDataType>::Serialize(
+void LeakyReLU<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
@@ -51,7 +51,7 @@ void LeakyReLU<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(alpha, "alpha");
+  ar & BOOST_SERIALIZATION_NVP(alpha);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/linear.hpp
+++ b/src/mlpack/methods/ann/layer/linear.hpp
@@ -117,7 +117,7 @@ class Linear
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input units.

--- a/src/mlpack/methods/ann/layer/linear_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_impl.hpp
@@ -80,6 +80,11 @@ void Linear<InputDataType, OutputDataType>::serialize(
 {
   ar & BOOST_SERIALIZATION_NVP(inSize);
   ar & BOOST_SERIALIZATION_NVP(outSize);
+
+  // This is inefficient, but we have to allocate this memory so that
+  // WeightSetVisitor gets the right size.
+  if (Archive::is_loading::value)
+    weights.set_size(outSize * inSize + outSize, 1);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/linear_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_impl.hpp
@@ -78,8 +78,8 @@ template<typename Archive>
 void Linear<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(outSize, "outSize");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/linear_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_impl.hpp
@@ -75,7 +75,7 @@ void Linear<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Linear<InputDataType, OutputDataType>::Serialize(
+void Linear<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(weights, "weights");

--- a/src/mlpack/methods/ann/layer/linear_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_impl.hpp
@@ -78,7 +78,6 @@ template<typename Archive>
 void Linear<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(weights, "weights");
   ar & data::CreateNVP(inSize, "inSize");
   ar & data::CreateNVP(outSize, "outSize");
 }

--- a/src/mlpack/methods/ann/layer/linear_no_bias.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias.hpp
@@ -116,7 +116,7 @@ class LinearNoBias
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input units.

--- a/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
@@ -74,6 +74,11 @@ void LinearNoBias<InputDataType, OutputDataType>::serialize(
 {
   ar & BOOST_SERIALIZATION_NVP(inSize);
   ar & BOOST_SERIALIZATION_NVP(outSize);
+
+  // This is inefficient, but necessary so that WeightSetVisitor sets the right
+  // size.
+  if (Archive::is_loading::value)
+    weights.set_size(outSize * inSize, 1);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
@@ -72,7 +72,6 @@ template<typename Archive>
 void LinearNoBias<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(weights, "weights");
   ar & data::CreateNVP(inSize, "inSize");
   ar & data::CreateNVP(outSize, "outSize");
 }

--- a/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
@@ -69,7 +69,7 @@ void LinearNoBias<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void LinearNoBias<InputDataType, OutputDataType>::Serialize(
+void LinearNoBias<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(weights, "weights");

--- a/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
@@ -72,8 +72,8 @@ template<typename Archive>
 void LinearNoBias<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(outSize, "outSize");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/log_softmax.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax.hpp
@@ -84,7 +84,7 @@ class LogSoftMax
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
@@ -73,7 +73,7 @@ void LogSoftMax<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void LogSoftMax<InputDataType, OutputDataType>::Serialize(
+void LogSoftMax<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/lookup.hpp
+++ b/src/mlpack/methods/ann/layer/lookup.hpp
@@ -109,7 +109,7 @@ class Lookup
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input units.

--- a/src/mlpack/methods/ann/layer/lookup.hpp
+++ b/src/mlpack/methods/ann/layer/lookup.hpp
@@ -42,7 +42,7 @@ class Lookup
    * @param inSize The number of input units.
    * @param outSize The number of output units.
    */
-  Lookup(const size_t inSize, const size_t outSize);
+  Lookup(const size_t inSize = 0, const size_t outSize = 0);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/lookup_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lookup_impl.hpp
@@ -63,8 +63,8 @@ template<typename Archive>
 void Lookup<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(outSize, "outSize");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/lookup_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lookup_impl.hpp
@@ -63,7 +63,6 @@ template<typename Archive>
 void Lookup<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(weights, "weights");
   ar & data::CreateNVP(inSize, "inSize");
   ar & data::CreateNVP(outSize, "outSize");
 }

--- a/src/mlpack/methods/ann/layer/lookup_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lookup_impl.hpp
@@ -60,7 +60,7 @@ void Lookup<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Lookup<InputDataType, OutputDataType>::Serialize(
+void Lookup<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(weights, "weights");

--- a/src/mlpack/methods/ann/layer/lstm.hpp
+++ b/src/mlpack/methods/ann/layer/lstm.hpp
@@ -56,8 +56,14 @@ class LSTM
    * @param outSize The number of output units.
    * @param rho Maximum number of steps to backpropagate through time (BPTT).
    */
-  LSTM(const size_t inSize, const size_t outSize, const size_t rho =
-      std::numeric_limits<size_t>::max());
+  LSTM(const size_t inSize,
+       const size_t outSize,
+       const size_t rho = std::numeric_limits<size_t>::max());
+
+  /**
+   * Delete the LSTM and the layers it holds.
+   */
+  ~LSTM();
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/lstm.hpp
+++ b/src/mlpack/methods/ann/layer/lstm.hpp
@@ -143,7 +143,7 @@ class LSTM
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored number of input units.

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -338,9 +338,9 @@ template<typename Archive>
 void LSTM<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(inSize, "inSize");
-  ar & data::CreateNVP(outSize, "outSize");
-  ar & data::CreateNVP(rho, "rho");
+  ar & BOOST_SERIALIZATION_NVP(inSize);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
+  ar & BOOST_SERIALIZATION_NVP(rho);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -335,7 +335,7 @@ void LSTM<InputDataType, OutputDataType>::ResetCell()
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void LSTM<InputDataType, OutputDataType>::Serialize(
+void LSTM<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(weights, "weights");

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -83,6 +83,19 @@ LSTM<InputDataType, OutputDataType>::LSTM(
 }
 
 template<typename InputDataType, typename OutputDataType>
+LSTM<InputDataType, OutputDataType>::~LSTM()
+{
+  boost::apply_visitor(DeleteVisitor(), input2GateModule);
+  boost::apply_visitor(DeleteVisitor(), output2GateModule);
+  boost::apply_visitor(DeleteVisitor(), inputGateModule);
+  boost::apply_visitor(DeleteVisitor(), hiddenStateModule);
+  boost::apply_visitor(DeleteVisitor(), forgetGateModule);
+  boost::apply_visitor(DeleteVisitor(), outputGateModule);
+  boost::apply_visitor(DeleteVisitor(), cellModule);
+  boost::apply_visitor(DeleteVisitor(), cellActivationModule);
+}
+
+template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void LSTM<InputDataType, OutputDataType>::Forward(
     arma::Mat<eT>&& input, arma::Mat<eT>&& output)
@@ -338,9 +351,31 @@ template<typename Archive>
 void LSTM<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
+  // Clear old layers, if needed.
+  if (Archive::is_loading::value)
+  {
+    boost::apply_visitor(DeleteVisitor(), input2GateModule);
+    boost::apply_visitor(DeleteVisitor(), output2GateModule);
+    boost::apply_visitor(DeleteVisitor(), inputGateModule);
+    boost::apply_visitor(DeleteVisitor(), hiddenStateModule);
+    boost::apply_visitor(DeleteVisitor(), forgetGateModule);
+    boost::apply_visitor(DeleteVisitor(), outputGateModule);
+    boost::apply_visitor(DeleteVisitor(), cellModule);
+    boost::apply_visitor(DeleteVisitor(), cellActivationModule);
+  }
+
   ar & BOOST_SERIALIZATION_NVP(inSize);
   ar & BOOST_SERIALIZATION_NVP(outSize);
   ar & BOOST_SERIALIZATION_NVP(rho);
+
+  ar & BOOST_SERIALIZATION_NVP(input2GateModule);
+  ar & BOOST_SERIALIZATION_NVP(output2GateModule);
+  ar & BOOST_SERIALIZATION_NVP(inputGateModule);
+  ar & BOOST_SERIALIZATION_NVP(hiddenStateModule);
+  ar & BOOST_SERIALIZATION_NVP(forgetGateModule);
+  ar & BOOST_SERIALIZATION_NVP(outputGateModule);
+  ar & BOOST_SERIALIZATION_NVP(cellModule);
+  ar & BOOST_SERIALIZATION_NVP(cellActivationModule);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -338,7 +338,6 @@ template<typename Archive>
 void LSTM<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(weights, "weights");
   ar & data::CreateNVP(inSize, "inSize");
   ar & data::CreateNVP(outSize, "outSize");
   ar & data::CreateNVP(rho, "rho");

--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -138,7 +138,7 @@ class MaxPooling
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
  /**

--- a/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
@@ -133,7 +133,7 @@ void MaxPooling<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void MaxPooling<InputDataType, OutputDataType>::Serialize(
+void MaxPooling<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
@@ -137,10 +137,10 @@ void MaxPooling<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(kW, "kW");
-  ar & data::CreateNVP(kH, "kH");
-  ar & data::CreateNVP(dW, "dW");
-  ar & data::CreateNVP(dH, "dH");
+  ar & BOOST_SERIALIZATION_NVP(kW);
+  ar & BOOST_SERIALIZATION_NVP(kH);
+  ar & BOOST_SERIALIZATION_NVP(dW);
+  ar & BOOST_SERIALIZATION_NVP(dH);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -118,7 +118,7 @@ class MeanPooling
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /**

--- a/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
@@ -111,10 +111,10 @@ void MeanPooling<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(kW, "kW");
-  ar & data::CreateNVP(kH, "kH");
-  ar & data::CreateNVP(dW, "dW");
-  ar & data::CreateNVP(dH, "dH");
+  ar & BOOST_SERIALIZATION_NVP(kW);
+  ar & BOOST_SERIALIZATION_NVP(kH);
+  ar & BOOST_SERIALIZATION_NVP(dW);
+  ar & BOOST_SERIALIZATION_NVP(dH);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
@@ -107,7 +107,7 @@ void MeanPooling<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void MeanPooling<InputDataType, OutputDataType>::Serialize(
+void MeanPooling<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/layer/mean_squared_error.hpp
@@ -78,7 +78,7 @@ class MeanSquaredError
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_squared_error_impl.hpp
@@ -44,7 +44,7 @@ void MeanSquaredError<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void MeanSquaredError<InputDataType, OutputDataType>::Serialize(
+void MeanSquaredError<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/multiply_constant.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant.hpp
@@ -74,7 +74,7 @@ class MultiplyConstant
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored constant scalar value.

--- a/src/mlpack/methods/ann/layer/multiply_constant.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant.hpp
@@ -32,7 +32,7 @@ class MultiplyConstant
   /**
    * Create the MultiplyConstant object.
    */
-  MultiplyConstant(const double scalar);
+  MultiplyConstant(const double scalar = 1.0);
 
   /**
    * Ordinary feed forward pass of a neural network. Multiply the input with the

--- a/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
@@ -42,7 +42,7 @@ template<typename Archive>
 void MultiplyConstant<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(scalar, "scalar");
+  ar & BOOST_SERIALIZATION_NVP(scalar);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
@@ -39,7 +39,7 @@ void MultiplyConstant<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void MultiplyConstant<InputDataType, OutputDataType>::Serialize(
+void MultiplyConstant<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(scalar, "scalar");

--- a/src/mlpack/methods/ann/layer/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/layer/negative_log_likelihood.hpp
@@ -84,7 +84,7 @@ class NegativeLogLikelihood
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/negative_log_likelihood_impl.hpp
+++ b/src/mlpack/methods/ann/layer/negative_log_likelihood_impl.hpp
@@ -63,7 +63,7 @@ void NegativeLogLikelihood<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void NegativeLogLikelihood<InputDataType, OutputDataType>::Serialize(
+void NegativeLogLikelihood<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/parametric_relu.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu.hpp
@@ -53,7 +53,7 @@ class PReLU
    *
    * @param alpha Non zero gradient
    */
-  PReLU(const double user_alpha = 0.03);
+  PReLU(const double userAlpha = 0.03);
 
   /*
    * Reset the layer parameter.
@@ -201,7 +201,7 @@ class PReLU
   OutputDataType gradient;
 
   //! Leakyness Parameter given by user in the range 0 < alpha < 1.
-  double user_alpha;
+  double userAlpha;
 }; // class PReLU
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/parametric_relu.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu.hpp
@@ -128,7 +128,7 @@ class PReLU
    * Serialize the layer.
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /**

--- a/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
@@ -23,17 +23,17 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
 PReLU<InputDataType, OutputDataType>::PReLU(
-    const double user_alpha) : user_alpha(user_alpha)
+    const double userAlpha) : userAlpha(userAlpha)
 {
   alpha.set_size(1, 1);
-  alpha(0) = user_alpha;
+  alpha(0) = userAlpha;
 }
 
 template<typename InputDataType, typename OutputDataType>
 void PReLU<InputDataType, OutputDataType>::Reset()
 {
   //! Set value of alpha to the one given by user.
-  alpha(0) = user_alpha;
+  alpha(0) = userAlpha;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
@@ -71,7 +71,7 @@ void PReLU<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void PReLU<InputDataType, OutputDataType>::Serialize(
+void PReLU<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
@@ -75,7 +75,7 @@ void PReLU<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const unsigned int /* version */)
 {
-  ar & data::CreateNVP(alpha, "alpha");
+  ar & BOOST_SERIALIZATION_NVP(alpha);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/recurrent.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent.hpp
@@ -44,6 +44,12 @@ class Recurrent
 {
  public:
   /**
+   * Default constructor---this will create a Recurrent object that can't be
+   * used, so be careful!  Make sure to set all the parameters before use.
+   */
+  Recurrent();
+
+  /**
    * Create the Recurrent object using the specified modules.
    *
    * @param start The start module.

--- a/src/mlpack/methods/ann/layer/recurrent.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent.hpp
@@ -141,7 +141,7 @@ class Recurrent
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored start module.

--- a/src/mlpack/methods/ann/layer/recurrent_attention.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention.hpp
@@ -148,7 +148,7 @@ class RecurrentAttention
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Calculate the gradient of the attention module.

--- a/src/mlpack/methods/ann/layer/recurrent_attention.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention.hpp
@@ -201,17 +201,8 @@ class RecurrentAttention
   //! Locally-stored weight object.
   OutputDataType parameters;
 
-  //! Locally-stored initial module.
-  LayerTypes initialModule;
-
-  //! Locally-stored recurrent module.
-  LayerTypes recurrentModule;
-
   //! Locally-stored model modules.
   std::vector<LayerTypes> network;
-
-  //! Locally-stored merge module.
-  LayerTypes mergeModule;
 
   //! Locally-stored weight size visitor.
   WeightSizeVisitor weightSizeVisitor;

--- a/src/mlpack/methods/ann/layer/recurrent_attention.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention.hpp
@@ -56,6 +56,12 @@ class RecurrentAttention
 {
  public:
   /**
+   * Default constructor: this will not give a usable RecurrentAttention object,
+   * so be sure to set all the parameters before use.
+   */
+  RecurrentAttention();
+
+  /**
    * Create the RecurrentAttention object using the specified modules.
    *
    * @param start The module output size.

--- a/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
@@ -214,6 +214,9 @@ void RecurrentAttention<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(outSize);
   ar & BOOST_SERIALIZATION_NVP(forwardStep);
   ar & BOOST_SERIALIZATION_NVP(backwardStep);
+
+  ar & BOOST_SERIALIZATION_NVP(rnnModule);
+  ar & BOOST_SERIALIZATION_NVP(actionModule);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
@@ -26,6 +26,16 @@
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
+template<typename InputDataType, typename OutputDataType>
+RecurrentAttention<InputDataType, OutputDataType>::RecurrentAttention() :
+    rho(0),
+    forwardStep(0),
+    backwardStep(0),
+    deterministic(false)
+{
+  // Nothing to do.
+}
+
 template <typename InputDataType, typename OutputDataType>
 template<typename RNNModuleType, typename ActionModuleType>
 RecurrentAttention<InputDataType, OutputDataType>::RecurrentAttention(

--- a/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
@@ -210,10 +210,10 @@ template<typename Archive>
 void RecurrentAttention<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(rho, "rho");
-  ar & data::CreateNVP(outSize, "outSize");
-  ar & data::CreateNVP(forwardStep, "forwardStep");
-  ar & data::CreateNVP(backwardStep, "backwardStep");
+  ar & BOOST_SERIALIZATION_NVP(rho);
+  ar & BOOST_SERIALIZATION_NVP(outSize);
+  ar & BOOST_SERIALIZATION_NVP(forwardStep);
+  ar & BOOST_SERIALIZATION_NVP(backwardStep);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
@@ -207,7 +207,7 @@ void RecurrentAttention<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void RecurrentAttention<InputDataType, OutputDataType>::Serialize(
+void RecurrentAttention<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(rho, "rho");

--- a/src/mlpack/methods/ann/layer/recurrent_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_impl.hpp
@@ -210,7 +210,7 @@ void Recurrent<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Recurrent<InputDataType, OutputDataType>::Serialize(
+void Recurrent<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(rho, "rho");

--- a/src/mlpack/methods/ann/layer/recurrent_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_impl.hpp
@@ -24,6 +24,17 @@
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
+template<typename InputDataType, typename OutputDataType>
+Recurrent<InputDataType, OutputDataType>::Recurrent() :
+    rho(0),
+    forwardStep(0),
+    backwardStep(0),
+    gradientStep(0),
+    deterministic(false)
+{
+  // Nothing to do.
+}
+
 template <typename InputDataType, typename OutputDataType>
 template<
     typename StartModuleType,

--- a/src/mlpack/methods/ann/layer/recurrent_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_impl.hpp
@@ -213,7 +213,11 @@ template<typename Archive>
 void Recurrent<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(rho, "rho");
+  ar & BOOST_SERIALIZATION_NVP(startModule);
+  ar & BOOST_SERIALIZATION_NVP(inputModule);
+  ar & BOOST_SERIALIZATION_NVP(feedbackModule);
+  ar & BOOST_SERIALIZATION_NVP(transferModule);
+  ar & BOOST_SERIALIZATION_NVP(rho);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/reinforce_normal.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal.hpp
@@ -34,7 +34,7 @@ class ReinforceNormal
    *
    * @param stdev Standard deviation used during the forward and backward pass.
    */
-  ReinforceNormal(const double stdev);
+  ReinforceNormal(const double stdev = 1.0);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/reinforce_normal.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal.hpp
@@ -87,7 +87,7 @@ class ReinforceNormal
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Standard deviation used during the forward and backward pass.

--- a/src/mlpack/methods/ann/layer/reinforce_normal_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal_impl.hpp
@@ -57,7 +57,7 @@ void ReinforceNormal<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void ReinforceNormal<InputDataType, OutputDataType>::Serialize(
+void ReinforceNormal<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */, const unsigned int /* version */)
 {
   // Nothing to do here.

--- a/src/mlpack/methods/ann/layer/select.hpp
+++ b/src/mlpack/methods/ann/layer/select.hpp
@@ -38,7 +38,7 @@ class Select
    * @param index The column which should be extracted from the given input.
    * @param elements The number of elements that should be used.
    */
-  Select(const size_t index, const size_t elements = 0);
+  Select(const size_t index = 0, const size_t elements = 0);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/select.hpp
+++ b/src/mlpack/methods/ann/layer/select.hpp
@@ -83,7 +83,7 @@ class Select
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& ar, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Locally-stored column index.

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -65,8 +65,8 @@ template<typename Archive>
 void Select<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar & data::CreateNVP(index, "index");
-  ar & data::CreateNVP(elements, "elements");
+  ar & BOOST_SERIALIZATION_NVP(index);
+  ar & BOOST_SERIALIZATION_NVP(elements);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -62,7 +62,7 @@ void Select<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Select<InputDataType, OutputDataType>::Serialize(
+void Select<InputDataType, OutputDataType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & data::CreateNVP(index, "index");

--- a/src/mlpack/methods/ann/layer/sequential.hpp
+++ b/src/mlpack/methods/ann/layer/sequential.hpp
@@ -146,7 +146,7 @@ class Sequential
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Parameter which indicates if the modules should be exposed.

--- a/src/mlpack/methods/ann/layer/sequential_impl.hpp
+++ b/src/mlpack/methods/ann/layer/sequential_impl.hpp
@@ -149,9 +149,17 @@ void Sequential<InputDataType, OutputDataType>::Gradient(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void Sequential<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */, const unsigned int /* version */)
+    Archive& ar, const unsigned int /* version */)
 {
-  // Nothing to do here.
+  // If loading, delete the old layers.
+  if (Archive::is_loading::value)
+  {
+    for (LayerTypes& layer : network)
+      boost::apply_visitor(deleteVisitor, layer);
+  }
+
+  ar & BOOST_SERIALIZATION_NVP(model);
+  ar & BOOST_SERIALIZATION_NVP(network);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/sequential_impl.hpp
+++ b/src/mlpack/methods/ann/layer/sequential_impl.hpp
@@ -148,7 +148,7 @@ void Sequential<InputDataType, OutputDataType>::Gradient(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void Sequential<InputDataType, OutputDataType>::Serialize(
+void Sequential<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */, const unsigned int /* version */)
 {
   // Nothing to do here.

--- a/src/mlpack/methods/ann/layer/vr_class_reward.hpp
+++ b/src/mlpack/methods/ann/layer/vr_class_reward.hpp
@@ -107,7 +107,7 @@ class VRClassReward
    * Serialize the layer
    */
   template<typename Archive>
-  void Serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
   //! Locally-stored value to scale the reward.

--- a/src/mlpack/methods/ann/layer/vr_class_reward_impl.hpp
+++ b/src/mlpack/methods/ann/layer/vr_class_reward_impl.hpp
@@ -90,7 +90,7 @@ void VRClassReward<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void VRClassReward<InputDataType, OutputDataType>::Serialize(
+void VRClassReward<InputDataType, OutputDataType>::serialize(
     Archive& /* ar */,
     const unsigned int /* version */)
 {

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -25,9 +25,10 @@
 #include "visitor/gradient_visitor.hpp"
 #include "visitor/weight_set_visitor.hpp"
 
+#include <boost/serialization/variant.hpp>
+
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
-
 
 template<typename OutputLayerType, typename InitializationRuleType>
 RNN<OutputLayerType, InitializationRuleType>::RNN(
@@ -418,6 +419,14 @@ void RNN<OutputLayerType, InitializationRuleType>::Serialize(
   ar & data::CreateNVP(outputSize, "outputSize");
   ar & data::CreateNVP(targetSize, "targetSize");
   ar & data::CreateNVP(currentInput, "currentInput");
+
+  if (Archive::is_loading::value)
+  {
+    std::for_each(network.begin(), network.end(),
+        boost::apply_visitor(deleteVisitor));
+    network.clear();
+  }
+
   ar & BOOST_SERIALIZATION_NVP(network);
 
   // If we are loading, we need to initialize the weights.
@@ -433,6 +442,9 @@ void RNN<OutputLayerType, InitializationRuleType>::Serialize(
 
       boost::apply_visitor(resetVisitor, layer);
     }
+
+    deterministic = true;
+    ResetDeterministic();
   }
 }
 

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -418,6 +418,7 @@ void RNN<OutputLayerType, InitializationRuleType>::Serialize(
   ar & data::CreateNVP(outputSize, "outputSize");
   ar & data::CreateNVP(targetSize, "targetSize");
   ar & data::CreateNVP(currentInput, "currentInput");
+  ar & BOOST_SERIALIZATION_NVP(network);
 
   // If we are loading, we need to initialize the weights.
   if (Archive::is_loading::value)

--- a/src/mlpack/tests/recurrent_network_test.cpp
+++ b/src/mlpack/tests/recurrent_network_test.cpp
@@ -551,7 +551,6 @@ BOOST_AUTO_TEST_CASE(LSTMRecursiveReberGrammarTest)
  */
 BOOST_AUTO_TEST_CASE(GRUReberGrammarTest)
 {
-  math::RandomSeed(std::time(NULL));
   ReberGrammarTestNetwork<GRU<>>(4, false);
 }
 

--- a/src/mlpack/tests/recurrent_network_test.cpp
+++ b/src/mlpack/tests/recurrent_network_test.cpp
@@ -18,6 +18,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"
+#include "serialization.hpp"
 
 using namespace mlpack;
 using namespace mlpack::ann;
@@ -550,6 +551,7 @@ BOOST_AUTO_TEST_CASE(LSTMRecursiveReberGrammarTest)
  */
 BOOST_AUTO_TEST_CASE(GRUReberGrammarTest)
 {
+  math::RandomSeed(std::time(NULL));
   ReberGrammarTestNetwork<GRU<>>(4, false);
 }
 
@@ -739,6 +741,71 @@ BOOST_AUTO_TEST_CASE(LSTMDistractedSequenceRecallTest)
 BOOST_AUTO_TEST_CASE(GRUDistractedSequenceRecallTest)
 {
   DistractedSequenceRecallTestNetwork<GRU<>>();
+}
+
+/**
+ * Make sure the RNN can be properly serialized.
+ */
+BOOST_AUTO_TEST_CASE(SerializationTest)
+{
+  const size_t rho = 10;
+
+  // Generate 12 (2 * 6) noisy sines. A single sine contains rho
+  // points/features.
+  arma::mat input, labelsTemp;
+  GenerateNoisySines(input, labelsTemp, rho, 6);
+
+  arma::mat labels = arma::zeros<arma::mat>(rho, labelsTemp.n_cols);
+  for (size_t i = 0; i < labelsTemp.n_cols; ++i)
+  {
+    const int value = arma::as_scalar(arma::find(
+        arma::max(labelsTemp.col(i)) == labelsTemp.col(i), 1)) + 1;
+    labels.col(i).fill(value);
+  }
+
+  /**
+   * Construct a network with 1 input unit, 4 hidden units and 10 output
+   * units. The hidden layer is connected to itself. The network structure
+   * looks like:
+   *
+   *  Input         Hidden        Output
+   * Layer(1)      Layer(4)      Layer(10)
+   * +-----+       +-----+       +-----+
+   * |     |       |     |       |     |
+   * |     +------>|     +------>|     |
+   * |     |    ..>|     |       |     |
+   * +-----+    .  +--+--+       +-----+
+   *            .     .
+   *            .     .
+   *            .......
+   */
+  Add<> add(4);
+  Linear<> lookup(1, 4);
+  SigmoidLayer<> sigmoidLayer;
+  Linear<> linear(4, 4);
+  Recurrent<> recurrent(add, lookup, linear, sigmoidLayer, rho);
+
+  RNN<> model(rho);
+  model.Add<IdentityLayer<> >();
+  model.Add(recurrent);
+  model.Add<Linear<> >(4, 10);
+  model.Add<LogSoftMax<> >();
+
+  StandardSGD opt(0.1, input.n_cols /* 1 epoch */, -100);
+  model.Train(input, labels, opt);
+
+  // Serialize the network.
+  RNN<> xmlModel(1), textModel(3), binaryModel(5);
+  SerializeObjectAll(model, xmlModel, textModel, binaryModel);
+
+  // Take predictions, check the output.
+  arma::mat prediction, xmlPrediction, textPrediction, binaryPrediction;
+  model.Predict(input, prediction);
+  xmlModel.Predict(input, xmlPrediction);
+  textModel.Predict(input, textPrediction);
+  binaryModel.Predict(input, binaryPrediction);
+
+  CheckMatrices(prediction, xmlPrediction, textPrediction, binaryPrediction);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This PR refactors the `FFN` and `RNN` classes so that the networks themselves are serialized.  To make this work, I had to give up on the `SerializationShim` and `data::CreateNVP()`.  Honestly, I think it is a good thing to get rid of them... I had fun writing them, but I am not sure the cost in terms of code is worth it just so that we can have a `Serialize()` function instead of a `serialize()` function and follow the style guide.  So we can modify the style guide and make an exception...

(A comment from a friend when I was discussing this... "I'm glad you've finally come to your senses and realized that the shim is stupid" :))

I also added some quick tests for serialization, but they are not comprehensive.  I think more ideally, we should make a simple network that tests each possible layer type and makes sure that it serializes correctly.  There is some amount of trickiness for serializing layers, so I think it would be a worthwhile test.

So I think this PR is fine to merge as-is, but we should open issues if we merge this:

 * Remove the serialization shim: convert `Serialize()` to `serialize()`, and `CreateNVP()` to `BOOST_SERIALIZATION_NVP()` where possible (and `make_nvp()` in other places).
 * Write serialization tests that cover each layer type.

What's nice too is that this serialization strategy allows us to serialize any arbitrary network structure and then load it in another program that knows nothing about the network structure.  I am really happy about that.