### PR TITLE
Add Loss Functions Folder, KL Divergence Loss

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
+++ b/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
@@ -1,24 +1,14 @@
 # Define the files we need to compile
 # Anything not in this list will not be compiled into mlpack.
 set(SOURCES
-  ffn.hpp
-  ffn_impl.hpp
-  rnn.hpp
-  rnn_impl.hpp
+  KLDivergence.hpp
+  KLDivergence_impl.hpp
 )
-
-add_subdirectory(visitor)
-add_subdirectory(activation_functions)
-add_subdirectory(init_rules)
-add_subdirectory(layer)
-add_subdirectory(loss_functions)
-add_subdirectory(convolution_rules)
-add_subdirectory(augmented)
 
 # Add directory name to sources.
 set(DIR_SRCS)
 foreach(file ${SOURCES})
-  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+    set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
 endforeach()
 # Append sources (with directory name) to list of all mlpack sources (used at
 # the parent scope).

--- a/src/mlpack/methods/ann/loss_functions/KLDivergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/KLDivergence.hpp
@@ -101,12 +101,12 @@ class KLDivergence
 
   //! Boolean variable for taking mean or not.
   bool takeMean;
-};// class KLDivergence
+}; // class KLDivergence
 
 } // namespace ann
 } // namespace mlpack
 
-//include implementation
+// include implementation
 #include "KLDivergence_impl.hpp"
 
 #endif

--- a/src/mlpack/methods/ann/loss_functions/KLDivergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/KLDivergence.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file KLDivergence.hpp
+ * @author Dakshit Agrawal
+ *
+ * Definition of the KL Divergence error function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_KLDIVERGENCE_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_KLDIVERGENCE_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * The KL divergence error function measures the network's
+ * performance according to the KL Divergence between input and
+ * target distributions.
+ *
+ * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template <
+        typename InputDataType = arma::mat,
+        typename OutputDataType = arma::mat
+>
+class KLDivergence
+{
+ public:
+  /**
+   * Create the KLDivergence object with the specified parameters.
+   *
+   * @param takeMean Boolean variable to specify whether to take mean or not.
+   */
+  KLDivergence(const bool takeMean = false);
+
+  /**
+   * Computes the KL divergence error function.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param target Target data to compare with.
+   */
+  template<typename InputType, typename TargetType>
+  double Forward(const InputType&& input, const TargetType&& target);
+
+  /**
+   * Ordinary feed backward pass of a neural network.
+   *
+   * @param input The propagated input activation.
+   * @param target The target vector.
+   * @param output The calculated error.
+   */
+  template<typename InputType, typename TargetType, typename OutputType>
+  void Backward(const InputType&& input,
+                const TargetType&& target,
+                OutputType&& output);
+
+  //! Get the input parameter.
+  InputDataType& InputParameter() const { return inputParameter; }
+  //! Modify the input parameter.
+  InputDataType& InputParameter() { return inputParameter; }
+
+  //! Get the output parameter.
+  OutputDataType& OutputParameter() const { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  //! Get the delta.
+  OutputDataType& Delta() const { return delta; }
+  //! Modify the delta.
+  OutputDataType& Delta() { return delta; }
+
+  //! Get the value of takeMean.
+  bool TakeMean() const { return takeMean; }
+  //! Modify the value of takeMean.
+  bool& TakeMean() { return takeMean; }
+
+  /**
+   * Serialize the loss function
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */);
+
+ private:
+  //! Locally-stored delta object.
+  OutputDataType delta;
+
+  //! Locally-stored input parameter object.
+  InputDataType inputParameter;
+
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
+
+  //! Boolean variable for taking mean or not.
+  bool takeMean;
+};// class KLDivergence
+
+} // namespace ann
+} // namespace mlpack
+
+//include implementation
+#include "KLDivergence_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/KLDivergence_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/KLDivergence_impl.hpp
@@ -1,0 +1,73 @@
+/**
+ * @file KLDivergence_impl.hpp
+ * @author Dakshit Agrawal
+ *
+ * Implementation of the KL Divergence error function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_KLDIVERGENCE_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_KLDIVERGENCE_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "KLDivergence.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+KLDivergence<InputDataType, OutputDataType>::KLDivergence(const bool takeMean) :
+    takeMean(takeMean)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename TargetType>
+double KLDivergence<InputDataType, OutputDataType>::Forward(
+    const InputType&& input, const TargetType&& target)
+{
+  // Input and Target should be of same size.
+  double loss;
+
+  if (takeMean) {
+    loss = arma::as_scalar(arma::mean(
+            arma::mean(input % (arma::log(input) - arma::log(target)))));
+  } else {
+    loss = arma::accu(input % (arma::log(input) - arma::log(target)));
+  }
+
+  return loss;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename TargetType, typename OutputType>
+void KLDivergence<InputDataType, OutputDataType>::Backward(
+    const InputType&& input,
+    const TargetType&& target,
+    OutputType&& output)
+{
+  if (takeMean) {
+    output = arma::mean(arma::mean(arma::log(input) - arma::log(target) + 1));
+  } else {
+    output = arma::accu(arma::log(input) - arma::log(target) + 1);
+  }
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void KLDivergence<InputDataType, OutputDataType>::serialize(
+    Archive& /* ar */,
+    const unsigned int /* version */)
+{
+  // Nothing to do here.
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(mlpack_test
   local_coordinate_coding_test.cpp
   log_test.cpp
   logistic_regression_test.cpp
+  loss_functions_test.cpp
   lrsdp_test.cpp
   lsh_test.cpp
   math_test.cpp

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file loss_functions_test.cpp
+ * @author Dakshit Agrawal
+ *
+ * Tests for loss functions in mlpack::methods::ann:loss_functions.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#include <mlpack/methods/ann/loss_functions/KLDivergence.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace mlpack;
+using namespace mlpack::ann;
+
+BOOST_AUTO_TEST_SUITE(LossFunctionsTest);
+
+/**
+ * Simple KL Divergence test.  The loss should be zero if input = target.
+ */
+BOOST_AUTO_TEST_CASE(SimpleKLDivergenceTest)
+{
+  arma::mat input, target, output;
+  double loss;
+  KLDivergence<> module(true);
+
+  // Test the Forward function.  Loss should be 0 if input = target.
+  input = arma::ones(10, 1);
+  target = arma::ones(10, 1);
+  loss = module.Forward(std::move(input), std::move(target));
+  BOOST_REQUIRE_SMALL(loss, 0.00001);
+}
+
+/**
+ * Test to check KL Divergence loss function when we take mean.
+ */
+
+BOOST_AUTO_TEST_CASE(KLDivergenceMeanTest)
+{
+  arma::mat input, target, output;
+  double loss;
+  KLDivergence<> module(true);
+
+  // Test the Forward function.
+  input = arma::mat("1 1 1 1 1 1 1 1 1 1");
+  target = arma::exp(arma::mat("2 1 1 1 1 1 1 1 1 1"));
+
+  loss = module.Forward(std::move(input), std::move(target));
+  BOOST_REQUIRE_CLOSE_FRACTION(loss, -1.1 , 0.00001);
+
+  // Test the Backward function.
+  module.Backward(std::move(input), std::move(target), std::move(output));
+  BOOST_REQUIRE_CLOSE_FRACTION(arma::as_scalar(output), -0.1, 0.00001);
+}
+
+/**
+ * Test to check KL Divergence loss function when we do not take mean.
+ */
+
+BOOST_AUTO_TEST_CASE(KLDivergenceNoMeanTest)
+{
+  arma::mat input, target, output;
+  double loss;
+  KLDivergence<> module(false);
+
+  // Test the Forward function.
+  input = arma::mat("1 1 1 1 1 1 1 1 1 1");
+  target = arma::exp(arma::mat("2 1 1 1 1 1 1 1 1 1"));
+
+  loss = module.Forward(std::move(input), std::move(target));
+  BOOST_REQUIRE_CLOSE_FRACTION(loss, -11, 0.00001);
+
+  // Test the Backward function.
+  module.Backward(std::move(input), std::move(target), std::move(output));
+  BOOST_REQUIRE_CLOSE_FRACTION(arma::as_scalar(output), -1, 0.00001);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This PR adds a `loss_functions` folder inside the `ann` folder.  The KL Divergence loss has been implemented and put into this folder.

Tests for KL Divergence loss function have been added as well.