### PR TITLE
Removing empty clusters instead of killing them.

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -89,6 +89,7 @@ Copyright:
   Copyright 2017&2018, Sourabh Varshney <sourabhvarshney111@gmail.com>
   Copyright 2018, Projyal Dev <projyal@gmail.com>
   Copyright 2018, Nikhil Goel <nikhilgoel199797@gmail.com>
+  Copyright 2018, Prabhat Sharma <prabhatsharma7298@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/doc/tutorials/kmeans/kmeans.txt
+++ b/doc/tutorials/kmeans/kmeans.txt
@@ -132,9 +132,16 @@ $ mlpack_kmeans -c 5 -i dataset.csv -v -o assignments.csv -C centroids.csv
 
 If you would like to allow empty clusters to exist, instead of reinitializing
 them, simply specify the \c -e (\c --allow_empty_clusters) option.  Note that
-when you save your clusters, some of the clusters may be filled with NaNs.  This
-is expected behavior -- if a cluster has no points, the concept of a centroid
-makes no sense.
+when you save your clusters, even empty clusters will still have centroids.
+The centroids of the empty cluster will be the same as what they were on the
+last iteration when the cluster was not empty.
+
+@subsection cli_ex3_kmtut Killing empty clusters
+
+If you would like to kill empty clusters , instead of reinitializing
+them, simply specify the \c -E (\c --kill_empty_clusters) option.  Note that
+when you save your clusters, all the empty clusters will be removed and the
+final result may contain less than specified number of clusters.
 
 @code
 $ mlpack_kmeans -c 5 -i dataset.csv -v -o assignments.csv -C centroids.csv

--- a/doc/tutorials/kmeans/kmeans.txt
+++ b/doc/tutorials/kmeans/kmeans.txt
@@ -136,6 +136,10 @@ when you save your clusters, even empty clusters will still have centroids.
 The centroids of the empty cluster will be the same as what they were on the
 last iteration when the cluster was not empty.
 
+@code
+$ mlpack_kmeans -c 5 -i dataset.csv -v -e -o assignments.csv -C centroids.csv
+@endcode
+
 @subsection cli_ex3_kmtut Killing empty clusters
 
 If you would like to kill empty clusters , instead of reinitializing
@@ -144,7 +148,7 @@ when you save your clusters, all the empty clusters will be removed and the
 final result may contain less than specified number of clusters.
 
 @code
-$ mlpack_kmeans -c 5 -i dataset.csv -v -o assignments.csv -C centroids.csv
+$ mlpack_kmeans -c 5 -i dataset.csv -v -E -o assignments.csv -C centroids.csv
 @endcode
 
 @subsection cli_ex4_kmtut Limiting the maximum number of iterations

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -232,6 +232,7 @@
  *   - Sourabh Varshney <sourabhvarshney111@gmail.com>
  *   - Projyal Dev <projyal@gmail.com>
  *   - Nikhil Goel <nikhilgoel199797@gmail.com>
+ *   - Prabhat Sharma <prabhatsharma7298@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -51,18 +51,17 @@ class KillEmptyClusters
       const size_t emptyCluster,
       const arma::mat& /* oldCentroids */,
       arma::mat& newCentroids,
-      arma::Col<size_t>& counts /* clusterCounts */,
+      arma::Col<size_t>& clusterCounts,
       MetricType& /* metric */,
       const size_t /* iteration */)
   {
     // Remove the empty cluster.
-      if (emptyCluster < newCentroids.n_cols)
+    if (emptyCluster < newCentroids.n_cols)
       {
           newCentroids.shed_col(emptyCluster);
-          counts.shed_row(emptyCluster);
-          return 0; // one cluster removed
+          clusterCounts.shed_row(emptyCluster);
       }
-      else return 0; // no point changed
+    return 0; // cluster removed
   }
 
   //! Serialize the empty cluster policy (nothing to do).

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -51,7 +51,7 @@ class KillEmptyClusters
       const size_t emptyCluster,
       const arma::mat& /* oldCentroids */,
       arma::mat& newCentroids,
-      arma::Col<size_t>& /* clusterCounts */,
+      arma::Col<size_t>& counts /* clusterCounts */,
       MetricType& /* metric */,
       const size_t /* iteration */)
   {
@@ -59,9 +59,10 @@ class KillEmptyClusters
       if (emptyCluster < newCentroids.n_cols)
       {
           newCentroids.shed_col(emptyCluster);
-          return 0; // No points were changed.
+          counts.shed_row(emptyCluster);
+          return 0; // one cluster removed
       }
-      else return 0;
+      else return 0; // no point changed
   }
 
   //! Serialize the empty cluster policy (nothing to do).

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -55,9 +55,12 @@ class KillEmptyClusters
       MetricType& /* metric */,
       const size_t /* iteration */)
   {
-    // Kill the empty cluster.
-    newCentroids.col(emptyCluster).fill(DBL_MAX);
-    return 0; // No points were changed.
+    // Remove the empty cluster.
+      if (emptyCluster < newCentroids.n_cols)
+      {
+          newCentroids.shed_col(emptyCluster);
+          return 0; // No points were changed.
+      } else return 0;
   }
 
   //! Serialize the empty cluster policy (nothing to do).

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -60,7 +60,8 @@ class KillEmptyClusters
       {
           newCentroids.shed_col(emptyCluster);
           return 0; // No points were changed.
-      } else return 0;
+      }
+      else return 0;
   }
 
   //! Serialize the empty cluster policy (nothing to do).

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -54,15 +54,15 @@ class KillEmptyClusters
       arma::Col<size_t>& clusterCounts,
       MetricType& /* metric */,
       const size_t /* iteration */)
+{
+  // Remove the empty cluster.
+  if (emptyCluster < newCentroids.n_cols)
   {
-    // Remove the empty cluster.
-    if (emptyCluster < newCentroids.n_cols)
-      {
-          newCentroids.shed_col(emptyCluster);
-          clusterCounts.shed_row(emptyCluster);
-      }
-    return 0; // cluster removed
+      newCentroids.shed_col(emptyCluster);
+      clusterCounts.shed_row(emptyCluster);
   }
+  return 0; // cluster removed
+}
 
   //! Serialize the empty cluster policy (nothing to do).
   template<typename Archive>

--- a/src/mlpack/methods/kmeans/kmeans.hpp
+++ b/src/mlpack/methods/kmeans/kmeans.hpp
@@ -124,7 +124,7 @@ class KMeans
    *      initial cluster centroids.
    */
   void Cluster(const MatType& data,
-               const size_t clusters,
+               size_t clusters,
                arma::mat& centroids,
                const bool initialGuess = false);
 

--- a/src/mlpack/methods/kmeans/kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/kmeans_impl.hpp
@@ -146,7 +146,7 @@ void KMeans<
     LloydStepType,
     MatType>::
 Cluster(const MatType& data,
-        const size_t clusters,
+        size_t clusters,
         arma::mat& centroids,
         const bool initialGuess)
 {
@@ -222,7 +222,7 @@ Cluster(const MatType& data,
 
     // If we are not allowing empty clusters, then check that all of our
     // clusters have points.
-    for (size_t i = 0; i < clusters; i++)
+    for (size_t i = 0; i < counts.n_elem; i++)
     {
       if (counts[i] == 0)
       {

--- a/src/mlpack/tests/kmeans_test.cpp
+++ b/src/mlpack/tests/kmeans_test.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(AllowEmptyClusterTest)
 }
 
 /**
- * Make sure kill empty cluster policy removes the empty cluster
+ * Make sure kill empty cluster policy removes the empty cluster.
  */
 BOOST_AUTO_TEST_CASE(KillEmptyClusterTest)
 {
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(KillEmptyClusterTest)
     BOOST_REQUIRE_EQUAL(counts[i], countsOld[i]);
 
   // Make sure that counts contain one less element than old counts.
-  BOOST_REQUIRE_GT(countsOld.n_elem,counts.n_elem);
+  BOOST_REQUIRE_GT(countsOld.n_elem, counts.n_elem);
 }
 
 /**

--- a/src/mlpack/tests/kmeans_test.cpp
+++ b/src/mlpack/tests/kmeans_test.cpp
@@ -23,6 +23,7 @@
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 
 #include <boost/test/unit_test.hpp>
+#include <mlpack/methods/kmeans/kill_empty_clusters.hpp>
 #include "test_tools.hpp"
 
 using namespace mlpack;
@@ -132,6 +133,41 @@ BOOST_AUTO_TEST_CASE(AllowEmptyClusterTest)
   // Make sure no counts were changed.
   for (size_t i = 0; i < 3; i++)
     BOOST_REQUIRE_EQUAL(counts[i], countsOld[i]);
+}
+
+/**
+ * Make sure kill empty cluster policy removes the empty cluster
+ */
+BOOST_AUTO_TEST_CASE(KillEmptyClusterTest)
+{
+  arma::Row<size_t> assignments;
+  assignments.randu(30);
+  arma::Row<size_t> assignmentsOld = assignments;
+
+  arma::mat centroids;
+  centroids.randu(30, 3); // This doesn't matter.
+
+  arma::Col<size_t> counts(3);
+  counts[0] = accu(assignments == 0);
+  counts[1] = accu(assignments == 1);
+  counts[2] = 0;
+  arma::Col<size_t> countsOld = counts;
+
+  // Make sure the method modify the specified point.
+  metric::LMetric<2, true> metric;
+  BOOST_REQUIRE_EQUAL(KillEmptyClusters::EmptyCluster(kMeansData, 2, centroids,
+                                                       centroids, counts, metric, 0), 0);
+
+  // Make sure no assignments were changed.
+  for (size_t i = 0; i < assignments.n_elem; i++)
+    BOOST_REQUIRE_EQUAL(assignments[i], assignmentsOld[i]);
+
+  // Make sure no counts were changed for clusters that are not empty.
+  for (size_t i = 0; i < 2; i++)
+    BOOST_REQUIRE_EQUAL(counts[i], countsOld[i]);
+
+  // Make sure that counts contain one less element than old counts.
+  BOOST_REQUIRE_GT(countsOld.n_elem,counts.n_elem);
 }
 
 /**


### PR DESCRIPTION
Fixes #1232 
While clustering instead of filling empty clusters with `DBL_MAX` empty clusters are entirely removed.