### PR TITLE
Add FunctionType API checks at compile time

### DIFF
--- a/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
+++ b/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
@@ -102,14 +102,16 @@ class AdaDelta
   double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
   {
     static_assert(static_checks::HasNumFunctions<DecomposableFunctionType,
-        NumFunctionsForm>::value,
+        static_checks::NumFunctionsForm>::value,
         "The FunctionType does not have a correct definition of NumFunctions.");
     static_assert(static_checks::HasDecomposableEvaluate<
-        DecomposableFunctionType, DecomposableEvaluateForm>::value,
+        DecomposableFunctionType,
+        static_checks::DecomposableEvaluateForm>::value,
         "The FunctionType does not have a correct definition of a decomposable"
         " Evaluate function.");
     static_assert(static_checks::HasDecomposableGradient<
-        DecomposableFunctionType, DecomposableGradientForm>::value,
+        DecomposableFunctionType,
+        static_checks::DecomposableGradientForm>::value,
         "The FunctionType does not have a correct definition of a decomposable"
         " Gradient function.");
     return optimizer.Optimize(function, iterate);

--- a/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
+++ b/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
@@ -18,6 +18,7 @@
 
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/sgd/sgd.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include "ada_delta_update.hpp"
 
 namespace mlpack {
@@ -89,7 +90,8 @@ class AdaDelta
   /**
    * Optimize the given function using AdaDelta. The given starting point will
    * be modified to store the finishing point of the algorithm, and the final
-   * objective value is returned.
+   * objective value is returned. The DecomposableFunctionType is checked for
+   * API consistency at compile time.
    *
    * @tparam DecomposableFunctionType Type of the function to optimize.
    * @param function Function to optimize.
@@ -99,6 +101,17 @@ class AdaDelta
   template<typename DecomposableFunctionType>
   double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
   {
+    static_assert(static_checks::HasNumFunctions<DecomposableFunctionType,
+        NumFunctionsForm>::value,
+        "The FunctionType does not have a correct definition of NumFunctions.");
+    static_assert(static_checks::HasDecomposableEvaluate<
+        DecomposableFunctionType, DecomposableEvaluateForm>::value,
+        "The FunctionType does not have a correct definition of a decomposable"
+        " Evaluate function.");
+    static_assert(static_checks::HasDecomposableGradient<
+        DecomposableFunctionType, DecomposableGradientForm>::value,
+        "The FunctionType does not have a correct definition of a decomposable"
+        " Gradient function.");
     return optimizer.Optimize(function, iterate);
   }
 

--- a/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
+++ b/src/mlpack/core/optimizers/ada_delta/ada_delta.hpp
@@ -18,7 +18,6 @@
 
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/sgd/sgd.hpp>
-#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include "ada_delta_update.hpp"
 
 namespace mlpack {
@@ -101,19 +100,6 @@ class AdaDelta
   template<typename DecomposableFunctionType>
   double Optimize(DecomposableFunctionType& function, arma::mat& iterate)
   {
-    static_assert(static_checks::HasNumFunctions<DecomposableFunctionType,
-        static_checks::NumFunctionsForm>::value,
-        "The FunctionType does not have a correct definition of NumFunctions.");
-    static_assert(static_checks::HasDecomposableEvaluate<
-        DecomposableFunctionType,
-        static_checks::DecomposableEvaluateForm>::value,
-        "The FunctionType does not have a correct definition of a decomposable"
-        " Evaluate function.");
-    static_assert(static_checks::HasDecomposableGradient<
-        DecomposableFunctionType,
-        static_checks::DecomposableGradientForm>::value,
-        "The FunctionType does not have a correct definition of a decomposable"
-        " Gradient function.");
     return optimizer.Optimize(function, iterate);
   }
 

--- a/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/src/mlpack/core/optimizers/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -15,6 +15,7 @@
 #define MLPACK_CORE_OPTIMIZERS_AUG_LAGRANGIAN_AUG_LAGRANGIAN_IMPL_HPP
 
 #include <mlpack/core/optimizers/lbfgs/lbfgs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include "aug_lagrangian_function.hpp"
 
 namespace mlpack {
@@ -62,6 +63,22 @@ bool AugLagrangian::Optimize(
     arma::mat& coordinates,
     const size_t maxIterations)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<
+      LagrangianFunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(mlpack::static_checks::CheckGradient<
+      LagrangianFunctionType>::value,
+      "The FunctionType does not have a correct definition of Gradient.");
+  static_assert(mlpack::static_checks::CheckNumConstraints<
+      LagrangianFunctionType>::value,
+      "The FunctionType does not have a correct definition of NumConstraints.");
+  static_assert(mlpack::static_checks::CheckEvaluateConstraint<
+      LagrangianFunctionType>::value, "The FunctionType does not have a correct"
+      " definition of EvaluateConstraint.");
+  static_assert(mlpack::static_checks::CheckGradientConstraint<
+      LagrangianFunctionType>::value, "The FunctionType does not have a correct"
+      " definition of GradientConstraint.");
+
   LagrangianFunctionType& function = augfunc.Function();
 
   // Ensure that we update lambda immediately.

--- a/src/mlpack/core/optimizers/fw/frank_wolfe.hpp
+++ b/src/mlpack/core/optimizers/fw/frank_wolfe.hpp
@@ -14,6 +14,7 @@
 
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include "update_span.hpp"
 #include "constr_lpball.hpp"
 

--- a/src/mlpack/core/optimizers/fw/frank_wolfe_impl.hpp
+++ b/src/mlpack/core/optimizers/fw/frank_wolfe_impl.hpp
@@ -42,6 +42,11 @@ template<typename FunctionType>
 double FrankWolfe<LinearConstrSolverType, UpdateRuleType>::
 Optimize(FunctionType& function, arma::mat& iterate)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(mlpack::static_checks::CheckGradient<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Gradient.");
+
   // To keep track of the function value.
   double currentObjective = function.Evaluate(iterate);
 

--- a/src/mlpack/core/optimizers/gradient_descent/gradient_descent.hpp
+++ b/src/mlpack/core/optimizers/gradient_descent/gradient_descent.hpp
@@ -13,6 +13,7 @@
 #define MLPACK_CORE_OPTIMIZERS_GRADIENT_DESCENT_GRADIENT_DESCENT_HPP
 
 #include <mlpack/core.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/gradient_descent/gradient_descent_impl.hpp
+++ b/src/mlpack/core/optimizers/gradient_descent/gradient_descent_impl.hpp
@@ -23,6 +23,11 @@ template<typename FunctionType>
 double GradientDescent::Optimize(
     FunctionType& function, arma::mat& iterate)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(mlpack::static_checks::CheckGradient<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Gradient.");
+
   // To keep track of where we are and how things are going.
   double overallObjective = function.Evaluate(iterate);
   double lastObjective = DBL_MAX;

--- a/src/mlpack/core/optimizers/grid_search/grid_search.hpp
+++ b/src/mlpack/core/optimizers/grid_search/grid_search.hpp
@@ -13,6 +13,7 @@
 #define MLPACK_CORE_OPTIMIZERS_GRID_SEARCH_GRID_SEARCH_HPP
 
 #include <mlpack/core.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/grid_search/grid_search_impl.hpp
+++ b/src/mlpack/core/optimizers/grid_search/grid_search_impl.hpp
@@ -59,6 +59,9 @@ void GridSearch::Optimize(
     data::DatasetMapper<data::IncrementPolicy, double>& datasetInfo,
     size_t i)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+
   if (i < datasetInfo.Dimensionality())
   {
     for (size_t j = 0; j < datasetInfo.NumMappings(i); ++j)

--- a/src/mlpack/core/optimizers/lbfgs/lbfgs.hpp
+++ b/src/mlpack/core/optimizers/lbfgs/lbfgs.hpp
@@ -14,6 +14,7 @@
 #define MLPACK_CORE_OPTIMIZERS_LBFGS_LBFGS_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/lbfgs/lbfgs_impl.hpp
+++ b/src/mlpack/core/optimizers/lbfgs/lbfgs_impl.hpp
@@ -173,6 +173,11 @@ bool L_BFGS::LineSearch(FunctionType& function,
 template<typename FunctionType>
 double L_BFGS::Optimize(FunctionType& function, arma::mat& iterate)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(mlpack::static_checks::CheckGradient<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Gradient.");
+
   // Ensure that the cubes holding past iterations' information are the right
   // size.  Also set the current best point value to the maximum.
   const size_t rows = iterate.n_rows;

--- a/src/mlpack/core/optimizers/line_search/line_search.hpp
+++ b/src/mlpack/core/optimizers/line_search/line_search.hpp
@@ -14,6 +14,7 @@
 
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/line_search/line_search_impl.hpp
+++ b/src/mlpack/core/optimizers/line_search/line_search_impl.hpp
@@ -23,6 +23,11 @@ double LineSearch::Optimize(FunctionType& function,
                             const arma::mat& x1,
                             arma::mat& x2)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(mlpack::static_checks::CheckGradient<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Gradient.");
+
   // Set up the search line, that is,
   // find the zero of der(gamma) = Derivative(gamma).
   arma::mat deltaX = x2 - x1;
@@ -36,7 +41,7 @@ double LineSearch::Optimize(FunctionType& function,
     x2 = x1;
     return function.Evaluate(x1);
   }
-  else if (derivativeNew <= 0.0) // Optimal solution at righ endpoint.
+  else if (derivativeNew <= 0.0) // Optimal solution at right endpoint.
     return function.Evaluate(x2);
   else if (secant < tolerance) // function too flat, just take left endpoint.
   {

--- a/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd.hpp
+++ b/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd.hpp
@@ -13,6 +13,7 @@
 #define MLPACK_CORE_OPTIMIZERS_MINIBATCH_SGD_MINIBATCH_SGD_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include <mlpack/core/optimizers/sgd/update_policies/vanilla_update.hpp>
 #include <mlpack/core/optimizers/minibatch_sgd/decay_policies/no_decay.hpp>
 

--- a/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/minibatch_sgd/minibatch_sgd_impl.hpp
@@ -55,6 +55,18 @@ double MiniBatchSGDType<
 >::Optimize(DecomposableFunctionType& function,
             arma::mat& iterate)
 {
+  static_assert(
+      static_checks::CheckNumFunctions<DecomposableFunctionType>::value,
+      "The FunctionType does not have a correct definition of NumFunctions.");
+  static_assert(static_checks::CheckDecomposableEvaluate<
+      DecomposableFunctionType>::value,
+      "The FunctionType does not have a correct definition of a decomposable"
+      " Evaluate function.");
+  static_assert(static_checks::CheckDecomposableGradient<
+      DecomposableFunctionType>::value,
+      "The FunctionType does not have a correct definition of a decomposable"
+      " Gradient function.");
+
   // Find the number of functions.
   const size_t numFunctions = function.NumFunctions();
   size_t numBatches = numFunctions / batchSize;

--- a/src/mlpack/core/optimizers/parallel_sgd/parallel_sgd.hpp
+++ b/src/mlpack/core/optimizers/parallel_sgd/parallel_sgd.hpp
@@ -14,6 +14,7 @@
 
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/math/random.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include "decay_policies/constant_step.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/optimizers/parallel_sgd/parallel_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/parallel_sgd/parallel_sgd_impl.hpp
@@ -38,6 +38,14 @@ double ParallelSGD<DecayPolicyType>::Optimize(
     SparseFunctionType& function,
     arma::mat& iterate)
 {
+  static_assert(static_checks::CheckNumFunctions<SparseFunctionType>::value,
+      "The FunctionType does not have a correct definition of NumFunctions.");
+  static_assert(static_checks::CheckEvaluate<SparseFunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(static_checks::CheckSparseGradient<SparseFunctionType>::value,
+      "The FunctionType does not have a correct definition of a sparse"
+      " Gradient function.");
+
   double overallObjective = DBL_MAX;
   double lastObjective;
 

--- a/src/mlpack/core/optimizers/sa/sa.hpp
+++ b/src/mlpack/core/optimizers/sa/sa.hpp
@@ -13,6 +13,7 @@
 #define MLPACK_CORE_OPTIMIZERS_SA_SA_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 
 #include "exponential_schedule.hpp"
 

--- a/src/mlpack/core/optimizers/sa/sa_impl.hpp
+++ b/src/mlpack/core/optimizers/sa/sa_impl.hpp
@@ -49,6 +49,9 @@ template<typename FunctionType>
 double SA<CoolingScheduleType>::Optimize(FunctionType& function,
                                          arma::mat& iterate)
 {
+  static_assert(mlpack::static_checks::CheckEvaluate<FunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+
   const size_t rows = iterate.n_rows;
   const size_t cols = iterate.n_cols;
 

--- a/src/mlpack/core/optimizers/scd/scd.hpp
+++ b/src/mlpack/core/optimizers/scd/scd.hpp
@@ -13,6 +13,7 @@
 #define MLPACK_CORE_OPTIMIZERS_SCD_SCD_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 #include "descent_policies/random_descent.hpp"
 
 namespace mlpack {

--- a/src/mlpack/core/optimizers/scd/scd_impl.hpp
+++ b/src/mlpack/core/optimizers/scd/scd_impl.hpp
@@ -38,6 +38,15 @@ template <typename ResolvableFunctionType>
 double SCD<DescentPolicyType>::Optimize(ResolvableFunctionType& function,
                                         arma::mat& iterate)
 {
+  static_assert(static_checks::CheckNumFeatures<ResolvableFunctionType>::value,
+      "The FunctionType does not have a correct definition of NumFeatures.");
+  static_assert(static_checks::CheckEvaluate<ResolvableFunctionType>::value,
+      "The FunctionType does not have a correct definition of Evaluate.");
+  static_assert(static_checks::CheckPartialGradient<
+      ResolvableFunctionType>::value,
+      "The FunctionType does not have a correct definition of a partial"
+      " Gradient function.");
+
   double overallObjective = 0;
   double lastObjective = DBL_MAX;
 

--- a/src/mlpack/core/optimizers/sgd/sgd.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd.hpp
@@ -17,6 +17,7 @@
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/optimizers/sgd/update_policies/vanilla_update.hpp>
 #include <mlpack/core/optimizers/sgd/update_policies/momentum_update.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
 
 namespace mlpack {
 namespace optimization {

--- a/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
@@ -46,6 +46,18 @@ double SGD<UpdatePolicyType>::Optimize(
     DecomposableFunctionType& function,
     arma::mat& iterate)
 {
+  static_assert(
+      static_checks::CheckNumFunctions<DecomposableFunctionType>::value,
+      "The FunctionType does not have a correct definition of NumFunctions.");
+  static_assert(static_checks::CheckDecomposableEvaluate<
+      DecomposableFunctionType>::value,
+      "The FunctionType does not have a correct definition of a decomposable"
+      " Evaluate function.");
+  static_assert(static_checks::CheckDecomposableGradient<
+      DecomposableFunctionType>::value,
+      "The FunctionType does not have a correct definition of a decomposable"
+      " Gradient function.");
+
   // Find the number of functions to use.
   const size_t numFunctions = function.NumFunctions();
 

--- a/src/mlpack/core/util/functiontype_method_forms.hpp
+++ b/src/mlpack/core/util/functiontype_method_forms.hpp
@@ -159,9 +159,66 @@ template <typename FunctionType>
 struct CheckGradientConstraint
 {
   const static bool value =
-    HasGradientConstraint<FunctionType, GradientConstraintFormConst>::value
-    || HasGradientConstraint<FunctionType,
-    GradientConstraintFormNonConst>::value;
+    HasGradientConstraint<FunctionType, GradientConstraintFormConst>::value ||
+    HasGradientConstraint<FunctionType, GradientConstraintFormNonConst>::value;
+};
+
+/*
+ * Definitions of method forms and checks for the SparseFunctionType API.
+ */
+HAS_METHOD_FORM(Gradient, HasSparseGradient);
+
+template <typename Class, typename...Ts>
+using SparseGradientFormConst = void(Class::*)(const arma::mat&, size_t,
+    arma::sp_mat&) const;
+
+template <typename Class, typename...Ts>
+using SparseGradientFormNonConst = void(Class::*)(const arma::mat&, size_t,
+    arma::sp_mat&);
+
+template <typename FunctionType>
+struct CheckSparseGradient
+{
+  const static bool value =
+    HasSparseGradient<FunctionType, SparseGradientFormConst>::value ||
+    HasSparseGradient<FunctionType, SparseGradientFormNonConst>::value;
+};
+
+/**
+ * Definitions of method forms and checks for the ResolvableFunctionType API.
+ */
+HAS_METHOD_FORM(NumFeatures, HasNumFeatures);
+
+template <typename Class, typename...Ts>
+using NumFeaturesFormConst = size_t(Class::*)() const;
+
+template <typename Class, typename...Ts>
+using NumFeaturesFormNonConst = size_t(Class::*)();
+
+template<typename FunctionType>
+struct CheckNumFeatures
+{
+  const static bool value =
+    HasNumFeatures<FunctionType, NumFeaturesFormConst>::value ||
+    HasNumFeatures<FunctionType, NumFeaturesFormNonConst>::value;
+};
+
+HAS_METHOD_FORM(PartialGradient, HasPartialGradient);
+
+template <typename Class, typename...Ts>
+using PartialGradientFormConst = void(Class::*)(const arma::mat&, size_t,
+    arma::sp_mat&) const;
+
+template <typename Class, typename...Ts>
+using PartialGradientFormNonConst = void(Class::*)(const arma::mat&, size_t,
+    arma::sp_mat&);
+
+template <typename FunctionType>
+struct CheckPartialGradient
+{
+  const static bool value =
+    HasPartialGradient<FunctionType, PartialGradientFormConst>::value ||
+    HasPartialGradient<FunctionType, PartialGradientFormNonConst>::value;
 };
 
 } // namespace static_checks

--- a/src/mlpack/core/util/functiontype_method_forms.hpp
+++ b/src/mlpack/core/util/functiontype_method_forms.hpp
@@ -22,24 +22,147 @@
 namespace mlpack {
 namespace static_checks {
 /*
- * Definitions of method forms for the DecomposableFunctionType API.
+ * Definitions of method forms and checks for the DecomposableFunctionType API.
  */
-template <typename Class, typename...Ts>
-using NumFunctionsForm = size_t(Class::*)(Ts...) const;
-
 HAS_METHOD_FORM(NumFunctions, HasNumFunctions);
 
 template <typename Class, typename...Ts>
-using DecomposableEvaluateForm = double(Class::*)(const arma::mat&, const size_t,
-    Ts...) const;
+using NumFunctionsFormConst = size_t(Class::*)() const;
+
+template <typename Class, typename...Ts>
+using NumFunctionsFormNonConst = size_t(Class::*)();
+
+template<typename FunctionType>
+struct CheckNumFunctions
+{
+  const static bool value =
+    HasNumFunctions<FunctionType, NumFunctionsFormConst>::value ||
+    HasNumFunctions<FunctionType, NumFunctionsFormNonConst>::value;
+};
 
 HAS_METHOD_FORM(Evaluate, HasDecomposableEvaluate);
 
 template <typename Class, typename...Ts>
-using DecomposableGradientForm = void(Class::*)(const arma::mat&, const size_t,
-    arma::mat&, Ts...) const;
+using DecomposableEvaluateFormConst = double(Class::*)(const arma::mat&, const
+    size_t) const;
+
+template <typename Class, typename...Ts>
+using DecomposableEvaluateFormNonConst = double(Class::*)(const arma::mat&,
+    const size_t);
+
+template<typename FunctionType>
+struct CheckDecomposableEvaluate
+{
+  const static bool value =
+    HasDecomposableEvaluate<FunctionType, DecomposableEvaluateFormConst>::value
+    || HasDecomposableEvaluate<FunctionType,
+    DecomposableEvaluateFormNonConst>::value;
+};
 
 HAS_METHOD_FORM(Gradient, HasDecomposableGradient);
+
+template <typename Class, typename...Ts>
+using DecomposableGradientFormConst = void(Class::*)(const arma::mat&, const
+    size_t, arma::mat&) const;
+
+template <typename Class, typename...Ts>
+using DecomposableGradientFormNonConst = void(Class::*)(const arma::mat&, const
+    size_t, arma::mat&);
+
+template <typename FunctionType>
+struct CheckDecomposableGradient
+{
+  const static bool value =
+    HasDecomposableGradient<FunctionType, DecomposableGradientFormConst>::value
+    || HasDecomposableGradient<FunctionType,
+    DecomposableGradientFormNonConst>::value;
+};
+
+/*
+ * Definitions of method forms and checks for the LagrangianFunctionType API.
+ */
+HAS_METHOD_FORM(Evaluate, HasEvaluate);
+
+template <typename Class, typename...Ts>
+using EvaluateFormConst = double(Class::*)(const arma::mat&) const;
+
+template <typename Class, typename...Ts>
+using EvaluateFormNonConst = double(Class::*)(const arma::mat&);
+
+template<typename FunctionType>
+struct CheckEvaluate
+{
+  const static bool value = HasEvaluate<FunctionType, EvaluateFormConst>::value
+    || HasEvaluate<FunctionType, EvaluateFormNonConst>::value;
+};
+
+HAS_METHOD_FORM(Gradient, HasGradient);
+
+template <typename Class, typename...Ts>
+using GradientFormConst = void(Class::*)(const arma::mat&, arma::mat&) const;
+
+template <typename Class, typename...Ts>
+using GradientFormNonConst = void(Class::*)(const arma::mat&, arma::mat&);
+
+template <typename FunctionType>
+struct CheckGradient
+{
+  const static bool value = HasGradient<FunctionType, GradientFormConst>::value
+    || HasGradient<FunctionType, GradientFormNonConst>::value;
+};
+
+HAS_METHOD_FORM(NumConstraints, HasNumConstraints);
+
+template <typename Class, typename...Ts>
+using NumConstraintsFormConst = size_t(Class::*)() const;
+
+template <typename Class, typename...Ts>
+using NumConstraintsFormNonConst = size_t(Class::*)();
+
+template<typename FunctionType>
+struct CheckNumConstraints
+{
+  const static bool value =
+    HasNumConstraints<FunctionType, NumConstraintsFormConst>::value ||
+    HasNumConstraints<FunctionType, NumConstraintsFormNonConst>::value;
+};
+
+HAS_METHOD_FORM(EvaluateConstraint, HasEvaluateConstraint);
+
+template <typename Class, typename...Ts>
+using EvaluateConstraintFormConst = double(Class::*)(size_t, const arma::mat&)
+  const;
+
+template <typename Class, typename...Ts>
+using EvaluateConstraintFormNonConst = double(Class::*)(size_t, const
+    arma::mat&);
+
+template<typename FunctionType>
+struct CheckEvaluateConstraint
+{
+  const static bool value =
+    HasEvaluateConstraint<FunctionType, EvaluateConstraintFormConst>::value ||
+    HasEvaluateConstraint<FunctionType, EvaluateConstraintFormNonConst>::value;
+};
+
+HAS_METHOD_FORM(GradientConstraint, HasGradientConstraint);
+
+template <typename Class, typename...Ts>
+using GradientConstraintFormConst = void(Class::*)(size_t, const arma::mat&,
+    arma::mat&) const;
+
+template <typename Class, typename...Ts>
+using GradientConstraintFormNonConst = void(Class::*)(size_t, const arma::mat&,
+    arma::mat&);
+
+template <typename FunctionType>
+struct CheckGradientConstraint
+{
+  const static bool value =
+    HasGradientConstraint<FunctionType, GradientConstraintFormConst>::value
+    || HasGradientConstraint<FunctionType,
+    GradientConstraintFormNonConst>::value;
+};
 
 } // namespace static_checks
 } // namespace mlpack

--- a/src/mlpack/core/util/functiontype_method_forms.hpp
+++ b/src/mlpack/core/util/functiontype_method_forms.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file functiontype_form.hpp
+ * @author Shikhar Bhardwaj
+ *
+ * This file contains the definitions of the method forms required by the
+ * FunctionType API used by the optimizers. These method forms can be used to
+ * check the compliance of a user provided FunctionType with the required
+ * interface from the optimizer at compile time.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_CORE_FUNCTIONTYPE_METHOD_FORMS
+#define MLPACK_CORE_FUNCTIONTYPE_METHOD_FORMS
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/util/sfinae_utility.hpp>
+
+namespace mlpack {
+namespace static_checks {
+/*
+ * Definitions of method forms for the DecomposableFunctionType API.
+ */
+template <typename Class, typename...Ts>
+using NumFunctionsForm = size_t(Class::*)(Ts...) const;
+
+HAS_METHOD_FORM(NumFunctions, HasNumFunctions);
+
+template <typename Class, typename...Ts>
+using DecomposableEvaluateForm = double(Class::*)(const arma::mat&, const size_t,
+    Ts...) const;
+
+HAS_METHOD_FORM(Evaluate, HasDecomposableEvaluate);
+
+template <typename Class, typename...Ts>
+using DecomposableGradientForm = void(Class::*)(const arma::mat&, const size_t,
+    arma::mat&, Ts...) const;
+
+HAS_METHOD_FORM(Gradient, HasDecomposableGradient);
+
+} // namespace static_checks
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/core/util/sfinae_utility.hpp
+++ b/src/mlpack/core/util/sfinae_utility.hpp
@@ -16,6 +16,7 @@
 #define MLPACK_CORE_SFINAE_UTILITY
 
 #include <type_traits>
+#include <cstring>
 
 namespace mlpack {
 namespace sfinae {

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -162,7 +162,18 @@ class FFN
    */
   double Evaluate(const arma::mat& parameters,
                   const size_t i,
-                  const bool deterministic = true);
+                  const bool deterministic);
+
+  /**
+   * Evaluate the recurrent neural network with the given parameters. This
+   * function is usually called by the optimizer to train the model. This
+   * overload is provided for compatibility with the DecomposableFunctionType
+   * API, calls the above function with deterministic = true.
+   *
+   * @param parameters Matrix model parameters.
+   * @param i Index of point to use for objective function evaluation.
+   */
+  double Evaluate(const arma::mat& /* parameters */, const size_t i);
 
   /**
    * Evaluate the feedforward network with the given parameters. This function

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -233,6 +233,13 @@ double FFN<OutputLayerType, InitializationRuleType>::Evaluate(
 
 template<typename OutputLayerType, typename InitializationRuleType>
 double FFN<OutputLayerType, InitializationRuleType>::Evaluate(
+    const arma::mat& /* parameters */, const size_t i)
+{
+  return Evaluate(arma::mat(), i, true);
+}
+
+template<typename OutputLayerType, typename InitializationRuleType>
+double FFN<OutputLayerType, InitializationRuleType>::Evaluate(
     const arma::mat& parameters)
 {
   double res = 0;

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -155,7 +155,18 @@ class RNN
    */
   double Evaluate(const arma::mat& /* parameters */,
                   const size_t i,
-                  const bool deterministic = true);
+                  const bool deterministic);
+
+  /**
+   * Evaluate the recurrent neural network with the given parameters. This
+   * function is usually called by the optimizer to train the model. This
+   * overload is provided for compatibility with the DecomposableFunctionType
+   * API, calls the above function with deterministic = true.
+   *
+   * @param parameters Matrix model parameters.
+   * @param i Index of point to use for objective function evaluation.
+   */
+  double Evaluate(const arma::mat& /* parameters */, const size_t i);
 
   /**
    * Evaluate the gradient of the recurrent neural network with the given

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -266,6 +266,13 @@ double RNN<OutputLayerType, InitializationRuleType>::Evaluate(
 }
 
 template<typename OutputLayerType, typename InitializationRuleType>
+double RNN<OutputLayerType, InitializationRuleType>::Evaluate(
+    const arma::mat& /* parameters */, const size_t i)
+{
+  return Evaluate(arma::mat(), i, true);
+}
+
+template<typename OutputLayerType, typename InitializationRuleType>
 void RNN<OutputLayerType, InitializationRuleType>::Gradient(
     const arma::mat& parameters, const size_t i, arma::mat& gradient)
 {

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(mlpack_test
   fastmks_test.cpp
   feedforward_network_test.cpp
   frankwolfe_test.cpp
+  functiontype_method_forms_test.cpp
   gmm_test.cpp
   gradient_clipping_test.cpp
   gradient_descent_test.cpp

--- a/src/mlpack/tests/functiontype_method_forms_test.cpp
+++ b/src/mlpack/tests/functiontype_method_forms_test.cpp
@@ -27,16 +27,22 @@ class A
 {
  public:
   size_t NumFunctions() const;
+  size_t NumFeatures() const;
   double Evaluate(const arma::mat&, const size_t) const;
   void Gradient(const arma::mat&, const size_t, arma::mat&) const;
+  void Gradient(const arma::mat&, const size_t, arma::sp_mat&) const;
+  void PartialGradient(const arma::mat&, const size_t, arma::sp_mat&) const;
 };
 
 class B
 {
  public:
   size_t NumFunctions();
+  size_t NumFeatures();
   double Evaluate(const arma::mat&, const size_t);
   void Gradient(const arma::mat&, const size_t, arma::mat&);
+  void Gradient(const arma::mat&, const size_t, arma::sp_mat&);
+  void PartialGradient(const arma::mat&, const size_t, arma::sp_mat&);
 };
 
 class C
@@ -63,7 +69,6 @@ class D
 /**
  * Test the correctness of the static check for DecomposableFunctionType API.
  */
-
 BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeCheckTest)
 {
   static_assert(CheckNumFunctions<A>::value,
@@ -94,6 +99,9 @@ BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeCheckTest)
       "CheckDecomposableGradient static check failed.");
 }
 
+/**
+ * Test the correctness of the static check for LagrangianFunctionType API.
+ */
 BOOST_AUTO_TEST_CASE(LagrangianFunctionTypeCheckTest)
 {
   static_assert(!CheckEvaluate<A>::value, "CheckEvaluate static check failed.");
@@ -132,6 +140,45 @@ BOOST_AUTO_TEST_CASE(LagrangianFunctionTypeCheckTest)
       "CheckGradientConstraint static check failed.");
   static_assert(CheckGradientConstraint<D>::value,
       "CheckGradientConstraint static check failed.");
+}
+
+/**
+ * Test the correctness of the static check for SparseFunctionType API.
+ */
+BOOST_AUTO_TEST_CASE(SparseFunctionTypeCheckTest)
+{
+  static_assert(CheckSparseGradient<A>::value,
+      "CheckSparseGradient static check failed.");
+  static_assert(CheckSparseGradient<B>::value,
+      "CheckSparseGradient static check failed.");
+  static_assert(!CheckSparseGradient<C>::value,
+      "CheckSparseGradient static check failed.");
+  static_assert(!CheckSparseGradient<D>::value,
+      "CheckSparseGradient static check failed.");
+}
+
+/**
+ * Test the correctness of the static check for SparseFunctionType API.
+ */
+BOOST_AUTO_TEST_CASE(ResolvableFunctionTypeCheckTest)
+{
+  static_assert(CheckNumFeatures<A>::value,
+      "CheckNumFeatures static check failed.");
+  static_assert(CheckNumFeatures<B>::value,
+      "CheckNumFeatures static check failed.");
+  static_assert(!CheckNumFeatures<C>::value,
+      "CheckNumFeatures static check failed.");
+  static_assert(!CheckNumFeatures<D>::value,
+      "CheckNumFeatures static check failed.");
+
+  static_assert(CheckPartialGradient<A>::value,
+      "CheckPartialGradient static check failed.");
+  static_assert(CheckPartialGradient<B>::value,
+      "CheckPartialGradient static check failed.");
+  static_assert(!CheckPartialGradient<C>::value,
+      "CheckPartialGradient static check failed.");
+  static_assert(!CheckPartialGradient<D>::value,
+      "CheckPartialGradient static check failed.");
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/functiontype_method_forms_test.cpp
+++ b/src/mlpack/tests/functiontype_method_forms_test.cpp
@@ -41,12 +41,12 @@ class B
 
 class C
 {
-  public:
-    size_t NumConstraints() const;
-    double Evaluate(const arma::mat&) const;
-    void Gradient(const arma::mat&, arma::mat&) const;
-    double EvaluateConstraint(const size_t, const arma::mat&) const;
-    void GradientConstraint(const size_t, const arma::mat&, arma::mat&) const;
+ public:
+  size_t NumConstraints() const;
+  double Evaluate(const arma::mat&) const;
+  void Gradient(const arma::mat&, arma::mat&) const;
+  double EvaluateConstraint(const size_t, const arma::mat&) const;
+  void GradientConstraint(const size_t, const arma::mat&, arma::mat&) const;
 };
 
 class D
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeCheckTest)
       "CheckDecomposableEvaluate static check failed.");
   static_assert(CheckDecomposableEvaluate<B>::value,
       "CheckDecomposableEvaluate static check failed.");
-  static_assert(!CheckDecomposableEvaluate<C>::value, 
+  static_assert(!CheckDecomposableEvaluate<C>::value,
       "CheckDecomposableEvaluate static check failed.");
-  static_assert(!CheckDecomposableEvaluate<D>::value, 
+  static_assert(!CheckDecomposableEvaluate<D>::value,
       "CheckDecomposableEvaluate static check failed.");
 
   static_assert(CheckDecomposableGradient<A>::value,
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeCheckTest)
       "CheckDecomposableGradient static check failed.");
   static_assert(!CheckDecomposableGradient<C>::value,
       "CheckDecomposableGradient static check failed.");
-  static_assert(!CheckDecomposableGradient<D>::value, 
+  static_assert(!CheckDecomposableGradient<D>::value,
       "CheckDecomposableGradient static check failed.");
 }
 

--- a/src/mlpack/tests/functiontype_method_forms_test.cpp
+++ b/src/mlpack/tests/functiontype_method_forms_test.cpp
@@ -25,40 +25,113 @@ BOOST_AUTO_TEST_SUITE(FunctionTypeMethodFormsTest);
 
 class A
 {
-  public:
-    size_t NumFunctions() const;
-    double Evaluate(const arma::mat&, const size_t) const;
-    void Gradient(const arma::mat&, const size_t, arma::mat&) const;
+ public:
+  size_t NumFunctions() const;
+  double Evaluate(const arma::mat&, const size_t) const;
+  void Gradient(const arma::mat&, const size_t, arma::mat&) const;
 };
 
 class B
 {
-  public:
-    size_t NumFunctions();
-    double Evaluate(const arma::mat&) const;
-    void Gradient(const arma::mat&, arma::mat&) const;
+ public:
+  size_t NumFunctions();
+  double Evaluate(const arma::mat&, const size_t);
+  void Gradient(const arma::mat&, const size_t, arma::mat&);
 };
 
-/**
- * Test the correctness of the method forms describing the
- * DecomposableFunctionType API.
- */
-BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeMethodFormsTest)
+class C
 {
-  static_assert(HasNumFunctions<A, NumFunctionsForm>::value,
-      "NumFunctions static check failed.");
-  static_assert(!HasNumFunctions<B, NumFunctionsForm>::value,
-      "NumFunctions static check failed.");
+  public:
+    size_t NumConstraints() const;
+    double Evaluate(const arma::mat&) const;
+    void Gradient(const arma::mat&, arma::mat&) const;
+    double EvaluateConstraint(const size_t, const arma::mat&) const;
+    void GradientConstraint(const size_t, const arma::mat&, arma::mat&) const;
+};
 
-  static_assert(HasDecomposableEvaluate<A, DecomposableEvaluateForm>::value,
-      "DecomposableEvaluate static check failed");
-  static_assert(!HasDecomposableEvaluate<B, DecomposableEvaluateForm>::value,
-      "DecomposableEvaluate static check failed");
+class D
+{
+ public:
+  size_t NumConstraints();
+  double Evaluate(const arma::mat&);
+  void Gradient(const arma::mat&, arma::mat&);
+  double EvaluateConstraint(const size_t, const arma::mat&);
+  void GradientConstraint(const size_t, const arma::mat&, arma::mat&);
+};
 
-  static_assert(HasDecomposableGradient<A, DecomposableGradientForm>::value,
-      "DecomposableGradient static check failed");
-  static_assert(!HasDecomposableGradient<B, DecomposableGradientForm>::value,
-      "DecomposableGradient static check failed");
+
+/**
+ * Test the correctness of the static check for DecomposableFunctionType API.
+ */
+
+BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeCheckTest)
+{
+  static_assert(CheckNumFunctions<A>::value,
+      "CheckNumFunctions static check failed.");
+  static_assert(CheckNumFunctions<B>::value,
+      "CheckNumFunctions static check failed.");
+  static_assert(!CheckNumFunctions<C>::value,
+      "CheckNumFunctions static check failed.");
+  static_assert(!CheckNumFunctions<D>::value,
+      "CheckNumFunctions static check failed.");
+
+  static_assert(CheckDecomposableEvaluate<A>::value,
+      "CheckDecomposableEvaluate static check failed.");
+  static_assert(CheckDecomposableEvaluate<B>::value,
+      "CheckDecomposableEvaluate static check failed.");
+  static_assert(!CheckDecomposableEvaluate<C>::value, 
+      "CheckDecomposableEvaluate static check failed.");
+  static_assert(!CheckDecomposableEvaluate<D>::value, 
+      "CheckDecomposableEvaluate static check failed.");
+
+  static_assert(CheckDecomposableGradient<A>::value,
+      "CheckDecomposableGradient static check failed.");
+  static_assert(CheckDecomposableGradient<B>::value,
+      "CheckDecomposableGradient static check failed.");
+  static_assert(!CheckDecomposableGradient<C>::value,
+      "CheckDecomposableGradient static check failed.");
+  static_assert(!CheckDecomposableGradient<D>::value, 
+      "CheckDecomposableGradient static check failed.");
+}
+
+BOOST_AUTO_TEST_CASE(LagrangianFunctionTypeCheckTest)
+{
+  static_assert(!CheckEvaluate<A>::value, "CheckEvaluate static check failed.");
+  static_assert(!CheckEvaluate<B>::value, "CheckEvaluate static check failed.");
+  static_assert(CheckEvaluate<C>::value, "CheckEvaluate static check failed.");
+  static_assert(CheckEvaluate<D>::value, "CheckEvaluate static check failed.");
+
+  static_assert(!CheckGradient<A>::value, "CheckGradient static check failed.");
+  static_assert(!CheckGradient<B>::value, "CheckGradient static check failed.");
+  static_assert(CheckGradient<C>::value, "CheckGradient static check failed.");
+  static_assert(CheckGradient<D>::value, "CheckGradient static check failed.");
+
+  static_assert(!CheckNumConstraints<A>::value,
+      "CheckNumConstraints static check failed.");
+  static_assert(!CheckNumConstraints<B>::value,
+      "CheckNumConstraints static check failed.");
+  static_assert(CheckNumConstraints<C>::value,
+      "CheckNumConstraints static check failed.");
+  static_assert(CheckNumConstraints<D>::value,
+      "CheckNumConstraints static check failed.");
+
+  static_assert(!CheckEvaluateConstraint<A>::value,
+      "CheckEvaluateConstraint static check failed.");
+  static_assert(!CheckEvaluateConstraint<B>::value,
+      "CheckEvaluateConstraint static check failed.");
+  static_assert(CheckEvaluateConstraint<C>::value,
+      "CheckEvaluateConstraint static check failed.");
+  static_assert(CheckEvaluateConstraint<D>::value,
+      "CheckEvaluateConstraint static check failed.");
+
+  static_assert(!CheckGradientConstraint<A>::value,
+      "CheckGradientConstraint static check failed.");
+  static_assert(!CheckGradientConstraint<B>::value,
+      "CheckGradientConstraint static check failed.");
+  static_assert(CheckGradientConstraint<C>::value,
+      "CheckGradientConstraint static check failed.");
+  static_assert(CheckGradientConstraint<D>::value,
+      "CheckGradientConstraint static check failed.");
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/functiontype_method_forms_test.cpp
+++ b/src/mlpack/tests/functiontype_method_forms_test.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file functiontype_method_forms.cpp
+ * @author Shikhar Bhardwaj
+ *
+ * Test file for FunctionType method forms.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/util/functiontype_method_forms.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include "test_tools.hpp"
+
+using namespace std;
+using namespace arma;
+using namespace mlpack;
+using namespace mlpack::static_checks;
+
+BOOST_AUTO_TEST_SUITE(FunctionTypeMethodFormsTest);
+
+class A
+{
+  public:
+    size_t NumFunctions() const;
+    double Evaluate(const arma::mat&, const size_t) const;
+    void Gradient(const arma::mat&, const size_t, arma::mat&) const;
+};
+
+class B
+{
+  public:
+    size_t NumFunctions();
+    double Evaluate(const arma::mat&) const;
+    void Gradient(const arma::mat&, arma::mat&) const;
+};
+
+/**
+ * Test the correctness of the method forms describing the
+ * DecomposableFunctionType API.
+ */
+BOOST_AUTO_TEST_CASE(DecomposableFunctionTypeMethodFormsTest)
+{
+  static_assert(HasNumFunctions<A, NumFunctionsForm>::value,
+      "NumFunctions static check failed.");
+  static_assert(!HasNumFunctions<B, NumFunctionsForm>::value,
+      "NumFunctions static check failed.");
+
+  static_assert(HasDecomposableEvaluate<A, DecomposableEvaluateForm>::value,
+      "DecomposableEvaluate static check failed");
+  static_assert(!HasDecomposableEvaluate<B, DecomposableEvaluateForm>::value,
+      "DecomposableEvaluate static check failed");
+
+  static_assert(HasDecomposableGradient<A, DecomposableGradientForm>::value,
+      "DecomposableGradient static check failed");
+  static_assert(!HasDecomposableGradient<B, DecomposableGradientForm>::value,
+      "DecomposableGradient static check failed");
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This PR adds static checking of FunctionType API at compile time. Currently, I have added a short testcase and made changes to the `AdaDelta` optimizer.

A few minor things : 
1. POD types passed by value are treated equally with or without the `const` qualifier. So `void Foo(size_t)` and `void Foo(const size_t)` are treated as same function prototypes.
2. `const` qualified member functions are enforced. So I think we should modify the `FunctionType` policy documentation to indicate that the functions must be `const` qualified.

I'll change other optimizers and add more method forms if these changes are fine.