### PR TITLE
Allow setting a fixed random seed in binding tests

### DIFF
--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -54,7 +54,7 @@ inline void RandomSeed(const size_t seed)
 #if (BINDING_TYPE == BINDING_TYPE_TEST)
 inline void SetFixedRandomSeed()
 {
-  const size_t seed = 54321;
+  const static size_t seed = rand();
   randGen.seed((uint32_t) seed);
   srand((unsigned int) seed);
   arma::arma_rng::set_seed(seed);

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -49,7 +49,7 @@ inline void RandomSeed(const size_t seed)
 }
 
 /**
- * Set the random seed to a predefined seed.
+ * Set the random seed to a fixed number.
  */
 #if (BINDING_TYPE == BINDING_TYPE_TEST)
 inline void SetFixedRandomSeed()

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -50,9 +50,13 @@ inline void RandomSeed(const size_t seed)
 
 /**
  * Set the random seed to a fixed number.
+ * This function is used in binding tests to set a fixed random seed before
+ * calling mlpack(). In this way we can test whether a certain parameter makes
+ * a difference to execution of CLI binding.
+ * Refer to pull request #1306 for discussion on this function.
  */
 #if (BINDING_TYPE == BINDING_TYPE_TEST)
-inline void SetFixedRandomSeed()
+inline void FixedRandomSeed()
 {
   const static size_t seed = rand();
   randGen.seed((uint32_t) seed);

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -49,6 +49,19 @@ inline void RandomSeed(const size_t seed)
 }
 
 /**
+ * Set the random seed to a predefined seed.
+ */
+#if (BINDING_TYPE == BINDING_TYPE_TEST)
+inline void SetFixedRandomSeed()
+{
+  const size_t seed = 54321;
+  randGen.seed((uint32_t) seed);
+  srand((unsigned int) seed);
+  arma::arma_rng::set_seed(seed);
+}
+#endif
+
+/**
  * Generates a uniform random number between 0 and 1.
  */
 inline double Random()


### PR DESCRIPTION
This PR adds a `SetFixedRandomSeed()`function to allow tests to set a predefined random seed.

I am writing binding test for CF and found that it's hard to test whether a certain parameter is used when I cannot set a fixed random seed (setting random seed was disabled in #1264). What I was trying to do was to run `mlpack()` multiple times with different values set to the tested parameter each time, to see if the results are different. This is impossible or hard to be done in CF when random seed cannot be set, and it is probably the same in other binding tests in #1152 (like nmf).  So I added this function to allow tests programs to set a **predefined** random seed. In this way every run of `mlpack_test` in a single build still gives the same testing results.

So in a binding test case, the code may look like:
```
BOOST_AUTO_TEST_CASE(...)
{
  ...
  mlpack::math::SetFixedRandomSeed();
  mlpack();
  double result1 = ...
  ResetSettings();
  ...
  mlpack::math::SetFixedRandomSeed();
  mlpack();
  double result2 = ...
  BOOST_REQUIRE_LT(std::abs(result2 - result1), 1e-5);
}
```