### PR TITLE
LinearRegression binding fixes and tests

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -83,6 +83,7 @@ Copyright:
   Copyright 2017, Samikshya Chand <samikshya289@gmail.com>
   Copyright 2017, N Rajiv Vaidyanathan <rajivvaidyanathan4@gmail.com>
   Copyright 2017, Kartik Nighania <kartiknighania@gmail.com>
+  Copyright 2017, Eugene Freyman <evg.freyman@gmail.com>
   
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -226,6 +226,7 @@
  *   - Samikshya Chand <samikshya289@gmail.com>
  *   - N Rajiv Vaidyanathan <rajivvaidyanathan4@gmail.com>
  *   - Kartik Nighania <kartiknighania@gmail.com>
+ *   - Eugene Freyman <evg.freyman@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/core/util/CMakeLists.txt
+++ b/src/mlpack/core/util/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
   timers.cpp
   version.hpp
   version.cpp
+  test_helper.hpp
 )
 
 # add directory name to sources

--- a/src/mlpack/core/util/test_helper.hpp
+++ b/src/mlpack/core/util/test_helper.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file test_helper.hpp
+ * @author Eugene Freyman
+ *
+ * Helper functions for testing.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+namespace mlpack {
+namespace util {
+
+// Utility function that is used in binding tests for setting a parameter and
+// marking it as passed, it uses copy semantics for lvalues and move semantics 
+// for rvalues.
+template<typename T>
+void SetInputParam(const std::string& name, T&& value)
+{
+  CLI::GetParam<typename std::remove_reference<T>::type>(name) = 
+    std::forward<T>(value);
+  CLI::SetPassed(name);
+}
+
+}
+}

--- a/src/mlpack/core/util/test_helper.hpp
+++ b/src/mlpack/core/util/test_helper.hpp
@@ -14,15 +14,15 @@ namespace mlpack {
 namespace util {
 
 // Utility function that is used in binding tests for setting a parameter and
-// marking it as passed, it uses copy semantics for lvalues and move semantics 
+// marking it as passed, it uses copy semantics for lvalues and move semantics
 // for rvalues.
 template<typename T>
 void SetInputParam(const std::string& name, T&& value)
 {
-  CLI::GetParam<typename std::remove_reference<T>::type>(name) = 
+  CLI::GetParam<typename std::remove_reference<T>::type>(name) =
     std::forward<T>(value);
   CLI::SetPassed(name);
 }
 
-}
-}
+} // namespace util
+} // namespace mlpack

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -93,6 +93,14 @@ problems.  Instead specify the C++11 standard (-std=c++11 with gcc or clang), \
 or upgrade Boost to 1.59 or newer.
 #endif
 
+// On Visual Studio, disable C4519 (default arguments for function templates)
+// since it's by default an error, which doesn't even make any sense because
+// it's part of the C++11 standard.
+#ifdef _MSC_VER
+  #pragma warning(disable : 4519)
+  #define ARMA_USE_CXX11
+#endif
+
 // Now include Armadillo through the special mlpack extensions.
 #include <mlpack/core/arma_extend/arma_extend.hpp>
 #include <mlpack/core/util/arma_traits.hpp>
@@ -105,13 +113,6 @@ or upgrade Boost to 1.59 or newer.
 #include <mlpack/core/util/log.hpp>
 #include <mlpack/core/util/timers.hpp>
 
-// On Visual Studio, disable C4519 (default arguments for function templates)
-// since it's by default an error, which doesn't even make any sense because
-// it's part of the C++11 standard.
-#ifdef _MSC_VER
-  #pragma warning(disable : 4519)
-  #define ARMA_USE_CXX11
-#endif
 // This can be removed with Visual Studio supports an OpenMP version with
 // unsigned loop variables.
 #ifdef _WIN32

--- a/src/mlpack/tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/linear_regression_test.cpp
@@ -1,4 +1,4 @@
-  /**
+/**
  * @file linear_regression_test.cpp
  *
  * Test for linear regression.

--- a/src/mlpack/tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/linear_regression_test.cpp
@@ -1,4 +1,4 @@
-/**
+  /**
  * @file linear_regression_test.cpp
  *
  * Test for linear regression.

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -4,6 +4,7 @@
  *
  * Test mlpackMain() of linear_regression_main.cpp.
  */
+
 #include <string>
 
 #define BINDING_TYPE BINDING_TYPE_TEST
@@ -11,22 +12,13 @@ static const std::string testName = "LinearRegression";
 
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/core/util/test_helper.hpp>
 #include <mlpack/methods/linear_regression/linear_regression_main.cpp>
 
 #include <boost/test/unit_test.hpp>
 #include "../test_tools.hpp"
 
 using namespace mlpack;
-
-// Utility function to set a parameter and mark it as passed,
-// using copy semantics for lvalues and move semantics for rvalues
-template<typename T>
-void SetInputParam(const std::string& name, T&& value)
-{
-  CLI::GetParam<typename std::remove_reference<T>::type>(name)
-    = std::forward<T>(value);
-  CLI::SetPassed(name);
-}
 
 struct LRTestFixture
 {
@@ -54,22 +46,23 @@ BOOST_FIXTURE_TEST_SUITE(LinearRegressionMainTest, LRTestFixture);
 
 /**
  * Training a model with different regularization parameter
- * and ensuring that predictions are different
+ * and ensuring that predictions are different.
  */
 BOOST_AUTO_TEST_CASE(LRDifferentLambdas)
 {
-  // required minimal difference between solutions
+  // A required minimal difference between solutions.
   const double delta = 0.1;
 
-  arma::mat trainX = { 1.0, 2.0, 3.0 };
-  arma::mat testX = { 4.0 };
-  arma::rowvec trainY = { 1.0, 4.0, 9.0 };
+  arma::mat trainX("1.0, 2.0, 3.0");
+  arma::mat testX("4.0");
+  arma::rowvec trainY("1.0, 4.0, 9.0");
+
   SetInputParam("training", trainX);
   SetInputParam("training_responses", trainY);
   SetInputParam("test", testX);
   SetInputParam("lambda", 0.1);
 
-  // first solution
+  // The first solution.
   mlpackMain();
   const double testY1 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
 
@@ -80,42 +73,42 @@ BOOST_AUTO_TEST_CASE(LRDifferentLambdas)
   SetInputParam("test", std::move(testX));
   SetInputParam("lambda", 1.0);
 
-  // second solution
+  // The second solution.
   mlpackMain();
   const double testY2 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
 
-  // second solution has stronger regularization,
-  // so the predicted value should be smaller
-  BOOST_REQUIRE(testY1 - delta > testY2);
+  // Second solution has stronger regularization,
+  // so the predicted value should be smaller.
+  BOOST_REQUIRE_GT(testY1 - delta, testY2);
 }
 
 
 /**
  * Checking two options of specifying responses (extra row in train matrix and
- * extra parameter) and ensuring that predictions are the same
+ * extra parameter) and ensuring that predictions are the same.
  */
 BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
 {
   constexpr double delta = 1e-5;
 
-  arma::mat trainX1 = {{1.0, 2.0, 3.0}, {1.0, 4.0, 9.0}};
-  arma::mat testX = {4.0};
+  arma::mat trainX1("1.0, 2.0, 3.0; 1.0, 4.0, 9.0");
+  arma::mat testX("4.0");
   SetInputParam("training", trainX1);
   SetInputParam("test", testX);
 
-  // first solution
+  // The first solution.
   mlpackMain();
   const double testY1 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
 
   ResetSettings();
 
-  arma::mat trainX2 = {1.0, 2.0, 3.0};
-  arma::rowvec trainY2 = {1.0, 4.0, 9.0};
+  arma::mat trainX2("1.0, 2.0, 3.0");
+  arma::rowvec trainY2("1.0, 4.0, 9.0");
   SetInputParam("training", std::move(trainX2));
   SetInputParam("training_responses", std::move(trainY2));
   SetInputParam("test", std::move(testX));
 
-  // second solution
+  // The second solution.
   mlpackMain();
   const double testY2 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
 
@@ -124,7 +117,7 @@ BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
 
 /**
  * Check that model can saved / loaded and used. Ensuring that
- * results are the same
+ * results are the same.
  */
 BOOST_AUTO_TEST_CASE(LRModelReload)
 {
@@ -159,7 +152,7 @@ BOOST_AUTO_TEST_CASE(LRModelReload)
 }
 
 /**
- * Ensuring that response size is is checked
+ * Ensuring that response size is is checked.
  */
 BOOST_AUTO_TEST_CASE(LRWrongResponseSizeTest)
 {
@@ -167,7 +160,7 @@ BOOST_AUTO_TEST_CASE(LRWrongResponseSizeTest)
   constexpr int D = 2;
 
   arma::mat trainX = arma::randu<arma::mat>(D, N);
-  arma::rowvec trainY = arma::randu<arma::rowvec>(N + 3); // wrong size
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N + 3); // Wrong size.
 
   SetInputParam("training", std::move(trainX));
   SetInputParam("training_responses", std::move(trainY));
@@ -178,7 +171,7 @@ BOOST_AUTO_TEST_CASE(LRWrongResponseSizeTest)
 }
 
 /**
- * Ensuring that test data dimensionality is is checked
+ * Ensuring that test data dimensionality is is checked.
  */
 BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest1)
 {
@@ -188,7 +181,7 @@ BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest1)
 
   arma::mat trainX = arma::randu<arma::mat>(D, N);
   arma::rowvec trainY = arma::randu<arma::rowvec>(N);
-  arma::mat testX = arma::randu<arma::mat>(D - 1, M); // wrong dimensionality
+  arma::mat testX = arma::randu<arma::mat>(D - 1, M); // Wrong dimensionality.
 
   SetInputParam("training", std::move(trainX));
   SetInputParam("training_responses", std::move(trainY));
@@ -201,7 +194,7 @@ BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest1)
 
 /**
  * Ensuring that test data dimensionality is is checked
- * when model is loaded
+ * when model is loaded.
  */
 BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest2)
 {
@@ -221,7 +214,7 @@ BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest2)
 
   ResetSettings();
 
-  arma::mat testX = arma::randu<arma::mat>(D - 1, M); // wrong dimensionality
+  arma::mat testX = arma::randu<arma::mat>(D - 1, M); // Wrong dimensionality.
   SetInputParam("input_model", std::move(model));
   SetInputParam("test", std::move(testX));
 
@@ -231,7 +224,7 @@ BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest2)
 }
 
 /**
- * Checking that that size and dimensionality of prediction is correct
+ * Checking that that size and dimensionality of prediction is correct.
  */
 BOOST_AUTO_TEST_CASE(LRPridictionSizeCheck)
 {
@@ -256,7 +249,7 @@ BOOST_AUTO_TEST_CASE(LRPridictionSizeCheck)
 }
 
 /**
- * Ensuring that absence of responses is checked
+ * Ensuring that absence of responses is checked.
  */
 BOOST_AUTO_TEST_CASE(LRNoResponses)
 {
@@ -272,7 +265,7 @@ BOOST_AUTO_TEST_CASE(LRNoResponses)
 }
 
 /**
- * Ensuring that absence of training data is checked
+ * Ensuring that absence of training data is checked.
  */
 BOOST_AUTO_TEST_CASE(LRNoTrainingData)
 {

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -18,49 +18,268 @@ static const std::string testName = "LinearRegression";
 
 using namespace mlpack;
 
-// Utility function to set a parameter and mark it as passed, using copy
-// semantics.
-template<typename T>
-void SetInputParam(const std::string& name, const T& value)
-{
-  CLI::GetParam<T>(name) = value;
-  CLI::SetPassed(name);
-}
-
-// Utility function to set a parameter and mark it as passed, using move
-// semantics.
+// Utility function to set a parameter and mark it as passed,
+// using copy semantics for lvalues and move semantics for rvalues
 template<typename T>
 void SetInputParam(const std::string& name, T&& value)
 {
-  CLI::GetParam<T>(name) = std::move(value);
+  CLI::GetParam<typename std::remove_reference<T>::type>(name)
+    = std::forward<T>(value);
   CLI::SetPassed(name);
 }
 
-struct LinearRegressionTestFixture
+struct LRTestFixture
 {
  public:
-  LinearRegressionTestFixture()
+  LRTestFixture()
   {
     // Cache in the options for this program.
     CLI::RestoreSettings(testName);
   }
 
-  ~LinearRegressionTestFixture()
+  ~LRTestFixture()
   {
     // Clear the settings.
     CLI::ClearSettings();
   }
 };
 
-BOOST_FIXTURE_TEST_SUITE(LinearRegressionMainTest, LinearRegressionTestFixture);
-
-BOOST_AUTO_TEST_CASE(LinearRegressionWrongResponseSizeTest)
+void ResetSettings()
 {
-  arma::mat x = arma::randu<arma::mat>(5, 5);
-  arma::rowvec y = arma::randu<arma::rowvec>(4);
+  CLI::ClearSettings();
+  CLI::RestoreSettings(testName);
+}
 
-  SetInputParam("training", std::move(x));
-  SetInputParam("training_responses", std::move(y));
+BOOST_FIXTURE_TEST_SUITE(LinearRegressionMainTest, LRTestFixture);
+
+/**
+ * Training a model with different regularization parameter
+ * and ensuring that predictions are different
+ */
+BOOST_AUTO_TEST_CASE(LRDifferentLambdas)
+{
+  // required minimal difference between solutions
+  const double delta = 0.1;
+
+  arma::mat trainX = arma::rowvec({1.0, 2.0, 3.0});
+  arma::mat testX = arma::rowvec({4.0});
+  arma::rowvec trainY = {1.0, 4.0, 9.0};
+  SetInputParam("training", trainX);
+  SetInputParam("training_responses", trainY);
+  SetInputParam("test", testX);
+  SetInputParam("lambda", 0.1);
+
+  // first solution
+  mlpackMain();
+  const double testY1 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
+
+  ResetSettings();
+
+  SetInputParam("training", std::move(trainX));
+  SetInputParam("training_responses", std::move(trainY));
+  SetInputParam("test", std::move(testX));
+  SetInputParam("lambda", 1.0);
+
+  // second solution
+  mlpackMain();
+  const double testY2 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
+
+  // second solution has stronger regularization,
+  // so the predicted value should be smaller
+  BOOST_REQUIRE(testY1 - delta > testY2);
+}
+
+
+/**
+ * Checking two options of specifying responses (extra row in train matrix and
+ * extra parameter) and ensuring that predictions are the same
+ */
+BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
+{
+  constexpr double delta = 1e-5;
+
+  arma::mat trainX1 = arma::mat({{1.0, 2.0, 3.0}, {1.0, 4.0, 9.0}});
+  arma::mat testX = arma::rowvec({4.0});
+  SetInputParam("training", trainX1);
+  SetInputParam("test", testX);
+
+  // first solution
+  mlpackMain();
+  const double testY1 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
+
+  ResetSettings();
+
+  arma::mat trainX2 = arma::rowvec({1.0, 2.0, 3.0});
+  arma::rowvec trainY2 = {1.0, 4.0, 9.0};
+  SetInputParam("training", std::move(trainX2));
+  SetInputParam("training_responses", std::move(trainY2));
+  SetInputParam("test", std::move(testX));
+
+  // second solution
+  mlpackMain();
+  const double testY2 = CLI::GetParam<arma::rowvec>("output_predictions")(0);
+
+  BOOST_REQUIRE(fabs(testY1 - testY2) < delta);
+}
+
+/**
+ * Check that model can saved / loaded and used. Ensuring that
+ * results are the same
+ */
+BOOST_AUTO_TEST_CASE(LRModelReload)
+{
+  constexpr double delta = 1e-5;
+  constexpr int N = 10;
+  constexpr int D = 4;
+
+  arma::mat trainX = arma::randu<arma::mat>(D, N);
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N);
+  arma::mat testX = arma::randu<arma::mat>(D, N);
+
+  SetInputParam("training", std::move(trainX));
+  SetInputParam("training_responses", std::move(trainY));
+  SetInputParam("test", testX);
+
+  mlpackMain();
+
+  LinearRegression model = CLI::GetParam<LinearRegression>("output_model");
+  const arma::rowvec testY1 = CLI::GetParam<arma::rowvec>("output_predictions");
+
+  ResetSettings();
+
+  SetInputParam("input_model", std::move(model));
+  SetInputParam("test", std::move(testX));
+
+  mlpackMain();
+
+  const arma::rowvec testY2 = CLI::GetParam<arma::rowvec>("output_predictions");
+
+  double norm = arma::norm(testY1 - testY2, 2);
+  BOOST_REQUIRE(norm < delta);
+}
+
+/**
+ * Ensuring that response size is is checked
+ */
+BOOST_AUTO_TEST_CASE(LRWrongResponseSizeTest)
+{
+  constexpr int N = 10;
+  constexpr int D = 2;
+
+  arma::mat trainX = arma::randu<arma::mat>(D, N);
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N + 3);// wrong size
+
+  SetInputParam("training", std::move(trainX));
+  SetInputParam("training_responses", std::move(trainY));
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+/**
+ * Ensuring that test data dimensionality is is checked
+ */
+BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest1)
+{
+  constexpr int N = 10;
+  constexpr int D = 3;
+  constexpr int M = 15;
+
+  arma::mat trainX = arma::randu<arma::mat>(D, N);
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N);
+  arma::mat testX = arma::randu<arma::mat>(D - 1, M);// wrong dimensionality
+
+  SetInputParam("training", std::move(trainX));
+  SetInputParam("training_responses", std::move(trainY));
+  SetInputParam("test", std::move(testX));
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+/**
+ * Ensuring that test data dimensionality is is checked
+ * when model is loaded
+ */
+BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest2)
+{
+  constexpr int N = 10;
+  constexpr int D = 3;
+  constexpr int M = 15;
+
+  arma::mat trainX = arma::randu<arma::mat>(D, N);
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N);
+
+  SetInputParam("training", std::move(trainX));
+  SetInputParam("training_responses", std::move(trainY));
+
+  mlpackMain();
+
+  LinearRegression model = CLI::GetParam<LinearRegression>("output_model");
+
+  ResetSettings();
+
+  arma::mat testX = arma::randu<arma::mat>(D - 1, M);// wrong dimensionality
+  SetInputParam("input_model", std::move(model));
+  SetInputParam("test", std::move(testX));
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+/**
+ * Checking that that size and dimensionality of prediction is correct
+ */
+BOOST_AUTO_TEST_CASE(LRPridictionSizeCheck)
+{
+  constexpr int N = 10;
+  constexpr int D = 3;
+  constexpr int M = 15;
+
+  arma::mat trainX = arma::randu<arma::mat>(D, N);
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N);
+  arma::mat testX = arma::randu<arma::mat>(D, M);
+
+  SetInputParam("training", std::move(trainX));
+  SetInputParam("training_responses", std::move(trainY));
+  SetInputParam("test", std::move(testX));
+
+  mlpackMain();
+
+  const arma::rowvec testY = CLI::GetParam<arma::rowvec>("output_predictions");
+
+  BOOST_REQUIRE_EQUAL(testY.n_rows, 1);
+  BOOST_REQUIRE_EQUAL(testY.n_cols, M);
+}
+
+/**
+ * Ensuring that absence of responses is checked
+ */
+BOOST_AUTO_TEST_CASE(LRNoResponses)
+{
+  constexpr int N = 10;
+  constexpr int D = 1;
+
+  arma::mat trainX = arma::randu<arma::mat>(D, N);
+  SetInputParam("training", std::move(trainX));
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+/**
+ * Ensuring that absence of training data is checked
+ */
+BOOST_AUTO_TEST_CASE(LRNoTrainingData)
+{
+  constexpr int N = 10;
+
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N);
+  SetInputParam("training_responses", std::move(trainY));
 
   Log::Fatal.ignoreInput = true;
   BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -61,9 +61,9 @@ BOOST_AUTO_TEST_CASE(LRDifferentLambdas)
   // required minimal difference between solutions
   const double delta = 0.1;
 
-  arma::mat trainX = arma::rowvec({1.0, 2.0, 3.0});
-  arma::mat testX = arma::rowvec({4.0});
-  arma::rowvec trainY = arma::rowvec({1.0, 4.0, 9.0});
+  arma::mat trainX = { 1.0, 2.0, 3.0 };
+  arma::mat testX = { 4.0 };
+  arma::rowvec trainY = { 1.0, 4.0, 9.0 };
   SetInputParam("training", trainX);
   SetInputParam("training_responses", trainY);
   SetInputParam("test", testX);
@@ -98,8 +98,8 @@ BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
 {
   constexpr double delta = 1e-5;
 
-  arma::mat trainX1 = arma::mat({{1.0, 2.0, 3.0}, {1.0, 4.0, 9.0}});
-  arma::mat testX = arma::rowvec({4.0});
+  arma::mat trainX1 = {{1.0, 2.0, 3.0}, {1.0, 4.0, 9.0}};
+  arma::mat testX = {4.0};
   SetInputParam("training", trainX1);
   SetInputParam("test", testX);
 
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
 
   ResetSettings();
 
-  arma::mat trainX2 = arma::rowvec({1.0, 2.0, 3.0});
-  arma::rowvec trainY2 = arma::rowvec({1.0, 4.0, 9.0});
+  arma::mat trainX2 = {1.0, 2.0, 3.0};
+  arma::rowvec trainY2 = {1.0, 4.0, 9.0};
   SetInputParam("training", std::move(trainX2));
   SetInputParam("training_responses", std::move(trainY2));
   SetInputParam("test", std::move(testX));

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -53,9 +53,9 @@ BOOST_AUTO_TEST_CASE(LRDifferentLambdas)
   // A required minimal difference between solutions.
   const double delta = 0.1;
 
-  arma::mat trainX("1.0, 2.0, 3.0");
-  arma::mat testX("4.0");
-  arma::rowvec trainY("1.0, 4.0, 9.0");
+  arma::mat trainX({1.0, 2.0, 3.0});
+  arma::mat testX({4.0});
+  arma::rowvec trainY({1.0, 4.0, 9.0});
 
   SetInputParam("training", trainX);
   SetInputParam("training_responses", trainY);
@@ -91,8 +91,8 @@ BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
 {
   constexpr double delta = 1e-5;
 
-  arma::mat trainX1("1.0, 2.0, 3.0; 1.0, 4.0, 9.0");
-  arma::mat testX("4.0");
+  arma::mat trainX1({{1.0, 2.0, 3.0}, {1.0, 4.0, 9.0}});
+  arma::mat testX({4.0});
   SetInputParam("training", trainX1);
   SetInputParam("test", testX);
 
@@ -102,8 +102,8 @@ BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
 
   ResetSettings();
 
-  arma::mat trainX2("1.0, 2.0, 3.0");
-  arma::rowvec trainY2("1.0, 4.0, 9.0");
+  arma::mat trainX2({1.0, 2.0, 3.0});
+  arma::rowvec trainY2({1.0, 4.0, 9.0});
   SetInputParam("training", std::move(trainX2));
   SetInputParam("training_responses", std::move(trainY2));
   SetInputParam("test", std::move(testX));

--- a/src/mlpack/tests/main_tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_regression_test.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(LRDifferentLambdas)
 
   arma::mat trainX = arma::rowvec({1.0, 2.0, 3.0});
   arma::mat testX = arma::rowvec({4.0});
-  arma::rowvec trainY = {1.0, 4.0, 9.0};
+  arma::rowvec trainY = arma::rowvec({1.0, 4.0, 9.0});
   SetInputParam("training", trainX);
   SetInputParam("training_responses", trainY);
   SetInputParam("test", testX);
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(LRResponsesRepresentation)
   ResetSettings();
 
   arma::mat trainX2 = arma::rowvec({1.0, 2.0, 3.0});
-  arma::rowvec trainY2 = {1.0, 4.0, 9.0};
+  arma::rowvec trainY2 = arma::rowvec({1.0, 4.0, 9.0});
   SetInputParam("training", std::move(trainX2));
   SetInputParam("training_responses", std::move(trainY2));
   SetInputParam("test", std::move(testX));
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(LRWrongResponseSizeTest)
   constexpr int D = 2;
 
   arma::mat trainX = arma::randu<arma::mat>(D, N);
-  arma::rowvec trainY = arma::randu<arma::rowvec>(N + 3);// wrong size
+  arma::rowvec trainY = arma::randu<arma::rowvec>(N + 3); // wrong size
 
   SetInputParam("training", std::move(trainX));
   SetInputParam("training_responses", std::move(trainY));
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest1)
 
   arma::mat trainX = arma::randu<arma::mat>(D, N);
   arma::rowvec trainY = arma::randu<arma::rowvec>(N);
-  arma::mat testX = arma::randu<arma::mat>(D - 1, M);// wrong dimensionality
+  arma::mat testX = arma::randu<arma::mat>(D - 1, M); // wrong dimensionality
 
   SetInputParam("training", std::move(trainX));
   SetInputParam("training_responses", std::move(trainY));
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(LRWrongDimOfDataTest2)
 
   ResetSettings();
 
-  arma::mat testX = arma::randu<arma::mat>(D - 1, M);// wrong dimensionality
+  arma::mat testX = arma::randu<arma::mat>(D - 1, M); // wrong dimensionality
   SetInputParam("input_model", std::move(model));
   SetInputParam("test", std::move(testX));
 

--- a/src/mlpack/tests/main_tests/pca_test.cpp
+++ b/src/mlpack/tests/main_tests/pca_test.cpp
@@ -18,21 +18,13 @@ static const std::string testName = "PrincipalComponentAnalysis";
 
 using namespace mlpack;
 
-// Utility function to set a parameter and mark it as passed, using copy
-// semantics.
-template<typename T>
-void SetInputParam(const std::string& name, const T& value)
-{
-  CLI::GetParam<T>(name) = value;
-  CLI::SetPassed(name);
-}
-
-// Utility function to set a parameter and mark it as passed, using move
-// semantics.
+// Utility function to set a parameter and mark it as passed,
+// using copy semantics for lvalues and move semantics for rvalues
 template<typename T>
 void SetInputParam(const std::string& name, T&& value)
 {
-  CLI::GetParam<T>(name) = std::move(value);
+  CLI::GetParam<typename std::remove_reference<T>::type>(name)
+    = std::forward<T>(value);
   CLI::SetPassed(name);
 }
 

--- a/src/mlpack/tests/main_tests/pca_test.cpp
+++ b/src/mlpack/tests/main_tests/pca_test.cpp
@@ -11,22 +11,13 @@ static const std::string testName = "PrincipalComponentAnalysis";
 
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/core/util/test_helper.hpp>
 #include <mlpack/methods/pca/pca_main.cpp>
 
 #include <boost/test/unit_test.hpp>
 #include "../test_tools.hpp"
 
 using namespace mlpack;
-
-// Utility function to set a parameter and mark it as passed,
-// using copy semantics for lvalues and move semantics for rvalues
-template<typename T>
-void SetInputParam(const std::string& name, T&& value)
-{
-  CLI::GetParam<typename std::remove_reference<T>::type>(name)
-    = std::forward<T>(value);
-  CLI::SetPassed(name);
-}
 
 struct PCATestFixture
 {


### PR DESCRIPTION
This PR contains tests for LinearRegression bindings as well as some fixes of binding itself. Aside from `main_tests/linear_regression_test.cpp` the following changes were made 

In `linear_regression_main.cpp`:
- output_predictions became `PARAM_ROW_OUT` (it was `PARAM_COL_OUT` and **never worked** because `LinearRegression` class outputs `rowvec predictions`). **Please confirm if this is correct and there is no need to use a transformation from row to column instead**.
- `std::move` trained model to `output_model` was moved to the end, after prediction proceudre. Earlier we tried to predict responses with using moved away model (and got an error)
- Lambda parameter was never used. Fixed that.
- Added error message if we trying to extract responses from a training data that consist only from 1 row

In `pca_test.cpp`:
- Modified `SetInputParam` in a way that it can accept both rvalue and lvalue. Although I used this ability in LinearRegression tests only, I guess it could help those who start implementing tests by looking at `pca_test.cpp`

I also added myself as a contributer to `COPYRIGHT.txt` and to `core.hpp`

