### PR TITLE
Boost serialization 1.66 fix

### DIFF
--- a/src/mlpack/core/util/sfinae_utility.hpp
+++ b/src/mlpack/core/util/sfinae_utility.hpp
@@ -203,10 +203,10 @@ struct NAME                                                                  \
   static typename                                                            \
   std::enable_if<std::is_member_function_pointer<decltype(&Q::FUNC)>::value, \
                  int>::type                                                  \
-  f(int t) { return 1;}                                                      \
+  f(int) { return 1;}                                                      \
                                                                              \
   template <typename Q = T>                                                  \
-  static char f(char t) { return 0; }                                        \
+  static char f(char) { return 0; }                                        \
                                                                              \
   static const bool value = sizeof(f<T>(0)) != sizeof(char);                 \
 };

--- a/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
@@ -203,7 +203,8 @@ class SVDCompleteIncrementalLearning<arma::sp_mat>
                       arma::mat& W,
                       const arma::mat& H)
   {
-    if (!isStart) (*it)++;
+    if (!isStart)
+        ++(*it);
     else isStart = false;
 
     if (*it == V.end())
@@ -234,12 +235,10 @@ class SVDCompleteIncrementalLearning<arma::sp_mat>
    * @param W Basis matrix.
    * @param H Encoding matrix to be updated.
    */
-  inline void HUpdate(const arma::sp_mat& V,
+  inline void HUpdate(const arma::sp_mat& /* V */,
                       const arma::mat& W,
                       arma::mat& H)
   {
-    (void)V;
-
     arma::mat deltaH(H.n_rows, 1);
     deltaH.zeros();
 

--- a/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
@@ -169,7 +169,7 @@ inline void SVDIncompleteIncrementalLearning::WUpdate<arma::sp_mat>(
   arma::mat deltaW(V.n_rows, W.n_cols);
   deltaW.zeros();
   for (arma::sp_mat::const_iterator it = V.begin_col(currentUserIndex);
-      it != V.end_col(currentUserIndex); it++)
+      it != V.end_col(currentUserIndex); ++it)
   {
     double val = *it;
     size_t i = it.row();
@@ -189,7 +189,7 @@ inline void SVDIncompleteIncrementalLearning::HUpdate<arma::sp_mat>(
   deltaH.zeros();
 
   for (arma::sp_mat::const_iterator it = V.begin_col(currentUserIndex);
-      it != V.end_col(currentUserIndex); it++)
+      it != V.end_col(currentUserIndex); ++it)
   {
     double val = *it;
     size_t i = it.row();

--- a/src/mlpack/methods/gmm/em_fit_impl.hpp
+++ b/src/mlpack/methods/gmm/em_fit_impl.hpp
@@ -383,7 +383,7 @@ ArmadilloGMMWrapper(const arma::mat& observations,
   for (size_t i = 0; i < dists.size(); ++i)
   {
     dists[i].Mean() = g.means.col(i);
-    dists[i].Covariance(std::move(arma::diagmat(g.dcovs.col(i))));
+    dists[i].Covariance(arma::diagmat(g.dcovs.col(i)));
   }
 }
 #endif

--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -169,7 +169,7 @@ static void mlpackMain()
         secondHashSize, bucketSize);
     Timer::Stop("hash_building");
   }
-  else if (CLI::HasParam("input_model"))
+  else // We must have an input model.
   {
     allkann = CLI::GetParam<LSHSearch<>*>("input_model");
   }

--- a/src/mlpack/methods/reinforcement_learning/training_config.hpp
+++ b/src/mlpack/methods/reinforcement_learning/training_config.hpp
@@ -19,7 +19,13 @@ namespace rl {
 class TrainingConfig
 {
  public:
-  TrainingConfig() : stepLimit(0), gradientLimit(40), doubleQLearning(false)
+  TrainingConfig() :
+      numWorkers(1),
+      updateInterval(1),
+      stepLimit(0),
+      explorationSteps(1),
+      gradientLimit(40),
+      doubleQLearning(false)
   { /* Nothing to do here. */ }
 
   TrainingConfig(

--- a/src/mlpack/tests/arma_extend_test.cpp
+++ b/src/mlpack/tests/arma_extend_test.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(ConstRowColIteratorTest)
   mat::const_row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 0;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -79,14 +79,14 @@ BOOST_AUTO_TEST_CASE(ConstRowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(RowColIteratorTest)
   mat::row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 0;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -125,14 +125,14 @@ BOOST_AUTO_TEST_CASE(RowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -155,14 +155,14 @@ BOOST_AUTO_TEST_CASE(MatRowColIteratorDecrementOperatorTest)
   mat::row_col_iterator it1 = test.begin_row_col();
   mat::row_col_iterator it2 = it1;
 
-  // check that postfix-- does not decrement the position when position is
-  // pointing to the begining
-  it2--;
+  // Check that postfix-- does not decrement the position when position is
+  // pointing to the beginning.
+  (void) it2--;
   BOOST_REQUIRE_EQUAL(it1.row(), it2.row());
   BOOST_REQUIRE_EQUAL(it1.col(), it2.col());
 
-  // check that prefix-- does not decrement the position when position is
-  // pointing to the begining
+  // Check that prefix-- does not decrement the position when position is
+  // pointing to the beginning.
   --it2;
   BOOST_REQUIRE_EQUAL(it1.row(), it2.row());
   BOOST_REQUIRE_EQUAL(it1.col(), it2.col());
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(ConstSpRowColIteratorTest)
   sp_mat::const_row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 1;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -196,14 +196,14 @@ BOOST_AUTO_TEST_CASE(ConstSpRowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(SpRowColIteratorTest)
   sp_mat::row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 1;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -241,14 +241,14 @@ BOOST_AUTO_TEST_CASE(SpRowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));

--- a/src/mlpack/tests/main_tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/main_tests/decision_tree_test.cpp
@@ -69,12 +69,12 @@ BOOST_AUTO_TEST_CASE(DecisionTreeOutputDimensionTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
   // Input test data.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
 
   mlpackMain();
 
@@ -116,12 +116,12 @@ BOOST_AUTO_TEST_CASE(DecisionTreeCategoricalOutputDimensionTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
   // Input test data.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
 
   mlpackMain();
 
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelReuseTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelReuseTest)
   CLI::GetSingleton().Parameters()["test"].wasPassed = false;
 
   // Input trained model.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
   SetInputParam("input_model",
       std::move(CLI::GetParam<DecisionTreeModel*>("output_model")));
 
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(DecisionTreeTrainingVerTest)
   arma::mat weights(1, labels.n_cols, arma::fill::ones);
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelCategoricalReuseTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelCategoricalReuseTest)
   CLI::GetSingleton().Parameters()["test"].wasPassed = false;
 
   // Input trained model.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
   SetInputParam("input_model",
       std::move(CLI::GetParam<DecisionTreeModel*>("output_model")));
 

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -230,7 +230,7 @@ void SerializeObject(T& t, T& newT)
   }
   ifs.close();
 
-//  remove(fileName.c_str());
+  remove(fileName.c_str());
 
   BOOST_REQUIRE_EQUAL(success, true);
 }

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -36,16 +36,19 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   // Use type_info name to get unique file name for serialization test files.
   std::string fileName = FilterFileName(typeid(IArchiveType).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(x);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
+    OArchiveType o(ofs);
+
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
 
   BOOST_REQUIRE_EQUAL(success, true);
@@ -55,16 +58,20 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   arma::Cube<CubeType> orig(x);
   success = true;
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(x);
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
-  }
+  ifs.close();
 
   remove(fileName.c_str());
 
@@ -115,16 +122,19 @@ void TestArmadilloSerialization(MatType& x)
   // First save it.
   std::string fileName = FilterFileName(typeid(IArchiveType).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(x);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
+    OArchiveType o(ofs);
+
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
 
   BOOST_REQUIRE_EQUAL(success, true);
@@ -134,16 +144,20 @@ void TestArmadilloSerialization(MatType& x)
   MatType orig(x);
   success = true;
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(x);
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
-  }
+  ifs.close();
 
   remove(fileName.c_str());
 
@@ -180,37 +194,43 @@ void SerializeObject(T& t, T& newT)
 {
   std::string fileName = FilterFileName(typeid(T).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(t);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    std::cerr << e.what() << std::endl;
-    success = false;
+    OArchiveType o(ofs);
+
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(t);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      std::cerr << e.what() << std::endl;
+      success = false;
+    }
   }
   ofs.close();
 
   BOOST_REQUIRE_EQUAL(success, true);
 
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(newT);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    std::cout << e.what() << "\n";
-    success = false;
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(newT);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      std::cout << e.what() << "\n";
+      success = false;
+    }
   }
   ifs.close();
 
-  remove(fileName.c_str());
+//  remove(fileName.c_str());
 
   BOOST_REQUIRE_EQUAL(success, true);
 }
@@ -233,33 +253,38 @@ void SerializePointerObject(T* t, T*& newT)
 {
   std::string fileName = FilterFileName(typeid(T).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(t);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    std::cout << e.what() << "\n";
-    success = false;
+    OArchiveType o(ofs);
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(t);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      std::cout << e.what() << "\n";
+      success = false;
+    }
   }
   ofs.close();
 
   BOOST_REQUIRE_EQUAL(success, true);
 
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(newT);
-  }
-  catch (std::exception& e)
-  {
-    std::cout << e.what() << "\n";
-    success = false;
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(newT);
+    }
+    catch (std::exception& e)
+    {
+      std::cout << e.what() << "\n";
+      success = false;
+    }
   }
   ifs.close();
 


### PR DESCRIPTION
Right now the docker matrix build fails for boost 1.66:

http://masterblaster.mlpack.org/job/docker%20mlpack%20nightly%20build/armadillo_version=armadillo-7.100.3,boost_version=boost_1_66_0,buildmode=debug,compiler_version=gcc-7.2.0,label=linux-amd64/

I spent way too long digging into it, and this is the fix I came up with.  Basically we just need to ensure the ifstream/ofstream doesn't close before the archive is destructed.  Also I fixed a few warnings.