### PR TITLE
removed some warning messages

### DIFF
--- a/src/mlpack/core/optimizers/fw/constr_lpball.hpp
+++ b/src/mlpack/core/optimizers/fw/constr_lpball.hpp
@@ -115,7 +115,7 @@ class ConstrLpBallSolver
       else
         s = arma::abs(v);
 
-      arma::uword k;
+      arma::uword k = 0;
       s.max(k);  // k is the linear index of the largest element.
       s.zeros();
       s(k) = - mlpack::math::Sign(v(k));

--- a/src/mlpack/methods/approx_kfn/drusilla_select_impl.hpp
+++ b/src/mlpack/methods/approx_kfn/drusilla_select_impl.hpp
@@ -95,7 +95,7 @@ void DrusillaSelect<MatType>::Train(
   for (size_t i = 0; i < l; ++i)
   {
     // Pick best index.
-    arma::uword maxIndex;
+    arma::uword maxIndex = 0;
     norms.max(maxIndex);
 
     arma::vec line(refCopy.col(maxIndex) / arma::norm(refCopy.col(maxIndex)));

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -331,7 +331,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
   // Now calculate maximum probabilities for each point.
   for (size_t i = 0; i < data.n_cols; ++i)
   {
-    arma::uword maxIndex;
+    arma::uword maxIndex = 0;
     logLikelihoods.unsafe_col(i).max(maxIndex);
     predictions[i] = maxIndex;
   }

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -148,7 +148,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Train(
   size_t j, i = 0;
   bool converged = false;
   size_t tempLabel;
-  arma::uword maxIndexRow, maxIndexCol;
+  arma::uword maxIndexRow = 0, maxIndexCol = 0;
   arma::mat tempLabelMat;
 
   LearnPolicy LP;

--- a/src/mlpack/tests/binarize_test.cpp
+++ b/src/mlpack/tests/binarize_test.cpp
@@ -2,7 +2,7 @@
  * @file binarize_test.cpp
  * @author Keon Kim
  *
- * Test the Binarzie method.
+ * Test the Binarize method.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the

--- a/src/mlpack/tests/main_tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/softmax_regression_test.cpp
@@ -306,8 +306,6 @@ BOOST_AUTO_TEST_CASE(SoftmaxRegressionDiffLambdaTest)
   // Delete the last row containing labels from test dataset.
   testData.shed_row(testData.n_rows - 1);
 
-  size_t testSize = testData.n_cols;
-
   // Input training data.
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
@@ -372,8 +370,6 @@ BOOST_AUTO_TEST_CASE(SoftmaxRegressionDiffMaxItrTest)
   // Delete the last row containing labels from test dataset.
   testData.shed_row(testData.n_rows - 1);
 
-  size_t testSize = testData.n_cols;
-
   // Input training data.
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
@@ -437,8 +433,6 @@ BOOST_AUTO_TEST_CASE(SoftmaxRegressionDiffInterceptTest)
 
   // Delete the last row containing labels from test dataset.
   testData.shed_row(testData.n_rows - 1);
-
-  size_t testSize = testData.n_cols;
 
   // Input training data.
   SetInputParam("training", inputData);


### PR DESCRIPTION
While building mlpack I encountered some warning messages corresponding to "uninitialised variables and unused variables". Hence I tried to remove them.