### PR TITLE
Modified CMakeLists.txt to not install as egg in python dist-packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   # use.
   - sudo pip install cython setuptools numpy pandas
   - sudo pip3 install cython setuptools numpy pandas
-  - curl http://masterblaster.mlpack.org:5005/armadillo-6.500.5.tar.gz | tar xvz && cd armadillo*
+  - curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-6.500.5.tar.gz | tar xvz && cd armadillo*
   - cmake . && make && sudo make install && cd ..
   - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${ARMADILLO_LIBRARIES})
 # Unfortunately this configuration variable is necessary and will need to be
 # updated as time goes on and new versions are released.
 set(Boost_ADDITIONAL_VERSIONS
+  "1.66.0" "1.66"
   "1.65.1" "1.65.0" "1.65"
   "1.64.1" "1.64.0" "1.64"
   "1.63.1" "1.63.0" "1.63"

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -167,7 +167,7 @@ install(CODE "set(ENV{PYTHONPATH} ${NEW_PYTHONPATH})")
 install(CODE "execute_process(COMMAND mkdir -p ${NEW_PYTHONPATH})")
 install(CODE "execute_process(COMMAND ${PYTHON}
     \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
-    --prefix=${CMAKE_INSTALL_PREFIX}
+    --prefix=${CMAKE_INSTALL_PREFIX} --single-version-externally-managed --root=/
     WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
 
 # Prepare __init__.py for having all of the convenience imports appended to it.

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -167,7 +167,7 @@ install(CODE "set(ENV{PYTHONPATH} ${NEW_PYTHONPATH})")
 install(CODE "execute_process(COMMAND mkdir -p ${NEW_PYTHONPATH})")
 install(CODE "execute_process(COMMAND ${PYTHON}
     \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
-    --prefix=${CMAKE_INSTALL_PREFIX} --single-version-externally-managed --root=/
+    --prefix=${CMAKE_INSTALL_PREFIX}
     WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
 
 # Prepare __init__.py for having all of the convenience imports appended to it.

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -69,4 +69,5 @@ setup(name='mlpack',
       cmdclass={ 'build_ext': build_ext },
       ext_modules = modules,
       setup_requires=['cython', 'pytest-runner'],
-      tests_require=['pytest'])
+      tests_require=['pytest'],
+      zip_safe = False)

--- a/src/mlpack/core/util/sfinae_utility.hpp
+++ b/src/mlpack/core/util/sfinae_utility.hpp
@@ -203,10 +203,10 @@ struct NAME                                                                  \
   static typename                                                            \
   std::enable_if<std::is_member_function_pointer<decltype(&Q::FUNC)>::value, \
                  int>::type                                                  \
-  f(int t) { return 1;}                                                      \
+  f(int) { return 1;}                                                      \
                                                                              \
   template <typename Q = T>                                                  \
-  static char f(char t) { return 0; }                                        \
+  static char f(char) { return 0; }                                        \
                                                                              \
   static const bool value = sizeof(f<T>(0)) != sizeof(char);                 \
 };

--- a/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
@@ -203,7 +203,8 @@ class SVDCompleteIncrementalLearning<arma::sp_mat>
                       arma::mat& W,
                       const arma::mat& H)
   {
-    if (!isStart) (*it)++;
+    if (!isStart)
+        ++(*it);
     else isStart = false;
 
     if (*it == V.end())
@@ -234,12 +235,10 @@ class SVDCompleteIncrementalLearning<arma::sp_mat>
    * @param W Basis matrix.
    * @param H Encoding matrix to be updated.
    */
-  inline void HUpdate(const arma::sp_mat& V,
+  inline void HUpdate(const arma::sp_mat& /* V */,
                       const arma::mat& W,
                       arma::mat& H)
   {
-    (void)V;
-
     arma::mat deltaH(H.n_rows, 1);
     deltaH.zeros();
 

--- a/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
@@ -169,7 +169,7 @@ inline void SVDIncompleteIncrementalLearning::WUpdate<arma::sp_mat>(
   arma::mat deltaW(V.n_rows, W.n_cols);
   deltaW.zeros();
   for (arma::sp_mat::const_iterator it = V.begin_col(currentUserIndex);
-      it != V.end_col(currentUserIndex); it++)
+      it != V.end_col(currentUserIndex); ++it)
   {
     double val = *it;
     size_t i = it.row();
@@ -189,7 +189,7 @@ inline void SVDIncompleteIncrementalLearning::HUpdate<arma::sp_mat>(
   deltaH.zeros();
 
   for (arma::sp_mat::const_iterator it = V.begin_col(currentUserIndex);
-      it != V.end_col(currentUserIndex); it++)
+      it != V.end_col(currentUserIndex); ++it)
   {
     double val = *it;
     size_t i = it.row();

--- a/src/mlpack/methods/gmm/em_fit_impl.hpp
+++ b/src/mlpack/methods/gmm/em_fit_impl.hpp
@@ -383,7 +383,7 @@ ArmadilloGMMWrapper(const arma::mat& observations,
   for (size_t i = 0; i < dists.size(); ++i)
   {
     dists[i].Mean() = g.means.col(i);
-    dists[i].Covariance(std::move(arma::diagmat(g.dcovs.col(i))));
+    dists[i].Covariance(arma::diagmat(g.dcovs.col(i)));
   }
 }
 #endif

--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -169,7 +169,7 @@ static void mlpackMain()
         secondHashSize, bucketSize);
     Timer::Stop("hash_building");
   }
-  else if (CLI::HasParam("input_model"))
+  else // We must have an input model.
   {
     allkann = CLI::GetParam<LSHSearch<>*>("input_model");
   }

--- a/src/mlpack/methods/reinforcement_learning/training_config.hpp
+++ b/src/mlpack/methods/reinforcement_learning/training_config.hpp
@@ -19,7 +19,13 @@ namespace rl {
 class TrainingConfig
 {
  public:
-  TrainingConfig() : stepLimit(0), gradientLimit(40), doubleQLearning(false)
+  TrainingConfig() :
+      numWorkers(1),
+      updateInterval(1),
+      stepLimit(0),
+      explorationSteps(1),
+      gradientLimit(40),
+      doubleQLearning(false)
   { /* Nothing to do here. */ }
 
   TrainingConfig(

--- a/src/mlpack/tests/arma_extend_test.cpp
+++ b/src/mlpack/tests/arma_extend_test.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(ConstRowColIteratorTest)
   mat::const_row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 0;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -79,14 +79,14 @@ BOOST_AUTO_TEST_CASE(ConstRowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(RowColIteratorTest)
   mat::row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 0;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -125,14 +125,14 @@ BOOST_AUTO_TEST_CASE(RowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -155,14 +155,14 @@ BOOST_AUTO_TEST_CASE(MatRowColIteratorDecrementOperatorTest)
   mat::row_col_iterator it1 = test.begin_row_col();
   mat::row_col_iterator it2 = it1;
 
-  // check that postfix-- does not decrement the position when position is
-  // pointing to the begining
-  it2--;
+  // Check that postfix-- does not decrement the position when position is
+  // pointing to the beginning.
+  (void) it2--;
   BOOST_REQUIRE_EQUAL(it1.row(), it2.row());
   BOOST_REQUIRE_EQUAL(it1.col(), it2.col());
 
-  // check that prefix-- does not decrement the position when position is
-  // pointing to the begining
+  // Check that prefix-- does not decrement the position when position is
+  // pointing to the beginning.
   --it2;
   BOOST_REQUIRE_EQUAL(it1.row(), it2.row());
   BOOST_REQUIRE_EQUAL(it1.col(), it2.col());
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(ConstSpRowColIteratorTest)
   sp_mat::const_row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 1;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -196,14 +196,14 @@ BOOST_AUTO_TEST_CASE(ConstSpRowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(SpRowColIteratorTest)
   sp_mat::row_col_iterator it;
   // Make sure ++ operator, operator* and comparison operators work fine.
   size_t count = 1;
-  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+  for (it = X.begin_row_col(); it != X.end_row_col(); ++it)
   {
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));
@@ -241,14 +241,14 @@ BOOST_AUTO_TEST_CASE(SpRowColIteratorTest)
     BOOST_REQUIRE_EQUAL(it.row(), count % 5);
     BOOST_REQUIRE_EQUAL(it.col(), count / 5);
 
-    count++;
+    ++count;
   }
   BOOST_REQUIRE_EQUAL(count, 25);
   it = X.end_row_col();
   do
   {
-    it--;
-    count--;
+    --it;
+    --count;
 
     // Check iterator value.
     BOOST_REQUIRE_EQUAL(*it, (count % 5) * 3 + (count / 5));

--- a/src/mlpack/tests/main_tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/main_tests/decision_tree_test.cpp
@@ -69,12 +69,12 @@ BOOST_AUTO_TEST_CASE(DecisionTreeOutputDimensionTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
   // Input test data.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
 
   mlpackMain();
 
@@ -116,12 +116,12 @@ BOOST_AUTO_TEST_CASE(DecisionTreeCategoricalOutputDimensionTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
   // Input test data.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
 
   mlpackMain();
 
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelReuseTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelReuseTest)
   CLI::GetSingleton().Parameters()["test"].wasPassed = false;
 
   // Input trained model.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
   SetInputParam("input_model",
       std::move(CLI::GetParam<DecisionTreeModel*>("output_model")));
 
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(DecisionTreeTrainingVerTest)
   arma::mat weights(1, labels.n_cols, arma::fill::ones);
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelCategoricalReuseTest)
   size_t testSize = testData.n_cols;
 
   // Input training data.
-  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(DecisionModelCategoricalReuseTest)
   CLI::GetSingleton().Parameters()["test"].wasPassed = false;
 
   // Input trained model.
-  SetInputParam("test", std::move(std::make_tuple(info, testData)));
+  SetInputParam("test", std::make_tuple(info, testData));
   SetInputParam("input_model",
       std::move(CLI::GetParam<DecisionTreeModel*>("output_model")));
 

--- a/src/mlpack/tests/serialization.hpp
+++ b/src/mlpack/tests/serialization.hpp
@@ -36,16 +36,19 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   // Use type_info name to get unique file name for serialization test files.
   std::string fileName = FilterFileName(typeid(IArchiveType).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(x);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
+    OArchiveType o(ofs);
+
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
 
   BOOST_REQUIRE_EQUAL(success, true);
@@ -55,16 +58,20 @@ void TestArmadilloSerialization(arma::Cube<CubeType>& x)
   arma::Cube<CubeType> orig(x);
   success = true;
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(x);
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
-  }
+  ifs.close();
 
   remove(fileName.c_str());
 
@@ -115,16 +122,19 @@ void TestArmadilloSerialization(MatType& x)
   // First save it.
   std::string fileName = FilterFileName(typeid(IArchiveType).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(x);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
+    OArchiveType o(ofs);
+
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
 
   BOOST_REQUIRE_EQUAL(success, true);
@@ -134,16 +144,20 @@ void TestArmadilloSerialization(MatType& x)
   MatType orig(x);
   success = true;
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(x);
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(x);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      success = false;
+    }
   }
-  catch (boost::archive::archive_exception& e)
-  {
-    success = false;
-  }
+  ifs.close();
 
   remove(fileName.c_str());
 
@@ -180,33 +194,39 @@ void SerializeObject(T& t, T& newT)
 {
   std::string fileName = FilterFileName(typeid(T).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(t);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    std::cerr << e.what() << std::endl;
-    success = false;
+    OArchiveType o(ofs);
+
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(t);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      std::cerr << e.what() << std::endl;
+      success = false;
+    }
   }
   ofs.close();
 
   BOOST_REQUIRE_EQUAL(success, true);
 
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(newT);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    std::cout << e.what() << "\n";
-    success = false;
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(newT);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      std::cout << e.what() << "\n";
+      success = false;
+    }
   }
   ifs.close();
 
@@ -233,33 +253,38 @@ void SerializePointerObject(T* t, T*& newT)
 {
   std::string fileName = FilterFileName(typeid(T).name());
   std::ofstream ofs(fileName, std::ios::binary);
-  OArchiveType o(ofs);
-
   bool success = true;
-  try
+
   {
-    o << BOOST_SERIALIZATION_NVP(t);
-  }
-  catch (boost::archive::archive_exception& e)
-  {
-    std::cout << e.what() << "\n";
-    success = false;
+    OArchiveType o(ofs);
+    try
+    {
+      o << BOOST_SERIALIZATION_NVP(t);
+    }
+    catch (boost::archive::archive_exception& e)
+    {
+      std::cout << e.what() << "\n";
+      success = false;
+    }
   }
   ofs.close();
 
   BOOST_REQUIRE_EQUAL(success, true);
 
   std::ifstream ifs(fileName, std::ios::binary);
-  IArchiveType i(ifs);
 
-  try
   {
-    i >> BOOST_SERIALIZATION_NVP(newT);
-  }
-  catch (std::exception& e)
-  {
-    std::cout << e.what() << "\n";
-    success = false;
+    IArchiveType i(ifs);
+
+    try
+    {
+      i >> BOOST_SERIALIZATION_NVP(newT);
+    }
+    catch (std::exception& e)
+    {
+      std::cout << e.what() << "\n";
+      success = false;
+    }
   }
   ifs.close();
 


### PR DESCRIPTION
Resolves #1231 
Added arguments to python setup.py install in CMakeLists.txt as mentioned here:[https://stackoverflow.com/questions/6301003/stopping-setup-py-from-installing-as-egg](url)
It now installs as a mlpack folder in python dist-packages and not an egg file, thus, drastically reducing the import time in python.