### PR TITLE
Fix neighbor search edge case

### DIFF
--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -274,7 +274,7 @@ static void mlpackMain()
     // when query data has not been provided.
     if (!CLI::HasParam("query") && k == kfn->Dataset().n_cols)
     {
-      Log::Fatal << "Invalid k: " << k << "; must not be equal to the number of "
+      Log::Fatal << "Invalid k: " << k << "; must be less than the number of "
           << "reference points (" << kfn->Dataset().n_cols << ") "
           << "if query data has not been provided." << endl;
     }

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -261,14 +261,22 @@ static void mlpackMain()
           << queryData.n_rows << "x" << queryData.n_cols << ")." << endl;
     }
 
-    // Sanity check on k value: must be greater than 0, must be less than the
-    // number of reference points.  Since it is unsigned, we only test the upper
-    // bound.
+    // Sanity check on k value: must be greater than 0, must be less than or
+    // equal to the number of reference points.  Since it is unsigned, 
+    // we only test the upper bound.
     if (k > kfn->Dataset().n_cols)
     {
       Log::Fatal << "Invalid k: " << k << "; must be greater than 0 and less "
           << "than or equal to the number of reference points ("
           << kfn->Dataset().n_cols << ")." << endl;
+    }
+    // Sanity check on k value: must not be equal to the number of reference points
+    // when query data has not been provided.
+    if (!CLI::HasParam("query") && k == kfn->Dataset().n_cols)
+    {
+      Log::Fatal << "Invalid k: " << k << "; must not be equal to the number of "
+          << "reference points (" << kfn->Dataset().n_cols << ") "
+          << "if query data has not been provided." << endl;
     }
 
     // Now run the search.

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -276,14 +276,22 @@ static void mlpackMain()
           << queryData.n_rows << "x" << queryData.n_cols << ")." << endl;
     }
 
-    // Sanity check on k value: must be greater than 0, must be less than the
-    // number of reference points.  Since it is unsigned, we only test the upper
-    // bound.
+    // Sanity check on k value: must be greater than 0, must be less than or
+    // equal to the number of reference points.  Since it is unsigned, 
+    // we only test the upper bound.
     if (k > knn->Dataset().n_cols)
     {
-      Log::Fatal << "Invalid k: " << k << "; must be greater than 0 and less ";
-      Log::Fatal << "than or equal to the number of reference points (";
-      Log::Fatal << knn->Dataset().n_cols << ")." << endl;
+      Log::Fatal << "Invalid k: " << k << "; must be greater than 0 and less "
+          << "than or equal to the number of reference points ("
+          << knn->Dataset().n_cols << ")." << endl;
+    }
+    // Sanity check on k value: must not be equal to the number of reference points
+    // when query data has not been provided.
+    if (!CLI::HasParam("query") && k == knn->Dataset().n_cols)
+    {
+      Log::Fatal << "Invalid k: " << k << "; must not be equal to the number of "
+          << "reference points (" << knn->Dataset().n_cols << ") "
+          << "if query data has not been provided." << endl;
     }
 
     // Now run the search.

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -289,7 +289,7 @@ static void mlpackMain()
     // when query data has not been provided.
     if (!CLI::HasParam("query") && k == knn->Dataset().n_cols)
     {
-      Log::Fatal << "Invalid k: " << k << "; must not be equal to the number of "
+      Log::Fatal << "Invalid k: " << k << "; must be less than the number of "
           << "reference points (" << knn->Dataset().n_cols << ") "
           << "if query data has not been provided." << endl;
     }

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -546,7 +546,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   if (k > referenceSet->n_cols)
   {
     std::stringstream ss;
-    ss << "requested value of k (" << k << ") is greater than the number of "
+    ss << "Requested value of k (" << k << ") is greater than the number of "
         << "points in the reference set (" << referenceSet->n_cols << ")";
     throw std::invalid_argument(ss.str());
   }
@@ -763,7 +763,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   if (k > referenceSet->n_cols)
   {
     std::stringstream ss;
-    ss << "requested value of k (" << k << ") is greater than the number of "
+    ss << "Requested value of k (" << k << ") is greater than the number of "
         << "points in the reference set (" << referenceSet->n_cols << ")";
     throw std::invalid_argument(ss.str());
   }
@@ -846,14 +846,14 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   if (k > referenceSet->n_cols)
   {
     std::stringstream ss;
-    ss << "requested value of k (" << k << ") is greater than the number of "
+    ss << "Requested value of k (" << k << ") is greater than the number of "
         << "points in the reference set (" << referenceSet->n_cols << ")";
     throw std::invalid_argument(ss.str());
   }
   if (k == referenceSet->n_cols)
   {
     std::stringstream ss;
-    ss << "requested value of k (" << k << ") is equal to the number of "
+    ss << "Requested value of k (" << k << ") is equal to the number of "
         << "points in the reference set (" << referenceSet->n_cols << ") and " 
         << "no query set has been provided.";
     throw std::invalid_argument(ss.str());

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -550,14 +550,6 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
         << "points in the reference set (" << referenceSet->n_cols << ")";
     throw std::invalid_argument(ss.str());
   }
-  if (k == referenceSet->n_cols)
-  {
-    std::stringstream ss;
-    ss << "requested value of k (" << k << ") is equal to the number of "
-        << "points in the reference set (" << referenceSet->n_cols << ") and " 
-        << "no query set has been provided.";
-    throw std::invalid_argument(ss.str());
-  }
 
   Timer::Start("computing_neighbors");
 
@@ -856,6 +848,14 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
     std::stringstream ss;
     ss << "requested value of k (" << k << ") is greater than the number of "
         << "points in the reference set (" << referenceSet->n_cols << ")";
+    throw std::invalid_argument(ss.str());
+  }
+  if (k == referenceSet->n_cols)
+  {
+    std::stringstream ss;
+    ss << "requested value of k (" << k << ") is equal to the number of "
+        << "points in the reference set (" << referenceSet->n_cols << ") and " 
+        << "no query set has been provided.";
     throw std::invalid_argument(ss.str());
   }
 

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -550,6 +550,14 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
         << "points in the reference set (" << referenceSet->n_cols << ")";
     throw std::invalid_argument(ss.str());
   }
+  if (k == referenceSet->n_cols)
+  {
+    std::stringstream ss;
+    ss << "requested value of k (" << k << ") is equal to the number of "
+        << "points in the reference set (" << referenceSet->n_cols << ") and " 
+        << "no query set has been provided.";
+    throw std::invalid_argument(ss.str());
+  }
 
   Timer::Start("computing_neighbors");
 


### PR DESCRIPTION
Solves #1259
Throw errors if k is set equal to the number of reference points when query data is not provided, in both kfn and knn.