### PR TITLE
Add He Initialization and Lecun Normal Initialization

### DIFF
--- a/src/mlpack/methods/ann/init_rules/CMakeLists.txt
+++ b/src/mlpack/methods/ann/init_rules/CMakeLists.txt
@@ -3,8 +3,10 @@
 set(SOURCES
   const_init.hpp
   gaussian_init.hpp
+  he_init.hpp
   init_rules_traits.hpp
   kathirvalavakumar_subavathi_init.hpp
+  lecun_normal_init.hpp
   network_init.hpp
   nguyen_widrow_init.hpp
   oivs_init.hpp

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -1,0 +1,100 @@
+/**
+ * @file he_init.hpp
+ * @author Dakshit Agrawal
+ *
+ * Intialization rule given by He et. al. for neural networks. The He
+ * initialization initializes weights of the neural network to better
+ * suit the rectified activation units.
+ *
+ * For more information, the following paper can be referred to:
+ *
+ * @code
+ * @article{He2015DelvingDI,
+ * title={Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification},
+ * author={Kaiming He and Xiangyu Zhang and Shaoqing Ren and Jian Sun},
+ * journal={2015 IEEE International Conference on Computer Vision (ICCV)},
+ * year={2015},
+ * pages={1026-1034}}
+ * @endcode
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_INIT_RULES_HE_INIT_HPP
+#define MLPACK_METHODS_ANN_INIT_RULES_HE_INIT_HPP
+
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
+
+using namespace mlpack::math;
+
+namespace mlpack {
+    namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * This class is used to initialize weight matrix with the He initialization rule.
+ */
+        class HeInitialization
+        {
+        public:
+            /**
+             * Initialize the HeInitialization object.
+             *
+             */
+            HeInitialization()
+            {
+                // Nothing to do here.
+            }
+
+            /**
+             * Initialize the elements of the weight matrix with the He initialization
+             * rule.
+             *
+             * @param W Weight matrix to initialize.
+             * @param rows Number of rows.
+             * @param cols Number of columns.
+             */
+            void Initialize(arma::mat& W,
+                            const size_t rows,
+                            const size_t cols)
+            {
+                double_t variance = 2 / rows;
+
+                if (W.is_empty())
+                {
+                    W = arma::mat(rows, cols);
+                }
+
+                W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
+            }
+
+            /**
+             * Initialize the elements of the specified weight 3rd order tensor
+             * with He initialization rule.
+             *
+             * @param W Weight matrix to initialize.
+             * @param rows Number of rows.
+             * @param cols Number of columns.
+             * @param slice Numbers of slices.
+             */
+            void Initialize(arma::cube & W,
+                            const size_t rows,
+                            const size_t cols,
+                            const size_t slices)
+            {
+                W = arma::cube(rows, cols, slices);
+
+                for (size_t i = 0; i < slices; i++) {
+                    Initialize(W.slice(i), rows, cols);
+                }
+            }
+
+        }; // class HeInitialization
+
+    } // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -10,7 +10,8 @@
  *
  * @code
  * @article{He2015DelvingDI,
- * title={Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification},
+ * title={Delving Deep into Rectifiers: Surpassing Human-Level Performance
+ * on ImageNet Classification},
  * author={Kaiming He and Xiangyu Zhang and Shaoqing Ren and Jian Sun},
  * journal={2015 IEEE International Conference on Computer Vision (ICCV)},
  * year={2015},
@@ -42,7 +43,8 @@ namespace ann /** Artificial Neural Network. */ {
  *
  * @code
  * @article{He2015DelvingDI,
- * title={Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification},
+ * title={Delving Deep into Rectifiers: Surpassing Human-Level Performance
+ * on ImageNet Classification},
  * author={Kaiming He and Xiangyu Zhang and Shaoqing Ren and Jian Sun},
  * journal={2015 IEEE International Conference on Computer Vision (ICCV)},
  * year={2015},
@@ -53,65 +55,65 @@ namespace ann /** Artificial Neural Network. */ {
 class HeInitialization
 {
  public:
-    /**
-     * Initialize the HeInitialization object.
-     *
-     */
-    HeInitialization()
+  /**
+   * Initialize the HeInitialization object.
+   *
+   */
+  HeInitialization()
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements of the weight matrix with the He initialization
+   * rule.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   */
+  void Initialize(arma::mat& W,
+                  const size_t rows,
+                  const size_t cols)
+  {
+    // He initialization rule says to initialize weights with random
+    // values taken from a gaussian distribution with mean = 0 and
+    // standard deviation = sqrt(2/rows), i.e. variance = (2/rows).
+    double variance =  2.0 / ((double) rows);
+
+    if (W.is_empty())
     {
-        // Nothing to do here.
+      W.set_size(rows, cols);
     }
 
-    /**
-     * Initialize the elements of the weight matrix with the He initialization
-     * rule.
-     *
-     * @param W Weight matrix to initialize.
-     * @param rows Number of rows.
-     * @param cols Number of columns.
-     */
-    void Initialize(arma::mat& W,
-                    const size_t rows,
-                    const size_t cols)
+    // Multipling a random variable X with variance V(X) by some factor c,
+    // then the variance V(cX) = (c^2)* V(X).
+    W.imbue( [&]() { return sqrt(variance) * arma::randn();} );
+  }
+
+  /**
+   * Initialize the elements of the specified weight 3rd order tensor
+   * with He initialization rule.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   * @param slice Numbers of slices.
+   */
+  void Initialize(arma::cube & W,
+                  const size_t rows,
+                  const size_t cols,
+                  const size_t slices)
+  {
+    if (W.is_empty())
     {
-        // He initialization rule says to initialize weights with random
-        // values taken from a gaussian distribution with mean = 0 and
-        // standard deviation = sqrt(2/rows), i.e. variance = (2/rows).
-        double variance =  2.0 / ((double) rows);
-
-        if (W.is_empty())
-        {
-            W.set_size(rows, cols);
-        }
-
-        // Multipling a random variable X with variance V(X) by some factor c,
-        // then the variance V(cX) = (c^2)* V(X).
-        W.imbue( [&]() { return sqrt(variance) * arma::randn();} );
+      W.set_size(rows, cols, slices);
     }
 
-    /**
-     * Initialize the elements of the specified weight 3rd order tensor
-     * with He initialization rule.
-     *
-     * @param W Weight matrix to initialize.
-     * @param rows Number of rows.
-     * @param cols Number of columns.
-     * @param slice Numbers of slices.
-     */
-    void Initialize(arma::cube & W,
-                    const size_t rows,
-                    const size_t cols,
-                    const size_t slices)
-    {
-        if (W.is_empty())
-        {
-            W.set_size(rows, cols, slices);
-        }
-
-        for (size_t i = 0; i < slices; i++) {
-            Initialize(W.slice(i), rows, cols);
-        }
+    for (size_t i = 0; i < slices; i++) {
+      Initialize(W.slice(i), rows, cols);
     }
+  }
 }; // class HeInitialization
 
 } // namespace ann

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -32,69 +32,68 @@
 using namespace mlpack::math;
 
 namespace mlpack {
-    namespace ann /** Artificial Neural Network. */ {
+namespace ann /** Artificial Neural Network. */ {
 
 /**
  * This class is used to initialize weight matrix with the He initialization rule.
  */
-        class HeInitialization
+class HeInitialization
+{
+ public:
+    /**
+     * Initialize the HeInitialization object.
+     *
+     */
+    HeInitialization()
+    {
+        // Nothing to do here.
+    }
+
+    /**
+     * Initialize the elements of the weight matrix with the He initialization
+     * rule.
+     *
+     * @param W Weight matrix to initialize.
+     * @param rows Number of rows.
+     * @param cols Number of columns.
+     */
+    void Initialize(arma::mat& W,
+                    const size_t rows,
+                    const size_t cols)
+    {
+        double_t variance = 2 / rows;
+
+        if (W.is_empty())
         {
-        public:
-            /**
-             * Initialize the HeInitialization object.
-             *
-             */
-            HeInitialization()
-            {
-                // Nothing to do here.
-            }
+            W = arma::mat(rows, cols);
+        }
 
-            /**
-             * Initialize the elements of the weight matrix with the He initialization
-             * rule.
-             *
-             * @param W Weight matrix to initialize.
-             * @param rows Number of rows.
-             * @param cols Number of columns.
-             */
-            void Initialize(arma::mat& W,
-                            const size_t rows,
-                            const size_t cols)
-            {
-                double_t variance = 2 / rows;
+        W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
+    }
 
-                if (W.is_empty())
-                {
-                    W = arma::mat(rows, cols);
-                }
+    /**
+     * Initialize the elements of the specified weight 3rd order tensor
+     * with He initialization rule.
+     *
+     * @param W Weight matrix to initialize.
+     * @param rows Number of rows.
+     * @param cols Number of columns.
+     * @param slice Numbers of slices.
+     */
+    void Initialize(arma::cube & W,
+                    const size_t rows,
+                    const size_t cols,
+                    const size_t slices)
+    {
+        W = arma::cube(rows, cols, slices);
 
-                W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
-            }
+        for (size_t i = 0; i < slices; i++) {
+            Initialize(W.slice(i), rows, cols);
+        }
+    }
+}; // class HeInitialization
 
-            /**
-             * Initialize the elements of the specified weight 3rd order tensor
-             * with He initialization rule.
-             *
-             * @param W Weight matrix to initialize.
-             * @param rows Number of rows.
-             * @param cols Number of columns.
-             * @param slice Numbers of slices.
-             */
-            void Initialize(arma::cube & W,
-                            const size_t rows,
-                            const size_t cols,
-                            const size_t slices)
-            {
-                W = arma::cube(rows, cols, slices);
-
-                for (size_t i = 0; i < slices; i++) {
-                    Initialize(W.slice(i), rows, cols);
-                }
-            }
-
-        }; // class HeInitialization
-
-    } // namespace ann
+} // namespace ann
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -62,7 +62,7 @@ class HeInitialization
         // He initialization rule says to initialize weights with random
         // values taken from a gaussian distribution with mean = 0 and
         // standard deviation = sqrt(2/rows), i.e. variance = (2/rows).
-        double_t variance =  2.0 / rows;
+        double_t variance =  2.0 / ((double) rows);
 
         if (W.is_empty())
         {

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -29,8 +29,6 @@
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/math/random.hpp>
 
-using namespace mlpack::math;
-
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
@@ -61,11 +59,14 @@ class HeInitialization
                     const size_t rows,
                     const size_t cols)
     {
-        double_t variance = 2 / rows;
+        // He initialization rule says to initialize weights with random
+        // values taken from a gaussian distribution with mean = 0 and
+        // standard deviation = sqrt(2/rows), i.e. variance = (2/rows).
+        double_t variance =  2.0 / rows;
 
         if (W.is_empty())
         {
-            W = arma::mat(rows, cols);
+            W.set_size(rows, cols);
         }
 
         W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
@@ -85,7 +86,10 @@ class HeInitialization
                     const size_t cols,
                     const size_t slices)
     {
-        W = arma::cube(rows, cols, slices);
+        if (W.is_empty())
+        {
+            W.set_size(rows, cols, slices);
+        }
 
         for (size_t i = 0; i < slices; i++) {
             Initialize(W.slice(i), rows, cols);

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -33,7 +33,22 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 /**
- * This class is used to initialize weight matrix with the He initialization rule.
+ * This class is used to initialize weight matrix with the He
+ * initialization rule given by He et. al. for neural networks. The He
+ * initialization initializes weights of the neural network to better
+ * suit the rectified activation units.
+ *
+ * For more information, the following paper can be referred to:
+ *
+ * @code
+ * @article{He2015DelvingDI,
+ * title={Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification},
+ * author={Kaiming He and Xiangyu Zhang and Shaoqing Ren and Jian Sun},
+ * journal={2015 IEEE International Conference on Computer Vision (ICCV)},
+ * year={2015},
+ * pages={1026-1034}}
+ * @endcode
+ *
  */
 class HeInitialization
 {
@@ -62,14 +77,16 @@ class HeInitialization
         // He initialization rule says to initialize weights with random
         // values taken from a gaussian distribution with mean = 0 and
         // standard deviation = sqrt(2/rows), i.e. variance = (2/rows).
-        double_t variance =  2.0 / ((double) rows);
+        double variance =  2.0 / ((double) rows);
 
         if (W.is_empty())
         {
             W.set_size(rows, cols);
         }
 
-        W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
+        // Multipling a random variable X with variance V(X) by some factor c,
+        // then the variance V(cX) = (c^2)* V(X).
+        W.imbue( [&]() { return sqrt(variance) * arma::randn();} );
     }
 
     /**

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -39,6 +39,23 @@ namespace ann /** Artificial Neural Network. */ {
 /**
 * This class is used to initialize weight matrix with the Lecun Normalization
 * initialization rule.
+ *
+ * For more information, the following papers can be referred to:
+ *
+ * @code
+ * @inproceedings{conf/nips/KlambauerUMH17,
+ * title = {Self-Normalizing Neural Networks.},
+ * author = {Klambauer, Günter and Unterthiner, Thomas and Mayr, Andreas and Hochreiter, Sepp},
+ * pages = {972-981},
+ * year = 2017}
+ *
+ * @inproceedings{LeCun:1998:EB:645754.668382,
+ * title = {Efficient BackProp},
+ * author = {LeCun, Yann and Bottou, L{\'e}on and Orr, Genevieve B. and M\"{u}ller, Klaus-Robert},
+ * year = {1998},
+ * pages = {9--50}}
+ * @endcode
+ *
 */
 class LecunNormalInitialization
 {
@@ -67,14 +84,16 @@ class LecunNormalInitialization
         // He initialization rule says to initialize weights with random
         // values taken from a gaussian distribution with mean = 0 and
         // standard deviation = sqrt(1/rows), i.e. variance = (1/rows).
-        double_t variance = 1.0 / ((double) rows);
+        double variance = 1.0 / ((double) rows);
 
         if (W.is_empty())
         {
             W.set_size(rows, cols);
         }
 
-        W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
+        // Multipling a random variable X with variance V(X) by some factor c,
+        // then the variance V(cX) = (c^2)* V(X).
+        W.imbue( [&]() { return sqrt(variance) * arma::randn();} );
     }
 
     /**

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -1,0 +1,105 @@
+/**
+ * @file lecun_normal_init.hpp
+ * @author Dakshit Agrawal
+ *
+ * Intialization rule given by Lecun et. al. for neural networks and
+ * also mentioned in Self Normalizing Networks.
+ *
+ * For more information, the following papers can be referred to:
+ *
+ * @code
+ * @inproceedings{conf/nips/KlambauerUMH17,
+ * title = {Self-Normalizing Neural Networks.},
+ * author = {Klambauer, Günter and Unterthiner, Thomas and Mayr, Andreas and Hochreiter, Sepp},
+ * pages = {972-981},
+ * year = 2017}
+ *
+ * @inproceedings{LeCun:1998:EB:645754.668382,
+ * title = {Efficient BackProp},
+ * author = {LeCun, Yann and Bottou, L{\'e}on and Orr, Genevieve B. and M\"{u}ller, Klaus-Robert},
+ * year = {1998},
+ * pages = {9--50}}
+ * @endcode
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_INIT_RULES_LECUN_NORMAL_INIT_HPP
+#define MLPACK_METHODS_ANN_INIT_RULES_LECUN_NORMAL_INIT_HPP
+
+#include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/random.hpp>
+
+using namespace mlpack::math;
+
+namespace mlpack {
+    namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * This class is used to initialize weight matrix with the Lecun Normalization
+ * initialization rule.
+ */
+        class LecunNormalInitialization
+        {
+        public:
+            /**
+             * Initialize the LecunNormalInitialization object.
+             *
+             */
+            LecunNormalInitialization()
+            {
+                // Nothing to do here.
+            }
+
+            /**
+             * Initialize the elements of the weight matrix with the Lecun
+             * Normal initialization rule.
+             *
+             * @param W Weight matrix to initialize.
+             * @param rows Number of rows.
+             * @param cols Number of columns.
+             */
+            void Initialize(arma::mat& W,
+                            const size_t rows,
+                            const size_t cols)
+            {
+                double_t variance = 1 / rows;
+
+                if (W.is_empty())
+                {
+                    W = arma::mat(rows, cols);
+                }
+
+                W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
+            }
+
+            /**
+             * Initialize the elements of the specified weight 3rd order tensor
+             * with Lecun Normal initialization rule.
+             *
+             * @param W Weight matrix to initialize.
+             * @param rows Number of rows.
+             * @param cols Number of columns.
+             * @param slice Numbers of slices.
+             */
+            void Initialize(arma::cube & W,
+                            const size_t rows,
+                            const size_t cols,
+                            const size_t slices)
+            {
+                W = arma::cube(rows, cols, slices);
+
+                for (size_t i = 0; i < slices; i++) {
+                    Initialize(W.slice(i), rows, cols);
+                }
+            }
+
+        }; // class LecunNormalInitialization
+
+    } // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -36,70 +36,69 @@
 using namespace mlpack::math;
 
 namespace mlpack {
-    namespace ann /** Artificial Neural Network. */ {
+namespace ann /** Artificial Neural Network. */ {
 
 /**
- * This class is used to initialize weight matrix with the Lecun Normalization
- * initialization rule.
- */
-        class LecunNormalInitialization
+* This class is used to initialize weight matrix with the Lecun Normalization
+* initialization rule.
+*/
+class LecunNormalInitialization
+{
+ public:
+    /**
+     * Initialize the LecunNormalInitialization object.
+     *
+     */
+    LecunNormalInitialization()
+    {
+        // Nothing to do here.
+    }
+
+    /**
+     * Initialize the elements of the weight matrix with the Lecun
+     * Normal initialization rule.
+     *
+     * @param W Weight matrix to initialize.
+     * @param rows Number of rows.
+     * @param cols Number of columns.
+     */
+    void Initialize(arma::mat& W,
+                    const size_t rows,
+                    const size_t cols)
+    {
+        double_t variance = 1 / rows;
+
+        if (W.is_empty())
         {
-        public:
-            /**
-             * Initialize the LecunNormalInitialization object.
-             *
-             */
-            LecunNormalInitialization()
-            {
-                // Nothing to do here.
-            }
+            W = arma::mat(rows, cols);
+        }
 
-            /**
-             * Initialize the elements of the weight matrix with the Lecun
-             * Normal initialization rule.
-             *
-             * @param W Weight matrix to initialize.
-             * @param rows Number of rows.
-             * @param cols Number of columns.
-             */
-            void Initialize(arma::mat& W,
-                            const size_t rows,
-                            const size_t cols)
-            {
-                double_t variance = 1 / rows;
+        W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
+    }
 
-                if (W.is_empty())
-                {
-                    W = arma::mat(rows, cols);
-                }
+    /**
+     * Initialize the elements of the specified weight 3rd order tensor
+     * with Lecun Normal initialization rule.
+     *
+     * @param W Weight matrix to initialize.
+     * @param rows Number of rows.
+     * @param cols Number of columns.
+     * @param slice Numbers of slices.
+     */
+    void Initialize(arma::cube & W,
+                    const size_t rows,
+                    const size_t cols,
+                    const size_t slices)
+    {
+        W = arma::cube(rows, cols, slices);
 
-                W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
-            }
+        for (size_t i = 0; i < slices; i++) {
+            Initialize(W.slice(i), rows, cols);
+        }
+    }
+}; // class LecunNormalInitialization
 
-            /**
-             * Initialize the elements of the specified weight 3rd order tensor
-             * with Lecun Normal initialization rule.
-             *
-             * @param W Weight matrix to initialize.
-             * @param rows Number of rows.
-             * @param cols Number of columns.
-             * @param slice Numbers of slices.
-             */
-            void Initialize(arma::cube & W,
-                            const size_t rows,
-                            const size_t cols,
-                            const size_t slices)
-            {
-                W = arma::cube(rows, cols, slices);
-
-                for (size_t i = 0; i < slices; i++) {
-                    Initialize(W.slice(i), rows, cols);
-                }
-            }
-
-        }; // class LecunNormalInitialization
-
-    } // namespace ann
+} // namespace ann
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -33,8 +33,6 @@
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/math/random.hpp>
 
-using namespace mlpack::math;
-
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
@@ -66,11 +64,14 @@ class LecunNormalInitialization
                     const size_t rows,
                     const size_t cols)
     {
-        double_t variance = 1 / rows;
+        // He initialization rule says to initialize weights with random
+        // values taken from a gaussian distribution with mean = 0 and
+        // standard deviation = sqrt(1/rows), i.e. variance = (1/rows).
+        double_t variance = 1.0 / rows;
 
         if (W.is_empty())
         {
-            W = arma::mat(rows, cols);
+            W.set_size(rows, cols);
         }
 
         W.imbue( [&]() { return arma::as_scalar(RandNormal(0, variance)); } );
@@ -90,7 +91,10 @@ class LecunNormalInitialization
                     const size_t cols,
                     const size_t slices)
     {
-        W = arma::cube(rows, cols, slices);
+        if (W.is_empty())
+        {
+            W.set_size(rows, cols, slices);
+        }
 
         for (size_t i = 0; i < slices; i++) {
             Initialize(W.slice(i), rows, cols);

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -67,7 +67,7 @@ class LecunNormalInitialization
         // He initialization rule says to initialize weights with random
         // values taken from a gaussian distribution with mean = 0 and
         // standard deviation = sqrt(1/rows), i.e. variance = (1/rows).
-        double_t variance = 1.0 / rows;
+        double_t variance = 1.0 / ((double) rows);
 
         if (W.is_empty())
         {

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -10,13 +10,15 @@
  * @code
  * @inproceedings{conf/nips/KlambauerUMH17,
  * title = {Self-Normalizing Neural Networks.},
- * author = {Klambauer, Günter and Unterthiner, Thomas and Mayr, Andreas and Hochreiter, Sepp},
+ * author = {Klambauer, Günter and Unterthiner, Thomas
+ * and Mayr, Andreas and Hochreiter, Sepp},
  * pages = {972-981},
  * year = 2017}
  *
  * @inproceedings{LeCun:1998:EB:645754.668382,
  * title = {Efficient BackProp},
- * author = {LeCun, Yann and Bottou, L{\'e}on and Orr, Genevieve B. and M\"{u}ller, Klaus-Robert},
+ * author = {LeCun, Yann and Bottou, L{\'e}on and Orr, Genevieve B.
+ * and M\"{u}ller, Klaus-Robert},
  * year = {1998},
  * pages = {9--50}}
  * @endcode
@@ -37,21 +39,23 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 /**
-* This class is used to initialize weight matrix with the Lecun Normalization
-* initialization rule.
+ * This class is used to initialize weight matrix with the Lecun Normalization
+ * initialization rule.
  *
  * For more information, the following papers can be referred to:
  *
  * @code
  * @inproceedings{conf/nips/KlambauerUMH17,
  * title = {Self-Normalizing Neural Networks.},
- * author = {Klambauer, Günter and Unterthiner, Thomas and Mayr, Andreas and Hochreiter, Sepp},
+ * author = {Klambauer, Günter and Unterthiner, Thomas
+ * and Mayr, Andreas and Hochreiter, Sepp},
  * pages = {972-981},
  * year = 2017}
  *
  * @inproceedings{LeCun:1998:EB:645754.668382,
  * title = {Efficient BackProp},
- * author = {LeCun, Yann and Bottou, L{\'e}on and Orr, Genevieve B. and M\"{u}ller, Klaus-Robert},
+ * author = {LeCun, Yann and Bottou, L{\'e}on and Orr, Genevieve B.
+ * and M\"{u}ller, Klaus-Robert},
  * year = {1998},
  * pages = {9--50}}
  * @endcode
@@ -60,65 +64,65 @@ namespace ann /** Artificial Neural Network. */ {
 class LecunNormalInitialization
 {
  public:
-    /**
-     * Initialize the LecunNormalInitialization object.
-     *
-     */
-    LecunNormalInitialization()
+  /**
+   * Initialize the LecunNormalInitialization object.
+   *
+   */
+  LecunNormalInitialization()
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements of the weight matrix with the Lecun
+   * Normal initialization rule.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   */
+  void Initialize(arma::mat& W,
+                  const size_t rows,
+                  const size_t cols)
+  {
+    // He initialization rule says to initialize weights with random
+    // values taken from a gaussian distribution with mean = 0 and
+    // standard deviation = sqrt(1/rows), i.e. variance = (1/rows).
+    double variance = 1.0 / ((double) rows);
+
+    if (W.is_empty())
     {
-        // Nothing to do here.
+      W.set_size(rows, cols);
     }
 
-    /**
-     * Initialize the elements of the weight matrix with the Lecun
-     * Normal initialization rule.
-     *
-     * @param W Weight matrix to initialize.
-     * @param rows Number of rows.
-     * @param cols Number of columns.
-     */
-    void Initialize(arma::mat& W,
-                    const size_t rows,
-                    const size_t cols)
+    // Multipling a random variable X with variance V(X) by some factor c,
+    // then the variance V(cX) = (c^2)* V(X).
+    W.imbue( [&]() { return sqrt(variance) * arma::randn();} );
+  }
+
+  /**
+   * Initialize the elements of the specified weight 3rd order tensor
+   * with Lecun Normal initialization rule.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   * @param slice Numbers of slices.
+   */
+  void Initialize(arma::cube & W,
+                  const size_t rows,
+                  const size_t cols,
+                  const size_t slices)
+  {
+    if (W.is_empty())
     {
-        // He initialization rule says to initialize weights with random
-        // values taken from a gaussian distribution with mean = 0 and
-        // standard deviation = sqrt(1/rows), i.e. variance = (1/rows).
-        double variance = 1.0 / ((double) rows);
-
-        if (W.is_empty())
-        {
-            W.set_size(rows, cols);
-        }
-
-        // Multipling a random variable X with variance V(X) by some factor c,
-        // then the variance V(cX) = (c^2)* V(X).
-        W.imbue( [&]() { return sqrt(variance) * arma::randn();} );
+      W.set_size(rows, cols, slices);
     }
 
-    /**
-     * Initialize the elements of the specified weight 3rd order tensor
-     * with Lecun Normal initialization rule.
-     *
-     * @param W Weight matrix to initialize.
-     * @param rows Number of rows.
-     * @param cols Number of columns.
-     * @param slice Numbers of slices.
-     */
-    void Initialize(arma::cube & W,
-                    const size_t rows,
-                    const size_t cols,
-                    const size_t slices)
-    {
-        if (W.is_empty())
-        {
-            W.set_size(rows, cols, slices);
-        }
-
-        for (size_t i = 0; i < slices; i++) {
-            Initialize(W.slice(i), rows, cols);
-        }
+    for (size_t i = 0; i < slices; i++) {
+      Initialize(W.slice(i), rows, cols);
     }
+  }
 }; // class LecunNormalInitialization
 
 } // namespace ann

--- a/src/mlpack/tests/init_rules_test.cpp
+++ b/src/mlpack/tests/init_rules_test.cpp
@@ -23,6 +23,7 @@
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
 #include <mlpack/methods/ann/init_rules/const_init.hpp>
 #include <mlpack/methods/ann/init_rules/gaussian_init.hpp>
+#include <mlpack/methods/ann/init_rules/he_init.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"
@@ -196,6 +197,32 @@ BOOST_AUTO_TEST_CASE(GaussianInitTest)
   BOOST_REQUIRE_EQUAL(weights3d.n_cols, cols);
   BOOST_REQUIRE_EQUAL(weights3d.n_slices, slices);
 }
+
+/**
+* Simple test of the HeInitialization class.
+*/
+BOOST_AUTO_TEST_CASE(HeInitTest)
+{
+  const size_t rows = 4;
+  const size_t cols = 4;
+  const size_t slices = 2;
+
+  arma::mat weights;
+  arma::cube weights3d;
+
+  HeInitialization initialization;
+
+  initialization.Initialize(weights, rows, cols);
+  initialization.Initialize(weights3d, rows, cols, slices);
+
+  BOOST_REQUIRE_EQUAL(weights.n_rows, rows);
+  BOOST_REQUIRE_EQUAL(weights.n_cols, cols);
+
+  BOOST_REQUIRE_EQUAL(weights3d.n_rows, rows);
+  BOOST_REQUIRE_EQUAL(weights3d.n_cols, cols);
+  BOOST_REQUIRE_EQUAL(weights3d.n_slices, slices);
+}
+
 
 /**
  * Simple test of the NetworkInitialization class, we test it with every

--- a/src/mlpack/tests/init_rules_test.cpp
+++ b/src/mlpack/tests/init_rules_test.cpp
@@ -24,6 +24,7 @@
 #include <mlpack/methods/ann/init_rules/const_init.hpp>
 #include <mlpack/methods/ann/init_rules/gaussian_init.hpp>
 #include <mlpack/methods/ann/init_rules/he_init.hpp>
+#include <mlpack/methods/ann/init_rules/lecun_normal_init.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"
@@ -210,10 +211,35 @@ BOOST_AUTO_TEST_CASE(HeInitTest)
   arma::mat weights;
   arma::cube weights3d;
 
-  HeInitialization initialization;
+  HeInitialization initializer;
 
-  initialization.Initialize(weights, rows, cols);
-  initialization.Initialize(weights3d, rows, cols, slices);
+  initializer.Initialize(weights, rows, cols);
+  initializer.Initialize(weights3d, rows, cols, slices);
+
+  BOOST_REQUIRE_EQUAL(weights.n_rows, rows);
+  BOOST_REQUIRE_EQUAL(weights.n_cols, cols);
+
+  BOOST_REQUIRE_EQUAL(weights3d.n_rows, rows);
+  BOOST_REQUIRE_EQUAL(weights3d.n_cols, cols);
+  BOOST_REQUIRE_EQUAL(weights3d.n_slices, slices);
+}
+
+/**
+* Simple test of the LecunNormalInitialization class.
+*/
+BOOST_AUTO_TEST_CASE(LecunNormalInitTest)
+{
+  const size_t rows = 4;
+  const size_t cols = 4;
+  const size_t slices = 2;
+
+  arma::mat weights;
+  arma::cube weights3d;
+
+  LecunNormalInitialization initializer;
+
+  initializer.Initialize(weights, rows, cols);
+  initializer.Initialize(weights3d, rows, cols, slices);
 
   BOOST_REQUIRE_EQUAL(weights.n_rows, rows);
   BOOST_REQUIRE_EQUAL(weights.n_cols, cols);


### PR DESCRIPTION
This PR adds the following initialization rules with regards to issue #1228:
1. He initialization as given in this [paper](https://www.cv-foundation.org/openaccess/content_iccv_2015/papers/He_Delving_Deep_into_ICCV_2015_paper.pdf). 
2. Lecun Normal initialization as given in this [paper](http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf) and also used in [Self Normalizing Networks](https://arxiv.org/pdf/1706.02515.pdf). 

I will add the tests for the same after the implementation is approved.