### PR TITLE
Resolved bug 

### DIFF
--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -76,10 +76,13 @@ static void mlpackMain()
   // Parse command line options.
   const double testRatio = CLI::GetParam<double>("test_ratio");
 
-  if (CLI::GetParam<int>("seed") == 0)
-    mlpack::math::RandomSeed(std::time(NULL));
-  else
-    mlpack::math::RandomSeed((size_t) CLI::GetParam<int>("seed"));
+#if(BINDING_TYPE != BINDING_TYPE_TEST) // This is a unit test
+
+      if ((CLI::GetParam<int>("seed") == 0))
+          mlpack::math::RandomSeed(std::time(NULL));
+      else
+          mlpack::math::RandomSeed((size_t) CLI::GetParam<int>("seed"));
+#endif
 
   // Make sure the user specified output filenames.
   RequireAtLeastOnePassed({ "training" }, false, "no training set will be "


### PR DESCRIPTION
Fix for #1227 
Whenever `mlpackMain()` is called from any of the test suite a random seed is set by calling `RandomSeed(time(NULL))` which is different for different runtimes. Thus, call to `RandomSeed()` is restricted from any of mlpack test suites
I've done it as of now for only `preprocess_split_test`. If it is acceptable then I can extend it for every test.
wip