### PR TITLE
Switch back to the Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: trusty
 language: cpp
 
 env:
@@ -8,22 +8,17 @@ env:
   - CMAKE_OPTIONS="-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF"
 
 before_install:
-  # xenial is not stable yet, so we have to manually disable the systemd
-  # automatic updates services.  Ideas adapted from here:
-  # https://unix.stackexchange.com/questions/315502/how-to-disable-apt-daily-service-on-ubuntu-cloud-vm-image
-  - sudo systemctl stop apt-daily.service apt-daily.timer apt-daily-upgrade.service apt-daily-upgrade.timer
-  - sudo systemctl kill --kill-who=all apt-daily.service apt-daily-upgrade.service
-  - while !(systemctl list-units --all apt-daily.service | grep -q dead); do sleep 1; done
-  - while !(systemctl list-units --all apt-daily-upgrade.service | grep -q dead); do sleep 1; done
+  # For the python bindings we need cython >= 0.24.
+  - sudo add-apt-repository -y ppa:imcode/s3ql-trusty-backport
+  # For the python bindings we need pandas >= 0.15.0.
+  - wget -O- http://neuro.debian.net/lists/trusty.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+  - sudo apt-key adv --recv-keys --keyserver hkp://ha.pool.sks-keyservers.net 0xA5D32F012649A5A9
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libopenblas-dev liblapack-dev g++ libboost-all-dev python3-pip
-  - sudo wget https://launchpadlibrarian.net/260609315/fix-std-vector-load.diff -O /usr/include/fix-std-vector-load.diff
-  - cd /usr/include && sudo patch -p1 < fix-std-vector-load.diff && sudo rm fix-std-vector-load.diff && cd -
+  - sudo apt-get install -qq libopenblas-dev liblapack-dev g++ libboost-all-dev python3-pip cython3 python3-numpy python3-pandas
   # Install both python2 and python3 modules, and the build will decide which to
   # use.
   - sudo pip install cython numpy pandas
   - sudo pip install --upgrade --ignore-installed setuptools
-  - sudo pip3 install cython numpy pandas
   - sudo pip3 install --upgrade --ignore-installed setuptools
   - curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-6.500.5.tar.gz | tar xvz && cd armadillo*
   - cmake . && make && sudo make install && cd ..


### PR DESCRIPTION
This commit does a switch back to the Trusty image, since the Xenial image is unstable.