### PR TITLE
fix maxIterations=0 bug in SimpleResidueTermination

### DIFF
--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -82,7 +82,9 @@ class SimpleResidueTermination
     Log::Info << "Iteration " << iteration << "; residue " << residue << ".\n";
 
     // Check if termination criterion is met.
-    return (residue < minResidue || iteration > maxIterations);
+    // If maxIterations == 0, there is no iteration limit.
+    return (residue < minResidue || 
+      ((maxIterations != 0) && (iteration > maxIterations)));
   }
 
   //! Get current value of residue

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -83,7 +83,7 @@ class SimpleResidueTermination
 
     // Check if termination criterion is met.
     // If maxIterations == 0, there is no iteration limit.
-    return (residue < minResidue || iteration == maxIterations)
+    return (residue < minResidue || iteration == maxIterations);
   }
 
   //! Get current value of residue

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -53,7 +53,7 @@ class SimpleResidueTermination
   {
     // Initialize the things we keep track of.
     residue = DBL_MAX;
-    iteration = 1;
+    iteration = 0;
     nm = V.n_rows * V.n_cols;
     // Remove history.
     normOld = 0;
@@ -84,7 +84,7 @@ class SimpleResidueTermination
     // Check if termination criterion is met.
     // If maxIterations == 0, there is no iteration limit.
     return (residue < minResidue || 
-        (maxIterations != 0 && iteration > maxIterations));
+        (maxIterations != 0 && iteration >= maxIterations));
   }
 
   //! Get current value of residue

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -83,8 +83,7 @@ class SimpleResidueTermination
 
     // Check if termination criterion is met.
     // If maxIterations == 0, there is no iteration limit.
-    return (residue < minResidue || 
-        (maxIterations != 0 && iteration >= maxIterations));
+    return (residue < minResidue || iteration == maxIterations)
   }
 
   //! Get current value of residue

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -84,7 +84,7 @@ class SimpleResidueTermination
     // Check if termination criterion is met.
     // If maxIterations == 0, there is no iteration limit.
     return (residue < minResidue || 
-      ((maxIterations != 0) && (iteration > maxIterations)));
+        (maxIterations != 0 && iteration > maxIterations));
   }
 
   //! Get current value of residue


### PR DESCRIPTION
In SimpleResidueTermination, there should be no limit on the number of iterations if maxIterations == 0:
https://github.com/mlpack/mlpack/blob/617a2acb52617e98f681a34137a7381e7c017db2/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp#L31-L45
But the IsConverged() function ignores this in its return statement:
https://github.com/mlpack/mlpack/blob/617a2acb52617e98f681a34137a7381e7c017db2/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp#L68-L86
which leads to nmf's immediate termination:
```
➜  build git:(master) mlpack_nmf --input_file test_data_3_1000.csv --rank 2 --verbose --max_iterations 0
[WARN ] Should pass either '--h_file (-H)' or '--w_file (-W)' or both; no output will be saved!
[INFO ] Loading 'test_data_3_1000.csv' as CSV data.  Size is 3 x 1000.
[INFO ] Performing NMF with multiplicative distance-based update rules.
[INFO ] Initialized W and H.
[INFO ] Iteration 2; residue inf.
[INFO ] AMF converged to residue of inf in 2 iterations.
```
So I used a simple modification to fix the bug.
