### PR TITLE
Reinclude 'total_time' timer.

### DIFF
--- a/src/mlpack/core/util/cli.cpp
+++ b/src/mlpack/core/util/cli.cpp
@@ -96,12 +96,16 @@ void CLI::Add(ParamData&& data)
   // If found in current map, print fatal error and terminate the program, but
   // only if the parameter is not consistent.
   if (parameters.count(data.name) && !data.persistent)
+  {
     outstr << "Parameter --" << data.name << " (-" << data.alias << ") "
            << "is defined multiple times with the same identifiers."
            << std::endl;
+  }
   if (data.alias != '\0' && aliases.count(data.alias) && !data.persistent)
+  {
     outstr << "Parameter --" << data.name << " (-" << data.alias << ") "
            << "is defined multiple times with the same alias." << std::endl;
+  }
 
   // Add the alias, if necessary.
   if (data.alias != '\0')
@@ -129,8 +133,10 @@ bool CLI::HasParam(const std::string& key)
       usedKey = GetSingleton().aliases[key[0]];
 
     if (!parameters.count(usedKey))
+    {
       Log::Fatal << "Parameter '--" << key << "' does not exist in this "
           << "program." << std::endl;
+    }
   }
   const std::string& checkKey = usedKey;
 
@@ -182,8 +188,10 @@ std::string CLI::ProgramName()
 void CLI::SetPassed(const std::string& name)
 {
   if (GetSingleton().parameters.count(name) == 0)
+  {
     throw std::invalid_argument("CLI::SetPassed(): parameter " + name +
         " not known!");
+  }
 
   // Set passed to true.
   GetSingleton().parameters[name].wasPassed = true;
@@ -205,8 +213,10 @@ void CLI::StoreSettings(const std::string& name)
 void CLI::RestoreSettings(const std::string& name, const bool fatal)
 {
   if (GetSingleton().storageMap.count(name) == 0 && fatal)
+  {
     throw std::invalid_argument("no settings stored under the name '" + name
         + "'");
+  }
   else if (GetSingleton().storageMap.count(name) == 0 && !fatal)
   {
     // Nothing to do, just clear what's there.

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -50,6 +50,9 @@ void mlpackMain(); // This is typically defined after this include.
 
 int main(int argc, char** argv)
 {
+  // A "total_time" timer is run by default for each mlpack program.
+  mlpack::Timer::Start("total_time");
+
   // Parse the command-line options; put them into CLI.
   mlpack::bindings::cli::ParseCommandLine(argc, argv);
 


### PR DESCRIPTION
Add a ``total_time`` timer that is added by default for each mlpack program.