### PR TITLE
Add guidelines and process for contributing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to mlpack
+
+Anyone is welcome to contribute to mlpack and join the community.  If you would
+like to make improvements to the library or have found a bug that you know how
+to fix, please submit a pull request!
+
+If you would like to learn more about how to get started contributing, see
+[Getting Involved](http://www.mlpack.org/involved.html), and if you are
+interested in participating in Google Summer of Code, see
+[mlpack and Google Summer of Code](http://www.mlpack.org/gsoc.html).
+
+## Pull request process
+
+Once a pull request is submitted, it must be reviewed by at least one member of
+mlpack's Contributors team, to ensure that (if applicable):
+
+ * the design meshes with the rest of mlpack
+ * the style matches the
+   [Style Guide](http://github.com/mlpack/mlpack/wiki/DesignGuidelines)
+ * any new functionality is tested and working
+
+Once the pull request is approved by one member of the Contributors team, it may
+be merged between 3 and 7 days after approval.  This allows other contributors
+and maintainers to have time to also review the PR.  If a pull request has at
+least two approvals from members of the Contributors team, then the pull
+request may be immediately merged.  This applies even if the submitter of the
+PR is a member of the Contributors team.


### PR DESCRIPTION
This adds a simple `CONTRIBUTING.md` that lays out a policy for how to merge PRs.  Since we have grown in size over the years, having some kind of framework for this should be helpful in making PRs get merged faster.