### PR TITLE
Add Embedding layer and test

### DIFF
--- a/src/mlpack/methods/ann/layer/CMakeLists.txt
+++ b/src/mlpack/methods/ann/layer/CMakeLists.txt
@@ -22,6 +22,8 @@ set(SOURCES
   dropout_impl.hpp
   elu.hpp
   elu_impl.hpp
+  embedding.hpp
+  embedding_impl.hpp
   fast_lstm.hpp
   fast_lstm_impl.hpp
   glimpse.hpp

--- a/src/mlpack/methods/ann/layer/embedding.hpp
+++ b/src/mlpack/methods/ann/layer/embedding.hpp
@@ -31,7 +31,7 @@ class Embedding
      *
      * @param vocabSize Size of
      * @param dimensionSize
-     * @param pretrained
+     * @param pretrain
      */
     Embedding(const size_t vocabSize,
               const size_t dimensionSize,
@@ -126,10 +126,10 @@ class Embedding
     bool pretrain;
 
     //! Locally-stored vocabSize parameter
-    bool vocabSize;
+    size_t vocabSize;
 
     //! Locally-stored dimensionSize parameter
-    bool dimensionSize;
+    size_t dimensionSize;
 
     //! Locally-stored gradient object.
     OutputDataType gradient;

--- a/src/mlpack/methods/ann/layer/embedding.hpp
+++ b/src/mlpack/methods/ann/layer/embedding.hpp
@@ -1,0 +1,144 @@
+/**
+ * @file embedding.hpp
+ * @author Manthan-R-Sheth
+ *
+ * Definition of the Embedding Layer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_EMBEDDING_HPP
+#define MLPACK_EMBEDDING_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template <
+  typename InputDataType = arma::mat,
+  typename OutputDataType = arma::mat
+>
+class Embedding
+{
+  public:
+    //! Create the Embedding object.
+    Embedding();
+
+    /**
+     *
+     * @param vocabSize Size of
+     * @param dimensionSize
+     * @param pretrained
+     */
+    Embedding(const size_t vocabSize,
+              const size_t dimensionSize,
+              const bool pretrain = false);
+   /**
+    * Reset the layer parameters.
+    */
+    void Reset();
+
+    /**
+     * Forward pass of the embedding layer, which forms a matrix containing
+     * numeric representations of input word matrix.
+     *
+     * @param input Input tokenised word index matrix
+     * @param output Output word representation matrix.
+     */
+    template<typename eT>
+    void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+
+    /**
+     * Ordinary feed backward pass of embedding layer,calculating the function
+     * f(x) by propagating x backwards through f,using the results from
+     * the feed forward pass.
+     *
+     * @param input The propagated input activation.
+     * @param gy The backpropagated error.
+     * @param g The calculated gradient.
+     */
+    template<typename eT>
+    void Backward(const arma::Mat<eT>&& /* input */,
+                  arma::Mat<eT>&& gy,
+                  arma::Mat<eT>&& g);
+
+    /*
+   * Calculate the gradient using the output delta and the input activation.
+   *
+   * @param input The input parameter used for calculating the gradient.
+   * @param error The calculated error.
+   * @param gradient The calculated gradient.
+   */
+    template<typename eT>
+    void Gradient(const arma::Mat<eT>&& input,
+                  arma::Mat<eT>&& error,
+                  arma::Mat<eT>&& gradient);
+
+    //! Get the parameters.
+    OutputDataType const& Parameters() const { return embeddingMatrix; }
+    //! Modify the parameters.
+    OutputDataType& Parameters() { return embeddingMatrix; }
+
+    //! Get the input parameter.
+    InputDataType const& InputParameter() const { return inputParameter; }
+    //! Modify the input parameter.
+    InputDataType& InputParameter() { return inputParameter; }
+
+    //! Get the output parameter.
+    OutputDataType const& OutputParameter() const { return outputParameter; }
+    //! Modify the output parameter.
+    OutputDataType& OutputParameter() { return outputParameter; }
+
+    //! Get the delta.
+    OutputDataType const& Delta() const { return delta; }
+    //! Modify the delta.
+    OutputDataType& Delta() { return delta; }
+
+    //! Get the gradient.
+    OutputDataType const& Gradient() const { return gradient; }
+    //! Modify the gradient.
+    OutputDataType& Gradient() { return gradient; }
+
+    /**
+     * Serialize the layer
+     */
+    template<typename Archive>
+    void serialize(Archive& ar, const unsigned int /* version */);
+
+  private:
+
+    //! Locally-stored delta object.
+    OutputDataType delta;
+
+    //! Locally-stored input parameter object.
+    InputDataType inputParameter;
+
+    //! Locally-stored output parameter object.
+    OutputDataType outputParameter;
+
+    //! Locally-stored embeddingMatrix object.
+    OutputDataType embeddingMatrix;
+
+    //! Locally-stored pretrain parameter
+    bool pretrain;
+
+    //! Locally-stored vocabSize parameter
+    bool vocabSize;
+
+    //! Locally-stored dimensionSize parameter
+    bool dimensionSize;
+
+    //! Locally-stored gradient object.
+    OutputDataType gradient;
+
+}; // class Embedding
+}
+}
+
+// Include implementation.
+#include "embedding_impl.hpp"
+
+#endif //MLPACK_EMBEDDING_HPP

--- a/src/mlpack/methods/ann/layer/embedding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/embedding_impl.hpp
@@ -1,0 +1,105 @@
+/**
+ * @file max_pooling_impl.hpp
+ * @author Manthan-R-Sheth
+ *
+ * Implementation of the Embedding class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_EMBEDDING_IMPL_HPP
+#define MLPACK_EMBEDDING_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "embedding.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+Embedding<InputDataType, OutputDataType>::Embedding()
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+Embedding<InputDataType, OutputDataType>::Embedding(
+  const size_t vocabSize,
+  const size_t dimensionSize,
+  const bool pretrain) :
+  vocabSize(vocabSize),
+  dimensionSize(dimensionSize),
+  pretrain(false)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+void Embedding<InputDataType, OutputDataType>::Reset()
+{
+  embeddingMatrix = arma::mat(vocabSize, dimensionSize,arma::fill::randu);
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void Embedding<InputDataType, OutputDataType>::Forward(
+  const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+{
+
+  // Apply embeddingMatrix multiplication to the input and store the results.
+  for (arma::uword j = 0; j < output.n_cols; ++j)
+  {
+    for (arma::uword i = 0; i < output.n_rows; ++i)
+    {
+      arma::rowvec wordRepresentation = embeddingMatrix.row(input(i,j));
+      output(i, j) = wordRepresentation;
+    }
+  }
+
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void Embedding<InputDataType, OutputDataType>::Backward(
+  const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+{
+  if (!pretrain)
+  {
+    g = embeddingMatrix.t() * gy;
+  }
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void Embedding<InputDataType, OutputDataType>::Gradient(
+  const arma::Mat<eT>&& input,
+  arma::Mat<eT>&& error,
+  arma::Mat<eT>&& gradient)
+{
+  if (!pretrain)
+    gradient.submat(0, 0, embeddingMatrix.n_elem - 1, 0) = arma::vectorise(
+      error * input.t());
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void Embedding<InputDataType, OutputDataType>::serialize(
+  Archive& ar,
+  const unsigned int /* version */)
+{
+  ar & BOOST_SERIALIZATION_NVP(vocabSize);
+  ar & BOOST_SERIALIZATION_NVP(dimensionSize);
+  ar & BOOST_SERIALIZATION_NVP(pretrain);
+
+  // This is inefficient, but we have to allocate this memory so that
+  // WeightSetVisitor gets the right size.
+  if (Archive::is_loading::value)
+    embeddingMatrix.set_size(vocabSize , dimensionSize);
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif //MLPACK_EMBEDDING_IMPL_HPP

--- a/src/mlpack/methods/ann/layer/embedding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/embedding_impl.hpp
@@ -31,7 +31,7 @@ Embedding<InputDataType, OutputDataType>::Embedding(
   const bool pretrain) :
   vocabSize(vocabSize),
   dimensionSize(dimensionSize),
-  pretrain(false)
+  pretrain(pretrain)
 {
   // Nothing to do here.
 }
@@ -49,13 +49,10 @@ void Embedding<InputDataType, OutputDataType>::Forward(
 {
 
   // Apply embeddingMatrix multiplication to the input and store the results.
-  for (arma::uword j = 0; j < output.n_cols; ++j)
+  for (arma::uword j = 0; j < input.n_cols; ++j)
   {
-    for (arma::uword i = 0; i < output.n_rows; ++i)
-    {
-      arma::rowvec wordRepresentation = embeddingMatrix.row(input(i,j));
-      output(i, j) = wordRepresentation;
-    }
+    arma::rowvec wordRepresentation = embeddingMatrix.row(input(0,j));
+    output(arma::span(j,j),arma::span::all) = wordRepresentation;
   }
 
 }

--- a/src/mlpack/methods/ann/layer/layer.hpp
+++ b/src/mlpack/methods/ann/layer/layer.hpp
@@ -16,6 +16,7 @@
 #include "concat_performance.hpp"
 #include "convolution.hpp"
 #include "dropconnect.hpp"
+#include "embedding.hpp"
 #include "glimpse.hpp"
 #include "layer_types.hpp"
 #include "linear.hpp"

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -21,6 +21,7 @@
 #include <mlpack/methods/ann/layer/cross_entropy_error.hpp>
 #include <mlpack/methods/ann/layer/dropout.hpp>
 #include <mlpack/methods/ann/layer/elu.hpp>
+#include <mlpack/methods/ann/layer/embedding.hpp>
 #include <mlpack/methods/ann/layer/hard_tanh.hpp>
 #include <mlpack/methods/ann/layer/join.hpp>
 #include <mlpack/methods/ann/layer/leaky_relu.hpp>
@@ -45,6 +46,7 @@ namespace mlpack {
 namespace ann {
 
 template<typename InputDataType, typename OutputDataType> class DropConnect;
+template<typename InputDataType, typename OutputDataType> class Embedding;
 template<typename InputDataType, typename OutputDataType> class Glimpse;
 template<typename InputDataType, typename OutputDataType> class Linear;
 template<typename InputDataType, typename OutputDataType> class LinearNoBias;
@@ -118,6 +120,7 @@ using LayerTypes = boost::variant<
     DropConnect<arma::mat, arma::mat>*,
     Dropout<arma::mat, arma::mat>*,
     ELU<arma::mat, arma::mat>*,
+    Embedding<arma::mat, arma::mat>*,
     Glimpse<arma::mat, arma::mat>*,
     HardTanH<arma::mat, arma::mat>*,
     Join<arma::mat, arma::mat>*,

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1282,4 +1282,25 @@ BOOST_AUTO_TEST_CASE(SimpleMeanSquaredErrorLayerTest)
   BOOST_REQUIRE_EQUAL(output.n_elem, 1);
 }
 
+/**
+* Simple Embedding module test.
+*/
+BOOST_AUTO_TEST_CASE(SimpleEmbeddingLayerTest)
+{
+  arma::mat output, input, delta;
+  Embedding<> module(2, 5, false);
+  module.Reset();
+  module.Parameters().randu();
+
+  // Test the Forward function.
+  input = arma::zeros(1, 5);
+  module.Forward(std::move(input), std::move(output));
+  BOOST_REQUIRE_CLOSE(5 * arma::accu(
+    module.Parameters().submat(0, 0, 0, 5)), arma::accu(output), 1e-3);
+
+  // Test the Backward function.
+  module.Backward(std::move(input), std::move(input), std::move(delta));
+  BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Main purpose of the` Embedding layer` is to have numeric representations of the words(string) inputs. This is with reference to #1276.

`Embedding<> model(vocabSize, dimensionSize, pretrain=false)
`
`
model.Reset()
`

This creates an `embeddingMatrix` of size `vocabSize x dimensionSize`. Input is considered to be a matrix of word indices. For eg:- If the vocabSize is 2 (which means there are only 2 words in the vocabulary), then a possible input is `[[0,1],[1,1]]`, which means that input has 2 sentences each of 2 words with the corresponding word indices as matrix elements.

The `embeddingMatrix` consists of either pretrained word representations (pretrain=true) or trainable word representations(pretrain=false).

For the above example with word dimension of 3, the output of embedding layer will be of the form `[[[0.2,0.3],[0.5,0.6]],[[0.5,0.6],[0.5,0.6]]]`, which is the numeric representation of each word of the input sentence.

TODO 
A tokenizer needs to be made which tokenizes and pads the input sentences thereby making the input compatible with the embedding layer. 
