### PR TITLE
Making the CLI singleton thread local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ find_package(Boost 1.49
       program_options
       unit_test_framework
       serialization
+      thread
     REQUIRED
 )
 

--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -63,11 +63,7 @@ void CLI::StopTimers()
  */
 void CLI::Destroy()
 {
-  if (singleton != NULL)
-  {
-    delete singleton;
-    singleton = NULL; // Reset pointer.
-  }
+  singleton.reset();
 }
 
 void CLI::Add(ParamData&& data)
@@ -140,10 +136,10 @@ bool CLI::HasParam(const std::string& key)
 // Returns the sole instance of this class.
 CLI& CLI::GetSingleton()
 {
-  if (singleton == NULL)
-    singleton = new CLI();
+  if (!singleton.get())
+    singleton.reset(new CLI());
 
-  return *singleton;
+  return *(singleton.get());
 }
 
 /**

--- a/src/mlpack/core/util/cli.hpp
+++ b/src/mlpack/core/util/cli.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <boost/any.hpp>
+#include <boost/thread/tss.hpp>
 
 #include <mlpack/prereqs.hpp>
 
@@ -309,7 +310,7 @@ class CLI
 
  private:
   //! The singleton itself.
-  static CLI* singleton;
+  static boost::thread_specific_ptr<CLI> singleton;
 
   //! True, if CLI was used to parse command line options.
  public:

--- a/src/mlpack/core/util/singletons.cpp
+++ b/src/mlpack/core/util/singletons.cpp
@@ -32,7 +32,7 @@ using namespace mlpack::util;
   #define BASH_CLEAR ""
 #endif
 
-CLI* CLI::singleton = NULL;
+boost::thread_specific_ptr<CLI> CLI::singleton;
 
 // Only output debugging output if in debug mode.
 #ifdef DEBUG


### PR DESCRIPTION
My take on the threading issue. This patch would make the CLI object thread local using the boost::thread_specific_ptr class. Downsides:
- pulls Boost Thread as a dependency
- Timers are not available across threads (in the unit test it can be clearly seen that outside the thread that created the them the timers do not exist) 
