### PR TITLE
Make timers threadsafe by holding one timer for each thread.

### DIFF
--- a/src/mlpack/bindings/cli/end_program.hpp
+++ b/src/mlpack/bindings/cli/end_program.hpp
@@ -21,7 +21,7 @@ namespace cli {
 inline void EndProgram()
 {
   // Stop the CLI timers.
-  CLI::StopTimers();
+  CLI::GetSingleton().timer.StopAllTimers();
 
   // Print any output.
   const std::map<std::string, util::ParamData>& parameters = CLI::Parameters();
@@ -61,12 +61,10 @@ inline void EndProgram()
     }
 
     Log::Info << "Program timers:" << std::endl;
-    std::list<std::string> timerNames =
-        CLI::GetSingleton().timer.GetAllTimerNames();
-    for (auto it2 : timerNames)
+    for (auto it2 : CLI::GetSingleton().timer.GetAllTimers())
     {
-      Log::Info << "  " << it2 << ": ";
-      CLI::GetSingleton().timer.PrintTimer(it2);
+      Log::Info << "  " << it2.first << ": ";
+      CLI::GetSingleton().timer.PrintTimer(it2.first);
     }
   }
 }

--- a/src/mlpack/bindings/cli/end_program.hpp
+++ b/src/mlpack/bindings/cli/end_program.hpp
@@ -61,13 +61,12 @@ inline void EndProgram()
     }
 
     Log::Info << "Program timers:" << std::endl;
-    std::map<std::string, std::chrono::microseconds>::iterator it2;
-    for (it2 = CLI::GetSingleton().timer.GetAllTimers().begin();
-         it2 != CLI::GetSingleton().timer.GetAllTimers().end(); ++it2)
+    std::list<std::string> timerNames =
+        CLI::GetSingleton().timer.GetAllTimerNames();
+    for (auto it2 : timerNames)
     {
-      std::string i = (*it2).first;
-      Log::Info << "  " << i << ": ";
-      CLI::GetSingleton().timer.PrintTimer((*it2).first);
+      Log::Info << "  " << it2 << ": ";
+      CLI::GetSingleton().timer.PrintTimer(it2);
     }
   }
 }

--- a/src/mlpack/bindings/python/mlpack/cli.pxd
+++ b/src/mlpack/bindings/python/mlpack/cli.pxd
@@ -43,6 +43,7 @@ cdef extern from "<mlpack/bindings/python/mlpack/cli_util.hpp>" \
   void EnableVerbose() nogil except +
   void DisableBacktrace() nogil except +
   void ResetTimers() nogil except +
+  void EnableTimers() nogil except +
 
 cdef extern from "<mlpack/bindings/python/mlpack/move.hpp>" \
     namespace "mlpack::util" nogil:

--- a/src/mlpack/bindings/python/mlpack/cli_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/cli_util.hpp
@@ -117,6 +117,14 @@ inline void ResetTimers()
   CLI::GetSingleton().timer = Timers();
 }
 
+/**
+ * Enable timing.
+ */
+inline void EnableTimers()
+{
+  Timer::Enabled() = true;
+}
+
 } // namespace util
 } // namespace mlpack
 

--- a/src/mlpack/bindings/python/mlpack/cli_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/cli_util.hpp
@@ -114,7 +114,7 @@ inline void DisableBacktrace()
 inline void ResetTimers()
 {
   // Just get a new object---removes all old timers.
-  CLI::GetSingleton().timer = Timers();
+  CLI::GetSingleton().timer.Reset();
 }
 
 /**
@@ -122,7 +122,7 @@ inline void ResetTimers()
  */
 inline void EnableTimers()
 {
-  Timer::Enabled() = true;
+  Timer::EnableTiming();
 }
 
 } // namespace util

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -72,8 +72,8 @@ void PrintPYX(const ProgramDoc& programInfo,
   cout << "cimport arma_numpy" << endl;
   cout << "from cli cimport CLI" << endl;
   cout << "from cli cimport SetParam, SetParamWithInfo" << endl;
-  cout << "from cli cimport EnableVerbose, DisableBacktrace, ResetTimers"
-      << endl;
+  cout << "from cli cimport EnableVerbose, DisableBacktrace, ResetTimers, "
+      << "EnableTimers" << endl;
   cout << "from cli cimport MoveFromPtr, MoveToPtr" << endl;
   cout << "from matrix_utils import to_matrix, to_matrix_with_info" << endl;
   cout << endl;
@@ -171,6 +171,7 @@ void PrintPYX(const ProgramDoc& programInfo,
 
   // Reset any timers and disable backtraces.
   cout << "  ResetTimers()" << endl;
+  cout << "  EnableTimers()" << endl;
   cout << "  DisableBacktrace()" << endl;
 
   // Restore the parameters.

--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -43,19 +43,6 @@ CLI::CLI(const CLI& /* other */) : didParse(false), doc(&emptyProgramDoc)
   return;
 }
 
-void CLI::StopTimers()
-{
-  // Terminate the program timers.
-  for (auto it : CLI::GetSingleton().timer.GetAllTimers())
-  {
-    for (auto it2 : it.second)
-    {
-      if (CLI::GetSingleton().timer.GetState(it2.first, it.first) == 1)
-        CLI::GetSingleton().timer.StopTimer(it2.first, it.first);
-    }
-  }
-}
-
 /**
  * Destroy the CLI object.  This resets the pointer to the singleton, so in case
  * someone tries to access it after destruction, a new one will be made (the

--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -43,6 +43,9 @@ CLI::CLI(const CLI& /* other */) : didParse(false), doc(&emptyProgramDoc)
   return;
 }
 
+// Private copy operator; don't want copies floating around.
+CLI& CLI::operator=(const CLI& /* other */) { return *this; }
+
 /**
  * Destroy the CLI object.  This resets the pointer to the singleton, so in case
  * someone tries to access it after destruction, a new one will be made (the

--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -46,13 +46,13 @@ CLI::CLI(const CLI& /* other */) : didParse(false), doc(&emptyProgramDoc)
 void CLI::StopTimers()
 {
   // Terminate the program timers.
-  std::map<std::string, std::chrono::microseconds>::iterator it;
-  for (it = CLI::GetSingleton().timer.GetAllTimers().begin();
-       it != CLI::GetSingleton().timer.GetAllTimers().end(); ++it)
+  for (auto it : CLI::GetSingleton().timer.GetAllTimers())
   {
-    std::string i = (*it).first;
-    if (CLI::GetSingleton().timer.GetState(i) == 1)
-      Timer::Stop(i);
+    for (auto it2 : it.second)
+    {
+      if (CLI::GetSingleton().timer.GetState(it2.first, it.first) == 1)
+        CLI::GetSingleton().timer.StopTimer(it2.first, it.first);
+    }
   }
 }
 

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -203,11 +203,6 @@ class CLI
   static std::string GetPrintableParam(const std::string& identifier);
 
   /**
-   * Stop all of the timers.
-   */
-  static void StopTimers();
-
-  /**
    * Destroy the CLI object.  This resets the pointer to the singleton, so in
    * case someone tries to access it after destruction, a new one will be made
    * (the program will not fail).

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -333,6 +333,8 @@ class CLI
 
   //! Private copy constructor; we don't want copies floating around.
   CLI(const CLI& other);
+  //! Private copy operator; we don't want copies floating around.
+  CLI& operator=(const CLI& other);
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -52,6 +52,8 @@ int main(int argc, char** argv)
 {
   // Parse the command-line options; put them into CLI.
   mlpack::bindings::cli::ParseCommandLine(argc, argv);
+  // Enable timing.
+  mlpack::Timer::EnableTiming();
 
   mlpackMain();
 

--- a/src/mlpack/core/util/timers.cpp
+++ b/src/mlpack/core/util/timers.cpp
@@ -50,6 +50,26 @@ microseconds Timer::Get(const string& name)
   return result;
 }
 
+// Enable timing.
+void Timer::EnableTiming()
+{
+  CLI::GetSingleton().timer.Enabled() = true;
+}
+
+// Disable timing.
+void Timer::DisableTiming()
+{
+  CLI::GetSingleton().timer.Enabled() = false;
+}
+
+// Reset all timers.  Save state of enabled.
+void Timer::ResetAll()
+{
+  bool wasEnabled = CLI::GetSingleton().timer.Enabled();
+  CLI::GetSingleton().timer = Timers();
+  CLI::GetSingleton().timer.Enabled() = wasEnabled;
+}
+
 map<thread::id, map<string, microseconds>>&
 Timers::GetAllTimers()
 {

--- a/src/mlpack/core/util/timers.cpp
+++ b/src/mlpack/core/util/timers.cpp
@@ -2,6 +2,7 @@
  * @file timers.cpp
  * @author Matthew Amidon
  * @author Marcus Edel
+ * @author Ryan Curtin
  *
  * Implementation of timers.
  *

--- a/src/mlpack/core/util/timers.cpp
+++ b/src/mlpack/core/util/timers.cpp
@@ -18,60 +18,86 @@
 #include <string>
 
 using namespace mlpack;
-using namespace std::chrono;
+using namespace std;
+using namespace chrono;
 
 /**
  * Start the given timer.
  */
-void Timer::Start(const std::string& name)
+void Timer::Start(const string& name)
 {
-  CLI::GetSingleton().timer.StartTimer(name);
+  CLI::GetSingleton().timer.StartTimer(name, this_thread::get_id());
 }
 
 /**
  * Stop the given timer.
  */
-void Timer::Stop(const std::string& name)
+void Timer::Stop(const string& name)
 {
-  CLI::GetSingleton().timer.StopTimer(name);
+  CLI::GetSingleton().timer.StopTimer(name, this_thread::get_id());
 }
 
 /**
- * Get the given timer.
+ * Get the given timer, summing over all threads.
  */
-microseconds Timer::Get(const std::string& name)
+microseconds Timer::Get(const string& name)
 {
-  return CLI::GetSingleton().timer.GetTimer(name);
+  microseconds result(0);
+  for (auto it : CLI::GetSingleton().timer.GetAllTimers())
+    if (it.second.count(name) > 0)
+      result += it.second[name];
+
+  return result;
 }
 
-std::map<std::string, microseconds>& Timers::GetAllTimers()
+map<thread::id, map<string, microseconds>>&
+Timers::GetAllTimers()
 {
   return timers;
 }
 
-microseconds Timers::GetTimer(const std::string& timerName)
+list<string> Timers::GetAllTimerNames()
 {
-  return timers[timerName];
+  list<string> l;
+  for (auto it : CLI::GetSingleton().timer.GetAllTimers())
+    for (auto it2 : it.second)
+      l.push_back(it2.first);
+
+  // Filter duplicates.
+  l.unique();
+
+  return l;
 }
 
-bool Timers::GetState(std::string timerName)
+microseconds Timers::GetTimer(const string& timerName,
+                              const thread::id& threadId)
 {
-  return timerState[timerName];
+  return timers[threadId][timerName];
 }
 
-void Timers::PrintTimer(const std::string& timerName)
+bool Timers::GetState(const string& timerName,
+                      const thread::id& threadId)
 {
-  microseconds totalDuration = timers[timerName];
+  return timerState[threadId][timerName];
+}
+
+void Timers::PrintTimer(const string& timerName)
+{
+  microseconds totalDuration(0);
+  for (auto it : timers)
+    if (it.second.count(timerName) > 0)
+      totalDuration += it.second[timerName];
+
   // Convert microseconds to seconds.
   seconds totalDurationSec = duration_cast<seconds>(totalDuration);
   microseconds totalDurationMicroSec =
       duration_cast<microseconds>(totalDuration % seconds(1));
-  Log::Info << totalDurationSec.count() << "." << std::setw(6)
-      << std::setfill('0') << totalDurationMicroSec.count() << "s";
+  Log::Info << totalDurationSec.count() << "." << setw(6)
+      << setfill('0') << totalDurationMicroSec.count() << "s";
 
   // Also output convenient day/hr/min/sec.
   // The following line is a custom duration for a day.
-  typedef duration<int, std::ratio<60 * 60 * 24, 1>> days;
+  typedef duration<int, ratio<60 * 60 * 24, 1>> days;
   days d = duration_cast<days>(totalDuration);
   hours h = duration_cast<hours>(totalDuration % days(1));
   minutes m = duration_cast<minutes>(totalDuration % hours(1));
@@ -109,7 +135,7 @@ void Timers::PrintTimer(const std::string& timerName)
     {
       if (output)
         Log::Info << ", ";
-      Log::Info << s.count() << "." << std::setw(1)
+      Log::Info << s.count() << "." << setw(1)
           << (totalDurationMicroSec.count() / 100000) << " secs";
       output = true;
     }
@@ -117,7 +143,7 @@ void Timers::PrintTimer(const std::string& timerName)
     Log::Info << ")";
   }
 
-  Log::Info << std::endl;
+  Log::Info << endl;
 }
 
 high_resolution_clock::time_point Timers::GetTime()
@@ -125,44 +151,46 @@ high_resolution_clock::time_point Timers::GetTime()
   return high_resolution_clock::now();
 }
 
-void Timers::StartTimer(const std::string& timerName)
+void Timers::StartTimer(const string& timerName,
+                        const thread::id& threadId)
 {
-  if ((timerState[timerName] == 1) && (timerName != "total_time"))
+  if ((timerState[threadId][timerName] == 1) && (timerName != "total_time"))
   {
-    std::ostringstream error;
+    ostringstream error;
     error << "Timer::Start(): timer '" << timerName
         << "' has already been started";
-    throw std::runtime_error(error.str());
+    throw runtime_error(error.str());
   }
 
-  timerState[timerName] = true;
+  timerState[threadId][timerName] = true;
 
   high_resolution_clock::time_point currTime = GetTime();
 
-  // If the timer is added first time
-  if (timers.count(timerName) == 0)
+  // If the timer is added first time.
+  if (timers[threadId].count(timerName) == 0)
   {
-    timers[timerName] = (microseconds) 0;
+    timers[threadId][timerName] = (microseconds) 0;
   }
 
-  timerStartTime[timerName] = currTime;
+  timerStartTime[threadId][timerName] = currTime;
 }
 
-void Timers::StopTimer(const std::string& timerName)
+void Timers::StopTimer(const string& timerName,
+                       const thread::id& threadId)
 {
-  if ((timerState[timerName] == 0) && (timerName != "total_time"))
+  if ((timerState[threadId][timerName] == 0) && (timerName != "total_time"))
   {
-    std::ostringstream error;
+    ostringstream error;
     error << "Timer::Stop(): timer '" << timerName
         << "' has already been stopped";
-    throw std::runtime_error(error.str());
+    throw runtime_error(error.str());
   }
 
-  timerState[timerName] = false;
+  timerState[threadId][timerName] = false;
 
   high_resolution_clock::time_point currTime = GetTime();
 
   // Calculate the delta time.
-  timers[timerName] += duration_cast<microseconds>(currTime -
-      timerStartTime[timerName]);
+  timers[threadId][timerName] += duration_cast<microseconds>(currTime -
+      timerStartTime[threadId][timerName]);
 }

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -71,13 +71,31 @@ class Timer
    * @param name Name of timer to return value of.
    */
   static std::chrono::microseconds Get(const std::string& name);
+
+  /**
+   * Enable timing of mlpack programs.  Do not run this while timers are
+   * running!
+   */
+  static void EnableTiming();
+
+  /**
+   * Disable timing of mlpack programs.  Do not run this while timers are
+   * running!
+   */
+  static void DisableTiming();
+
+  /**
+   * Stop and reset all running timers.  This removes all knowledge of any
+   * existing timers.
+   */
+  static void ResetAll();
 };
 
 class Timers
 {
  public:
-  //! Nothing to do for the constructor.
-  Timers() { }
+  //! Default to disabled.
+  Timers() : enabled(false) { }
 
   /**
    * Returns a copy of all the timers used via this interface.
@@ -138,6 +156,11 @@ class Timers
   bool GetState(const std::string& timerName,
                 const std::thread::id& threadId = std::thread::id());
 
+  //! Modify whether or not timing is enabled.
+  bool& Enabled() { return enabled; }
+  //! Get whether or not timing is enabled.
+  bool Enabled() const { return enabled; }
+
  private:
   //! A map of all the timers that are being tracked.
   std::map<std::thread::id, std::map<std::string, std::chrono::microseconds>>
@@ -149,6 +172,9 @@ class Timers
       std::chrono::high_resolution_clock::time_point>> timerStartTime;
 
   std::chrono::high_resolution_clock::time_point GetTime();
+
+  //! Whether or not timing is enabled.
+  bool enabled;
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -19,6 +19,7 @@
 #include <thread> // std::thread is used for thread safety.
 #include <mutex>
 #include <list>
+#include <atomic>
 
 #if defined(_WIN32)
   // uint64_t isn't defined on every windows.
@@ -101,7 +102,7 @@ class Timers
   /**
    * Returns a copy of all the timers used via this interface.
    */
-  std::map<std::string, std::chrono::microseconds>& GetAllTimers();
+  std::map<std::string, std::chrono::microseconds> GetAllTimers();
 
   /**
    * Reset the timers.  This stops all running timers and removes them.  Whether
@@ -161,7 +162,7 @@ class Timers
   void StopAllTimers();
 
   //! Modify whether or not timing is enabled.
-  bool& Enabled() { return enabled; }
+  std::atomic<bool>& Enabled() { return enabled; }
   //! Get whether or not timing is enabled.
   bool Enabled() const { return enabled; }
 
@@ -170,16 +171,12 @@ class Timers
   std::map<std::string, std::chrono::microseconds> timers;
   //! A mutex for modifying the timers.
   std::mutex timersMutex;
-  //! A map that contains whether or not each timer is currently running.
-  std::map<std::thread::id, std::map<std::string, bool>> timerState;
   //! A map for the starting values of the timers.
   std::map<std::thread::id, std::map<std::string,
       std::chrono::high_resolution_clock::time_point>> timerStartTime;
 
-  std::chrono::high_resolution_clock::time_point GetTime();
-
   //! Whether or not timing is enabled.
-  bool enabled;
+  std::atomic<bool> enabled;
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -2,8 +2,9 @@
  * @file timers.hpp
  * @author Matthew Amidon
  * @author Marcus Edel
+ * @author Ryan Curtin
  *
- * Timers for MLPACK.
+ * Timers for mlpack.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the

--- a/src/mlpack/tests/timer_test.cpp
+++ b/src/mlpack/tests/timer_test.cpp
@@ -33,6 +33,7 @@ BOOST_AUTO_TEST_SUITE(TimerTest);
  */
 BOOST_AUTO_TEST_CASE(MultiRunTimerTest)
 {
+  Timer::EnableTiming();
   Timer::Start("test_timer");
 
   // On Windows (or, at least, in Windows not using VS2010) we cannot use
@@ -73,26 +74,33 @@ BOOST_AUTO_TEST_CASE(MultiRunTimerTest)
   Timer::Stop("test_timer");
 
   BOOST_REQUIRE_GE(Timer::Get("test_timer").count(), 40000);
+  Timer::DisableTiming();
 }
 
 BOOST_AUTO_TEST_CASE(TwiceStopTimerTest)
 {
+  Timer::EnableTiming();
   Timer::Start("test_timer");
   Timer::Stop("test_timer");
 
   BOOST_REQUIRE_THROW(Timer::Stop("test_timer"), std::runtime_error);
+
+  Timer::DisableTiming();
 }
 
 BOOST_AUTO_TEST_CASE(TwiceStartTimerTest)
 {
+  Timer::EnableTiming();
   Timer::Start("test_timer");
 
   BOOST_REQUIRE_THROW(Timer::Start("test_timer"), std::runtime_error);
   Timer::Stop("test_timer");
+  Timer::DisableTiming();
 }
 
 BOOST_AUTO_TEST_CASE(MultithreadTimerTest)
 {
+  Timer::EnableTiming();
   // Make three different threads all start a timer then stop a timer.
   std::thread threads[3];
   for (size_t i = 0; i < 3; ++i)

--- a/src/mlpack/tests/timer_test.cpp
+++ b/src/mlpack/tests/timer_test.cpp
@@ -98,6 +98,7 @@ BOOST_AUTO_TEST_CASE(TwiceStartTimerTest)
   Timer::DisableTiming();
 }
 
+#include <errno.h>
 BOOST_AUTO_TEST_CASE(MultithreadTimerTest)
 {
   Timer::EnableTiming();
@@ -112,7 +113,10 @@ BOOST_AUTO_TEST_CASE(MultithreadTimerTest)
           #ifdef _WIN32
           Sleep(20);
           #else
-          usleep(20000);
+          int restarts = 0;
+          // Catch occasional EINTR failures.
+          while (usleep(20000) != 0 && restarts < 3)
+            ++restarts;
           #endif
 
           Timer::Stop("thread_timer");

--- a/src/mlpack/tests/timer_test.cpp
+++ b/src/mlpack/tests/timer_test.cpp
@@ -98,7 +98,6 @@ BOOST_AUTO_TEST_CASE(TwiceStartTimerTest)
   Timer::DisableTiming();
 }
 
-#include <errno.h>
 BOOST_AUTO_TEST_CASE(MultithreadTimerTest)
 {
   Timer::EnableTiming();
@@ -130,6 +129,22 @@ BOOST_AUTO_TEST_CASE(MultithreadTimerTest)
   // worked.  Next we ensure that the total timer time is counting multiple
   // threads.
   BOOST_REQUIRE(Timer::Get("thread_timer") > std::chrono::microseconds(50000));
+}
+
+BOOST_AUTO_TEST_CASE(DisabledTimingTest)
+{
+  // It should be disabled by default but let's be paranoid.
+  Timer::DisableTiming();
+
+  Timer::Start("test_timer");
+  #ifdef _WIN32
+  Sleep(20);
+  #else
+  usleep(20000);
+  #endif
+  Timer::Stop("test_timer");
+
+  BOOST_REQUIRE(Timer::Get("test_timer") == std::chrono::microseconds(0));
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This should fix #1133.  @sgiurgiu: you can try this branch and see if it fixes your problem.  I wrote a simple test to imitate your bug report.

Since `std::this_thread::get_id()` is guaranteed to produce a different result for every thread, I simply made the `Timers` class hold a set of timers for each possible thread, then when the result is printed, each timer across all threads is summed up.  So in the code in #1133, if you printed the value of the timers at the end of the program, it would be the sum of all softmax regression trainings.