### PR TITLE
Fix serialization issue for boost v1.58

### DIFF
--- a/src/mlpack/core/boost_backport/CMakeLists.txt
+++ b/src/mlpack/core/boost_backport/CMakeLists.txt
@@ -14,6 +14,9 @@ set(SOURCES
   unordered_collections_load_imp.hpp
   unordered_collections_save_imp.hpp
   unordered_map.hpp
+  vector.hpp
+  collections_load_imp.hpp
+  collections_save_imp.hpp
 )
 
 # add directory name to sources

--- a/src/mlpack/core/boost_backport/boost_backport_serialization.hpp
+++ b/src/mlpack/core/boost_backport/boost_backport_serialization.hpp
@@ -24,5 +24,13 @@
   #include <boost/serialization/unordered_map.hpp>
 #endif
 
+#if BOOST_VERSION <= 105800
+  #include "mlpack/core/boost_backport/collections_load_imp.hpp"
+  #include "mlpack/core/boost_backport/collections_save_imp.hpp"
+  #include "mlpack/core/boost_backport/vector.hpp"
+#else
+  #include <boost/serialization/vector.hpp>
+#endif
+
 #endif // MLPACK_CORE_BOOST_BACKPORT_SERIALIZATION_HPP
 

--- a/src/mlpack/core/boost_backport/boost_backport_serialization.hpp
+++ b/src/mlpack/core/boost_backport/boost_backport_serialization.hpp
@@ -6,6 +6,7 @@
  * following boost functionality here:
  *
  *  * unordered_set serialization support (added in boost 1.56.0)
+ *  * vector serialization (changed after boost 1.58.0)
  *
  * If the detected boost version is greater than 1.58.0, we include the normal
  * serialization functions (not the backported ones).  For all older versions we
@@ -25,6 +26,14 @@
 #endif
 
 #if BOOST_VERSION <= 105800
+  /**
+   * Boost versions 1.58.0 and earlier have a different vector serialization
+   * behaivor as compared to later versions. Notably, loading a
+   * std::vector<arma::mat> does not clear the vector before the load
+   * in v1.58 and earlier; while in the later versions, the vector is cleared
+   * before loading. This causes some tests related to serialization to fail
+   * with versions 1.58. This backport solves the issue.
+   */
   #include "mlpack/core/boost_backport/collections_load_imp.hpp"
   #include "mlpack/core/boost_backport/collections_save_imp.hpp"
   #include "mlpack/core/boost_backport/vector.hpp"

--- a/src/mlpack/core/boost_backport/boost_backport_serialization.hpp
+++ b/src/mlpack/core/boost_backport/boost_backport_serialization.hpp
@@ -25,7 +25,7 @@
   #include <boost/serialization/unordered_map.hpp>
 #endif
 
-#if BOOST_VERSION <= 105800
+#if BOOST_VERSION == 105800
   /**
    * Boost versions 1.58.0 and earlier have a different vector serialization
    * behaivor as compared to later versions. Notably, loading a
@@ -34,6 +34,12 @@
    * before loading. This causes some tests related to serialization to fail
    * with versions 1.58. This backport solves the issue.
    */
+  #ifdef BOOST_SERIALIZATION_VECTOR_HPP
+  #pragma message "Detected Boost version is 1.58. Including\
+  boost/serialization/vector.hpp before mlpack/core.hpp can cause problems. It\
+  should only be necessary to include mlpack/core.hpp and not\
+  boost/serialization/vector.hpp."
+  #endif
   #include "mlpack/core/boost_backport/collections_load_imp.hpp"
   #include "mlpack/core/boost_backport/collections_save_imp.hpp"
   #include "mlpack/core/boost_backport/vector.hpp"

--- a/src/mlpack/core/boost_backport/collections_load_imp.hpp
+++ b/src/mlpack/core/boost_backport/collections_load_imp.hpp
@@ -1,0 +1,105 @@
+#ifndef  BOOST_SERIALIZATION_COLLECTIONS_LOAD_IMP_HPP
+#define BOOST_SERIALIZATION_COLLECTIONS_LOAD_IMP_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1020)
+#  pragma warning (disable : 4786) // too long name, harmless warning
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// collections_load_imp.hpp: serialization for loading stl collections
+
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for updates, documentation, and revision history.
+
+// helper function templates for serialization of collections
+
+#include <boost/assert.hpp>
+#include <cstddef> // size_t
+#include <boost/config.hpp> // msvc 6.0 needs this for warning suppression
+#if defined(BOOST_NO_STDC_NAMESPACE)
+namespace std{ 
+    using ::size_t; 
+} // namespace std
+#endif
+#include <boost/detail/workaround.hpp>
+
+#include <boost/archive/detail/basic_iarchive.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/detail/stack_constructor.hpp>
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/item_version_type.hpp>
+#include <boost/serialization/detail/is_default_constructible.hpp>
+#include <boost/utility/enable_if.hpp>
+
+namespace boost{
+namespace serialization {
+namespace stl {
+
+//////////////////////////////////////////////////////////////////////
+// implementation of serialization for STL containers
+//
+
+template<
+    class Archive,
+    class T
+>
+typename boost::enable_if<
+    typename detail::is_default_constructible<
+        typename T::value_type
+    >,
+    void
+>::type
+collection_load_impl(
+    Archive & ar,
+    T & t,
+    collection_size_type count,
+    item_version_type
+){
+    t.resize(count);
+    typename T::iterator hint;
+    hint = t.begin();
+    while(count-- > 0){
+        ar >> boost::serialization::make_nvp("item", *hint++);
+    }
+}
+
+template<
+    class Archive,
+    class T
+>
+typename boost::disable_if<
+    typename detail::is_default_constructible<
+        typename T::value_type
+    >,
+    void
+>::type
+collection_load_impl(
+    Archive & ar,
+    T & t,
+    collection_size_type count,
+    item_version_type item_version
+){
+    t.clear();
+    while(count-- > 0){
+        detail::stack_construct<Archive, typename T::value_type> u(ar, item_version);
+        ar >> boost::serialization::make_nvp("item", u.reference());
+        t.push_back(u.reference());
+        ar.reset_object_address(& t.back() , & u.reference());
+     }
+}
+
+} // namespace stl 
+} // namespace serialization
+} // namespace boost
+
+#endif //BOOST_SERIALIZATION_COLLECTIONS_LOAD_IMP_HPP

--- a/src/mlpack/core/boost_backport/collections_save_imp.hpp
+++ b/src/mlpack/core/boost_backport/collections_save_imp.hpp
@@ -1,0 +1,82 @@
+#ifndef BOOST_SERIALIZATION_COLLECTIONS_SAVE_IMP_HPP
+#define BOOST_SERIALIZATION_COLLECTIONS_SAVE_IMP_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// collections_save_imp.hpp: serialization for stl collections
+
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for updates, documentation, and revision history.
+
+// helper function templates for serialization of collections
+
+#include <boost/config.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/version.hpp>
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/item_version_type.hpp>
+
+namespace boost{
+namespace serialization {
+namespace stl {
+
+//////////////////////////////////////////////////////////////////////
+// implementation of serialization for STL containers
+//
+
+template<class Archive, class Container>
+inline void save_collection(
+    Archive & ar,
+    const Container &s,
+    collection_size_type count)
+{
+    ar << BOOST_SERIALIZATION_NVP(count);
+    // record number of elements
+    const item_version_type item_version(
+        version<typename Container::value_type>::value
+    );
+    #if 0
+        boost::archive::library_version_type library_version(
+            ar.get_library_version()
+        );
+        if(boost::archive::library_version_type(3) < library_version){
+            ar << BOOST_SERIALIZATION_NVP(item_version);
+        }
+    #else
+        ar << BOOST_SERIALIZATION_NVP(item_version);
+    #endif
+
+    typename Container::const_iterator it = s.begin();
+    while(count-- > 0){
+        // note borland emits a no-op without the explicit namespace
+        boost::serialization::save_construct_data_adl(
+            ar, 
+            &(*it), 
+            item_version
+        );
+        ar << boost::serialization::make_nvp("item", *it++);
+    }
+}
+
+template<class Archive, class Container>
+inline void save_collection(Archive & ar, const Container &s)
+{
+    // record number of elements
+    collection_size_type count(s.size());
+    save_collection(ar, s, count);
+}
+
+} // namespace stl 
+} // namespace serialization
+} // namespace boost
+
+#endif //BOOST_SERIALIZATION_COLLECTIONS_SAVE_IMP_HPP

--- a/src/mlpack/core/boost_backport/vector.hpp
+++ b/src/mlpack/core/boost_backport/vector.hpp
@@ -1,0 +1,227 @@
+#ifndef  BOOST_SERIALIZATION_VECTOR_HPP
+#define BOOST_SERIALIZATION_VECTOR_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// vector.hpp: serialization for stl vector templates
+
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// fast array serialization (C) Copyright 2005 Matthias Troyer 
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for updates, documentation, and revision history.
+
+#include <vector>
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+
+#include <boost/archive/detail/basic_iarchive.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/item_version_type.hpp>
+
+#include <boost/serialization/collections_save_imp.hpp>
+#include <boost/serialization/collections_load_imp.hpp>
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/detail/get_data.hpp>
+#include <boost/serialization/detail/stack_constructor.hpp>
+#include <boost/mpl/bool_fwd.hpp>
+#include <boost/mpl/if.hpp>
+
+// default is being compatible with version 1.34.1 files, not 1.35 files
+#ifndef BOOST_SERIALIZATION_VECTOR_VERSIONED
+#define BOOST_SERIALIZATION_VECTOR_VERSIONED(V) (V==4 || V==5)
+#endif
+
+// function specializations must be defined in the appropriate
+// namespace - boost::serialization
+#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+#define STD _STLP_STD
+#else
+#define STD std
+#endif
+
+namespace boost { 
+namespace serialization {
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// vector< T >
+
+// the default versions
+
+template<class Archive, class U, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::false_
+){
+    boost::serialization::stl::save_collection<Archive, STD::vector<U, Allocator> >(
+        ar, t
+    );
+}
+
+template<class Archive, class U, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::false_
+){
+    const boost::archive::library_version_type library_version(
+        ar.get_library_version()
+    );
+    // retrieve number of elements
+    item_version_type item_version(0);
+    collection_size_type count;
+    ar >> BOOST_SERIALIZATION_NVP(count);
+    if(boost::archive::library_version_type(3) < library_version){
+        ar >> BOOST_SERIALIZATION_NVP(item_version);
+    }
+    t.reserve(count);
+    stl::collection_load_impl(ar, t, count, item_version);
+}
+
+// the optimized versions
+
+template<class Archive, class U, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::true_
+){
+    const collection_size_type count(t.size());
+    ar << BOOST_SERIALIZATION_NVP(count);
+    if (!t.empty())
+        ar << boost::serialization::make_array(detail::get_data(t),t.size());
+}
+
+template<class Archive, class U, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::true_
+){
+    collection_size_type count(t.size());
+    ar >> BOOST_SERIALIZATION_NVP(count);
+    t.resize(count);
+    unsigned int item_version=0;
+    if(BOOST_SERIALIZATION_VECTOR_VERSIONED(ar.get_library_version())) {
+        ar >> BOOST_SERIALIZATION_NVP(item_version);
+    }
+    if (!t.empty())
+        ar >> boost::serialization::make_array(detail::get_data(t),t.size());
+  }
+
+// dispatch to either default or optimized versions
+
+template<class Archive, class U, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<U, Allocator> &t,
+    const unsigned int file_version
+){
+    typedef typename 
+    boost::serialization::use_array_optimization<Archive>::template apply<
+        typename remove_const<U>::type 
+    >::type use_optimized;
+    save(ar,t,file_version, use_optimized());
+}
+
+template<class Archive, class U, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<U, Allocator> &t,
+    const unsigned int file_version
+){
+#ifdef BOOST_SERIALIZATION_VECTOR_135_HPP
+    if (ar.get_library_version()==boost::archive::library_version_type(5))
+    {
+      load(ar,t,file_version, boost::is_arithmetic<U>());
+      return;
+    }
+#endif
+    typedef typename 
+    boost::serialization::use_array_optimization<Archive>::template apply<
+        typename remove_const<U>::type 
+    >::type use_optimized;
+    load(ar,t,file_version, use_optimized());
+}
+
+// split non-intrusive serialization function member into separate
+// non intrusive save/load member functions
+template<class Archive, class U, class Allocator>
+inline void serialize(
+    Archive & ar,
+    std::vector<U, Allocator> & t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// vector<bool>
+template<class Archive, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<bool, Allocator> &t,
+    const unsigned int /* file_version */
+){
+    // record number of elements
+    collection_size_type count (t.size());
+    ar << BOOST_SERIALIZATION_NVP(count);
+    std::vector<bool>::const_iterator it = t.begin();
+    while(count-- > 0){
+        bool tb = *it++;
+        ar << boost::serialization::make_nvp("item", tb);
+    }
+}
+
+template<class Archive, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<bool, Allocator> &t,
+    const unsigned int /* file_version */
+){
+    // retrieve number of elements
+    collection_size_type count;
+    ar >> BOOST_SERIALIZATION_NVP(count);
+    t.resize(count);
+    for(collection_size_type i = collection_size_type(0); i < count; ++i){
+        bool b;
+        ar >> boost::serialization::make_nvp("item", b);
+        t[i] = b;
+    }
+}
+
+// split non-intrusive serialization function member into separate
+// non intrusive save/load member functions
+template<class Archive, class Allocator>
+inline void serialize(
+    Archive & ar,
+    std::vector<bool, Allocator> & t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+} // serialization
+} // namespace boost
+
+#include <boost/serialization/collection_traits.hpp>
+
+BOOST_SERIALIZATION_COLLECTION_TRAITS(std::vector)
+#undef STD
+
+#endif // BOOST_SERIALIZATION_VECTOR_HPP

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -72,6 +72,10 @@ using enable_if_t = typename enable_if<B, T>::type;
 // defined, but we still need to define it (as nothing) so that the mlpack
 // serialization shim compiles.
 #include <boost/serialization/serialization.hpp>
+// We are not including boost/serialization/vector.hpp here. It is included in
+// mlpack/core/boost_backport/boost_backport_serialization.hpp because of
+// different behaviors of vector serialization in different versions of boost.
+// #include <boost/serialization/vector.hpp>
 #include <boost/serialization/map.hpp>
 // boost_backport.hpp handles the version and backporting of serialization (and
 // other) features.

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -72,7 +72,6 @@ using enable_if_t = typename enable_if<B, T>::type;
 // defined, but we still need to define it (as nothing) so that the mlpack
 // serialization shim compiles.
 #include <boost/serialization/serialization.hpp>
-#include <boost/serialization/vector.hpp>
 #include <boost/serialization/map.hpp>
 // boost_backport.hpp handles the version and backporting of serialization (and
 // other) features.


### PR DESCRIPTION
**TL,DR**: This PR backports `boost/serialization/vector.hpp` for boost 1.58 (and earlier) because of various failing tests related to different serialization behaviors in v1.58 and later versions.

In boost v1.58 when objects of type `std::vector<arma::mat>` are loaded, the vector gets appended to rather than being cleared and rewritten. See [this](https://stackoverflow.com/questions/34042933/boost-vector-serialization-append-issue) question on SO to understand the issue. As a result of this, several tests (`PerceptronSerializationTest`, `DecisionStumpSerializationTest`, `GMMLoadSaveTest` etc) failed while running mlpack_test with boost 1.58. Another problem that this behavior of v1.58 created (which I pointed out on IRC - [link](http://mlpack.org/irc/mlpack.20180207.html)) was that training an HMM using `mlpack_hmm_train` and then trying to use the remaining HMM utilities on the saved model (such as `mlpack_hmm_loglik`) gave errors -- which the tests did not report (maybe the tests need to be more rigorous?).

The first fix I considered was trying to find all instances where a vector of `arma::mat`s is trying to be loaded - and clear the vector before the loading step. This is tedious - and since the tests were not reporting all possible errors (as in the case of `mlpack_hmm_train` and subsequent `mlpack_hmm_loglik`) - not guaranteed to be foolproof.

Later, while working on the tests for the `mlpack_hmm_train` CLI binding, @rcurtin suggested backporting an armadillo function (for some other issue specific to that code). I found that `unordered_map` in `boost/serialization` was already backported for boost versions 1.56 and earlier. Using that as a template, I backported `boost/serialization/vector.hpp` from v1.62 for v1.58 and earlier.

Now,
1. All tests should pass for boost version v1.58 and v1.62 and armadillo 8.400 (thats what I'm running on my system)
2. The `hmm_train` followed by `hmm_loglik` should work without errors on v1.58

Sorry for the painfully detailed comment - I've been struggling with this for quite some time and telling the story is, well .. cathartic.