### PR TITLE
Optimized LRSDP Computations

### DIFF
--- a/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
@@ -91,11 +91,8 @@ class LRSDPFunction
   //! Get R*R^T matrix.
   const arma::mat& RRT() const { return rrt; }
 
-  /**
-   * Update R*R^T matrix. Note caching R*R^T provide computation
-   * optimization by reducing redundant R*R^T calculations.
-   */
-  void UpdateRRT(const arma::mat& newrrt) const;
+  //! Modify R*R^T matrix.
+  arma::mat& RRT()  { return rrt; }
 
  private:
   //! SDP object representing the problem

--- a/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
@@ -22,6 +22,15 @@ namespace optimization {
 
 /**
  * The objective function that LRSDP is trying to optimize.
+ *
+ * Note: LRSDPfunction is designed and implemented to specifically work
+ * with a combination of AugLagrangian and L-BFGS optimizer. Implemenation
+ * of LRSDPFunction includes caching R * R^T matrix in order to avoid redundant
+ * computations(Specifically with above two optimizers) of R * R^T matrix
+ * through AugLagrangian optimizer call, as only L-BFGS takes part in updating
+ * R(coordinates) matrix. So, be careful while using LRSDP with some other
+ * optimizer. You may need to modify caching process of R * R^T matrix.
+ * See EvaluateImpl() in lrsdp_function_impl.hpp for more details.
  */
 template <typename SDPType>
 class LRSDPFunction

--- a/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
@@ -88,12 +88,24 @@ class LRSDPFunction
   //! Modify the SDP object representing the problem.
   SDPType& SDP() { return sdp; }
 
+  //! Get R*R^T matrix.
+  const arma::mat& RRT() const { return rrt; }
+
+  /**
+   * Update R*R^T matrix. Note caching R*R^T provide computation
+   * optimization by reducing redundant R*R^T calculations.
+   */
+  void UpdateRRT(const arma::mat& newrrt) const;
+
  private:
   //! SDP object representing the problem
   SDPType sdp;
 
   //! Initial point.
   arma::mat initialPoint;
+
+  //! R*R^T matrix.
+  arma::mat rrt;
 };
 
 // Declare specializations in lrsdp_function.cpp.

--- a/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp_function.hpp
@@ -101,7 +101,7 @@ class LRSDPFunction
   //! Initial point.
   arma::mat initialPoint;
 
-  //! R*R^T matrix.
+  //! Cache R*R^T matrix.
   arma::mat rrt;
 };
 

--- a/src/mlpack/core/optimizers/sdp/lrsdp_function_impl.hpp
+++ b/src/mlpack/core/optimizers/sdp/lrsdp_function_impl.hpp
@@ -94,10 +94,14 @@ void LRSDPFunction<SDPType>::GradientConstraint(
       << "for arbitrary optimizers!" << std::endl;
 }
 
+//! Utility function for updating R*R^T matrix.
+//! Note: Caching R*R^T provide computation optimization by reducing
+//! redundant R*R^T calculations.
 template <typename SDPType>
-void LRSDPFunction<SDPType>::UpdateRRT(const arma::mat& newrrt) const
+void UpdateRRT(LRSDPFunction<SDPType>& function,
+               const arma::mat& newrrt)
 {
-  *(arma::mat*)(&rrt) = newrrt;
+  function.RRT() = newrrt;
 }
 
 //! Utility function for calculating part of the objective when AugLagrangian is
@@ -149,7 +153,7 @@ UpdateGradient(arma::mat& s,
 
 template <typename SDPType>
 static inline double
-EvaluateImpl(const LRSDPFunction<SDPType>& function,
+EvaluateImpl(LRSDPFunction<SDPType>& function,
              const arma::mat& coordinates,
              const arma::vec& lambda,
              const double sigma)
@@ -177,7 +181,7 @@ EvaluateImpl(const LRSDPFunction<SDPType>& function,
   // Note that we can only use this optimization in case of L-BFGS optimizer
   // or any other optimizer which calls Evaluate() before Gradient()
   // with same coordinates matrix.
-  function.UpdateRRT(rrt);
+  UpdateRRT(function, rrt);
 
   // Optimized objective function.
   double objective = trace((trans(coordinates) * function.SDP().C())


### PR DESCRIPTION
Reduces number of computations by taking `R^T * C ` first in objective function and `R^T * A` in constraints converting objective function to `Tr((R^T * C) * R)` and similarly constraints to `Tr((R^T * A) * R)`.