### PR TITLE
CodeAi fixes: remove dead code, prevent possible null deref

### DIFF
--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
@@ -94,7 +94,7 @@ CosineTree::CosineTree(const arma::mat& dataset,
   // Initialize Monte Carlo error estimate for comparison.
   double monteCarloError = root.FrobNormSquared();
 
-  while (monteCarloError > epsilon * root.FrobNormSquared())
+  while (treeQueue.top() && (monteCarloError > epsilon * root.FrobNormSquared()))
   {
     // Pop node from queue with highest projection error.
     CosineTree* currentNode;

--- a/src/mlpack/core/util/timers.cpp
+++ b/src/mlpack/core/util/timers.cpp
@@ -111,7 +111,6 @@ void Timers::PrintTimer(const std::string& timerName)
         Log::Info << ", ";
       Log::Info << s.count() << "." << std::setw(1)
           << (totalDurationMicroSec.count() / 100000) << " secs";
-      output = true;
     }
 
     Log::Info << ")";

--- a/src/mlpack/methods/rann/ra_util.cpp
+++ b/src/mlpack/methods/rann/ra_util.cpp
@@ -46,7 +46,6 @@ size_t mlpack::neighbor::RAUtil::MinimumSamplesReqd(const size_t n,
     {
       if (prob - alpha < 0.001 || ub < lb + 2)
       {
-        done = true;
         break;
       }
       else

--- a/src/mlpack/methods/rann/ra_util.cpp
+++ b/src/mlpack/methods/rann/ra_util.cpp
@@ -65,7 +65,6 @@ size_t mlpack::neighbor::RAUtil::MinimumSamplesReqd(const size_t n,
       }
       else
       {
-        done = true;
         break;
       }
     }


### PR DESCRIPTION
CodeAi suggest the removal of 3 lines of dead code in timers.cpp and ra_util.cpp.

CodeAi suggests a condition tightening to prevent possible null dereference in cosine_tree.cpp.