### PR TITLE
Add binding tests for mean shift

### DIFF
--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ add_executable(mlpack_test
   main_tests/decision_stump_test.cpp
   main_tests/linear_regression_test.cpp
   main_tests/logistic_regression_test.cpp
+  main_tests/mean_shift_test.cpp
   main_tests/nbc_test.cpp
   main_tests/pca_test.cpp
   main_tests/perceptron_test.cpp
@@ -145,7 +146,6 @@ add_executable(mlpack_test
   main_tests/softmax_regression_test.cpp
   main_tests/sparse_coding_test.cpp
   main_tests/hoeffding_tree_test.cpp
-  main_tests/mean_shift_test.cpp
 )
 
 # Link dependencies of test executable.

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -145,6 +145,7 @@ add_executable(mlpack_test
   main_tests/softmax_regression_test.cpp
   main_tests/sparse_coding_test.cpp
   main_tests/hoeffding_tree_test.cpp
+  main_tests/mean_shift_test.cpp
 )
 
 # Link dependencies of test executable.

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -16,8 +16,8 @@ static const std::string testName = "Mean Shift";
 
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
-#include "test_helper.hpp"
 #include <mlpack/methods/mean_shift/mean_shift_main.cpp>
+#include "test_helper.hpp"
 
 #include <boost/test/unit_test.hpp>
 #include "../test_tools.hpp"
@@ -43,74 +43,45 @@ struct MeanShiftTestFixture
 
 BOOST_FIXTURE_TEST_SUITE(MeanShiftMainTest, MeanShiftTestFixture);
 
-// Generate dataset; written transposed because it's easier to read.
-arma::mat meanShiftData("  0.0   0.0;" // Class 1.
-                     "  0.3   0.4;"
-                     "  0.1   0.0;"
-                     "  0.1   0.3;"
-                     " -0.2  -0.2;"
-                     " -0.1   0.3;"
-                     " -0.4   0.1;"
-                     "  0.2  -0.1;"
-                     "  0.3   0.0;"
-                     " -0.3  -0.3;"
-                     "  0.1  -0.1;"
-                     "  0.2  -0.3;"
-                     " -0.3   0.2;"
-                     " 10.0  10.0;" // Class 2.
-                     " 10.1   9.9;"
-                     "  9.9  10.0;"
-                     " 10.2   9.7;"
-                     " 10.2   9.8;"
-                     "  9.7  10.3;"
-                     "  9.9  10.1;"
-                     "-10.0   5.0;" // Class 3.
-                     " -9.8   5.1;"
-                     " -9.9   4.9;"
-                     "-10.0   4.9;"
-                     "-10.2   5.2;"
-                     "-10.1   5.1;"
-                     "-10.3   5.3;"
-                     "-10.0   4.8;"
-                     " -9.6   5.0;"
-                     " -9.8   5.1;");
-
 /**
  * Ensure that the output has 1 extra row for the labels and
  * check the number of points for output remain the same.
- * Also ensure that the centroid points output has same number of rows.
  */
 BOOST_AUTO_TEST_CASE(MeanShiftOutputDimensionTest)
 {
+  arma::mat x;
+  x.randu(3,100); // 100 points in 3 dimension
+
   // Input random data points.
-  SetInputParam("input", meanShiftData);
+  SetInputParam("input", std::move(x));
 
   mlpackMain();
 
   // Now check that the output has 1 extra row for labels.
-  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 2 + 1);
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 3 + 1);
   // Check number of output points are the same.
-  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 30);
-
-  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("centroid").n_cols, 2);
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 100);
 }
 
 /**
  * Ensure that if we ask for labels_only, output has 1 column and
  * same number of rows for each point's label.
  */
-BOOST_AUTO_TEST_CASE(MeanShiftLabelOutputDimensionTest)
+BOOST_AUTO_TEST_CASE(MeanShiftLabelOnlyOutputDimensionTest)
 {
+  arma::mat x;
+  x.randu(3,100); // 100 points in 3 dimension
+
   // Input random data points.
-  SetInputParam("input", meanShiftData);
+  SetInputParam("input", std::move(x));
   SetInputParam("labels_only", true);
 
   mlpackMain();
 
-  // Now check that the output has 1 extra row for labels.
-  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 2 + 1);
   // Check number of output points are the same.
-  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 30);
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 100);
+  // Check that there is only 1 column containing all the labels.
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 1);
 }
 
 /**
@@ -118,8 +89,12 @@ BOOST_AUTO_TEST_CASE(MeanShiftLabelOutputDimensionTest)
  */
 BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterations)
 {
+  arma::mat x;
+  x.randu(3,100); // 100 points in 3 dimension
+
   // Input random data points.
-  SetInputParam("input", meanShiftData);
+  SetInputParam("input", x);
+  // Input invalid max number of iterations.
   SetInputParam("max_iterations", (int) -1);
 
   Log::Fatal.ignoreInput = true;

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file mean_shift_test.cpp
+ * @author Tan Jun An
+ *
+ * Test mlpackMain() of mean_shift_main.cpp.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <string>
+
+#define BINDING_TYPE BINDING_TYPE_TEST
+static const std::string testName = "Mean Shift";
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/util/mlpack_main.hpp>
+#include "test_helper.hpp"
+#include <mlpack/methods/mean_shift/mean_shift_main.cpp>
+
+#include <boost/test/unit_test.hpp>
+#include "../test_tools.hpp"
+
+using namespace mlpack;
+
+struct MeanShiftTestFixture
+{
+ public:
+  MeanShiftTestFixture()
+  {
+    // Cache in the options for this program.
+    CLI::RestoreSettings(testName);
+  }
+
+  ~MeanShiftTestFixture()
+  {
+    // Clear the settings.
+    bindings::tests::CleanMemory();
+    CLI::ClearSettings();
+  }
+};
+
+BOOST_FIXTURE_TEST_SUITE(MeanShiftMainTest, MeanShiftTestFixture);
+
+// Generate dataset; written transposed because it's easier to read.
+arma::mat meanShiftData("  0.0   0.0;" // Class 1.
+                     "  0.3   0.4;"
+                     "  0.1   0.0;"
+                     "  0.1   0.3;"
+                     " -0.2  -0.2;"
+                     " -0.1   0.3;"
+                     " -0.4   0.1;"
+                     "  0.2  -0.1;"
+                     "  0.3   0.0;"
+                     " -0.3  -0.3;"
+                     "  0.1  -0.1;"
+                     "  0.2  -0.3;"
+                     " -0.3   0.2;"
+                     " 10.0  10.0;" // Class 2.
+                     " 10.1   9.9;"
+                     "  9.9  10.0;"
+                     " 10.2   9.7;"
+                     " 10.2   9.8;"
+                     "  9.7  10.3;"
+                     "  9.9  10.1;"
+                     "-10.0   5.0;" // Class 3.
+                     " -9.8   5.1;"
+                     " -9.9   4.9;"
+                     "-10.0   4.9;"
+                     "-10.2   5.2;"
+                     "-10.1   5.1;"
+                     "-10.3   5.3;"
+                     "-10.0   4.8;"
+                     " -9.6   5.0;"
+                     " -9.8   5.1;");
+
+/**
+ * Ensure that we can't specify an invalid max number of iterations.
+ */
+BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterations)
+{
+  // Input random data points.
+  SetInputParam("input", meanShiftData);
+  SetInputParam("max_iterations", -1);
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -79,7 +79,6 @@ arma::mat meanShiftData("  0.0   0.0;" // Class 1.
  * Ensure that the output has 1 extra row for the labels and
  * check the number of points for output remain the same.
  * Also ensure that the centroid points output has same number of rows.
- * .
  */
 BOOST_AUTO_TEST_CASE(MeanShiftOutputDimensionTest)
 {
@@ -94,6 +93,24 @@ BOOST_AUTO_TEST_CASE(MeanShiftOutputDimensionTest)
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 30);
 
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("centroid").n_cols, 2);
+}
+
+/**
+ * Ensure that if we ask for labels_only, output has 1 column and
+ * same number of rows for each point's label.
+ */
+BOOST_AUTO_TEST_CASE(MeanShiftLabelOutputDimensionTest)
+{
+  // Input random data points.
+  SetInputParam("input", meanShiftData);
+  SetInputParam("labels_only", true);
+
+  mlpackMain();
+
+  // Now check that the output has 1 extra row for labels.
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 2 + 1);
+  // Check number of output points are the same.
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 30);
 }
 
 /**

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -76,8 +76,10 @@ arma::mat meanShiftData("  0.0   0.0;" // Class 1.
                      " -9.8   5.1;");
 
 /**
- * Ensure that the output has 1 row for the labels and
- * check the number of points remain the same.
+ * Ensure that the output has 1 extra row for the labels and
+ * check the number of points for output remain the same.
+ * Also ensure that the centroid points output has same number of rows.
+ * .
  */
 BOOST_AUTO_TEST_CASE(MeanShiftOutputDimensionTest)
 {
@@ -90,6 +92,8 @@ BOOST_AUTO_TEST_CASE(MeanShiftOutputDimensionTest)
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 2 + 1);
   // Check number of output points are the same.
   BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 30);
+
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("centroid").n_cols, 2);
 }
 
 /**

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -98,11 +98,12 @@ BOOST_AUTO_TEST_CASE(MeanShiftLabelOnlyOutputDimensionTest)
 BOOST_AUTO_TEST_CASE(MeanShiftRadiusTest)
 {
   arma::mat x;
-  x.randu(3,100); // 100 points in 3 dimension
+  if (!data::Load("iris_test.csv", x))
+    BOOST_FAIL("Cannot load test dataset iris_test.csv!");
 
   // Input random data points.
   SetInputParam("input", x);
-  // Set a radius.
+  // Set a small radius.
   SetInputParam("radius", (double) 0.1);
 
   mlpackMain();
@@ -123,9 +124,41 @@ BOOST_AUTO_TEST_CASE(MeanShiftRadiusTest)
 }
 
 /**
+ * Ensure that max_iterations is used by testing that the
+ * max_iteration makes a difference in the program.
+ */
+BOOST_AUTO_TEST_CASE(MeanShiftMaxIterationsTest)
+{
+  arma::mat x;
+  if (!data::Load("iris_test.csv", x))
+    BOOST_FAIL("Cannot load test dataset iris_test.csv!");
+
+  // Input random data points.
+  SetInputParam("input", x);
+  // Set a small max_iterations.
+  SetInputParam("max_iterations", (int) 4);
+
+  mlpackMain();
+
+  const int numCentroids1 = CLI::GetParam<arma::mat>("centroid").n_cols;
+
+  ResetSettings();
+
+  SetInputParam("input", std::move(x));                                                                                                                                                         
+  // Set a larger max_iterations.
+  SetInputParam("max_iterations", (int) 20);
+
+  mlpackMain();
+
+  const int numCentroids2 = CLI::GetParam<arma::mat>("centroid").n_cols;
+  // Resulting number of centroids should be different.
+  BOOST_REQUIRE_NE(numCentroids1, numCentroids2);
+}
+
+/**
  * Ensure that we can't specify an invalid max number of iterations.
  */
-BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterationsTest)
+BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxIterationsTest)
 {
   arma::mat x;
   x.randu(3,100); // 100 points in 3 dimension

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -12,7 +12,7 @@
 #include <string>
 
 #define BINDING_TYPE BINDING_TYPE_TEST
-static const std::string testName = "Mean Shift";
+static const std::string testName = "MeanShift";
 
 #include <mlpack/core.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
@@ -40,6 +40,13 @@ struct MeanShiftTestFixture
     CLI::ClearSettings();
   }
 };
+
+static void ResetSettings()
+{
+  bindings::tests::CleanMemory();
+  CLI::ClearSettings();
+  CLI::RestoreSettings(testName);
+}
 
 BOOST_FIXTURE_TEST_SUITE(MeanShiftMainTest, MeanShiftTestFixture);
 
@@ -85,9 +92,40 @@ BOOST_AUTO_TEST_CASE(MeanShiftLabelOnlyOutputDimensionTest)
 }
 
 /**
+ * Ensure that radius is used by testing that the radius
+ * makes a difference in the program.
+ */
+BOOST_AUTO_TEST_CASE(MeanShiftRadiusTest)
+{
+  arma::mat x;
+  x.randu(3,100); // 100 points in 3 dimension
+
+  // Input random data points.
+  SetInputParam("input", x);
+  // Set a radius.
+  SetInputParam("radius", (double) 0.1);
+
+  mlpackMain();
+
+  const int numCentroids1 = CLI::GetParam<arma::mat>("centroid").n_cols;
+
+  ResetSettings();
+
+  SetInputParam("input", std::move(x));                                                                                                                                                         
+  // Set a larger radius.
+  SetInputParam("radius", (double) 1.0);
+
+  mlpackMain();
+
+  const int numCentroids2 = CLI::GetParam<arma::mat>("centroid").n_cols;
+  // Resulting number of centroids should be different.
+  BOOST_REQUIRE_NE(numCentroids1, numCentroids2);
+}
+
+/**
  * Ensure that we can't specify an invalid max number of iterations.
  */
-BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterations)
+BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterationsTest)
 {
   arma::mat x;
   x.randu(3,100); // 100 points in 3 dimension

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterations)
   x.randu(3,100); // 100 points in 3 dimension
 
   // Input random data points.
-  SetInputParam("input", x);
+  SetInputParam("input", std::move(x));
   // Input invalid max number of iterations.
   SetInputParam("max_iterations", (int) -1);
 

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -76,13 +76,30 @@ arma::mat meanShiftData("  0.0   0.0;" // Class 1.
                      " -9.8   5.1;");
 
 /**
+ * Ensure that the output has 1 row for the labels and
+ * check the number of points remain the same.
+ */
+BOOST_AUTO_TEST_CASE(MeanShiftOutputDimensionTest)
+{
+  // Input random data points.
+  SetInputParam("input", meanShiftData);
+
+  mlpackMain();
+
+  // Now check that the output has 1 extra row for labels.
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_rows, 2 + 1);
+  // Check number of output points are the same.
+  BOOST_REQUIRE_EQUAL(CLI::GetParam<arma::mat>("output").n_cols, 30);
+}
+
+/**
  * Ensure that we can't specify an invalid max number of iterations.
  */
 BOOST_AUTO_TEST_CASE(MeanShiftInvalidMaxNumberOfIterations)
 {
   // Input random data points.
   SetInputParam("input", meanShiftData);
-  SetInputParam("max_iterations", -1);
+  SetInputParam("max_iterations", (int) -1);
 
   Log::Fatal.ignoreInput = true;
   BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);


### PR DESCRIPTION
Part of #1152.
Added mean_shift.cpp with binding tests for mean shift. Let me know if there are other tests that I should include in here.

Also, while testing `mlpack_mean_shift`, there seems to be a bug where if `max_iterations` is too low w.r.t the number of reference points, the program crashes with an `std::invalid_argument`. This is because we may not have found any centroids and run the `KNN.search` with an empty matrix. 
Should I fix this by ensuring we find at least 1 centroid despite the `max_iterations` before breaking from the loop?