### PR TITLE
Fix recurrent layers' compatibility with batch sizes > 1.

### DIFF
--- a/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
@@ -103,7 +103,8 @@ double SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
     }
 
     // Find the effective batch size (the last batch may be smaller).
-    const size_t effectiveBatchSize = std::min(batchSize,
+    const size_t effectiveBatchSize = std::min(
+        std::min(batchSize, actualMaxIterations - i),
         numFunctions - currentFunction);
 
     function.Gradient(iterate, currentFunction, gradient, effectiveBatchSize);

--- a/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/sgd/sgd_impl.hpp
@@ -102,7 +102,12 @@ double SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
         function.Shuffle();
     }
 
-    // Find the effective batch size (the last batch may be smaller).
+    // Find the effective batch size; we have to take the minimum of three
+    // things:
+    // - the batch size can't be larger than the user-specified batch size;
+    // - the batch size can't be larger than the number of iterations left
+    //       before actualMaxIterations is hit;
+    // - the batch size can't be larger than the number of functions left.
     const size_t effectiveBatchSize = std::min(
         std::min(batchSize, actualMaxIterations - i),
         numFunctions - currentFunction);

--- a/src/mlpack/core/optimizers/spalera_sgd/spalera_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/spalera_sgd/spalera_sgd_impl.hpp
@@ -116,7 +116,7 @@ double SPALeRASGD<DecayPolicyType>::Optimize(DecomposableFunctionType& function,
     // - the batch size can't be larger than the number of functions left.
     const size_t effectiveBatchSize = std::min(
         std::min(batchSize, actualMaxIterations - i),
-        numFunctions - currentFunction);ons - currentFunction);
+        numFunctions - currentFunction);
 
     function.Gradient(iterate, currentFunction, gradient, effectiveBatchSize);
 

--- a/src/mlpack/core/optimizers/spalera_sgd/spalera_sgd_impl.hpp
+++ b/src/mlpack/core/optimizers/spalera_sgd/spalera_sgd_impl.hpp
@@ -108,9 +108,15 @@ double SPALeRASGD<DecayPolicyType>::Optimize(DecomposableFunctionType& function,
         function.Shuffle();
     }
 
-    // Find the effective batch size (the last batch may be smaller).
-    const size_t effectiveBatchSize = std::min(batchSize,
-        numFunctions - currentFunction);
+    // Find the effective batch size; we have to take the minimum of three
+    // things:
+    // - the batch size can't be larger than the user-specified batch size;
+    // - the batch size can't be larger than the number of iterations left
+    //       before actualMaxIterations is hit;
+    // - the batch size can't be larger than the number of functions left.
+    const size_t effectiveBatchSize = std::min(
+        std::min(batchSize, actualMaxIterations - i),
+        numFunctions - currentFunction);ons - currentFunction);
 
     function.Gradient(iterate, currentFunction, gradient, effectiveBatchSize);
 

--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -197,7 +197,7 @@ void FastLSTM<InputDataType, OutputDataType>::Backward(
       backwardStep - batchStep, 3 * outSize - 1, backwardStep) %
       cellActivationError;
 
-  if (backwardStep != 0)
+  if (backwardStep > batchStep)
   {
     prevError.submat(2 * outSize, 0, 3 * outSize - 1, batchStep) =
         cell.cols((backwardStep - batchSize) - batchStep,
@@ -258,13 +258,13 @@ void FastLSTM<InputDataType, OutputDataType>::Gradient(
       gradient.n_elem - 1, 0) = arma::vectorise(prevError *
       outParameter.cols(gradientStep - batchStep, gradientStep).t());
 
-  if (gradientStep == 0)
+  if (gradientStep > batchStep)
   {
-    gradientStep = batchSize * bpttSteps - 1;
+    gradientStep -= batchSize;
   }
   else
   {
-    gradientStep -= batchSize;
+    gradientStep = batchSize * bpttSteps - 1;
   }
 }
 

--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -80,7 +80,7 @@ void FastLSTM<InputDataType, OutputDataType>::ResetCell(const size_t size)
   gradientStep = batchSize * size - 1;
 
   const size_t rhoBatchSize = size * batchSize;
-  if (gate.is_empty() || gate.n_cols < rhoBatchSize)
+  if (gate.is_empty() || gate.n_cols != rhoBatchSize)
   {
     gate.set_size(4 * outSize, rhoBatchSize);
     gateActivation.set_size(outSize * 3, rhoBatchSize);

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -92,8 +92,6 @@ template<typename eT>
 void GRU<InputDataType, OutputDataType>::Forward(
     arma::Mat<eT>&& input, arma::Mat<eT>&& output)
 {
-  std::cout << "GRU::Forward(): input " << input.n_rows << "x" << input.n_cols
-<< "; batchSize " << batchSize << "; forwardStep " << forwardStep << "\n";
   if (input.n_cols != batchSize)
   {
     batchSize = input.n_cols;
@@ -209,8 +207,6 @@ template<typename eT>
 void GRU<InputDataType, OutputDataType>::Backward(
   const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
 {
-  std::cout << "GRU::Backward(): input " << input.n_rows << "x" << input.n_cols
-<< "; batchSize " << batchSize << "; backwardStep " << backwardStep << "\n";
   if (input.n_cols != batchSize)
   {
     batchSize = input.n_cols;
@@ -327,8 +323,6 @@ void GRU<InputDataType, OutputDataType>::Gradient(
     arma::Mat<eT>&& /* error */,
     arma::Mat<eT>&& /* gradient */)
 {
-  std::cout << "GRU::Gradient(): input " << input.n_rows << "x" << input.n_cols
-<< "; batchSize " << batchSize << "; gradientStep " << gradientStep << "\n";
   if (input.n_cols != batchSize)
   {
     batchSize = input.n_cols;

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -188,12 +188,12 @@ void LSTM<InputDataType, OutputDataType>::Forward(
   if (forwardStep > 0)
   {
     inputGate.cols(forwardStep, forwardStep + batchStep) +=
-        arma::repmat(cell2GateInputWeight, 1, batchSize) % cell.cols(forwardStep - batchSize,
-        forwardStep - batchSize + batchStep);
+        arma::repmat(cell2GateInputWeight, 1, batchSize) %
+        cell.cols(forwardStep - batchSize, forwardStep - batchSize + batchStep);
 
     forgetGate.cols(forwardStep, forwardStep + batchStep) +=
-        arma::repmat(cell2GateForgetWeight, 1, batchSize) % cell.cols(forwardStep - batchSize,
-        forwardStep - batchSize + batchStep);
+        arma::repmat(cell2GateForgetWeight, 1, batchSize) %
+        cell.cols(forwardStep - batchSize, forwardStep - batchSize + batchStep);
   }
 
   inputGateActivation.cols(forwardStep, forwardStep + batchStep) = 1.0 /
@@ -398,12 +398,14 @@ void LSTM<InputDataType, OutputDataType>::Gradient(
   if (gradientStep > batchStep)
   {
     gradient.submat(offset, 0, offset + cell2GateForgetWeight.n_elem - 1, 0) =
-        arma::sum(forgetGateError % cell.cols((gradientStep - batchSize) - batchStep,
-        (gradientStep - batchSize)), 1);
+        arma::sum(forgetGateError %
+                  cell.cols((gradientStep - batchSize) - batchStep,
+                            (gradientStep - batchSize)), 1);
     gradient.submat(offset + cell2GateForgetWeight.n_elem, 0, offset +
         cell2GateForgetWeight.n_elem + cell2GateInputWeight.n_elem - 1, 0) =
-        arma::sum(inputGateError % cell.cols((gradientStep - batchSize) - batchStep,
-        (gradientStep - batchSize)), 1);
+        arma::sum(inputGateError %
+                  cell.cols((gradientStep - batchSize) - batchStep,
+                            (gradientStep - batchSize)), 1);
   }
   else
   {

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -222,7 +222,14 @@ class RNN
   size_t& Rho() { return rho; }
 
   /**
-   * Reset the module infomration (weights/parameters).
+   * Reset the state of the network.  This ensures that all internally-held
+   * gradients are set to 0, all memory cells are reset, and the parameters
+   * matrix is the right size.
+   */
+  void Reset();
+
+  /**
+   * Reset the module information (weights/parameters).
    */
   void ResetParameters();
 

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -102,7 +102,6 @@ void RNN<OutputLayerType, InitializationRuleType>::Train(
   if (!reset)
   {
     ResetParameters();
-    reset = true;
   }
 
   // Train the model.
@@ -139,7 +138,6 @@ void RNN<OutputLayerType, InitializationRuleType>::Train(
   if (!reset)
   {
     ResetParameters();
-    reset = true;
   }
 
   OptimizerType optimizer;
@@ -207,7 +205,6 @@ double RNN<OutputLayerType, InitializationRuleType>::Evaluate(
   if (parameter.is_empty())
   {
     ResetParameters();
-    reset = true;
   }
 
   if (deterministic != this->deterministic)
@@ -272,7 +269,6 @@ void RNN<OutputLayerType, InitializationRuleType>::Gradient(
     if (parameter.is_empty())
     {
       ResetParameters();
-      reset = true;
     }
 
     gradient = arma::zeros<arma::mat>(parameter.n_rows, parameter.n_cols);
@@ -337,6 +333,17 @@ void RNN<OutputLayerType, InitializationRuleType>::ResetParameters()
   // Reset the network parameter with the given initialization rule.
   NetworkInitialization<InitializationRuleType> networkInit(initializeRule);
   networkInit.Initialize(network, parameter);
+
+  reset = true;
+}
+
+template<typename OutputLayerType, typename InitializationRuleType>
+void RNN<OutputLayerType, InitializationRuleType>::Reset()
+{
+  ResetParameters();
+  ResetCells();
+  currentGradient.zeros();
+  ResetGradients(currentGradient);
 }
 
 template<typename OutputLayerType, typename InitializationRuleType>


### PR DESCRIPTION
I tried to build an LSTM network with batch size > 1, but there were some Armadillo shape errors.  I believe this code fixes that; however, the tests do not work right now.  I need to redesign the tests...