### PR TITLE
Fix LogisticRegressionMainTest

### DIFF
--- a/src/mlpack/tests/main_tests/logistic_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/logistic_regression_test.cpp
@@ -616,14 +616,7 @@ BOOST_AUTO_TEST_CASE(LRDecisionBoundaryTest)
   mlpackMain();
 
   // Get the output after first training.
-  const arma::Row<size_t> &output1 = CLI::GetParam<arma::Row<size_t>>("output");
-
-  // Check that the parameters (parameters1 and parameters2) are not equal which
-  // ensures that decision boundary has some effect on the output.
-  // arma::all function checks that each element of the vector is equal to zero.
-  BOOST_REQUIRE_MESSAGE(arma::all(output1 == 0),
-                        "Parameter(Decision Boudary) has"
-                        "no effect on the output");
+  const arma::Row<size_t> output1 = CLI::GetParam<arma::Row<size_t>>("output");
 
   // Reset the settings.
   bindings::tests::CleanMemory();
@@ -641,12 +634,8 @@ BOOST_AUTO_TEST_CASE(LRDecisionBoundaryTest)
   // Get the output after second training.
   const arma::Row<size_t> &output2 = CLI::GetParam<arma::Row<size_t>>("output");
 
-  // Check that the parameters (parameters1 and parameters2) are not equal which
-  // ensures that decision boundary has som effect on the output.
-  // arma::all function checks that each element of the vector is equal to one.
-  BOOST_REQUIRE_MESSAGE(arma::all(output2 == 1),
-                        "Parameter(Decision Boudary) has"
-                        "no effect on the output");
+  // Check that the output changed when the decision boundary moved.
+  BOOST_REQUIRE_GT(arma::accu(output1 != output2), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
I guess I have filed a bunch of PRs today but they are all simple...

The `LogisticRegressionMainTest/LRDecisionBoundaryTest` test can sometimes fail:

http://masterblaster.mlpack.org/job/docker%20mlpack%20nightly%20build/241/armadillo_version=armadillo-7.100.3,boost_version=boost_1_49_0,buildmode=release,compiler_version=llvm-3.5.2-patch,label=linux-amd64/

In order to handle this I have just changed the testing strategy.  Previously the test checked if every assignment was 0 when the decision boundary was 1, and it then checked that every assignment was 1 when the decision boundary was 0.  But this can fail when the point lies directly on the decision boundary.

Thus all I've done here is changed the test so that it ensures that the results are different for at least one point when we change the decision boundary.

@KARTHEEKCIC: this was originally your test, so if you don't mind taking a quick look and making sure I haven't broken anything I would appreciate it.