### PR TITLE
Disallow compilation on clang 3.4 and older.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.10)
 project(mlpack C CXX)
 
 include(CMake/cotire.cmake)
@@ -62,6 +62,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 # Only GCC-like compilers support -Wextra, and other compilers give tons of
 # output for -Wall, so only -Wall and -Wextra on GCC.
 if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # Ensure that we can't compile with clang 3.4, since this causes strange
+  # issues.
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
+    message(FATAL_ERROR "mlpack does not build correctly with clang < 3.5.  "
+        "Please upgrade your compiler and reconfigure mlpack.")
+  endif ()
+
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -ftemplate-depth=1000")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 endif()


### PR DESCRIPTION
mlpack actually compiles fine in those cases but when you try to run the tests there is a segfault that I believe to be a compiler error in initialization.

I spent a while debugging it and wasn't able to really find any reason for the failure, but I think that clang 3.4.2 is so old that we don't need to worry about it.  So I think it is reasonable to issue an error during configuration if clang is too old.

Example failure: http://masterblaster.mlpack.org/view/docker/job/docker%20mlpack%20nightly%20build/240/armadillo_version=armadillo-6.500.5,boost_version=boost_1_49_0,buildmode=debug,compiler_version=llvm-3.4.2,label=linux-amd64/