### PR TITLE
Remove Rescale Boolean Variable from Dropout Layer

### DIFF
--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -16,7 +16,8 @@
 #include <mlpack/prereqs.hpp>
 
 namespace mlpack {
-    namespace ann /** Artificial Neural Network. */ {
+namespace ann /** Artificial Neural Network. */ {
+
 
 /**
  * The dropout layer is a regularizer that randomly with probability 'ratio'
@@ -46,80 +47,84 @@ namespace mlpack {
  * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
  *         arma::sp_mat or arma::cube).
  */
-        template<
+template<
                 typename InputDataType = arma::mat,
                 typename OutputDataType = arma::mat
         >
-        class Dropout {
-        public:
-            /**
-             * Create the Dropout object using the specified ratio parameter.
-             *
-             * @param ratio The probability of setting a value to zero.
-             */
-            Dropout(const double ratio = 0.5);
+class Dropout {
+ public:
+    /**
+     * Create the Dropout object using the specified ratio parameter.
+     *
+     * @param ratio The probability of setting a value to zero.
+     */
+    Dropout(const double ratio = 0.5);
 
-            /**
-             * Ordinary feed forward pass of the dropout layer.
-             *
-             * @param input Input data used for evaluating the specified function.
-             * @param output Resulting output activation.
-             */
-            template<typename eT>
-            void Forward(const arma::Mat<eT> &&input, arma::Mat<eT> &&output);
+    /**
+     * Ordinary feed forward pass of the dropout layer.
+     *
+     * @param input Input data used for evaluating the specified function.
+     * @param output Resulting output activation.
+     */
+    template<typename eT>
+    void Forward(const arma::Mat<eT> &&input, arma::Mat<eT> &&output);
 
-            /**
-             * Ordinary feed backward pass of the dropout layer.
-             *
-             * @param input The propagated input activation.
-             * @param gy The backpropagated error.
-             * @param g The calculated gradient.
-             */
-            template<typename eT>
-            void Backward(const arma::Mat<eT> && /* input */,
-                          arma::Mat<eT> &&gy,
-                          arma::Mat<eT> &&g);
+    /**
+     * Ordinary feed backward pass of the dropout layer.
+     *
+     * @param input The propagated input activation.
+     * @param gy The backpropagated error.
+     * @param g The calculated gradient.
+     */
+    template<typename eT>
+    void Backward(const arma::Mat<eT> && /* input */,
+                  arma::Mat<eT> &&gy,
+                  arma::Mat<eT> &&g);
 
-            //! Get the input parameter.
-            InputDataType const &InputParameter() const { return inputParameter; }
+    //! Get the input parameter.
+    InputDataType const &InputParameter() const {
+        return inputParameter;
+    }
 
-            //! Modify the input parameter.
-            InputDataType &InputParameter() { return inputParameter; }
+    //! Modify the input parameter.
+    InputDataType &InputParameter() { return inputParameter; }
 
-            //! Get the output parameter.
-            OutputDataType const &OutputParameter() const { return outputParameter; }
+    //! Get the output parameter.
+    OutputDataType const &OutputParameter() const {
+        return outputParameter;
+    }
 
-            //! Modify the output parameter.
-            OutputDataType &OutputParameter() { return outputParameter; }
+    //! Modify the output parameter.
+    OutputDataType &OutputParameter() { return outputParameter; }
 
-            //! Get the detla.
-            OutputDataType const &Delta() const { return delta; }
+    //! Get the detla.
+    OutputDataType const &Delta() const { return delta; }
 
-            //! Modify the delta.
-            OutputDataType &Delta() { return delta; }
+    //! Modify the delta.
+    OutputDataType &Delta() { return delta; }
 
-            //! The value of the deterministic parameter.
-            bool Deterministic() const { return deterministic; }
+    //! The value of the deterministic parameter.
+    bool Deterministic() const { return deterministic; }
 
-            //! Modify the value of the deterministic parameter.
-            bool &Deterministic() { return deterministic; }
+    //! Modify the value of the deterministic parameter.
+    bool &Deterministic() { return deterministic; }
 
-            //! The probability of setting a value to zero.
-            double Ratio() const { return ratio; }
+    //! The probability of setting a value to zero.
+    double Ratio() const { return ratio; }
 
-            //! Modify the probability of setting a value to zero.
-            void Ratio(const double r) {
-                ratio = r;
-                scale = 1.0 / (1.0 - ratio);
-            }
+    //! Modify the probability of setting a value to zero.
+    void Ratio(const double r) {
+        ratio = r;
+        scale = 1.0 / (1.0 - ratio);
+    }
 
-            /**
-             * Serialize the layer.
-             */
-            template<typename Archive>
-            void serialize(Archive &ar, const unsigned int /* version */);
+    /**
+     * Serialize the layer.
+     */
+    template<typename Archive>
+    void serialize(Archive &ar, const unsigned int /* version */);
 
-        private:
+ private:
             //! Locally-stored delta object.
             OutputDataType delta;
 
@@ -140,10 +145,9 @@ namespace mlpack {
 
             //! If true dropout and scaling is disabled, see notes above.
             bool deterministic;
+}; // class Dropout
 
-        }; // class Dropout
-
-    } // namespace ann
+} // namespace ann
 } // namespace mlpack
 
 // Include implementation.

--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -3,7 +3,7 @@
  * @author Marcus Edel
  *
  * Definition of the Dropout class, which implements a regularizer that
- * randomly sets units to zero. Preventing units from co-adapting.
+ * randomly sets units to zero preventing units from co-adapting.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -16,14 +16,13 @@
 #include <mlpack/prereqs.hpp>
 
 namespace mlpack {
-namespace ann /** Artificial Neural Network. */ {
+    namespace ann /** Artificial Neural Network. */ {
 
 /**
- * The dropout layer is a regularizer that randomly with probability ratio
+ * The dropout layer is a regularizer that randomly with probability 'ratio'
  * sets input values to zero and scales the remaining elements by factor 1 /
- * (1 - ratio). If rescale is true the input is scaled with 1 / (1-p) when
- * deterministic is false. In the deterministic mode (during testing), the layer
- * just scales the output.
+ * (1 - ratio) rather than during test time so as to keep the expected sum same.
+ * In the deterministic mode (during testing), there is no change in the input.
  *
  * Note: During training you should set deterministic to false and during
  * testing you should set deterministic to true.
@@ -47,111 +46,104 @@ namespace ann /** Artificial Neural Network. */ {
  * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
  *         arma::sp_mat or arma::cube).
  */
-template <
-    typename InputDataType = arma::mat,
-    typename OutputDataType = arma::mat
->
-class Dropout
-{
- public:
-  /**
-   * Create the Dropout object using the specified ratio and rescale
-   * parameter.
-   *
-   * @param ratio The probability of setting a value to zero.
-   * @param rescale If true the input is rescaled when deterministic is False.
-   */
-  Dropout(const double ratio = 0.5, const bool rescale = true);
+        template<
+                typename InputDataType = arma::mat,
+                typename OutputDataType = arma::mat
+        >
+        class Dropout {
+        public:
+            /**
+             * Create the Dropout object using the specified ratio parameter.
+             *
+             * @param ratio The probability of setting a value to zero.
+             */
+            Dropout(const double ratio = 0.5);
 
-  /**
-   * Ordinary feed forward pass of the dropout layer.
-   *
-   * @param input Input data used for evaluating the specified function.
-   * @param output Resulting output activation.
-   */
-  template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+            /**
+             * Ordinary feed forward pass of the dropout layer.
+             *
+             * @param input Input data used for evaluating the specified function.
+             * @param output Resulting output activation.
+             */
+            template<typename eT>
+            void Forward(const arma::Mat<eT> &&input, arma::Mat<eT> &&output);
 
-  /**
-   * Ordinary feed backward pass of the dropout layer.
-   *
-   * @param input The propagated input activation.
-   * @param gy The backpropagated error.
-   * @param g The calculated gradient.
-   */
-  template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+            /**
+             * Ordinary feed backward pass of the dropout layer.
+             *
+             * @param input The propagated input activation.
+             * @param gy The backpropagated error.
+             * @param g The calculated gradient.
+             */
+            template<typename eT>
+            void Backward(const arma::Mat<eT> && /* input */,
+                          arma::Mat<eT> &&gy,
+                          arma::Mat<eT> &&g);
 
-  //! Get the input parameter.
-  InputDataType const& InputParameter() const { return inputParameter; }
-  //! Modify the input parameter.
-  InputDataType& InputParameter() { return inputParameter; }
+            //! Get the input parameter.
+            InputDataType const &InputParameter() const { return inputParameter; }
 
-  //! Get the output parameter.
-  OutputDataType const& OutputParameter() const { return outputParameter; }
-  //! Modify the output parameter.
-  OutputDataType& OutputParameter() { return outputParameter; }
+            //! Modify the input parameter.
+            InputDataType &InputParameter() { return inputParameter; }
 
-  //! Get the detla.
-  OutputDataType const& Delta() const { return delta; }
-  //! Modify the delta.
-  OutputDataType& Delta() { return delta; }
+            //! Get the output parameter.
+            OutputDataType const &OutputParameter() const { return outputParameter; }
 
-  //! The value of the deterministic parameter.
-  bool Deterministic() const { return deterministic; }
-  //! Modify the value of the deterministic parameter.
-  bool& Deterministic() { return deterministic; }
+            //! Modify the output parameter.
+            OutputDataType &OutputParameter() { return outputParameter; }
 
-  //! The probability of setting a value to zero.
-  double Ratio() const { return ratio; }
+            //! Get the detla.
+            OutputDataType const &Delta() const { return delta; }
 
-  //! Modify the probability of setting a value to zero.
-  void Ratio(const double r)
-  {
-    ratio = r;
-    scale = 1.0 / (1.0 - ratio);
-  }
+            //! Modify the delta.
+            OutputDataType &Delta() { return delta; }
 
-  //! The value of the rescale parameter.
-  bool Rescale() const {return rescale; }
-  //! Modify the value of the rescale parameter.
-  bool& Rescale() {return rescale; }
+            //! The value of the deterministic parameter.
+            bool Deterministic() const { return deterministic; }
 
-  /**
-   * Serialize the layer.
-   */
-  template<typename Archive>
-  void serialize(Archive& ar, const unsigned int /* version */);
+            //! Modify the value of the deterministic parameter.
+            bool &Deterministic() { return deterministic; }
 
- private:
-  //! Locally-stored delta object.
-  OutputDataType delta;
+            //! The probability of setting a value to zero.
+            double Ratio() const { return ratio; }
 
-  //! Locally-stored input parameter object.
-  InputDataType inputParameter;
+            //! Modify the probability of setting a value to zero.
+            void Ratio(const double r) {
+                ratio = r;
+                scale = 1.0 / (1.0 - ratio);
+            }
 
-  //! Locally-stored output parameter object.
-  OutputDataType outputParameter;
+            /**
+             * Serialize the layer.
+             */
+            template<typename Archive>
+            void serialize(Archive &ar, const unsigned int /* version */);
 
-  //! Locally-stored mast object.
-  OutputDataType mask;
+        private:
+            //! Locally-stored delta object.
+            OutputDataType delta;
 
-  //! The probability of setting a value to zero.
-  double ratio;
+            //! Locally-stored input parameter object.
+            InputDataType inputParameter;
 
-  //! The scale fraction.
-  double scale;
+            //! Locally-stored output parameter object.
+            OutputDataType outputParameter;
 
-  //! If true dropout and scaling is disabled, see notes above.
-  bool deterministic;
+            //! Locally-stored mast object.
+            OutputDataType mask;
 
-  //! If true the input is rescaled when deterministic is False.
-  bool rescale;
-}; // class Dropout
+            //! The probability of setting a value to zero.
+            double ratio;
 
-} // namespace ann
+            //! The scale fraction.
+            double scale;
+
+            //! If true dropout and scaling is disabled, see notes above.
+            bool deterministic;
+
+        }; // class Dropout
+
+    } // namespace ann
 } // namespace mlpack
 
 // Include implementation.

--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -53,98 +53,94 @@ template<
         >
 class Dropout {
  public:
-    /**
-     * Create the Dropout object using the specified ratio parameter.
-     *
-     * @param ratio The probability of setting a value to zero.
-     */
-    Dropout(const double ratio = 0.5);
+  /**
+   * Create the Dropout object using the specified ratio parameter.
+   *
+   * @param ratio The probability of setting a value to zero.
+   */
+  Dropout(const double ratio = 0.5);
 
-    /**
-     * Ordinary feed forward pass of the dropout layer.
-     *
-     * @param input Input data used for evaluating the specified function.
-     * @param output Resulting output activation.
-     */
-    template<typename eT>
-    void Forward(const arma::Mat<eT> &&input, arma::Mat<eT> &&output);
+  /**
+   * Ordinary feed forward pass of the dropout layer.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param output Resulting output activation.
+   */
+  template<typename eT>
+  void Forward(const arma::Mat<eT> &&input, arma::Mat<eT> &&output);
 
-    /**
-     * Ordinary feed backward pass of the dropout layer.
-     *
-     * @param input The propagated input activation.
-     * @param gy The backpropagated error.
-     * @param g The calculated gradient.
-     */
-    template<typename eT>
-    void Backward(const arma::Mat<eT> && /* input */,
-                  arma::Mat<eT> &&gy,
-                  arma::Mat<eT> &&g);
+  /**
+   * Ordinary feed backward pass of the dropout layer.
+   *
+   * @param input The propagated input activation.
+   * @param gy The backpropagated error.
+   * @param g The calculated gradient.
+   */
+  template<typename eT>
+  void Backward(const arma::Mat<eT> && /* input */,
+                arma::Mat<eT> &&gy,
+                arma::Mat<eT> &&g);
 
-    //! Get the input parameter.
-    InputDataType const &InputParameter() const {
-        return inputParameter;
-    }
+  //! Get the input parameter.
+  InputDataType const &InputParameter() const { return inputParameter;  }
 
-    //! Modify the input parameter.
-    InputDataType &InputParameter() { return inputParameter; }
+  //! Modify the input parameter.
+  InputDataType &InputParameter() { return inputParameter; }
 
-    //! Get the output parameter.
-    OutputDataType const &OutputParameter() const {
-        return outputParameter;
-    }
+  //! Get the output parameter.
+  OutputDataType const &OutputParameter() const { return outputParameter; }
 
-    //! Modify the output parameter.
-    OutputDataType &OutputParameter() { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType &OutputParameter() { return outputParameter; }
 
-    //! Get the detla.
-    OutputDataType const &Delta() const { return delta; }
+  //! Get the detla.
+  OutputDataType const &Delta() const { return delta; }
 
-    //! Modify the delta.
-    OutputDataType &Delta() { return delta; }
+  //! Modify the delta.
+  OutputDataType &Delta() { return delta; }
 
-    //! The value of the deterministic parameter.
-    bool Deterministic() const { return deterministic; }
+  //! The value of the deterministic parameter.
+  bool Deterministic() const { return deterministic; }
 
-    //! Modify the value of the deterministic parameter.
-    bool &Deterministic() { return deterministic; }
+  //! Modify the value of the deterministic parameter.
+  bool &Deterministic() { return deterministic; }
 
-    //! The probability of setting a value to zero.
-    double Ratio() const { return ratio; }
+  //! The probability of setting a value to zero.
+  double Ratio() const { return ratio; }
 
-    //! Modify the probability of setting a value to zero.
-    void Ratio(const double r) {
-        ratio = r;
-        scale = 1.0 / (1.0 - ratio);
-    }
+  //! Modify the probability of setting a value to zero.
+  void Ratio(const double r) {
+    ratio = r;
+    scale = 1.0 / (1.0 - ratio);
+  }
 
-    /**
-     * Serialize the layer.
-     */
-    template<typename Archive>
-    void serialize(Archive &ar, const unsigned int /* version */);
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive &ar, const unsigned int /* version */);
 
  private:
-            //! Locally-stored delta object.
-            OutputDataType delta;
+  //! Locally-stored delta object.
+  OutputDataType delta;
 
-            //! Locally-stored input parameter object.
-            InputDataType inputParameter;
+  //! Locally-stored input parameter object.
+  InputDataType inputParameter;
 
-            //! Locally-stored output parameter object.
-            OutputDataType outputParameter;
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
 
-            //! Locally-stored mast object.
-            OutputDataType mask;
+  //! Locally-stored mast object.
+  OutputDataType mask;
 
-            //! The probability of setting a value to zero.
-            double ratio;
+  //! The probability of setting a value to zero.
+  double ratio;
 
-            //! The scale fraction.
-            double scale;
+  //! The scale fraction.
+  double scale;
 
-            //! If true dropout and scaling is disabled, see notes above.
-            bool deterministic;
+  //! If true dropout and scaling is disabled, see notes above.
+  bool deterministic;
 }; // class Dropout
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -17,72 +17,56 @@
 #include "dropout.hpp"
 
 namespace mlpack {
-namespace ann /** Artificial Neural Network. */ {
+    namespace ann /** Artificial Neural Network. */ {
 
-template<typename InputDataType, typename OutputDataType>
-Dropout<InputDataType, OutputDataType>::Dropout(
-    const double ratio, const bool rescale) :
-    ratio(ratio),
-    scale(1.0 / (1.0 - ratio)),
-    deterministic(true),
-    rescale(rescale)
-{
-  // Nothing to do here.
-}
+        template<typename InputDataType, typename OutputDataType>
+        Dropout<InputDataType, OutputDataType>::Dropout(
+                const double ratio) :
+                ratio(ratio),
+                scale(1.0 / (1.0 - ratio)),
+                deterministic(false) {
+            // Nothing to do here.
+        }
 
-template<typename InputDataType, typename OutputDataType>
-template<typename eT>
-void Dropout<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& output)
-{
-  // The dropout mask will not be multiplied in the deterministic mode
-  // (during testing).
-  if (deterministic)
-  {
-    if (!rescale)
-    {
-      output = input;
-    }
-    else
-    {
-      output = input * scale;
-    }
-  }
-  else
-  {
-    // Scale with input / (1 - ratio) and set values to zero with probability
-    // ratio.
-    mask = arma::randu<arma::Mat<eT> >(input.n_rows, input.n_cols);
-    mask.transform( [&](double val) { return (val > ratio); } );
-    output = input % mask * scale;
-  }
-}
+        template<typename InputDataType, typename OutputDataType>
+        template<typename eT>
+        void Dropout<InputDataType, OutputDataType>::Forward(
+                const arma::Mat<eT> &&input,
+                arma::Mat<eT> &&output) {
+            // The dropout mask will not be multiplied in the deterministic mode
+            // (during testing).
+            if (deterministic) {
+                output = input;
+            } else {
+                // Scale with input / (1 - ratio) and set values to zero with probability
+                // ratio.
+                mask = arma::randu < arma::Mat<eT> > (input.n_rows, input.n_cols);
+                mask.transform([&](double val) { return (val > ratio); });
+                output = input % mask * scale;
+            }
+        }
 
-template<typename InputDataType, typename OutputDataType>
-template<typename eT>
-void Dropout<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
-{
-  g = gy % mask * scale;
-}
+        template<typename InputDataType, typename OutputDataType>
+        template<typename eT>
+        void Dropout<InputDataType, OutputDataType>::Backward(
+                const arma::Mat<eT> && /* input */,
+                arma::Mat<eT> &&gy,
+                arma::Mat<eT> &&g) {
+            g = gy % mask * scale;
+        }
 
-template<typename InputDataType, typename OutputDataType>
-template<typename Archive>
-void Dropout<InputDataType, OutputDataType>::serialize(
-    Archive& ar,
-    const unsigned int /* version */)
-{
-  ar & BOOST_SERIALIZATION_NVP(ratio);
-  ar & BOOST_SERIALIZATION_NVP(rescale);
+        template<typename InputDataType, typename OutputDataType>
+        template<typename Archive>
+        void Dropout<InputDataType, OutputDataType>::serialize(
+                Archive &ar,
+                const unsigned int /* version */) {
+            ar & BOOST_SERIALIZATION_NVP(ratio);
 
-  // Reset scale.
-  scale = 1.0 / (1.0 - ratio);
-}
+            // Reset scale.
+            scale = 1.0 / (1.0 - ratio);
+        }
 
-} // namespace ann
+    } // namespace ann
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -17,56 +17,57 @@
 #include "dropout.hpp"
 
 namespace mlpack {
-    namespace ann /** Artificial Neural Network. */ {
+namespace ann /** Artificial Neural Network. */ {
 
-        template<typename InputDataType, typename OutputDataType>
-        Dropout<InputDataType, OutputDataType>::Dropout(
-                const double ratio) :
-                ratio(ratio),
-                scale(1.0 / (1.0 - ratio)),
-                deterministic(false) {
-            // Nothing to do here.
+    template<typename InputDataType, typename OutputDataType>
+    Dropout<InputDataType, OutputDataType>::Dropout(
+            const double ratio) :
+            ratio(ratio),
+            scale(1.0 / (1.0 - ratio)),
+            deterministic(false) {
+        // Nothing to do here.
+    }
+
+    template<typename InputDataType, typename OutputDataType>
+    template<typename eT>
+    void Dropout<InputDataType, OutputDataType>::Forward(
+            const arma::Mat<eT> &&input,
+            arma::Mat<eT> &&output) {
+        // The dropout mask will not be multiplied in the deterministic mode
+        // (during testing).
+        if (deterministic) {
+            output = input;
+        } else {
+            // Scale with input / (1 - ratio) and set values to zero
+            // with probability 'ratio'.
+
+            mask = arma::randu<arma::Mat<eT> >(input.n_rows, input.n_cols);
+            mask.transform([&](double val) { return (val > ratio); });
+            output = input % mask * scale;
         }
+    }
 
-        template<typename InputDataType, typename OutputDataType>
-        template<typename eT>
-        void Dropout<InputDataType, OutputDataType>::Forward(
-                const arma::Mat<eT> &&input,
-                arma::Mat<eT> &&output) {
-            // The dropout mask will not be multiplied in the deterministic mode
-            // (during testing).
-            if (deterministic) {
-                output = input;
-            } else {
-                // Scale with input / (1 - ratio) and set values to zero with probability
-                // ratio.
-                mask = arma::randu < arma::Mat<eT> > (input.n_rows, input.n_cols);
-                mask.transform([&](double val) { return (val > ratio); });
-                output = input % mask * scale;
-            }
-        }
+    template<typename InputDataType, typename OutputDataType>
+    template<typename eT>
+    void Dropout<InputDataType, OutputDataType>::Backward(
+            const arma::Mat<eT> && /* input */,
+            arma::Mat<eT> &&gy,
+            arma::Mat<eT> &&g) {
+        g = gy % mask * scale;
+    }
 
-        template<typename InputDataType, typename OutputDataType>
-        template<typename eT>
-        void Dropout<InputDataType, OutputDataType>::Backward(
-                const arma::Mat<eT> && /* input */,
-                arma::Mat<eT> &&gy,
-                arma::Mat<eT> &&g) {
-            g = gy % mask * scale;
-        }
+    template<typename InputDataType, typename OutputDataType>
+    template<typename Archive>
+    void Dropout<InputDataType, OutputDataType>::serialize(
+            Archive &ar,
+            const unsigned int /* version */) {
+        ar & BOOST_SERIALIZATION_NVP(ratio);
 
-        template<typename InputDataType, typename OutputDataType>
-        template<typename Archive>
-        void Dropout<InputDataType, OutputDataType>::serialize(
-                Archive &ar,
-                const unsigned int /* version */) {
-            ar & BOOST_SERIALIZATION_NVP(ratio);
+        // Reset scale.
+        scale = 1.0 / (1.0 - ratio);
+    }
 
-            // Reset scale.
-            scale = 1.0 / (1.0 - ratio);
-        }
-
-    } // namespace ann
+} // namespace ann
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -19,53 +19,57 @@
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
-    template<typename InputDataType, typename OutputDataType>
-    Dropout<InputDataType, OutputDataType>::Dropout(
-            const double ratio) :
-            ratio(ratio),
-            scale(1.0 / (1.0 - ratio)),
-            deterministic(false) {
-        // Nothing to do here.
-    }
+template<typename InputDataType, typename OutputDataType>
+Dropout<InputDataType, OutputDataType>::Dropout(
+    const double ratio) :
+    ratio(ratio),
+    scale(1.0 / (1.0 - ratio)),
+    deterministic(false)
+{
+  // Nothing to do here.
+}
 
-    template<typename InputDataType, typename OutputDataType>
-    template<typename eT>
-    void Dropout<InputDataType, OutputDataType>::Forward(
-            const arma::Mat<eT> &&input,
-            arma::Mat<eT> &&output) {
-        // The dropout mask will not be multiplied in the deterministic mode
-        // (during testing).
-        if (deterministic) {
-            output = input;
-        } else {
-            // Scale with input / (1 - ratio) and set values to zero
-            // with probability 'ratio'.
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void Dropout<InputDataType, OutputDataType>::Forward(
+    const arma::Mat<eT> &&input,
+    arma::Mat<eT> &&output)
+{
+  // The dropout mask will not be multiplied in the deterministic mode
+  // (during testing).
+  if (deterministic) {
+    output = input;
+  } else {
+    // Scale with input / (1 - ratio) and set values to zero
+    // with probability 'ratio'.
 
-            mask = arma::randu<arma::Mat<eT> >(input.n_rows, input.n_cols);
-            mask.transform([&](double val) { return (val > ratio); });
-            output = input % mask * scale;
-        }
-    }
+    mask = arma::randu<arma::Mat<eT> >(input.n_rows, input.n_cols);
+    mask.transform([&](double val) { return (val > ratio); });
+    output = input % mask * scale;
+  }
+}
 
-    template<typename InputDataType, typename OutputDataType>
-    template<typename eT>
-    void Dropout<InputDataType, OutputDataType>::Backward(
-            const arma::Mat<eT> && /* input */,
-            arma::Mat<eT> &&gy,
-            arma::Mat<eT> &&g) {
-        g = gy % mask * scale;
-    }
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void Dropout<InputDataType, OutputDataType>::Backward(
+    const arma::Mat<eT> && /* input */,
+    arma::Mat<eT> &&gy,
+    arma::Mat<eT> &&g)
+{
+  g = gy % mask * scale;
+}
 
-    template<typename InputDataType, typename OutputDataType>
-    template<typename Archive>
-    void Dropout<InputDataType, OutputDataType>::serialize(
-            Archive &ar,
-            const unsigned int /* version */) {
-        ar & BOOST_SERIALIZATION_NVP(ratio);
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void Dropout<InputDataType, OutputDataType>::serialize(
+    Archive &ar,
+    const unsigned int /* version */)
+{
+  ar & BOOST_SERIALIZATION_NVP(ratio);
 
-        // Reset scale.
-        scale = 1.0 / (1.0 - ratio);
-    }
+  // Reset scale.
+  scale = 1.0 / (1.0 - ratio);
+}
 
 } // namespace ann
 } // namespace mlpack

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -317,8 +317,7 @@ BOOST_AUTO_TEST_CASE(JacobianConstantLayerTest)
  */
 BOOST_AUTO_TEST_CASE(SimpleDropoutLayerTest)
 {
-  // Initialize the probability of setting a value to zero and the scale
-  // parameter.
+  // Initialize the probability of setting a value to zero.
   const double p = 0.2;
 
   // Initialize the input parameter.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -320,7 +320,6 @@ BOOST_AUTO_TEST_CASE(SimpleDropoutLayerTest)
   // Initialize the probability of setting a value to zero and the scale
   // parameter.
   const double p = 0.2;
-  const double scale = 1.0 / (1.0 - p);
 
   // Initialize the input parameter.
   arma::mat input(1000, 1);
@@ -343,14 +342,8 @@ BOOST_AUTO_TEST_CASE(SimpleDropoutLayerTest)
 
   // Test the Forward function.
   module.Deterministic() = true;
-  module.Rescale() = false;
   module.Forward(std::move(input), std::move(output));
   BOOST_REQUIRE_EQUAL(arma::accu(input), arma::accu(output));
-
-  // Test the Forward function.
-  module.Rescale() = true;
-  module.Forward(std::move(input), std::move(output));
-  BOOST_REQUIRE_CLOSE(arma::accu(input) * scale, arma::accu(output), 1e-3);
 }
 
 /**


### PR DESCRIPTION
This PR removes the unnecessary rescale boolean variable used in the dropout layer.  The user should not be given the option of rescaling the inputs during the testing phase.  The inputs are scaled during the training phase so that the expected sum remains unchanged.

@zoq please have a review of the changes.