### PR TITLE
Regularisation for Decision Tree.

### DIFF
--- a/src/mlpack/methods/decision_tree/all_categorical_split.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split.hpp
@@ -61,9 +61,9 @@ class AllCategoricalSplit
       const size_t numClasses,
       const WeightVecType& weights,
       const size_t minimumLeafSize,
+      const double minimumGainSplit,
       arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux,
-      const double minimumGainSplit);
+      AuxiliarySplitInfo<typename VecType::elem_type>& aux,);
 
   /**
    * Return the number of children in the split.

--- a/src/mlpack/methods/decision_tree/all_categorical_split.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split.hpp
@@ -62,7 +62,8 @@ class AllCategoricalSplit
       const WeightVecType& weights,
       const size_t minimumLeafSize,
       arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux);
+      AuxiliarySplitInfo<typename VecType::elem_type>& aux,
+      const double minimumGainSplit);
 
   /**
    * Return the number of children in the split.

--- a/src/mlpack/methods/decision_tree/all_categorical_split.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split.hpp
@@ -63,7 +63,7 @@ class AllCategoricalSplit
       const size_t minimumLeafSize,
       const double minimumGainSplit,
       arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux,);
+      AuxiliarySplitInfo<typename VecType::elem_type>& aux);
 
   /**
    * Return the number of children in the split.

--- a/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
@@ -25,9 +25,9 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
     const size_t numClasses,
     const WeightVecType& weights,
     const size_t minimumLeafSize,
+    const double minimumGainSplit,
     arma::Col<typename VecType::elem_type>& classProbabilities,
-    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */,
-    const double minimumGainSplit)
+    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */)
 {
   // Count the number of elements in each potential child.
   const double epsilon = 1e-7; // Tolerance for floating-point errors.

--- a/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
@@ -26,7 +26,8 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
     const WeightVecType& weights,
     const size_t minimumLeafSize,
     arma::Col<typename VecType::elem_type>& classProbabilities,
-    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */)
+    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */,
+    const double minimumGainSplit)
 {
   // Count the number of elements in each potential child.
   const double epsilon = 1e-7; // Tolerance for floating-point errors.
@@ -96,7 +97,7 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
     overallGain += childPct * childGain;
   }
 
-  if (overallGain > bestGain + epsilon)
+  if (overallGain > bestGain + minimumGainSplit + epsilon)
   {
     // This is better, so set up the class probabilities vector and return.
     classProbabilities.set_size(1);

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split.hpp
@@ -59,7 +59,8 @@ class BestBinaryNumericSplit
       const WeightVecType& weights,
       const size_t minimumLeafSize,
       arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux);
+      AuxiliarySplitInfo<typename VecType::elem_type>& aux,
+      const double minimumGainSplit);
 
   /**
    * Returns 2, since the binary split always has two children.

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split.hpp
@@ -58,9 +58,9 @@ class BestBinaryNumericSplit
       const size_t numClasses,
       const WeightVecType& weights,
       const size_t minimumLeafSize,
+      const double minimumGainSplit,
       arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux,
-      const double minimumGainSplit);
+      AuxiliarySplitInfo<typename VecType::elem_type>& aux);
 
   /**
    * Returns 2, since the binary split always has two children.

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -25,7 +25,8 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     const WeightVecType& weights,
     const size_t minimumLeafSize,
     arma::Col<typename VecType::elem_type>& classProbabilities,
-    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */)
+    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */,
+    const double minimumGainSplit)
 {
   // First sanity check: if we don't have enough points, we can't split.
   if (data.n_elem < (minimumLeafSize * 2))
@@ -104,7 +105,7 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
           data[sortedIndices[index]]) / 2.0;
       return gain;
     }
-    else if (gain > bestFoundGain)
+    else if (gain > bestFoundGain + minimumGainSplit)
     {
       // We still have a better split.
       bestFoundGain = gain;

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -24,9 +24,9 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     const size_t numClasses,
     const WeightVecType& weights,
     const size_t minimumLeafSize,
+    const double minimumGainSplit,
     arma::Col<typename VecType::elem_type>& classProbabilities,
-    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */,
-    const double minimumGainSplit)
+    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */)
 {
   // First sanity check: if we don't have enough points, we can't split.
   if (data.n_elem < (minimumLeafSize * 2))

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -61,13 +61,15 @@ class DecisionTree :
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   DecisionTree(MatType&& data,
                const data::DatasetInfo& datasetInfo,
                LabelsType&& labels,
                const size_t numClasses,
-               const size_t minimumLeafSize = 10);
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7);
 
   /**
    * Construct the decision tree on the given data and labels, assuming that the
@@ -79,12 +81,14 @@ class DecisionTree :
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   DecisionTree(MatType&& data,
                LabelsType&& labels,
                const size_t numClasses,
-               const size_t minimumLeafSize = 10);
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7);
 
   /**
    * Construct the decision tree on the given data and labels with weights,
@@ -98,6 +102,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights The weight list of given label.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   DecisionTree(MatType&& data,
@@ -106,6 +111,7 @@ class DecisionTree :
                const size_t numClasses,
                WeightsType&& weights,
                const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7,
                const std::enable_if_t<arma::is_arma_type<
                    typename std::remove_reference<WeightsType>::type>::value>*
                     = 0);
@@ -121,6 +127,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights The Weight list of given labels.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   DecisionTree(MatType&& data,
@@ -128,6 +135,7 @@ class DecisionTree :
                const size_t numClasses,
                WeightsType&& weights,
                const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7,
                const std::enable_if_t<arma::is_arma_type<
                    typename std::remove_reference<WeightsType>::type>::value>*
                     = 0);
@@ -188,13 +196,15 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   void Train(MatType&& data,
              const data::DatasetInfo& datasetInfo,
              LabelsType&& labels,
              const size_t numClasses,
-             const size_t minimumLeafSize = 10);
+             const size_t minimumLeafSize = 10,
+             const double minimumGainSplit = 1e-7);
 
   /**
    * Train the decision tree on the given data, assuming that all dimensions are
@@ -207,12 +217,14 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   void Train(MatType&& data,
              LabelsType&& labels,
              const size_t numClasses,
-             const size_t minimumLeafSize = 10);
+             const size_t minimumLeafSize = 10,
+             const double minimumGainSplit = 1e-7);
 
   /**
    * Train the decision tree on the given weighted data.  This will overwrite
@@ -227,6 +239,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   void Train(MatType&& data,
@@ -235,6 +248,7 @@ class DecisionTree :
              const size_t numClasses,
              WeightsType&& weights,
              const size_t minimumLeafSize = 10,
+             const double minimumGainSplit = 1e-7,
              const std::enable_if_t<arma::is_arma_type<typename
                  std::remove_reference<WeightsType>::type>::value>* = 0);
 
@@ -249,6 +263,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   void Train(MatType&& data,
@@ -256,6 +271,7 @@ class DecisionTree :
              const size_t numClasses,
              WeightsType&& weights,
              const size_t minimumLeafSize = 10,
+             const double minimumGainSplit = 1e-7,
              const std::enable_if_t<arma::is_arma_type<typename
                  std::remove_reference<WeightsType>::type>::value>* = 0);
 
@@ -383,6 +399,7 @@ class DecisionTree :
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<bool UseWeights, typename MatType>
   void Train(MatType& data,
@@ -392,7 +409,8 @@ class DecisionTree :
              arma::Row<size_t>& labels,
              const size_t numClasses,
              arma::rowvec& weights,
-             const size_t minimumLeafSize = 10);
+             const size_t minimumLeafSize = 10,
+             const double minimumGainSplit = 1e-7);
 
   /**
    * Corresponding to the public Train() method, this method is designed for
@@ -406,6 +424,7 @@ class DecisionTree :
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum Gain for the node to split.
    */
   template<bool UseWeights, typename MatType>
   void Train(MatType& data,
@@ -414,7 +433,8 @@ class DecisionTree :
              arma::Row<size_t>& labels,
              const size_t numClasses,
              arma::rowvec& weights,
-             const size_t minimumLeafSize = 10);
+             const size_t minimumLeafSize = 10,
+             const double minimumGainSplit = 1e-7);
 };
 
 /**

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -52,16 +52,16 @@ class DecisionTree :
 
   /**
    * Construct the decision tree on the given data and labels, where the data
-   * can be both numeric and categorical.  Setting minimumLeafSize too small may
-   * cause the tree to overfit, but setting it too large may cause it to
-   * underfit.
+   * can be both numeric and categorical. Setting minimumLeafSize and
+   * minimumGainSplit too small may cause the tree to overfit, but setting them
+   * too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension of the dataset.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   DecisionTree(MatType&& data,
@@ -73,15 +73,15 @@ class DecisionTree :
 
   /**
    * Construct the decision tree on the given data and labels, assuming that the
-   * data is all of the numeric type.  Setting minimumLeafSize too small may
-   * cause the tree to overfit, but setting it too large may cause it to
-   * underfit.
+   * data is all of the numeric type.  Setting minimumLeafSize and
+   * minimumGainSplit too small may cause the tree to overfit, but setting them
+   * too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   DecisionTree(MatType&& data,
@@ -92,9 +92,9 @@ class DecisionTree :
 
   /**
    * Construct the decision tree on the given data and labels with weights,
-   * where the data can be both numeric and categorical.  Setting
-   * minimumLeafSize too small may cause the tree to overfit, but setting it too
-   * large may cause it to underfit.
+   * where the data can be both numeric and categorical. Setting minimumLeafSize
+   * and minimumGainSplit too small may cause the tree to overfit, but setting
+   * them too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension of the dataset.
@@ -102,7 +102,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights The weight list of given label.
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   DecisionTree(MatType&& data,
@@ -118,16 +118,16 @@ class DecisionTree :
 
   /**
    * Construct the decision tree on the given data and labels with weights,
-   * assuming that the data is all of the numeric type.  Setting minimumLeafSize
-   * too small may cause the tree to overfit, but setting it too large may cause
-   * it to underfit.
+   * assuming that the data is all of the numeric type. Setting minimumLeafSize
+   * and minimumGainSplit too small may cause the tree to overfit, but setting
+   * them too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param weights The Weight list of given labels.
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   DecisionTree(MatType&& data,
@@ -187,8 +187,9 @@ class DecisionTree :
   /**
    * Train the decision tree on the given data.  This will overwrite the
    * existing model.  The data may have numeric and categorical types, specified
-   * by the datasetInfo parameter.  Setting minimumLeafSize too small may cause
-   * the tree to overfit, but setting it too large may cause it to underfit.
+   * by the datasetInfo parameter.  Setting minimumLeafSize and
+   * minimumGainSplit too small may cause the tree to overfit, but setting them
+   * too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension.
@@ -196,7 +197,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   void Train(MatType&& data,
@@ -208,16 +209,16 @@ class DecisionTree :
 
   /**
    * Train the decision tree on the given data, assuming that all dimensions are
-   * numeric.  This will overwrite the given model.  Setting minimumLeafSize too
-   * small may cause the tree to overfit, but setting it too large may cause it
-   * to underfit.
+   * numeric.  This will overwrite the given model. Setting minimumLeafSize and
+   * minimumGainSplit too small may cause the tree to overfit, but setting them
+   * too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
   void Train(MatType&& data,
@@ -229,9 +230,9 @@ class DecisionTree :
   /**
    * Train the decision tree on the given weighted data.  This will overwrite
    * the existing model.  The data may have numeric and categorical types,
-   * specified by the datasetInfo parameter.  Setting minimumLeafSize too small
-   * may cause the tree to overfit, but setting it too large may cause it to
-   * underfit.
+   * specified by the datasetInfo parameter.  Setting minimumLeafSize and
+   * minimumGainSplit too small may cause the tree to overfit, but setting them
+   * too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension.
@@ -239,7 +240,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   void Train(MatType&& data,
@@ -254,16 +255,16 @@ class DecisionTree :
 
   /**
    * Train the decision tree on the given weighted data, assuming that all
-   * dimensions are numeric.  This will overwrite the given model.  Setting
-   * minimumLeafSize too small may cause the tree to overfit, but setting it too
-   * large may cause it to underfit.
+   * dimensions are numeric.  This will overwrite the given model. Setting
+   * minimumLeafSize and minimumGainSplit too small may cause the tree to
+   * overfit, but setting them too large may cause it to underfit.
    *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   void Train(MatType&& data,
@@ -399,7 +400,7 @@ class DecisionTree :
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<bool UseWeights, typename MatType>
   void Train(MatType& data,
@@ -424,7 +425,7 @@ class DecisionTree :
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
-   * @param minimumGainSplit Minimum Gain for the node to split.
+   * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<bool UseWeights, typename MatType>
   void Train(MatType& data,

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -33,7 +33,7 @@ DecisionTree<FitnessFunction,
                                         LabelsType&& labels,
                                         const size_t numClasses,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+                                        const double minimumGainSplit = 1e-7)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -65,7 +65,7 @@ DecisionTree<FitnessFunction,
                                         LabelsType&& labels,
                                         const size_t numClasses,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+                                        const double minimumGainSplit = 1e-7)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -99,7 +99,7 @@ DecisionTree<FitnessFunction,
                                         const size_t numClasses,
                                         WeightsType&& weights,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit,
+                                        const double minimumGainSplit = 1e-7,
                                         const std::enable_if_t<
                                             arma::is_arma_type<
                                             typename std::remove_reference<
@@ -137,7 +137,7 @@ DecisionTree<FitnessFunction,
                                         const size_t numClasses,
                                         WeightsType&& weights,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit,
+                                        const double minimumGainSplit = 1e-7,
                                         const std::enable_if_t<
                                             arma::is_arma_type<
                                             typename std::remove_reference<
@@ -350,7 +350,7 @@ void DecisionTree<FitnessFunction,
                                       LabelsType&& labels,
                                       const size_t numClasses,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                                      const double minimumGainSplit = 1e-7)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -392,7 +392,7 @@ void DecisionTree<FitnessFunction,
                                       LabelsType&& labels,
                                       const size_t numClasses,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                                      const double minimumGainSplit = 1e-7)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -436,7 +436,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       WeightsType&& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit,
+                                      const double minimumGainSplit = 1e-7,
                                       const std::enable_if_t<arma::is_arma_type<
                                           typename std::remove_reference<
                                           WeightsType>::type>::value>*)
@@ -483,7 +483,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       WeightsType&& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit,
+                                      const double minimumGainSplit = 1e-7,
                                       const std::enable_if_t<arma::is_arma_type<
                                           typename std::remove_reference<
                                           WeightsType>::type>::value>*)
@@ -533,7 +533,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       arma::rowvec& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                                      const double minimumGainSplit = 1e-7)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -697,7 +697,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       arma::rowvec& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                                      const double minimumGainSplit = 1e-7)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -33,7 +33,7 @@ DecisionTree<FitnessFunction,
                                         LabelsType&& labels,
                                         const size_t numClasses,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit = 1e-7)
+                                        const double minimumGainSplit)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -65,7 +65,7 @@ DecisionTree<FitnessFunction,
                                         LabelsType&& labels,
                                         const size_t numClasses,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit = 1e-7)
+                                        const double minimumGainSplit)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -99,7 +99,7 @@ DecisionTree<FitnessFunction,
                                         const size_t numClasses,
                                         WeightsType&& weights,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit = 1e-7,
+                                        const double minimumGainSplit,
                                         const std::enable_if_t<
                                             arma::is_arma_type<
                                             typename std::remove_reference<
@@ -137,7 +137,7 @@ DecisionTree<FitnessFunction,
                                         const size_t numClasses,
                                         WeightsType&& weights,
                                         const size_t minimumLeafSize,
-                                        const double minimumGainSplit = 1e-7,
+                                        const double minimumGainSplit,
                                         const std::enable_if_t<
                                             arma::is_arma_type<
                                             typename std::remove_reference<
@@ -350,7 +350,7 @@ void DecisionTree<FitnessFunction,
                                       LabelsType&& labels,
                                       const size_t numClasses,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit = 1e-7)
+                                      const double minimumGainSplit)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -392,7 +392,7 @@ void DecisionTree<FitnessFunction,
                                       LabelsType&& labels,
                                       const size_t numClasses,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit = 1e-7)
+                                      const double minimumGainSplit)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -436,7 +436,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       WeightsType&& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit = 1e-7,
+                                      const double minimumGainSplit,
                                       const std::enable_if_t<arma::is_arma_type<
                                           typename std::remove_reference<
                                           WeightsType>::type>::value>*)
@@ -483,7 +483,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       WeightsType&& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit = 1e-7,
+                                      const double minimumGainSplit,
                                       const std::enable_if_t<arma::is_arma_type<
                                           typename std::remove_reference<
                                           WeightsType>::type>::value>*)
@@ -533,7 +533,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       arma::rowvec& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit = 1e-7)
+                                      const double minimumGainSplit)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -564,9 +564,9 @@ void DecisionTree<FitnessFunction,
           numClasses,
           UseWeights ? weights.subvec(begin, begin + count - 1) : weights,
           minimumLeafSize,
+          minimumGainSplit,
           classProbabilities,
-          *this,
-          minimumGainSplit);
+          *this);
     }
     else if (datasetInfo.Type(i) == data::Datatype::numeric)
     {
@@ -576,9 +576,9 @@ void DecisionTree<FitnessFunction,
           numClasses,
           UseWeights ? weights.subvec(begin, begin + count - 1) : weights,
           minimumLeafSize,
+          minimumGainSplit,
           classProbabilities,
-          *this,
-          minimumGainSplit);
+          *this);
     }
 
     // Was there an improvement?  If so mark that it's the new best dimension.
@@ -697,7 +697,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       arma::rowvec& weights,
                                       const size_t minimumLeafSize,
-                                      const double minimumGainSplit = 1e-7)
+                                      const double minimumGainSplit)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -728,9 +728,9 @@ void DecisionTree<FitnessFunction,
                                       weights.cols(begin, begin + count - 1) :
                                       weights,
                                   minimumLeafSize,
+                                  minimumGainSplit,
                                   classProbabilities,
-                                  *this,
-                                  minimumGainSplit);
+                                  *this);
 
     if (dimGain > bestGain)
     {

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -32,7 +32,8 @@ DecisionTree<FitnessFunction,
                                         const data::DatasetInfo& datasetInfo,
                                         LabelsType&& labels,
                                         const size_t numClasses,
-                                        const size_t minimumLeafSize)
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -44,7 +45,7 @@ DecisionTree<FitnessFunction,
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   Train<false>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
-      weights, minimumLeafSize);
+      weights, minimumLeafSize, minimumGainSplit);
 }
 
 //! Construct and train.
@@ -63,7 +64,8 @@ DecisionTree<FitnessFunction,
              NoRecursion>::DecisionTree(MatType&& data,
                                         LabelsType&& labels,
                                         const size_t numClasses,
-                                        const size_t minimumLeafSize)
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -75,7 +77,7 @@ DecisionTree<FitnessFunction,
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   Train<false>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, weights,
-      minimumLeafSize);
+      minimumLeafSize, minimumGainSplit);
 }
 
 //! Construct and train with weights.
@@ -97,6 +99,7 @@ DecisionTree<FitnessFunction,
                                         const size_t numClasses,
                                         WeightsType&& weights,
                                         const size_t minimumLeafSize,
+                                        const double minimumGainSplit,
                                         const std::enable_if_t<
                                             arma::is_arma_type<
                                             typename std::remove_reference<
@@ -113,7 +116,7 @@ DecisionTree<FitnessFunction,
 
   // Pass off work to the weighted Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
-      tmpWeights, minimumLeafSize);
+      tmpWeights, minimumLeafSize, minimumGainSplit);
 }
 
 //! Construct and train with weights.
@@ -134,6 +137,7 @@ DecisionTree<FitnessFunction,
                                         const size_t numClasses,
                                         WeightsType&& weights,
                                         const size_t minimumLeafSize,
+                                        const double minimumGainSplit,
                                         const std::enable_if_t<
                                             arma::is_arma_type<
                                             typename std::remove_reference<
@@ -150,7 +154,7 @@ DecisionTree<FitnessFunction,
 
   // Pass off work to the weighted Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, tmpWeights,
-      minimumLeafSize);
+      minimumLeafSize, minimumGainSplit);
 }
 
 //! Construct, don't train.
@@ -345,7 +349,8 @@ void DecisionTree<FitnessFunction,
                                       const data::DatasetInfo& datasetInfo,
                                       LabelsType&& labels,
                                       const size_t numClasses,
-                                      const size_t minimumLeafSize)
+                                      const size_t minimumLeafSize,
+                                      const double minimumGainSplit)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -367,7 +372,7 @@ void DecisionTree<FitnessFunction,
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   Train<false>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
-      weights, minimumLeafSize);
+      weights, minimumLeafSize, minimumGainSplit);
 }
 
 //! Train on the given data, assuming all dimensions are numeric.
@@ -386,7 +391,8 @@ void DecisionTree<FitnessFunction,
                   NoRecursion>::Train(MatType&& data,
                                       LabelsType&& labels,
                                       const size_t numClasses,
-                                      const size_t minimumLeafSize)
+                                      const size_t minimumLeafSize,
+                                      const double minimumGainSplit)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -430,6 +436,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       WeightsType&& weights,
                                       const size_t minimumLeafSize,
+                                      const double minimumGainSplit,
                                       const std::enable_if_t<arma::is_arma_type<
                                           typename std::remove_reference<
                                           WeightsType>::type>::value>*)
@@ -455,7 +462,7 @@ void DecisionTree<FitnessFunction,
 
   // Pass off work to the Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
-      tmpWeights, minimumLeafSize);
+      tmpWeights, minimumLeafSize, minimumGainSplit);
 }
 
 //! Train on the given weighted data.
@@ -476,6 +483,7 @@ void DecisionTree<FitnessFunction,
                                       const size_t numClasses,
                                       WeightsType&& weights,
                                       const size_t minimumLeafSize,
+                                      const double minimumGainSplit,
                                       const std::enable_if_t<arma::is_arma_type<
                                           typename std::remove_reference<
                                           WeightsType>::type>::value>*)
@@ -501,7 +509,7 @@ void DecisionTree<FitnessFunction,
 
   // Pass off work to the Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, tmpWeights,
-      minimumLeafSize);
+      minimumLeafSize, minimumGainSplit);
 }
 
 //! Train on the given data.
@@ -524,7 +532,8 @@ void DecisionTree<FitnessFunction,
                                       arma::Row<size_t>& labels,
                                       const size_t numClasses,
                                       arma::rowvec& weights,
-                                      const size_t minimumLeafSize)
+                                      const size_t minimumLeafSize,
+                                      const double minimumGainSplit)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -533,7 +542,7 @@ void DecisionTree<FitnessFunction,
 
   // Look through the list of dimensions and obtain the gain of the best split.
   // We'll cache the best numeric and categorical split auxiliary information in
-  // numericAux and categoricalAux (and clear them later if we make not split),
+  // numericAux and categoricalAux (and clear them later if we make no split),
   // and use classProbabilities as auxiliary information.  Later we'll overwrite
   // classProbabilities to the empirical class probabilities if we do not split.
   double bestGain = FitnessFunction::template Evaluate<UseWeights>(
@@ -556,7 +565,8 @@ void DecisionTree<FitnessFunction,
           UseWeights ? weights.subvec(begin, begin + count - 1) : weights,
           minimumLeafSize,
           classProbabilities,
-          *this);
+          *this,
+          minimumGainSplit);
     }
     else if (datasetInfo.Type(i) == data::Datatype::numeric)
     {
@@ -567,7 +577,8 @@ void DecisionTree<FitnessFunction,
           UseWeights ? weights.subvec(begin, begin + count - 1) : weights,
           minimumLeafSize,
           classProbabilities,
-          *this);
+          *this,
+          minimumGainSplit);
     }
 
     // Was there an improvement?  If so mark that it's the new best dimension.
@@ -641,13 +652,13 @@ void DecisionTree<FitnessFunction,
       {
         child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, datasetInfo, labels, numClasses,
-            weights, currentCol - currentChildBegin);
+            weights, currentCol - currentChildBegin, minimumGainSplit);
       }
       else
       {
         child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, datasetInfo, labels, numClasses,
-            weights, minimumLeafSize);
+            weights, minimumLeafSize, minimumGainSplit);
       }
       children.push_back(child);
     }
@@ -685,7 +696,8 @@ void DecisionTree<FitnessFunction,
                                       arma::Row<size_t>& labels,
                                       const size_t numClasses,
                                       arma::rowvec& weights,
-                                      const size_t minimumLeafSize)
+                                      const size_t minimumLeafSize,
+                                      const double minimumGainSplit)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -717,7 +729,8 @@ void DecisionTree<FitnessFunction,
                                       weights,
                                   minimumLeafSize,
                                   classProbabilities,
-                                  *this);
+                                  *this,
+                                  minimumGainSplit);
 
     if (dimGain > bestGain)
     {
@@ -776,13 +789,13 @@ void DecisionTree<FitnessFunction,
       {
         child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, labels, numClasses, weights,
-            currentCol - currentChildBegin);
+            currentCol - currentChildBegin, minimumGainSplit);
       }
       else
       {
         child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, labels, numClasses, weights,
-            minimumLeafSize);
+            minimumLeafSize, minimumGainSplit);
       }
       children.push_back(child);
     }

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -84,7 +84,7 @@ PARAM_UMATRIX_IN("test_labels", "Test point labels, if accuracy calculation "
 // Training parameters.
 PARAM_INT_IN("minimum_leaf_size", "Minimum number of points in a leaf.", "n",
     20);
-PARAM_INT_IN("minimum_gain_split", "Minimum gain for node splitting.", "g",
+PARAM_DOUBLE_IN("minimum_gain_split", "Minimum gain for node splitting.", "g",
     1e-7);
 PARAM_FLAG("print_training_error", "Print the training error.", "e");
 
@@ -140,8 +140,8 @@ static void mlpackMain()
   RequireParamValue<int>("minimum_leaf_size", [](int x) { return x > 0; }, true,
       "leaf size must be positive");
 
-  RequireParamValue<int>("minimum_gain_split", [](double x)
-                         { return x > 0.0 && x < 1.0; }, true,
+  RequireParamValue<double>("minimum_gain_split", [](double x)
+                         { return (x > 0.0 && x < 1.0); }, true,
                          "gain split must be a fraction in range [0,1]");
 
   // Load the model or build the tree.
@@ -172,8 +172,8 @@ static void mlpackMain()
 
     // Now build the tree.
     const size_t minLeafSize = (size_t) CLI::GetParam<int>("minimum_leaf_size");
-    const size_t minimumGainSplit =
-                              (size_t) CLI::GetParam<int>("minimum_gain_split");
+    const double minimumGainSplit =
+                           (double) CLI::GetParam<double>("minimum_gain_split");
 
     // Create decision tree with weighted labels.
     if (CLI::HasParam("weights"))

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -39,7 +39,8 @@ PROGRAM_INFO("Decision tree",
     "may not be specified when the " + PRINT_PARAM_STRING("training") + " "
     "parameter is specified.  The " + PRINT_PARAM_STRING("minimum_leaf_size") +
     " parameter specifies the minimum number of training points that must fall"
-    " into each leaf for it to be split.  If " +
+    " into each leaf for it to be split.  The " + PRINT_PARAM_STRING("minimum_gain_split") +
+    " parameter specifies the minimum gain that is needed for the node to split. If " +
     PRINT_PARAM_STRING("print_training_error") + " is specified, the training "
     "error will be printed."
     "\n\n"
@@ -58,7 +59,7 @@ PROGRAM_INFO("Decision tree",
     "call"
     "\n\n" +
     PRINT_CALL("decision_tree", "training", "data", "labels", "labels",
-        "output_model", "tree", "minimum_leaf_size", 20,
+        "output_model", "tree", "minimum_leaf_size", 20, "minimum_gain_split", 1e-3,
         "print_training_error", true) +
     "\n\n"
     "Then, to use that model to classify points in " +
@@ -82,6 +83,8 @@ PARAM_UMATRIX_IN("test_labels", "Test point labels, if accuracy calculation "
 // Training parameters.
 PARAM_INT_IN("minimum_leaf_size", "Minimum number of points in a leaf.", "n",
     20);
+PARAM_INT_IN("minimum_gain_split", "Minimum gain for node splitting.", "n",
+    1e-3);
 PARAM_FLAG("print_training_error", "Print the training error.", "e");
 
 // Output parameters.
@@ -164,6 +167,7 @@ static void mlpackMain()
 
     // Now build the tree.
     const size_t minLeafSize = (size_t) CLI::GetParam<int>("minimum_leaf_size");
+    const size_t minimumGainSplit = (size_t) CLI::GetParam<int>("minimum_gain_split");
 
     // Create decision tree with weighted labels.
     if (CLI::HasParam("weights"))
@@ -171,12 +175,12 @@ static void mlpackMain()
       arma::Row<double> weights =
           std::move(CLI::GetParam<arma::Mat<double>>("weights"));
       model->tree = DecisionTree<>(trainingSet, model->info, labels,
-          numClasses, weights, minLeafSize);
+          numClasses, weights, minLeafSize, minimumGainSplit);
     }
     else
     {
       model->tree = DecisionTree<>(trainingSet, model->info, labels,
-          numClasses, minLeafSize);
+          numClasses, minLeafSize, minimumGainSplit);
     }
 
     // Do we need to print training error?

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -139,6 +139,9 @@ static void mlpackMain()
   RequireParamValue<int>("minimum_leaf_size", [](int x) { return x > 0; }, true,
       "leaf size must be positive");
 
+  RequireParamValue<int>("minimum_gain_split", [](int x) { return x > 0 && x < 1; }, true,
+                         "leaf size must be a fraction in range [0,1]");
+
   // Load the model or build the tree.
   DecisionTreeModel* model;
   arma::mat trainingSet;

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -39,8 +39,9 @@ PROGRAM_INFO("Decision tree",
     "may not be specified when the " + PRINT_PARAM_STRING("training") + " "
     "parameter is specified.  The " + PRINT_PARAM_STRING("minimum_leaf_size") +
     " parameter specifies the minimum number of training points that must fall"
-    " into each leaf for it to be split.  The " + PRINT_PARAM_STRING("minimum_gain_split") +
-    " parameter specifies the minimum gain that is needed for the node to split. If " +
+    " into each leaf for it to be split.  The " +
+    PRINT_PARAM_STRING("minimum_gain_split") + " parameter specifies "
+    "the minimum gain that is needed for the node to split. If " +
     PRINT_PARAM_STRING("print_training_error") + " is specified, the training "
     "error will be printed."
     "\n\n"
@@ -59,8 +60,8 @@ PROGRAM_INFO("Decision tree",
     "call"
     "\n\n" +
     PRINT_CALL("decision_tree", "training", "data", "labels", "labels",
-        "output_model", "tree", "minimum_leaf_size", 20, "minimum_gain_split", 1e-3,
-        "print_training_error", true) +
+        "output_model", "tree", "minimum_leaf_size", 20, "minimum_gain_split",
+        1e-3, "print_training_error", true) +
     "\n\n"
     "Then, to use that model to classify points in " +
     PRINT_DATASET("test_set") + " and print the test error given the "
@@ -139,8 +140,9 @@ static void mlpackMain()
   RequireParamValue<int>("minimum_leaf_size", [](int x) { return x > 0; }, true,
       "leaf size must be positive");
 
-  RequireParamValue<int>("minimum_gain_split", [](int x) { return x > 0 && x < 1; }, true,
-                         "leaf size must be a fraction in range [0,1]");
+  RequireParamValue<int>("minimum_gain_split", [](double x)
+                         { return x > 0.0 && x < 1.0; }, true,
+                         "gain split must be a fraction in range [0,1]");
 
   // Load the model or build the tree.
   DecisionTreeModel* model;
@@ -170,7 +172,8 @@ static void mlpackMain()
 
     // Now build the tree.
     const size_t minLeafSize = (size_t) CLI::GetParam<int>("minimum_leaf_size");
-    const size_t minimumGainSplit = (size_t) CLI::GetParam<int>("minimum_gain_split");
+    const size_t minimumGainSplit =
+                              (size_t) CLI::GetParam<int>("minimum_gain_split");
 
     // Create decision tree with weighted labels.
     if (CLI::HasParam("weights"))

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -83,8 +83,8 @@ PARAM_UMATRIX_IN("test_labels", "Test point labels, if accuracy calculation "
 // Training parameters.
 PARAM_INT_IN("minimum_leaf_size", "Minimum number of points in a leaf.", "n",
     20);
-PARAM_INT_IN("minimum_gain_split", "Minimum gain for node splitting.", "n",
-    1e-3);
+PARAM_INT_IN("minimum_gain_split", "Minimum gain for node splitting.", "g",
+    1e-7);
 PARAM_FLAG("print_training_error", "Print the training error.", "e");
 
 // Output parameters.

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -384,7 +384,8 @@ BOOST_AUTO_TEST_CASE(AllCategoricalSplitSimpleSplitTest)
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 3, weights);
   const double gain = AllCategoricalSplit<GiniGain>::SplitIfBetter<false>(
-      bestGain, values, 4, labels, 3, weights, 3, 1e-7, classProbabilities, aux);
+      bestGain, values, 4, labels, 3, weights, 3, 1e-7, classProbabilities,
+      aux);
   const double weightedGain =
       AllCategoricalSplit<GiniGain>::SplitIfBetter<true>(bestGain, values, 4,
       labels, 3, weights, 3, 1e-7, classProbabilities, aux);
@@ -419,7 +420,8 @@ BOOST_AUTO_TEST_CASE(AllCategoricalSplitMinSamplesTest)
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 3, weights);
   const double gain = AllCategoricalSplit<GiniGain>::SplitIfBetter<false>(
-      bestGain, values, 4, labels, 3, weights, 4, 1e-7, classProbabilities, aux);
+      bestGain, values, 4, labels, 3, weights, 4, 1e-7, classProbabilities,
+      aux);
 
   // Make sure it's not split.
   BOOST_REQUIRE_EQUAL(gain, bestGain);
@@ -451,7 +453,8 @@ BOOST_AUTO_TEST_CASE(AllCategoricalSplitNoGainTest)
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 3, weights);
   const double gain = AllCategoricalSplit<GiniGain>::SplitIfBetter<false>(
-      bestGain, values, 10, labels, 3, weights, 10, 1e-7, classProbabilities, aux);
+      bestGain, values, 10, labels, 3, weights, 10, 1e-7, classProbabilities,
+      aux);
   const double weightedGain =
       AllCategoricalSplit<GiniGain>::SplitIfBetter<true>(bestGain, values, 10,
       labels, 3, weights, 10, 1e-7, classProbabilities, aux);
@@ -1113,7 +1116,7 @@ BOOST_AUTO_TEST_CASE(RegularisedDecisionTree)
     dRegularised.Classify(dataset.col(i), predictionsregularised,
                           probabilitiesRegularised);
 
-    if(prediction != predictionsregularised)
+    if (prediction != predictionsregularised)
       count++;
 
     BOOST_REQUIRE_EQUAL(probabilities.n_elem, 3);

--- a/src/mlpack/tests/main_tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/main_tests/decision_tree_test.cpp
@@ -168,6 +168,35 @@ BOOST_AUTO_TEST_CASE(DecisionTreeMinimumLeafSizeTest)
 }
 
 /**
+ * Make sure minimum gain split is always a fraction in range [0,1].
+ */
+BOOST_AUTO_TEST_CASE(DecisionMinimumGainSplitTest)
+{
+  arma::mat inputData;
+  DatasetInfo info;
+  if (!data::Load("braziltourism.arff", inputData, info))
+    BOOST_FAIL("Cannot load train dataset braziltourism.arff!");
+
+  arma::Row<size_t> labels;
+  if (!data::Load("braziltourism_labels.txt", labels))
+    BOOST_FAIL("Cannot load labels for braziltourism_labels.txt");
+
+  // Initialize an all-ones weight matrix.
+  arma::mat weights(1, labels.n_cols, arma::fill::ones);
+
+  // Input training data.
+  SetInputParam("training", std::move(std::make_tuple(info, inputData)));
+  SetInputParam("labels", std::move(labels));
+  SetInputParam("weights", std::move(weights));
+
+  SetInputParam("minimum_gain_split", 1.5); // Invalid.
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+/**
  * Ensure that saved model can be used again.
  */
 BOOST_AUTO_TEST_CASE(DecisionModelReuseTest)

--- a/src/mlpack/tests/main_tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/main_tests/decision_tree_test.cpp
@@ -201,36 +201,40 @@ BOOST_AUTO_TEST_CASE(DecisionMinimumGainSplitTest)
  */
 BOOST_AUTO_TEST_CASE(DecisionRegularisationTest)
 {
-  // Completely random dataset with no structure.
-  arma::mat dataset(10, 1000, arma::fill::randu);
-  arma::Row<size_t> labels(1000);
-  for (size_t i = 0; i < 1000; ++i)
-    labels[i] = i % 3; // 3 classes.
-  arma::rowvec weights(labels.n_elem);
-  weights.ones();
+  arma::mat inputData;
+  DatasetInfo info;
+  if (!data::Load("braziltourism.arff", inputData, info))
+    BOOST_FAIL("Cannot load train dataset braziltourism.arff!");
+
+  arma::Row<size_t> labels;
+  if (!data::Load("braziltourism_labels.txt", labels))
+    BOOST_FAIL("Cannot load labels for braziltourism_labels.txt");
+
+  // Initialize an all-ones weight matrix.
+  arma::mat weights(1, labels.n_cols, arma::fill::ones);
 
   // Input training data.
-  SetInputParam("training", dataset);
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", labels);
   SetInputParam("weights", weights);
 
   SetInputParam("minimum_gain_split", 1e-7);
 
   // Input test data.
-  SetInputParam("test", dataset);
+  SetInputParam("test", std::make_tuple(info, inputData));
   arma::Row<size_t> pred;
   mlpackMain();
   pred = std::move(CLI::GetParam<arma::Row<size_t>>("predictions"));
 
   // Input training data.
-  SetInputParam("training", dataset);
+  SetInputParam("training", std::make_tuple(info, inputData));
   SetInputParam("labels", std::move(labels));
   SetInputParam("weights", std::move(weights));
 
   SetInputParam("minimum_gain_split", 0.01);
 
   // Input test data.
-  SetInputParam("test", std::move(dataset));
+  SetInputParam("test", std::move(std::make_tuple(info, inputData)));
   arma::Row<size_t> predRegularised;
   mlpackMain();
   predRegularised = std::move(CLI::GetParam<arma::Row<size_t>>("predictions"));

--- a/src/mlpack/tests/main_tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/main_tests/decision_tree_test.cpp
@@ -220,9 +220,7 @@ BOOST_AUTO_TEST_CASE(DecisionRegularisationTest)
   // Input test data.
   SetInputParam("test", dataset);
 
-  Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
-  Log::Fatal.ignoreInput = false;
+  mlpackMain();
   pred = std::move(CLI::GetParam<arma::Row<size_t>>("predictions"));
 
   // Input training data.
@@ -235,9 +233,7 @@ BOOST_AUTO_TEST_CASE(DecisionRegularisationTest)
   // Input test data.
   SetInputParam("test", std::move(dataset));
 
-  Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
-  Log::Fatal.ignoreInput = false;
+  mlpackMain();
   predRegularised = std::move(CLI::GetParam<arma::Row<size_t>>("predictions"));
 
   size_t count = 0;

--- a/src/mlpack/tests/main_tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/main_tests/decision_tree_test.cpp
@@ -203,7 +203,6 @@ BOOST_AUTO_TEST_CASE(DecisionRegularisationTest)
 {
   // Completely random dataset with no structure.
   arma::mat dataset(10, 1000, arma::fill::randu);
-  arma::mat pred, predRegularised;
   arma::Row<size_t> labels(1000);
   for (size_t i = 0; i < 1000; ++i)
     labels[i] = i % 3; // 3 classes.
@@ -219,7 +218,7 @@ BOOST_AUTO_TEST_CASE(DecisionRegularisationTest)
 
   // Input test data.
   SetInputParam("test", dataset);
-
+  arma::Row<size_t> pred;
   mlpackMain();
   pred = std::move(CLI::GetParam<arma::Row<size_t>>("predictions"));
 
@@ -232,7 +231,7 @@ BOOST_AUTO_TEST_CASE(DecisionRegularisationTest)
 
   // Input test data.
   SetInputParam("test", std::move(dataset));
-
+  arma::Row<size_t> predRegularised;
   mlpackMain();
   predRegularised = std::move(CLI::GetParam<arma::Row<size_t>>("predictions"));
 


### PR DESCRIPTION
Early stopping is a regularisation method for decision trees i.e. it reduces overfitting. In this method, the splitting of the node is prevented if the information gain is less than the given threshold. 

This PR introduces the paramter `minimumGainSplit` to the Decision Tree API for the users to stop the growth of the tree if the gain is less than the threshold.

Tests for early stopping and implemetnation of post-pruning (another regularisation technique for decision tree) will be added in the following commits.