### PR TITLE
Octree: adjust SplitType/TypeInfo structure

### DIFF
--- a/src/mlpack/core/tree/octree/octree.hpp
+++ b/src/mlpack/core/tree/octree/octree.hpp
@@ -428,15 +428,18 @@ class Octree
   /**
    * This is used for sorting points while splitting.
    */
-  struct SplitInfo
+  struct SplitType
   {
-    //! Create the SplitInfo object.
-    SplitInfo(const size_t d, const arma::vec& c) : d(d), center(c) {}
+    struct SplitInfo
+    {
+      //! Create the SplitInfo object.
+      SplitInfo(const size_t d, const arma::vec& c) : d(d), center(c) {}
 
-    //! The dimension we are splitting on.
-    size_t d;
-    //! The center of the node.
-    const arma::vec& center;
+      //! The dimension we are splitting on.
+      size_t d;
+      //! The center of the node.
+      const arma::vec& center;
+    };
 
     template<typename VecType>
     static bool AssignToLeftNode(const VecType& point, const SplitInfo& s)

--- a/src/mlpack/core/tree/octree/octree_impl.hpp
+++ b/src/mlpack/core/tree/octree/octree_impl.hpp
@@ -695,8 +695,8 @@ void Octree<MetricType, StatisticType, MatType>::SplitNode(
     // children of index 2^(d - 1) - 1 and less will be on the left side, and
     // all points belonging to children of index 2^(d - 1) and above will be on
     // the right side.
-    SplitInfo s(d, center);
-    const size_t firstRight = split::PerformSplit<MatType, SplitInfo>(*dataset,
+    typename SplitType::SplitInfo s(d, center);
+    const size_t firstRight = split::PerformSplit<MatType, SplitType>(*dataset,
         childBegin, childCount, s);
 
     // We can set the first index of the right child.  The first index of the
@@ -797,8 +797,8 @@ void Octree<MetricType, StatisticType, MatType>::SplitNode(
     // children of index 2^(d - 1) - 1 and less will be on the left side, and
     // all points belonging to children of index 2^(d - 1) and above will be on
     // the right side.
-    SplitInfo s(d, center);
-    const size_t firstRight = split::PerformSplit<MatType, SplitInfo>(*dataset,
+    typename SplitType::SplitInfo s(d, center);
+    const size_t firstRight = split::PerformSplit<MatType, SplitType>(*dataset,
         childBegin, childCount, s, oldFromNew);
 
     // We can set the first index of the right child.  The first index of the


### PR DESCRIPTION
The issue is a result of a Windows build session, not sure why clang/gcc is able to build this code without any complaints on Linux/mac OS.