### PR TITLE
Fixed issue with redifenition at binding tests

### DIFF
--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -68,7 +68,8 @@ class CLIOption
             const std::string& cppName,
             const bool required = false,
             const bool input = true,
-            const bool noTranspose = false)
+            const bool noTranspose = false,
+	    const std::string& /*programName*/ = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -60,6 +60,7 @@ class CLIOption
    * @param input Whether or not the option is an input option.
    * @param noTranspose If the parameter is a matrix and this is true, then the
    *      matrix will not be transposed on loading.
+   * @param testName Is not used and added for compatibility reasons.
    */
   CLIOption(const N defaultValue,
             const std::string& identifier,
@@ -69,7 +70,7 @@ class CLIOption
             const bool required = false,
             const bool input = true,
             const bool noTranspose = false,
-            const std::string& /*programName*/ = "")
+            const std::string& /*testName*/ = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -69,7 +69,7 @@ class CLIOption
             const bool required = false,
             const bool input = true,
             const bool noTranspose = false,
-	    const std::string& /*programName*/ = "")
+            const std::string& /*programName*/ = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -43,7 +43,7 @@ class PyOption
            const bool required = false,
            const bool input = true,
            const bool noTranspose = false,
-	   const std::string& /*programName*/ = "")
+           const std::string& /*programName*/ = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -42,7 +42,8 @@ class PyOption
            const std::string& cppName,
            const bool required = false,
            const bool input = true,
-           const bool noTranspose = false)
+           const bool noTranspose = false,
+	   const std::string& /*programName*/ = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -33,7 +33,8 @@ class PyOption
  public:
   /**
    * Construct a PyOption object.  When constructed, it will register itself
-   * with CLI.
+   * with CLI. The testName parameter is not used and added for compatibility 
+   * reasons.
    */
   PyOption(const T defaultValue,
            const std::string& identifier,
@@ -43,7 +44,7 @@ class PyOption
            const bool required = false,
            const bool input = true,
            const bool noTranspose = false,
-           const std::string& /*programName*/ = "")
+           const std::string& /*testName*/ = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -52,7 +52,7 @@ PARAM_MODEL_OUT(GaussianKernel, "model_out", "Output model, with twice the "
     "bandwidth.", "");
 PARAM_DOUBLE_OUT("model_bw_out", "The bandwidth of the model.");
 
-void mlpackMain()
+static void mlpackMain()
 {
   const string s = CLI::GetParam<string>("string_in");
   const int i = CLI::GetParam<int>("int_in");

--- a/src/mlpack/bindings/tests/test_option.hpp
+++ b/src/mlpack/bindings/tests/test_option.hpp
@@ -61,7 +61,8 @@ class TestOption
              const std::string& cppName,
              const bool required = false,
              const bool input = true,
-             const bool noTranspose = false)
+             const bool noTranspose = false,
+	     const std::string& programName = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/bindings/tests/test_option.hpp
+++ b/src/mlpack/bindings/tests/test_option.hpp
@@ -54,7 +54,7 @@ class TestOption
    * @param noTranspose If the parameter is a matrix and this is true, then the
    *      matrix will not be transposed on loading.
    * @param testName Name of the test (used for identifiying which binding test 
-   * this option belongs to)
+   *      this option belongs to)
    */
   TestOption(const N defaultValue,
              const std::string& identifier,

--- a/src/mlpack/bindings/tests/test_option.hpp
+++ b/src/mlpack/bindings/tests/test_option.hpp
@@ -53,6 +53,8 @@ class TestOption
    * @param input Whether or not the option is an input option.
    * @param noTranspose If the parameter is a matrix and this is true, then the
    *      matrix will not be transposed on loading.
+   * @param testName Name of the test (used for identifiying which binding test 
+   * this option belongs to)
    */
   TestOption(const N defaultValue,
              const std::string& identifier,
@@ -62,7 +64,7 @@ class TestOption
              const bool required = false,
              const bool input = true,
              const bool noTranspose = false,
-             const std::string& programName = "")
+             const std::string& testName = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;
@@ -82,7 +84,7 @@ class TestOption
 
     const std::string tname = data.tname;
 
-    CLI::RestoreSettings(programName, false);
+    CLI::RestoreSettings(testName, false);
 
     // Set some function pointers that we need.
     CLI::GetSingleton().functionMap[tname]["GetPrintableParam"] =
@@ -95,7 +97,7 @@ class TestOption
     if (!input)
       CLI::SetPassed(identifier);
 
-    CLI::StoreSettings(programName);
+    CLI::StoreSettings(testName);
     CLI::ClearSettings();
   }
 };

--- a/src/mlpack/bindings/tests/test_option.hpp
+++ b/src/mlpack/bindings/tests/test_option.hpp
@@ -62,7 +62,7 @@ class TestOption
              const bool required = false,
              const bool input = true,
              const bool noTranspose = false,
-	     const std::string& programName = "")
+             const std::string& programName = "")
   {
     // Create the ParamData object to give to CLI.
     util::ParamData data;

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -148,5 +148,3 @@ PARAM_FLAG("verbose", "Display informational messages and the full list of "
 #include "param_checks.hpp"
 
 #endif
-
-

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -92,7 +92,7 @@ using Option = mlpack::bindings::tests::TestOption<T>;
 }
 }
 
-//testName symbol should be defined in each binding test file
+// testName symbol should be defined in each binding test file
 #include <mlpack/core/util/param.hpp>
 
 #undef PROGRAM_INFO

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -46,11 +46,12 @@ using Option = mlpack::bindings::cli::CLIOption<T>;
 }
 }
 
+static const std::string testName = "";
 #include <mlpack/core/util/param.hpp>
 #include <mlpack/bindings/cli/parse_command_line.hpp>
 #include <mlpack/bindings/cli/end_program.hpp>
 
-void mlpackMain(); // This is typically defined after this include.
+static void mlpackMain(); // This is typically defined after this include.
 
 int main(int argc, char** argv)
 {
@@ -91,6 +92,7 @@ using Option = mlpack::bindings::tests::TestOption<T>;
 }
 }
 
+//testName symbol should be defined in each binding test file
 #include <mlpack/core/util/param.hpp>
 
 #undef PROGRAM_INFO
@@ -119,6 +121,7 @@ using Option = mlpack::bindings::python::PyOption<T>;
 }
 }
 
+static const std::string testName = "";
 #include <mlpack/core/util/param.hpp>
 
 #undef PROGRAM_INFO

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -96,14 +96,7 @@ using Option = mlpack::bindings::tests::TestOption<T>;
 #undef PROGRAM_INFO
 #define PROGRAM_INFO(NAME, DESC) static mlpack::util::ProgramDoc \
     cli_programdoc_dummy_object = mlpack::util::ProgramDoc(NAME, \
-        []() { return DESC; }); \
-    namespace mlpack { \
-    namespace bindings { \
-    namespace tests { \
-    std::string programName = NAME; \
-    } \
-    } \
-    }
+        []() { return DESC; });
 
 #elif(BINDING_TYPE == BINDING_TYPE_PYX) // This is a Python binding.
 
@@ -155,3 +148,5 @@ PARAM_FLAG("verbose", "Display informational messages and the full list of "
 #include "param_checks.hpp"
 
 #endif
+
+

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -15,24 +15,6 @@
 #ifndef MLPACK_CORE_UTIL_PARAM_HPP
 #define MLPACK_CORE_UTIL_PARAM_HPP
 
-#include <string>
-
-// PROGRAM_NAME is used for mlpackMain modification (mlpackMain##PROGRAM_NAME)
-// PROGRAM_NAME_SUBSTUTIDE is used for passing unique program name to TestOption
-#ifdef PROGRAM_NAME
-#define PROGRAM_NAME_SUBSTITUDE PROGRAM_NAME
-#else
-#define PROGRAM_NAME
-#define PROGRAM_NAME_SUBSTITUDE programNameSubstitude
-static const std::string programNameSubstitude = "programNameSubstitude";
-#endif
-// The MAIN macro is mlpackMain##PROGRAM_NAME. The goal is to have different
-// names of main procedure for main tests when all method's  main functions
-// are linked into one executable (mlpack_test)
-#define TOKENPASTE1(x, y) x ## y
-#define TOKENPASTE2(x, y) TOKENPASTE1(x, y)
-#define MAIN TOKENPASTE2(mlpackMain, PROGRAM_NAME)
-
 // Required forward declarations.
 namespace mlpack {
 namespace data {
@@ -1030,55 +1012,55 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
   #define PARAM_IN(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(cli_option_dummy_object_in_, __COUNTER__) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, true, false, PROGRAM_NAME_SUBSTITUDE);
+      (DEF, ID, DESC, ALIAS, #T, REQ, true, false, testName);
 
   #define PARAM_OUT(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(cli_option_dummy_object_out_, __COUNTER__) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, false, false, PROGRAM_NAME_SUBSTITUDE);
+      (DEF, ID, DESC, ALIAS, #T, REQ, false, false, testName);
 
   #define PARAM_MATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::mat> \
       JOIN(cli_option_dummy_matrix_, __COUNTER__) \
       (arma::mat(), ID, DESC, ALIAS, "arma::mat", \
-      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      REQ, IN, !TRANS, testName);
 
   #define PARAM_UMATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Mat<size_t>> \
       JOIN(cli_option_dummy_umatrix_, __COUNTER__) \
       (arma::Mat<size_t>(), ID, DESC, ALIAS, "arma::Mat<size_t>", \
-      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      REQ, IN, !TRANS, testName);
 
   #define PARAM_COL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::vec> \
       JOIN(cli_option_dummy_col_, __COUNTER__) \
       (arma::vec(), ID, DESC, ALIAS, "arma::vec", \
-      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      REQ, IN, !TRANS, testName);
 
   #define PARAM_UCOL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Col<size_t>> \
       JOIN(cli_option_dummy_ucol_, __COUNTER__) \
       (arma::Col<size_t>(), ID, DESC, ALIAS, "arma::Col<size_t>", \
-      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      REQ, IN, !TRANS, testName);
 
   #define PARAM_ROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::rowvec> \
       JOIN(cli_option_dummy_row_, __COUNTER__) \
       (arma::rowvec(), ID, DESC, ALIAS, "arma::rowvec", \
-      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      REQ, IN, !TRANS, testName);
 
   #define PARAM_UROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Row<size_t>> \
       JOIN(cli_option_dummy_urow_, __COUNTER__) \
       (arma::Row<size_t>(), ID, DESC, ALIAS, "arma::Row<size_t>", \
-      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      REQ, IN, !TRANS, testName);
 
   // There are no uses of required models, so that is not an option to this
   // macro (it would be easy to add).
   #define PARAM_MODEL(TYPE, ID, DESC, ALIAS, REQ, IN) \
       static mlpack::util::Option<TYPE> \
       JOIN(cli_option_dummy_model_, __COUNTER__) \
-      (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN, false, PROGRAM_NAME_SUBSTITUDE);
+      (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN, false, testName);
 #else
   // We have to do some really bizarre stuff since __COUNTER__ isn't defined. I
   // don't think we can absolutely guarantee success, but it should be "good
@@ -1087,54 +1069,54 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
   #define PARAM_IN(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(JOIN(cli_option_dummy_object_in_, __LINE__), opt) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, true, false, PROGRAM_NAME_SUBSTITUDE);
+      (DEF, ID, DESC, ALIAS, #T, REQ, true, false, testName);
 
   #define PARAM_OUT(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(JOIN(cli_option_dummy_object_out_, __LINE__), opt) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, false, false, PROGRAM_NAME_SUBSTITUDE);
+      (DEF, ID, DESC, ALIAS, #T, REQ, false, false, testName);
 
   #define PARAM_MATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::mat> \
       JOIN(JOIN(cli_option_dummy_object_matrix_, __LINE__), opt) \
       (arma::mat(), ID, DESC, ALIAS, "arma::mat", REQ, IN, !TRANS, \
-      PROGRAM_NAME_SUBSTITUDE);
+      testName);
 
   #define PARAM_UMATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Mat<size_t>> \
       JOIN(JOIN(cli_option_dummy_object_umatrix_, __LINE__), opt) \
       (arma::Mat<size_t>(), ID, DESC, ALIAS, "arma::Mat<size_t>", REQ, IN, \
-      !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      !TRANS, testName);
 
   #define PARAM_COL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::vec> \
       JOIN(cli_option_dummy_object_col_, __LINE__) \
       (arma::vec(), ID, DESC, ALIAS, "arma::vec", REQ, IN, !TRANS, \
-      PROGRAM_NAME_SUBSTITUDE);
+      testName);
 
   #define PARAM_UCOL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Col<size_t>> \
       JOIN(cli_option_dummy_object_ucol_, __LINE__) \
       (arma::Col<size_t>(), ID, DESC, ALIAS, "arma::Col<size_t>", REQ, IN, \
-      !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      !TRANS, testName);
 
   #define PARAM_ROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::rowvec> \
       JOIN(cli_option_dummy_object_row_, __LINE__) \
       (arma::rowvec(), ID, DESC, ALIAS, "arma::rowvec", REQ, IN, !TRANS, \
-      PROGRAM_NAME_SUBSTITUDE);
+      testName);
 
   #define PARAM_UROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Row<size_t>> \
       JOIN(cli_option_dummy_object_urow_, __LINE__) \
       (arma::Row<size_t>(), ID, DESC, ALIAS, "arma::Row<size_t>", REQ, IN, \
-      !TRANS, PROGRAM_NAME_SUBSTITUDE);
+      !TRANS, testName);
 
   #define PARAM_MODEL(TYPE, ID, DESC, ALIAS, REQ, IN) \
       static mlpack::util::Option<TYPE> \
       JOIN(JOIN(cli_option_dummy_object_model_, __LINE__), opt) \
       (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN, false, \
-      PROGRAM_NAME_SUBSTITUDE);
+      testName);
 #endif
 
 #endif

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -17,8 +17,8 @@
 
 #include <string>
 
-//PROGRAM_NAME is used for mlpackMain modification (mlpackMain##PROGRAM_NAME)
-//PROGRAM_NAME_SUBSTUTIDE is used for passing unique program name to TestOption
+// PROGRAM_NAME is used for mlpackMain modification (mlpackMain##PROGRAM_NAME)
+// PROGRAM_NAME_SUBSTUTIDE is used for passing unique program name to TestOption
 #ifdef PROGRAM_NAME
 #define PROGRAM_NAME_SUBSTITUDE PROGRAM_NAME
 #else
@@ -26,9 +26,9 @@
 #define PROGRAM_NAME_SUBSTITUDE programNameSubstitude
 static const std::string programNameSubstitude = "programNameSubstitude";
 #endif
-//The MAIN macro is mlpackMain##PROGRAM_NAME. The goal is to have different
-//names of main procedure for main tests when all method's  main functions
-//are linked into one executable (mlpack_test)
+// The MAIN macro is mlpackMain##PROGRAM_NAME. The goal is to have different
+// names of main procedure for main tests when all method's  main functions
+// are linked into one executable (mlpack_test)
 #define TOKENPASTE1(x, y) x ## y
 #define TOKENPASTE2(x, y) TOKENPASTE1(x, y)
 #define MAIN TOKENPASTE2(mlpackMain, PROGRAM_NAME)

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -15,6 +15,24 @@
 #ifndef MLPACK_CORE_UTIL_PARAM_HPP
 #define MLPACK_CORE_UTIL_PARAM_HPP
 
+#include <string>
+
+//PROGRAM_NAME is used for mlpackMain modification (mlpackMain##PROGRAM_NAME)
+//PROGRAM_NAME_SUBSTUTIDE is used for passing unique program name to TestOption
+#ifdef PROGRAM_NAME
+#define PROGRAM_NAME_SUBSTITUDE PROGRAM_NAME
+#else
+#define PROGRAM_NAME
+#define PROGRAM_NAME_SUBSTITUDE programNameSubstitude
+static const std::string programNameSubstitude = "programNameSubstitude";
+#endif
+//The MAIN macro is mlpackMain##PROGRAM_NAME. The goal is to have different
+//names of main procedure for main tests when all method's  main functions
+//are linked into one executable (mlpack_test)
+#define TOKENPASTE1(x, y) x ## y
+#define TOKENPASTE2(x, y) TOKENPASTE1(x, y)
+#define MAIN TOKENPASTE2(mlpackMain, PROGRAM_NAME)
+
 // Required forward declarations.
 namespace mlpack {
 namespace data {
@@ -1012,53 +1030,55 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
   #define PARAM_IN(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(cli_option_dummy_object_in_, __COUNTER__) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, true, false);
+      (DEF, ID, DESC, ALIAS, #T, REQ, true, false, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_OUT(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(cli_option_dummy_object_out_, __COUNTER__) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, false, false);
+      (DEF, ID, DESC, ALIAS, #T, REQ, false, false, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_MATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::mat> \
       JOIN(cli_option_dummy_matrix_, __COUNTER__) \
-      (arma::mat(), ID, DESC, ALIAS, "arma::mat", REQ, IN, !TRANS);
+      (arma::mat(), ID, DESC, ALIAS, "arma::mat", \
+      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_UMATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Mat<size_t>> \
       JOIN(cli_option_dummy_umatrix_, __COUNTER__) \
-      (arma::Mat<size_t>(), ID, DESC, ALIAS, "arma::Mat<size_t>", REQ, IN, \
-      !TRANS);
+      (arma::Mat<size_t>(), ID, DESC, ALIAS, "arma::Mat<size_t>", \
+      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_COL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::vec> \
       JOIN(cli_option_dummy_col_, __COUNTER__) \
-      (arma::vec(), ID, DESC, ALIAS, "arma::vec", REQ, IN, !TRANS);
+      (arma::vec(), ID, DESC, ALIAS, "arma::vec", \
+      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_UCOL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Col<size_t>> \
       JOIN(cli_option_dummy_ucol_, __COUNTER__) \
-      (arma::Col<size_t>(), ID, DESC, ALIAS, "arma::Col<size_t>", REQ, IN, \
-      !TRANS);
+      (arma::Col<size_t>(), ID, DESC, ALIAS, "arma::Col<size_t>", \
+      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_ROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::rowvec> \
       JOIN(cli_option_dummy_row_, __COUNTER__) \
-      (arma::rowvec(), ID, DESC, ALIAS, "arma::rowvec", REQ, IN, !TRANS);
+      (arma::rowvec(), ID, DESC, ALIAS, "arma::rowvec", \
+      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_UROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Row<size_t>> \
       JOIN(cli_option_dummy_urow_, __COUNTER__) \
-      (arma::Row<size_t>(), ID, DESC, ALIAS, "arma::Row<size_t>", REQ, IN, \
-      !TRANS);
-
+      (arma::Row<size_t>(), ID, DESC, ALIAS, "arma::Row<size_t>", \
+      REQ, IN, !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   // There are no uses of required models, so that is not an option to this
   // macro (it would be easy to add).
   #define PARAM_MODEL(TYPE, ID, DESC, ALIAS, REQ, IN) \
       static mlpack::util::Option<TYPE> \
       JOIN(cli_option_dummy_model_, __COUNTER__) \
-      (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN);
+      (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN, false, PROGRAM_NAME_SUBSTITUDE);
 #else
   // We have to do some really bizarre stuff since __COUNTER__ isn't defined. I
   // don't think we can absolutely guarantee success, but it should be "good
@@ -1067,50 +1087,54 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
   #define PARAM_IN(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(JOIN(cli_option_dummy_object_in_, __LINE__), opt) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, true, false);
+      (DEF, ID, DESC, ALIAS, #T, REQ, true, false, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_OUT(T, ID, DESC, ALIAS, DEF, REQ) \
       static mlpack::util::Option<T> \
       JOIN(JOIN(cli_option_dummy_object_out_, __LINE__), opt) \
-      (DEF, ID, DESC, ALIAS, #T, REQ, false, false);
+      (DEF, ID, DESC, ALIAS, #T, REQ, false, false, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_MATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::mat> \
       JOIN(JOIN(cli_option_dummy_object_matrix_, __LINE__), opt) \
-      (arma::mat(), ID, DESC, ALIAS, "arma::mat", REQ, IN, !TRANS);
+      (arma::mat(), ID, DESC, ALIAS, "arma::mat", REQ, IN, !TRANS, \
+      PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_UMATRIX(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Mat<size_t>> \
       JOIN(JOIN(cli_option_dummy_object_umatrix_, __LINE__), opt) \
       (arma::Mat<size_t>(), ID, DESC, ALIAS, "arma::Mat<size_t>", REQ, IN, \
-      !TRANS);
+      !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_COL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::vec> \
       JOIN(cli_option_dummy_object_col_, __LINE__) \
-      (arma::vec(), ID, DESC, ALIAS, "arma::vec", REQ, IN, !TRANS);
+      (arma::vec(), ID, DESC, ALIAS, "arma::vec", REQ, IN, !TRANS, \
+      PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_UCOL(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Col<size_t>> \
       JOIN(cli_option_dummy_object_ucol_, __LINE__) \
       (arma::Col<size_t>(), ID, DESC, ALIAS, "arma::Col<size_t>", REQ, IN, \
-      !TRANS);
+      !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_ROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::rowvec> \
       JOIN(cli_option_dummy_object_row_, __LINE__) \
-      (arma::rowvec(), ID, DESC, ALIAS, "arma::rowvec", REQ, IN, !TRANS);
+      (arma::rowvec(), ID, DESC, ALIAS, "arma::rowvec", REQ, IN, !TRANS, \
+      PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_UROW(ID, DESC, ALIAS, REQ, TRANS, IN) \
       static mlpack::util::Option<arma::Row<size_t>> \
       JOIN(cli_option_dummy_object_urow_, __LINE__) \
       (arma::Row<size_t>(), ID, DESC, ALIAS, "arma::Row<size_t>", REQ, IN, \
-      !TRANS);
+      !TRANS, PROGRAM_NAME_SUBSTITUDE);
 
   #define PARAM_MODEL(TYPE, ID, DESC, ALIAS, REQ, IN) \
       static mlpack::util::Option<TYPE> \
       JOIN(JOIN(cli_option_dummy_object_model_, __LINE__), opt) \
-      (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN);
+      (TYPE(), ID, DESC, ALIAS, #TYPE, REQ, IN, false, \
+      PROGRAM_NAME_SUBSTITUDE);
 #endif
 
 #endif

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -111,7 +111,7 @@ PARAM_MODEL_IN(AdaBoostModel, "input_model", "Input AdaBoost model.", "m");
 PARAM_MODEL_OUT(AdaBoostModel, "output_model", "Output trained AdaBoost model.",
     "M");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check input parameters and issue warnings/errors as necessary.
 

--- a/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
+++ b/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
@@ -141,7 +141,7 @@ PARAM_MODEL_IN(ApproxKFNModel, "input_model", "File containing input model.",
 PARAM_MODEL_OUT(ApproxKFNModel, "output_model", "File to save output model to.",
     "M");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // We have to pass either a reference set or an input model.
   RequireOnlyOnePassed({ "reference", "input_model" });

--- a/src/mlpack/methods/cf/cf_main.cpp
+++ b/src/mlpack/methods/cf/cf_main.cpp
@@ -263,7 +263,7 @@ void AssembleFactorizerType(const std::string& algorithm,
   }
 }
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") == 0)
     math::RandomSeed(std::time(NULL));

--- a/src/mlpack/methods/dbscan/dbscan_main.cpp
+++ b/src/mlpack/methods/dbscan/dbscan_main.cpp
@@ -112,7 +112,7 @@ void RunDBSCAN(RangeSearchType rs = RangeSearchType())
     CLI::GetParam<arma::Row<size_t>>("assignments") = std::move(assignments);
 }
 
-void mlpackMain()
+static void mlpackMain()
 {
   RequireAtLeastOnePassed({ "assignments", "centroids" }, false,
       "no output will be saved");

--- a/src/mlpack/methods/decision_stump/decision_stump_main.cpp
+++ b/src/mlpack/methods/decision_stump/decision_stump_main.cpp
@@ -103,7 +103,7 @@ PARAM_MODEL_OUT(DSModel, "output_model", "Output decision stump model to save.",
 PARAM_INT_IN("bucket_size", "The minimum number of training points in each "
     "decision stump bucket.", "b", 6);
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check that the parameters are reasonable.
   RequireOnlyOnePassed({ "training", "input_model" }, true);

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -115,7 +115,7 @@ PARAM_MODEL_IN(DecisionTreeModel, "input_model", "Pre-trained decision tree, "
 PARAM_MODEL_OUT(DecisionTreeModel, "output_model", "Output for trained decision"
     " tree.", "M");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check parameters.
   RequireOnlyOnePassed({ "training", "input_model" }, true);

--- a/src/mlpack/methods/det/det_main.cpp
+++ b/src/mlpack/methods/det/det_main.cpp
@@ -100,7 +100,7 @@ PARAM_FLAG("volume_regularization", "This flag gives the used the option to use"
 */
 
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Validate input parameters.
   RequireOnlyOnePassed({ "training", "input_model" }, true);

--- a/src/mlpack/methods/emst/emst_main.cpp
+++ b/src/mlpack/methods/emst/emst_main.cpp
@@ -72,7 +72,7 @@ using namespace mlpack::metric;
 using namespace mlpack::util;
 using namespace std;
 
-void mlpackMain()
+static void mlpackMain()
 {
   RequireAtLeastOnePassed({ "output" }, false, "no output will be saved");
 

--- a/src/mlpack/methods/fastmks/fastmks_main.cpp
+++ b/src/mlpack/methods/fastmks/fastmks_main.cpp
@@ -83,7 +83,7 @@ PARAM_FLAG("single", "If true, single-tree search is used (as opposed to "
 PARAM_MATRIX_OUT("kernels", "Output matrix of kernels.", "p");
 PARAM_UMATRIX_OUT("indices", "Output matrix of indices.", "i");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Validate command-line parameters.
   RequireOnlyOnePassed({ "reference", "input_model" }, true);

--- a/src/mlpack/methods/gmm/gmm_generate_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_generate_main.cpp
@@ -42,7 +42,7 @@ PARAM_MATRIX_OUT("output", "Matrix to save output samples in.", "o");
 
 PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Parameter sanity checks.
   RequireAtLeastOnePassed({ "output" }, false, "no results will be saved");

--- a/src/mlpack/methods/gmm/gmm_probability_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_probability_main.cpp
@@ -41,7 +41,7 @@ PARAM_MATRIX_IN_REQ("input", "Input matrix to calculate probabilities of.",
 
 PARAM_MATRIX_OUT("output", "Matrix to store calculated probabilities in.", "o");
 
-void mlpackMain()
+static void mlpackMain()
 {
   RequireAtLeastOnePassed({ "output" }, false, "no results will be saved");
 

--- a/src/mlpack/methods/gmm/gmm_train_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_train_main.cpp
@@ -121,7 +121,7 @@ PARAM_MODEL_IN(GMM, "input_model", "Initial input GMM model to start training "
     "with.", "m");
 PARAM_MODEL_OUT(GMM, "output_model", "Output for trained GMM model.", "M");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check parameters and load data.
   if (CLI::GetParam<int>("seed") != 0)

--- a/src/mlpack/methods/hmm/hmm_generate_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_generate_main.cpp
@@ -92,7 +92,7 @@ struct Generate
   }
 };
 
-void mlpackMain()
+static void mlpackMain()
 {
   RequireAtLeastOnePassed({ "output", "state" }, false, "no output will be "
       "saved");

--- a/src/mlpack/methods/hmm/hmm_loglik_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_loglik_main.cpp
@@ -76,7 +76,7 @@ struct Loglik
   }
 };
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Load model, and calculate the log-likelihood of the sequence.
   CLI::GetParam<HMMModel>("input_model").PerformAction<Loglik>((void*) NULL);

--- a/src/mlpack/methods/hmm/hmm_train_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_train_main.cpp
@@ -340,7 +340,7 @@ struct Train
   }
 };
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Set random seed.
   if (CLI::GetParam<int>("seed") != 0)

--- a/src/mlpack/methods/hmm/hmm_viterbi_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_viterbi_main.cpp
@@ -82,7 +82,7 @@ struct Viterbi
   }
 };
 
-void mlpackMain()
+static void mlpackMain()
 {
   RequireAtLeastOnePassed({ "output" }, false, "no results will be saved");
 

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
@@ -109,7 +109,7 @@ PARAM_INT_IN("observations_before_binning", "If the 'domingos' split strategy "
 // Convenience typedef.
 typedef tuple<DatasetInfo, arma::mat> TupleType;
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check input parameters for validity.
   const string numericSplitStrategy =

--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -164,7 +164,7 @@ void RunKPCA(arma::mat& dataset,
   }
 }
 
-void mlpackMain()
+static void mlpackMain()
 {
   RequireAtLeastOnePassed({ "output" }, false, "no output will be saved");
 

--- a/src/mlpack/methods/kmeans/kmeans_main.cpp
+++ b/src/mlpack/methods/kmeans/kmeans_main.cpp
@@ -140,7 +140,7 @@ template<typename InitialPartitionPolicy,
          template<class, class> class LloydStepType>
 void RunKMeans(const InitialPartitionPolicy& ipp);
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Initialize random seed.
   if (CLI::GetParam<int>("seed") != 0)

--- a/src/mlpack/methods/lars/lars_main.cpp
+++ b/src/mlpack/methods/lars/lars_main.cpp
@@ -101,7 +101,7 @@ PARAM_DOUBLE_IN("lambda2", "Regularization parameter for l2-norm penalty.", "L",
 PARAM_FLAG("use_cholesky", "Use Cholesky decomposition during computation "
     "rather than explicitly computing the full Gram matrix.", "c");
 
-void mlpackMain()
+static void mlpackMain()
 {
   double lambda1 = CLI::GetParam<double>("lambda1");
   double lambda2 = CLI::GetParam<double>("lambda2");

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -85,7 +85,7 @@ PARAM_COL_OUT("output_predictions", "If --test_file is specified, this "
 PARAM_DOUBLE_IN("lambda", "Tikhonov regularization for ridge regression.  If 0,"
     " the method reduces to linear regression.", "l", 0.0);
 
-void mlpackMain()
+void MAIN()
 {
   const double lambda = CLI::GetParam<double>("lambda");
 

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -85,7 +85,7 @@ PARAM_COL_OUT("output_predictions", "If --test_file is specified, this "
 PARAM_DOUBLE_IN("lambda", "Tikhonov regularization for ridge regression.  If 0,"
     " the method reduces to linear regression.", "l", 0.0);
 
-void MAIN()
+static void mlpackMain()
 {
   const double lambda = CLI::GetParam<double>("lambda");
 

--- a/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
+++ b/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
@@ -93,7 +93,7 @@ PARAM_MATRIX_OUT("codes", "Output codes matrix.", "c");
 
 PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/logistic_regression/logistic_regression_main.cpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_main.cpp
@@ -133,7 +133,7 @@ PARAM_DOUBLE_IN("decision_boundary", "Decision boundary for prediction; if the "
     "logistic function for a point is less than the boundary, the class is "
     "taken to be 0; otherwise, the class is 1.", "d", 0.5);
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Collect command-line options.
   const double lambda = CLI::GetParam<double>("lambda");

--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -82,7 +82,7 @@ PARAM_INT_IN("bucket_size", "The size of a bucket in the second level hash.",
     "B", 500);
 PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     math::RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/mean_shift/mean_shift_main.cpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_main.cpp
@@ -66,7 +66,7 @@ PARAM_DOUBLE_IN("radius", "If the distance between two centroids is less than "
     "the given radius, one will be removed.  A radius of 0 or less means an "
     "estimate will be calculated and used for the radius.", "r", 0);
 
-void mlpackMain()
+static void mlpackMain()
 {
   const double radius = CLI::GetParam<double>("radius");
   const int maxIterations = CLI::GetParam<int>("max_iterations");

--- a/src/mlpack/methods/naive_bayes/nbc_main.cpp
+++ b/src/mlpack/methods/naive_bayes/nbc_main.cpp
@@ -105,7 +105,7 @@ PARAM_UROW_OUT("output", "The matrix in which the predicted labels for the"
 PARAM_MATRIX_OUT("output_probs", "The matrix in which the predicted probability"
     " of labels for the test set will be written.", "p");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check input parameters.
   RequireOnlyOnePassed({ "training", "input_model" }, true);

--- a/src/mlpack/methods/nca/nca_main.cpp
+++ b/src/mlpack/methods/nca/nca_main.cpp
@@ -124,7 +124,7 @@ using namespace mlpack::optimization;
 using namespace mlpack::util;
 using namespace std;
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     math::RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -95,7 +95,7 @@ PARAM_DOUBLE_IN("percentage", "If specified, will do approximate furthest "
     "neighbors will be at least (p*100) % of the distance as the true furthest "
     "neighbor.", "p", 1);
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     math::RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -99,7 +99,7 @@ PARAM_STRING_IN("algorithm", "Type of neighbor search: 'naive', 'single_tree', "
 PARAM_DOUBLE_IN("epsilon", "If specified, will do approximate nearest neighbor "
     "search with given relative error.", "e", 0);
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     math::RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/nmf/nmf_main.cpp
+++ b/src/mlpack/methods/nmf/nmf_main.cpp
@@ -76,7 +76,7 @@ PARAM_DOUBLE_IN("min_residue", "The minimum root mean square residue allowed "
 PARAM_STRING_IN("update_rules", "Update rules for each iteration; ( multdist | "
     "multdiv | als ).", "u", "multdist");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Initialize random seed.
   if (CLI::GetParam<int>("seed") != 0)

--- a/src/mlpack/methods/pca/pca_main.cpp
+++ b/src/mlpack/methods/pca/pca_main.cpp
@@ -99,7 +99,7 @@ void RunPCA(arma::mat& dataset,
       dataset.n_rows << " dimensions)." << endl;
 }
 
-void mlpackMain()
+void MAIN()
 {
   // Load input dataset.
   arma::mat& dataset = CLI::GetParam<arma::mat>("input");

--- a/src/mlpack/methods/pca/pca_main.cpp
+++ b/src/mlpack/methods/pca/pca_main.cpp
@@ -99,7 +99,7 @@ void RunPCA(arma::mat& dataset,
       dataset.n_rows << " dimensions)." << endl;
 }
 
-void MAIN()
+static void mlpackMain()
 {
   // Load input dataset.
   arma::mat& dataset = CLI::GetParam<arma::mat>("input");

--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -118,7 +118,7 @@ PARAM_MATRIX_IN("test", "A matrix containing the test set.", "T");
 PARAM_UROW_OUT("output", "The matrix in which the predicted labels for the"
     " test set will be written.", "o");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // First, get all parameters and validate them.
   const size_t maxIterations = (size_t) CLI::GetParam<int>("max_iterations");

--- a/src/mlpack/methods/preprocess/preprocess_binarize_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_binarize_main.cpp
@@ -54,7 +54,7 @@ using namespace mlpack::util;
 using namespace arma;
 using namespace std;
 
-void mlpackMain()
+static void mlpackMain()
 {
   const size_t dimension = (size_t) CLI::GetParam<int>("dimension");
   const double threshold = CLI::GetParam<double>("threshold");

--- a/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
@@ -153,7 +153,7 @@ double StandardError(const size_t size, const double& fStd)
   return fStd / sqrt(size);
 }
 
-void mlpackMain()
+static void mlpackMain()
 {
   const size_t dimension = static_cast<size_t>(CLI::GetParam<int>("dimension"));
   const size_t precision = static_cast<size_t>(CLI::GetParam<int>("precision"));

--- a/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_imputer_main.cpp
@@ -53,7 +53,7 @@ using namespace arma;
 using namespace std;
 using namespace data;
 
-void mlpackMain()
+static void mlpackMain()
 {
   const string inputFile = CLI::GetParam<string>("input_file");
   const string outputFile = CLI::GetParam<string>("output_file");

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -71,7 +71,7 @@ using namespace mlpack::util;
 using namespace arma;
 using namespace std;
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Parse command line options.
   const double testRatio = CLI::GetParam<double>("test_ratio");

--- a/src/mlpack/methods/radical/radical_main.cpp
+++ b/src/mlpack/methods/radical/radical_main.cpp
@@ -57,7 +57,7 @@ using namespace mlpack::util;
 using namespace std;
 using namespace arma;
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Set random seed.
   if (CLI::GetParam<int>("seed") != 0)

--- a/src/mlpack/methods/random_forest/random_forest_main.cpp
+++ b/src/mlpack/methods/random_forest/random_forest_main.cpp
@@ -68,7 +68,7 @@ PARAM_MODEL_IN(RandomForestModel, "input_model", "Pre-trained random forest to "
 PARAM_MODEL_OUT(RandomForestModel, "output_model", "Model to save trained "
     "random forest to.", "M");
 
-void mlpackMain()
+static void mlpackMain()
 {
   // Check for incompatible input parameters.
   RequireOnlyOnePassed({ "training", "input_model" }, true);

--- a/src/mlpack/methods/range_search/range_search_main.cpp
+++ b/src/mlpack/methods/range_search/range_search_main.cpp
@@ -91,7 +91,7 @@ PARAM_FLAG("naive", "If true, O(n^2) naive mode is used for computation.", "N");
 PARAM_FLAG("single_mode", "If true, single-tree search is used (as opposed to "
     "dual-tree search).", "S");
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     math::RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/rann/krann_main.cpp
+++ b/src/mlpack/methods/rann/krann_main.cpp
@@ -96,7 +96,7 @@ PARAM_FLAG("first_leaf_exact", "The flag to trigger sampling only after "
 PARAM_INT_IN("single_sample_limit", "The limit on the maximum number of "
     "samples (and hence the largest node you can approximate).", "z", 20);
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     math::RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/methods/softmax_regression/softmax_regression_main.cpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_main.cpp
@@ -115,7 +115,7 @@ void TestClassifyAcc(const size_t numClasses, const Model& model);
 template<typename Model>
 unique_ptr<Model> TrainSoftmax(const size_t maxIterations);
 
-void mlpackMain()
+static void mlpackMain()
 {
   const int maxIterations = CLI::GetParam<int>("max_iterations");
 

--- a/src/mlpack/methods/sparse_coding/sparse_coding.cpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.cpp
@@ -12,7 +12,6 @@
  */
 #include "sparse_coding.hpp"
 #include <mlpack/core/math/lin_alg.hpp>
-#include <mlpack/core/util/param.hpp>
 
 namespace mlpack {
 namespace sparse_coding {

--- a/src/mlpack/methods/sparse_coding/sparse_coding_main.cpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding_main.cpp
@@ -96,7 +96,7 @@ PARAM_MATRIX_OUT("codes", "Matrix to save the output sparse codes of the test "
 
 PARAM_MATRIX_IN("test", "Optional matrix to be encoded by trained model.", "T");
 
-void mlpackMain()
+static void mlpackMain()
 {
   if (CLI::GetParam<int>("seed") != 0)
     RandomSeed((size_t) CLI::GetParam<int>("seed"));

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ add_executable(mlpack_test
   union_find_test.cpp
   vantage_point_tree_test.cpp
   main_tests/pca_test.cpp
+  main_tests/linear_regression_test.cpp
 )
 
 # Link dependencies of test executable.

--- a/src/mlpack/tests/cli_test.cpp
+++ b/src/mlpack/tests/cli_test.cpp
@@ -22,6 +22,8 @@ using Option = mlpack::bindings::cli::CLIOption<T>;
 } // namespace util
 } // namespace mlpack
 
+static const std::string testName = "";
+
 #include <mlpack/core/util/param.hpp>
 #include <mlpack/bindings/cli/parse_command_line.hpp>
 #include <mlpack/bindings/cli/end_program.hpp>

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file linear_regression_test.cpp
+ * @author Eugene Freyman
+ *
+ * Test mlpackMain() of linear_regression_main.cpp.
+ */
+#define BINDING_TYPE BINDING_TYPE_TEST
+#define PROGRAM_NAME linearRegressionProgramName
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/methods/linear_regression/linear_regression_main.cpp>
+
+#include <boost/test/unit_test.hpp>
+#include "../test_tools.hpp"
+
+using namespace mlpack;
+
+// Utility function to set a parameter and mark it as passed, using copy
+// semantics.
+template<typename T>
+void SetInputParam(const std::string& name, const T& value)
+{
+  CLI::GetParam<T>(name) = value;
+  CLI::SetPassed(name);
+}
+
+// Utility function to set a parameter and mark it as passed, using move
+// semantics.
+template<typename T>
+void SetInputParam(const std::string& name, T&& value)
+{
+  CLI::GetParam<T>(name) = std::move(value);
+  CLI::SetPassed(name);
+}
+
+struct LinearRegressionTestFixture
+{
+ public:
+  LinearRegressionTestFixture()
+  {
+    // Cache in the options for this program.
+    CLI::RestoreSettings(mlpack::bindings::tests::programName);
+  }
+
+  ~LinearRegressionTestFixture()
+  {
+    // Clear the settings.
+    CLI::ClearSettings();
+  }
+};
+
+BOOST_FIXTURE_TEST_SUITE(LinearRegressionMainTest, LinearRegressionTestFixture);
+
+BOOST_AUTO_TEST_CASE(LinearRegressionWringResponseSizeTest)
+{
+  std::cout << "1\n";
+  SetInputParam("lambda", 1.0);
+  std::cout << "2\n";
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -4,8 +4,11 @@
  *
  * Test mlpackMain() of linear_regression_main.cpp.
  */
+#include <string>
+
 #define BINDING_TYPE BINDING_TYPE_TEST
 #define PROGRAM_NAME linearRegressionProgramName
+static const std::string linearRegressionProgramName = "LinearRegression";
 
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
@@ -40,7 +43,7 @@ struct LinearRegressionTestFixture
   LinearRegressionTestFixture()
   {
     // Cache in the options for this program.
-    CLI::RestoreSettings(mlpack::bindings::tests::programName);
+    CLI::RestoreSettings(linearRegressionProgramName);
   }
 
   ~LinearRegressionTestFixture()
@@ -52,11 +55,17 @@ struct LinearRegressionTestFixture
 
 BOOST_FIXTURE_TEST_SUITE(LinearRegressionMainTest, LinearRegressionTestFixture);
 
-BOOST_AUTO_TEST_CASE(LinearRegressionWringResponseSizeTest)
+BOOST_AUTO_TEST_CASE(LinearRegressionWrongResponseSizeTest)
 {
-  std::cout << "1\n";
-  SetInputParam("lambda", 1.0);
-  std::cout << "2\n";
+  arma::mat x = arma::randu<arma::mat>(5, 5);
+  arma::rowvec y = arma::randu<arma::rowvec>(4);
+
+  SetInputParam("training", std::move(x));
+  SetInputParam("training_responses", std::move(y));
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(MAIN(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -7,8 +7,7 @@
 #include <string>
 
 #define BINDING_TYPE BINDING_TYPE_TEST
-#define PROGRAM_NAME linearRegressionProgramName
-static const std::string linearRegressionProgramName = "LinearRegression";
+static const std::string testName = "LinearRegression";
 
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
@@ -43,7 +42,7 @@ struct LinearRegressionTestFixture
   LinearRegressionTestFixture()
   {
     // Cache in the options for this program.
-    CLI::RestoreSettings(linearRegressionProgramName);
+    CLI::RestoreSettings(testName);
   }
 
   ~LinearRegressionTestFixture()
@@ -64,7 +63,7 @@ BOOST_AUTO_TEST_CASE(LinearRegressionWrongResponseSizeTest)
   SetInputParam("training_responses", std::move(y));
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(MAIN(), std::runtime_error);
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 

--- a/src/mlpack/tests/main_tests/pca_test.cpp
+++ b/src/mlpack/tests/main_tests/pca_test.cpp
@@ -4,7 +4,11 @@
  *
  * Test mlpackMain() of pca_main.cpp.
  */
+#include <string>
+
 #define BINDING_TYPE BINDING_TYPE_TEST
+#define PROGRAM_NAME pcaProgramName
+static const std::string pcaProgramName = "PrincipalComponentAnalysis";
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/methods/pca/pca_main.cpp>
@@ -48,7 +52,7 @@ struct PCATestFixture
   PCATestFixture()
   {
     // Cache in the options for this program.
-    CLI::RestoreSettings(mlpack::bindings::tests::programName);
+    CLI::RestoreSettings(pcaProgramName);
   }
 
   ~PCATestFixture()
@@ -71,7 +75,7 @@ BOOST_AUTO_TEST_CASE(PCADimensionTest)
   SetInputParam("input", std::move(x));
   SetInputParam("new_dimensionality", (int) 3);
 
-  mlpackMain();
+  MAIN();
 
   // Now check that the output has 3 dimensions.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 3);
@@ -91,7 +95,7 @@ BOOST_AUTO_TEST_CASE(PCAVarRetainTest)
   SetInputParam("scale", true);
   SetInputParam("new_dimensionality", (int) 3); // Should be ignored.
 
-  mlpackMain();
+  MAIN();
 
   // Check that the output has 5 dimensions.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 4);
@@ -110,7 +114,7 @@ BOOST_AUTO_TEST_CASE(PCANoVarRetainTest)
   SetInputParam("scale", true);
   SetInputParam("new_dimensionality", (int) 3); // Should be ignored.
 
-  mlpackMain();
+  MAIN();
 
   // Check that the output has 1 dimensions.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 1);
@@ -128,7 +132,7 @@ BOOST_AUTO_TEST_CASE(PCATooHighNewDimensionalityTest)
   SetInputParam("new_dimensionality", (int) 7); // Invalid.
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  BOOST_REQUIRE_THROW(MAIN(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 

--- a/src/mlpack/tests/main_tests/pca_test.cpp
+++ b/src/mlpack/tests/main_tests/pca_test.cpp
@@ -7,8 +7,8 @@
 #include <string>
 
 #define BINDING_TYPE BINDING_TYPE_TEST
-#define PROGRAM_NAME pcaProgramName
-static const std::string pcaProgramName = "PrincipalComponentAnalysis";
+static const std::string testName = "PrincipalComponentAnalysis";
+
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/methods/pca/pca_main.cpp>
@@ -17,16 +17,6 @@ static const std::string pcaProgramName = "PrincipalComponentAnalysis";
 #include "../test_tools.hpp"
 
 using namespace mlpack;
-
-namespace mlpack {
-namespace bindings {
-namespace tests {
-
-extern std::string programName;
-
-}
-}
-}
 
 // Utility function to set a parameter and mark it as passed, using copy
 // semantics.
@@ -52,7 +42,7 @@ struct PCATestFixture
   PCATestFixture()
   {
     // Cache in the options for this program.
-    CLI::RestoreSettings(pcaProgramName);
+    CLI::RestoreSettings(testName);
   }
 
   ~PCATestFixture()
@@ -75,7 +65,7 @@ BOOST_AUTO_TEST_CASE(PCADimensionTest)
   SetInputParam("input", std::move(x));
   SetInputParam("new_dimensionality", (int) 3);
 
-  MAIN();
+  mlpackMain();
 
   // Now check that the output has 3 dimensions.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 3);
@@ -95,7 +85,7 @@ BOOST_AUTO_TEST_CASE(PCAVarRetainTest)
   SetInputParam("scale", true);
   SetInputParam("new_dimensionality", (int) 3); // Should be ignored.
 
-  MAIN();
+  mlpackMain();
 
   // Check that the output has 5 dimensions.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 4);
@@ -114,7 +104,7 @@ BOOST_AUTO_TEST_CASE(PCANoVarRetainTest)
   SetInputParam("scale", true);
   SetInputParam("new_dimensionality", (int) 3); // Should be ignored.
 
-  MAIN();
+  mlpackMain();
 
   // Check that the output has 1 dimensions.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 1);
@@ -132,7 +122,7 @@ BOOST_AUTO_TEST_CASE(PCATooHighNewDimensionalityTest)
   SetInputParam("new_dimensionality", (int) 7); // Invalid.
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(MAIN(), std::runtime_error);
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 


### PR DESCRIPTION
If you follow proposed way of writing tests (similar to `src/mlpack/tests/main_tests/pca_test.cpp`) then you get `mlpackMain` and `mlpack::bindings::tests::programName` redefined. This happens because we include all main files of bindings into one executable (mlpack_test)

Solution:

- Unique naming for each `mlpackMain` in case of binding tests. (through macros MAIN)
- All implementations of class `Option` consume an extra parameter - `programName`. It is defined unique in case of each binding test and dummy in other cases. Only second level macros are changed, so there is no need to change bindings themself.
- Only `TestOption` uses `programName` extra parameter, `PyOption` still uses global `programName`. I left it in order not to breake anything. This probably should be refactored

The existing code of bindings and tests are modified only a little:

- Using `MAIN()` - instead of `mlpackMain()` 
- At each binding tests two unique lines are added:

```
#define PROGRAM_NAME pcaProgramName
static const std::string pcaProgramName = "PrincipalComponentAnalysis";
```

Here is also a test suit for LinearRegression included. It has only one test case in it, just to show that this approach works.