### PR TITLE
Greedy Traverser Fix for KNN

### DIFF
--- a/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
@@ -41,7 +41,10 @@ class GreedySingleTreeTraverser
   size_t NumPrunes() const { return numPrunes; }
 
   //! Set value of minBaseCases.
-  void MinBaseCases(size_t baseCases) { minBaseCases = baseCases; }
+  size_t& MinBaseCases() { return minBaseCases; }
+
+  //! Get value of minBaseCases.
+  size_t MinBaseCases() const { return minBaseCases; }
 
  private:
   //! Reference to the rules with which the tree will be traversed.

--- a/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
@@ -40,8 +40,8 @@ class GreedySingleTreeTraverser
   //! Get the number of prunes.
   size_t NumPrunes() const { return numPrunes; }
 
-  //! Set value of k.
-  void K(size_t K) { k = K; }
+  //! Set value of minBaseCases.
+  void MinBaseCases(size_t baseCases) { minBaseCases = baseCases; }
 
  private:
   //! Reference to the rules with which the tree will be traversed.
@@ -50,9 +50,9 @@ class GreedySingleTreeTraverser
   //! The number of nodes which have been pruned during traversal.
   size_t numPrunes;
 
-  //! The number of results required. For example number of nearest
-  //! neighbours in case of knn.
-  size_t k;
+  //! The number of base cases required. For example the number of nearest
+  //! neighbours(k) in case of knn.
+  size_t minBaseCases;
 };
 
 } // namespace tree

--- a/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser.hpp
@@ -40,12 +40,19 @@ class GreedySingleTreeTraverser
   //! Get the number of prunes.
   size_t NumPrunes() const { return numPrunes; }
 
+  //! Set value of k.
+  void K(size_t K) { k = K; }
+
  private:
   //! Reference to the rules with which the tree will be traversed.
   RuleType& rule;
 
   //! The number of nodes which have been pruned during traversal.
   size_t numPrunes;
+
+  //! The number of results required. For example number of nearest
+  //! neighbours in case of knn.
+  size_t k;
 };
 
 } // namespace tree

--- a/src/mlpack/core/tree/greedy_single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser_impl.hpp
@@ -24,7 +24,8 @@ template<typename TreeType, typename RuleType>
 GreedySingleTreeTraverser<TreeType, RuleType>::GreedySingleTreeTraverser(
     RuleType& rule) :
     rule(rule),
-    numPrunes(0)
+    numPrunes(0),
+    k(0)
 { /* Nothing to do. */ }
 
 template<typename TreeType, typename RuleType>
@@ -32,17 +33,38 @@ void GreedySingleTreeTraverser<TreeType, RuleType>::Traverse(
     const size_t queryIndex,
     TreeType& referenceNode)
 {
-  // Run the base case as necessary for all the points in the reference node.
-  for (size_t i = 0; i < referenceNode.NumPoints(); ++i)
-    rule.BaseCase(queryIndex, referenceNode.Point(i));
+  if(referenceNode.IsLeaf())
+  {
+    // Run the base case as necessary for all the points in the reference node.
+    for (size_t i = 0; i < referenceNode.NumPoints(); ++i)
+      rule.BaseCase(queryIndex, referenceNode.Point(i));
+    return;
+  }
 
-  if (!referenceNode.IsLeaf())
+  size_t bestChild = rule.GetBestChild(queryIndex, referenceNode);
+  size_t numDescendants;
+
+  // Check that referencenode is not a leaf node while calculating number of
+  // descendants of it's best child.
+  if(!referenceNode.IsLeaf())
+    numDescendants = referenceNode.Child(bestChild).NumDescendants();
+  else
+    numDescendants = referenceNode.NumPoints();
+
+  // If number of descendants are more than k than we can go along with
+  // best child otherwise we need to traverse for each descendant to
+  // ensure that we get at least k nearest neighbors..
+  if (numDescendants > k)
   {
     // We are prunning all but one child.
     numPrunes += referenceNode.NumChildren() - 1;
     // Recurse the best child.
-    size_t bestChild = rule.GetBestChild(queryIndex, referenceNode);
     Traverse(queryIndex, referenceNode.Child(bestChild));
+  }
+  else
+  {
+    for (size_t i = 0; i < referenceNode.NumChildren(); ++i)
+      Traverse(queryIndex, referenceNode.Child(i));
   }
 }
 

--- a/src/mlpack/core/tree/greedy_single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser_impl.hpp
@@ -25,7 +25,7 @@ GreedySingleTreeTraverser<TreeType, RuleType>::GreedySingleTreeTraverser(
     RuleType& rule) :
     rule(rule),
     numPrunes(0),
-    k(0)
+    minBaseCases(0)
 { /* Nothing to do. */ }
 
 template<typename TreeType, typename RuleType>
@@ -33,38 +33,37 @@ void GreedySingleTreeTraverser<TreeType, RuleType>::Traverse(
     const size_t queryIndex,
     TreeType& referenceNode)
 {
-  if(referenceNode.IsLeaf())
-  {
-    // Run the base case as necessary for all the points in the reference node.
-    for (size_t i = 0; i < referenceNode.NumPoints(); ++i)
-      rule.BaseCase(queryIndex, referenceNode.Point(i));
-    return;
-  }
+  // Run the base case as necessary for all the points in the reference node.
+  for (size_t i = 0; i < referenceNode.NumPoints(); ++i)
+    rule.BaseCase(queryIndex, referenceNode.Point(i));
 
   size_t bestChild = rule.GetBestChild(queryIndex, referenceNode);
   size_t numDescendants;
 
   // Check that referencenode is not a leaf node while calculating number of
   // descendants of it's best child.
-  if(!referenceNode.IsLeaf())
+  if (!referenceNode.IsLeaf())
     numDescendants = referenceNode.Child(bestChild).NumDescendants();
   else
     numDescendants = referenceNode.NumPoints();
 
-  // If number of descendants are more than k than we can go along with
-  // best child otherwise we need to traverse for each descendant to
-  // ensure that we get at least k nearest neighbors..
-  if (numDescendants > k)
+  // If number of descendants are more than minBaseCases than we can go along
+  // with best child otherwise we need to traverse for each descendant to
+  // ensure that we calculate at least minBaseCases number of base cases.
+  if (!referenceNode.IsLeaf())
   {
-    // We are prunning all but one child.
-    numPrunes += referenceNode.NumChildren() - 1;
-    // Recurse the best child.
-    Traverse(queryIndex, referenceNode.Child(bestChild));
-  }
-  else
-  {
-    for (size_t i = 0; i < referenceNode.NumChildren(); ++i)
-      Traverse(queryIndex, referenceNode.Child(i));
+    if (numDescendants > minBaseCases)
+    {
+      // We are prunning all but one child.
+      numPrunes += referenceNode.NumChildren() - 1;
+      // Recurse the best child.
+      Traverse(queryIndex, referenceNode.Child(bestChild));
+    }
+    else
+    {
+      for (size_t i = 0; i < referenceNode.NumDescendants(); ++i)
+        rule.BaseCase(queryIndex, referenceNode.Descendant(i));
+    }
   }
 }
 

--- a/src/mlpack/core/tree/greedy_single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/greedy_single_tree_traverser_impl.hpp
@@ -61,7 +61,8 @@ void GreedySingleTreeTraverser<TreeType, RuleType>::Traverse(
     }
     else
     {
-      for (size_t i = 0; i < referenceNode.NumDescendants(); ++i)
+      // Run the base case over first minBaseCases number of descendants.
+      for (size_t i = 0; i <= minBaseCases; ++i)
         rule.BaseCase(queryIndex, referenceNode.Descendant(i));
     }
   }

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -663,7 +663,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
       tree::GreedySingleTreeTraverser<Tree, RuleType> traverser(rules);
 
       // Set the value of minBaseCases.
-      traverser.MinBaseCases(k);
+      traverser.MinBaseCases() = k;
 
       // Now have it traverse for each point.
       for (size_t i = 0; i < querySet.n_cols; ++i)
@@ -963,7 +963,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
       tree::GreedySingleTreeTraverser<Tree, RuleType> traverser(rules);
 
       // Set the value of minBaseCases.
-      traverser.MinBaseCases(k);
+      traverser.MinBaseCases() = k;
 
       // Now have it traverse for each point.
       for (size_t i = 0; i < referenceSet->n_cols; ++i)

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -662,6 +662,9 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
       // Create the traverser.
       tree::GreedySingleTreeTraverser<Tree, RuleType> traverser(rules);
 
+      // Set the value of K.
+      traverser.K(k);
+
       // Now have it traverse for each point.
       for (size_t i = 0; i < querySet.n_cols; ++i)
         traverser.Traverse(i, *referenceTree);
@@ -958,6 +961,9 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
     {
       // Create the traverser.
       tree::GreedySingleTreeTraverser<Tree, RuleType> traverser(rules);
+
+      // Set the value of K.
+      traverser.K(k);
 
       // Now have it traverse for each point.
       for (size_t i = 0; i < referenceSet->n_cols; ++i)

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -662,8 +662,8 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
       // Create the traverser.
       tree::GreedySingleTreeTraverser<Tree, RuleType> traverser(rules);
 
-      // Set the value of K.
-      traverser.K(k);
+      // Set the value of minBaseCases.
+      traverser.MinBaseCases(k);
 
       // Now have it traverse for each point.
       for (size_t i = 0; i < querySet.n_cols; ++i)
@@ -962,8 +962,8 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
       // Create the traverser.
       tree::GreedySingleTreeTraverser<Tree, RuleType> traverser(rules);
 
-      // Set the value of K.
-      traverser.K(k);
+      // Set the value of minBaseCases.
+      traverser.MinBaseCases(k);
 
       // Now have it traverse for each point.
       for (size_t i = 0; i < referenceSet->n_cols; ++i)

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -1443,8 +1443,9 @@ BOOST_AUTO_TEST_CASE(GreedyTreeSearch)
   // Initalize dataset.
   arma::mat dataset = arma::randu<arma::mat>(3, 100);
 
+  // Build tree with a leaf_size of 1.
   KDTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> tree(dataset);
+      arma::mat> tree(dataset, 1);
 
   NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, KDTree>
       greedyTreeSearch(std::move(tree), GREEDY_SINGLE_TREE_MODE);
@@ -1455,15 +1456,13 @@ BOOST_AUTO_TEST_CASE(GreedyTreeSearch)
   // Search for 5 nearest neighbours.
   greedyTreeSearch.Search(5, neighbors, distances);
 
-  // Check that all neighbour values are between 0 and 100 as only 100 points
-  // are present in dataset, hence in total we would be having 500 values.
-  BOOST_REQUIRE_EQUAL(arma::accu(neighbors >= 0 && neighbors <100),
-                      500);
+  // Check that all neighbour values are between 0 and 100, as only 100 points
+  // are present in dataset.
+  BOOST_REQUIRE_EQUAL(arma::accu(neighbors < 0 || neighbors >= 100), 0);
 
-  // Check that all distances values are between 0 and 1.0 as arma::randu
+  // Check that all distances values are between 0.0 and 1.0 as arma::randu
   // generates a uniform distribution in [0, 1].
-  BOOST_REQUIRE_EQUAL(arma::accu(distances >= 0 && distances <= 1.0),
-                      500);
+  BOOST_REQUIRE_EQUAL(arma::accu(distances < 0.0 || distances > 1.0), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -1434,4 +1434,36 @@ BOOST_AUTO_TEST_CASE(MoveOperatorNaiveTest)
   CheckMatrices(distances, distances2);
 }
 
+/**
+ * Check that no garbage value is returned when greedy tree traversal
+ * is performed over kd-tree.
+ */
+BOOST_AUTO_TEST_CASE(GreedyTreeSearch)
+{
+  // Initalize dataset.
+  arma::mat dataset = arma::randu<arma::mat>(3, 100);
+
+  KDTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
+      arma::mat> tree(dataset);
+
+  NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, KDTree>
+      greedyTreeSearch(std::move(tree), GREEDY_SINGLE_TREE_MODE);
+
+  arma::Mat<size_t> neighbors;
+  arma::mat distances;
+
+  // Search for 5 nearest neighbours.
+  greedyTreeSearch.Search(5, neighbors, distances);
+
+  // Check that all neighbour values are between 0 and 100 as only 100 points
+  // are present in dataset, hence in total we would be having 500 values.
+  BOOST_REQUIRE_EQUAL(arma::accu(neighbors >= 0 && neighbors <100),
+                      500);
+
+  // Check that all distances values are between 0 and 1.0 as arma::randu
+  // generates a uniform distribution in [0, 1].
+  BOOST_REQUIRE_EQUAL(arma::accu(distances >= 0 && distances <= 1.0),
+                      500);
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Fix for #1222 
Traverser traverse through greedy technique till more than `k` points are available and after that base case is taken over all the descendant points.
In order to access `k` value  through greedy, a private member `k` has been declared which is default set to 0 and hence do not interfere with the generality of traverser.For trees like kd-tree, ball tree which stores points in leaf nodes `k` can be set using `K()`.