### PR TITLE
Fix bug in mean shift when max_iterations is too low w.r.t size of data

### DIFF
--- a/src/mlpack/methods/mean_shift/mean_shift.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift.hpp
@@ -84,6 +84,7 @@ class MeanShift
   void Cluster(const MatType& data,
                arma::Row<size_t>& assignments,
                arma::mat& centroids,
+               bool forceConvergence = true,
                bool useSeeds = true);
 
   //! Get the maximum number of iterations.

--- a/src/mlpack/methods/mean_shift/mean_shift.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift.hpp
@@ -33,8 +33,8 @@ namespace meanshift /** Mean shift clustering. */ {
  * extern arma::mat data; // Dataset we want to run mean shift on.
  * arma::Row<size_t> assignments; // Cluster assignments.
  * arma::mat centroids; // Cluster centroids.
- * bool forceConvergence; // Flag whether to force each centroid seed to
- * converge regardless of maxIterations.
+ * bool forceConvergence = true; // Flag whether to force each centroid seed
+ * to converge regardless of maxIterations.
  *
  * MeanShift<> meanShift();
  * meanShift.Cluster(dataset, assignments, centroids, forceConvergence);

--- a/src/mlpack/methods/mean_shift/mean_shift.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift.hpp
@@ -33,9 +33,11 @@ namespace meanshift /** Mean shift clustering. */ {
  * extern arma::mat data; // Dataset we want to run mean shift on.
  * arma::Row<size_t> assignments; // Cluster assignments.
  * arma::mat centroids; // Cluster centroids.
+ * bool forceConvergence; // Flag whether to force each centroid seed to
+ * converge regardless of maxIterations.
  *
  * MeanShift<> meanShift();
- * meanShift.Cluster(dataset, assignments, centroids);
+ * meanShift.Cluster(dataset, assignments, centroids, forceConvergence);
  * @endcode
  *
  * @tparam UseKernel Use kernel or mean to calculate new centroid.
@@ -80,6 +82,8 @@ class MeanShift
    * @param data Dataset to cluster.
    * @param assignments Vector to store cluster assignments in.
    * @param centroids Matrix in which centroids are stored.
+   * @param forceConvergence Flag whether to force each centroid seed to
+   * converge regardless of maxIterations.
    */
   void Cluster(const MatType& data,
                arma::Row<size_t>& assignments,

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -278,6 +278,10 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
     }
     assignments.zeros();
   }
+  else if (centroids.n_cols == 1)
+  {
+    assignments.zeros();
+  }
   else
   {
     // Assign centroids to each point.

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -263,7 +263,7 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
 
   // If no centroid has converged due to too little iterations and without
   // forcing convergence, take 1 random centroid calculated.
-  if (centroids.empty()) 
+  if (centroids.empty())
   {
     Log::Warn << "No clusters converge, setting 1 random centroid calculated."
     << std::endl << "Try a larger max_iterations or pass force_convergence flag."
@@ -272,17 +272,23 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
     if (maxIterations == 0)
     {
       centroids.insert_cols(centroids.n_cols, data.col(0));
-    } else {
+    }
+    else 
+    {
       centroids.insert_cols(centroids.n_cols, allCentroids.col(0));
     }
-  }
+    assignments.zeros();
 
-  // Assign centroids to each point.
-  neighbor::KNN neighborSearcher(centroids);
-  arma::mat neighborDistances;
-  arma::Mat<size_t> resultingNeighbors;
-  neighborSearcher.Search(data, 1, resultingNeighbors, neighborDistances);
-  assignments = resultingNeighbors;
+  } 
+  else 
+  {
+    // Assign centroids to each point.
+    neighbor::KNN neighborSearcher(centroids);
+    arma::mat neighborDistances;
+    arma::Mat<size_t> resultingNeighbors;
+    neighborSearcher.Search(data, 1, resultingNeighbors, neighborDistances);
+    assignments = resultingNeighbors;
+  }
 }
 
 } // namespace meanshift

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -265,6 +265,10 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
   // forcing convergence, take 1 random centroid calculated.
   if (centroids.empty()) 
   {
+    Log::Warn << "No clusters converge, setting 1 random centroid calculated."
+    << std::endl << "Try a larger max_iterations or pass force_convergence flag."
+    << std::endl;
+
     if (maxIterations == 0)
     {
       centroids.insert_cols(centroids.n_cols, data.col(0));

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -260,6 +260,18 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
     }
   }
 
+  // If no centroid has converged due to too little iterations, take 1 random
+  // centroid calculated.
+  if (centroids.empty()) 
+  {
+    if (maxIterations == 0)
+    {
+      centroids.insert_cols(centroids.n_cols, data.col(0));
+    } else {
+      centroids.insert_cols(centroids.n_cols, allCentroids.col(0));
+    }
+  }
+
   // Assign centroids to each point.
   neighbor::KNN neighborSearcher(centroids);
   arma::mat neighborDistances;

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -217,8 +217,8 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
   {
     // Initial centroid is the seed itself.
     allCentroids.col(i) = pSeeds->unsafe_col(i);
-    for (size_t completedIterations = 0; completedIterations < maxIterations;
-         completedIterations++)
+    for (size_t completedIterations = 0; completedIterations < maxIterations
+      || forceConvergence; completedIterations++)
     {
       // Store new centroid in this.
       arma::colvec newCentroid = arma::zeros<arma::colvec>(pSeeds->n_rows);
@@ -261,8 +261,8 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
     }
   }
 
-  // If no centroid has converged due to too little iterations, take 1 random
-  // centroid calculated.
+  // If no centroid has converged due to too little iterations and without
+  // forcing convergence, take 1 random centroid calculated.
   if (centroids.empty()) 
   {
     if (maxIterations == 0)

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -185,6 +185,7 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
     const MatType& data,
     arma::Row<size_t>& assignments,
     arma::mat& centroids,
+    bool forceConvergence,
     bool useSeeds)
 {
   if (radius <= 0)

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -265,22 +265,20 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
   // forcing convergence, take 1 random centroid calculated.
   if (centroids.empty())
   {
-    Log::Warn << "No clusters converge, setting 1 random centroid calculated."
-    << std::endl << "Try a larger max_iterations or pass force_convergence flag."
-    << std::endl;
+    Log::Warn << "No clusters converge, setting 1 random centroid calculated. "
+    "Try a larger max_iterations or pass force_convergence flag." << std::endl;
 
     if (maxIterations == 0)
     {
       centroids.insert_cols(centroids.n_cols, data.col(0));
     }
-    else 
+    else
     {
       centroids.insert_cols(centroids.n_cols, allCentroids.col(0));
     }
     assignments.zeros();
-
-  } 
-  else 
+  }
+  else
   {
     // Assign centroids to each point.
     neighbor::KNN neighborSearcher(centroids);

--- a/src/mlpack/methods/mean_shift/mean_shift_main.cpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_main.cpp
@@ -53,6 +53,9 @@ PARAM_FLAG("in_place", "If specified, a column containing the learned cluster "
     "--output_file is overridden.  (Do not use with Python.)", "P");
 PARAM_FLAG("labels_only", "If specified, only the output labels will be "
     "written to the file specified by --output_file.", "l");
+PARAM_FLAG("force_convergence", "If specified, the mean shift algorithm will "
+  "continue running regardless of max_iterations until the clusters converge."
+  ,"f");
 PARAM_MATRIX_OUT("output", "Matrix to write output labels or labeled data to.",
     "o");
 PARAM_MATRIX_OUT("centroid", "If specified, the centroids of each cluster will "

--- a/src/mlpack/methods/mean_shift/mean_shift_main.cpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_main.cpp
@@ -92,7 +92,7 @@ static void mlpackMain()
 
   Timer::Start("clustering");
   Log::Info << "Performing mean shift clustering..." << endl;
-  meanShift.Cluster(dataset, assignments, centroids);
+  meanShift.Cluster(dataset, assignments, centroids, CLI::HasParam("force_convergence"));
   Timer::Stop("clustering");
 
   Log::Info << "Found " << centroids.n_cols << " centroids." << endl;

--- a/src/mlpack/methods/mean_shift/mean_shift_main.cpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_main.cpp
@@ -93,7 +93,7 @@ static void mlpackMain()
   Timer::Start("clustering");
   Log::Info << "Performing mean shift clustering..." << endl;
   meanShift.Cluster(dataset, assignments, centroids,
-   CLI::HasParam("force_convergence"));
+    CLI::HasParam("force_convergence"));
   Timer::Stop("clustering");
 
   Log::Info << "Found " << centroids.n_cols << " centroids." << endl;

--- a/src/mlpack/methods/mean_shift/mean_shift_main.cpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_main.cpp
@@ -55,7 +55,7 @@ PARAM_FLAG("labels_only", "If specified, only the output labels will be "
     "written to the file specified by --output_file.", "l");
 PARAM_FLAG("force_convergence", "If specified, the mean shift algorithm will "
   "continue running regardless of max_iterations until the clusters converge."
-  ,"f");
+  , "f");
 PARAM_MATRIX_OUT("output", "Matrix to write output labels or labeled data to.",
     "o");
 PARAM_MATRIX_OUT("centroid", "If specified, the centroids of each cluster will "
@@ -92,7 +92,8 @@ static void mlpackMain()
 
   Timer::Start("clustering");
   Log::Info << "Performing mean shift clustering..." << endl;
-  meanShift.Cluster(dataset, assignments, centroids, CLI::HasParam("force_convergence"));
+  meanShift.Cluster(dataset, assignments, centroids,
+   CLI::HasParam("force_convergence"));
   Timer::Stop("clustering");
 
   Log::Info << "Found " << centroids.n_cols << " centroids." << endl;

--- a/src/mlpack/tests/main_tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/main_tests/mean_shift_test.cpp
@@ -119,6 +119,41 @@ BOOST_AUTO_TEST_CASE(MeanShiftInPlaceTest)
 }
 
 /**
+ * Ensure that force_convergence is used by testing that the
+ * force_convergence flag makes a difference in the program.
+ */
+BOOST_AUTO_TEST_CASE(MeanShiftForceConvergenceTest)
+{
+  arma::mat x;
+  if (!data::Load("iris_test.csv", x))
+    BOOST_FAIL("Cannot load test dataset iris_test.csv!");
+
+  // Input random data points.
+  SetInputParam("input", x);
+  // Set a very small max_iterations.
+  SetInputParam("max_iterations", (int) 1);
+
+  mlpackMain();
+
+  const int numCentroids1 = CLI::GetParam<arma::mat>("centroid").n_cols;
+
+  ResetSettings();
+
+  // Input same random data points.
+  SetInputParam("input", std::move(x));
+  // Set the same small max_iterations.
+  SetInputParam("max_iterations", (int) 1);
+  // Set the force_convergence flag on.
+  SetInputParam("force_convergence", true);
+
+  mlpackMain();
+
+  const int numCentroids2 = CLI::GetParam<arma::mat>("centroid").n_cols;
+  // Resulting number of centroids should be different.
+  BOOST_REQUIRE_NE(numCentroids1, numCentroids2);
+}
+
+/**
  * Ensure that radius is used by testing that the radius
  * makes a difference in the program.
  */


### PR DESCRIPTION
In mean shift, when max_iterations specified is too low w.r.t size of data (e.g. 2 max iterations with `iris_test.csv` and 9 max iterations with `test_data_3_1000.csv`), the program terminates after throwing an instance of `std::invalid_argument`.
>what(): Requested value of k (1) is greater than the number of points in reference set (0).
Aborted (core dumped)

This is because we may not have any centroids converged after max iterations of the mean shift algorithm and then run the `neighbor::KNN.search` with an empty matrix.

This PR fixes this by adding 1 centroid previously calculated if the `centroids` matrix is empty.