### PR TITLE
RangeSearch: update methods and constructors to pass-by-value

### DIFF
--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -143,19 +143,11 @@ class RangeSearch
    * the mlpack abstractions, even though calling this "training" is maybe a bit
    * of a stretch.
    *
-   * @param referenceSet New set of reference data.
-   */
-  void Train(const MatType& referenceSet);
-
-  /**
-   * Set the reference set to a new reference set, taking ownership of the set.
-   * A tree is built if necessary.  This method is called 'Train()' in order to
-   * match the rest of the mlpack abstractions, even though calling this
-   * "training" is maybe a bit of a stretch.
+   * Use std::move to pass in the reference set if an additional copy is not needed.
    *
    * @param referenceSet New set of reference data.
    */
-  void Train(MatType&& referenceSet);
+  void Train(MatType referenceSet);
 
   /**
    * Set the reference tree to a new reference tree.

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -51,9 +51,9 @@ class RangeSearch
    * naive mode or single-tree mode. Additionally, an instantiated metric can be
    * given, for cases where the distance metric holds data.
    *
-   * This method will copy the matrices to internal copies, which are rearranged
-   * during tree-building.  You can avoid this extra copy by pre-constructing
-   * the trees and passing them using a different constructor.
+   * This method will move the matrices to internal copies, which are rearranged
+   * during tree-building.  You can avoid creating an extra copy by
+   * pre-constructing the trees and passing them in using std::move.
    *
    * @param referenceSet Reference dataset.
    * @param naive Whether the computation should be done in O(n^2) naive mode.
@@ -61,31 +61,7 @@ class RangeSearch
    *      opposed to dual-tree computation).
    * @param metric Instantiated distance metric.
    */
-  RangeSearch(const MatType& referenceSet,
-              const bool naive = false,
-              const bool singleMode = false,
-              const MetricType metric = MetricType());
-
-  /**
-   * Initialize the RangeSearch object with the given reference dataset (this is
-   * the dataset which is searched), taking ownership of the matrix.
-   * Optionally, perform the computation in naive mode or single-tree mode.
-   * Additionally, an instantiated metric can be given, for cases where the
-   * distance metric holds data.
-   *
-   * This method will not copy the data matrix, but will take ownership of it,
-   * and depending on the type of tree used, may rearrange the points.  If you
-   * would rather a copy be made, consider using the constructor that takes a
-   * const reference to the data instead.
-   *
-   * @param referenceSet Set of reference points.
-   * @param naive If true, brute force naive search will be used (as opposed to
-   *      dual-tree search).  This overrides singleMode (if it is set to true).
-   * @param singleMode If true, single-tree search will be used (as opposed to
-   *      dual-tree search).
-   * @param metric An optional instance of the MetricType class.
-   */
-  RangeSearch(MatType&& referenceSet,
+  RangeSearch(MatType referenceSet,
               const bool naive = false,
               const bool singleMode = false,
               const MetricType metric = MetricType());

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -125,17 +125,11 @@ class RangeSearch
 
   /**
    * Copy the given RangeSearch model.
+   * Use std::move to pass in the model if an additional copy is not needed.
    *
    * @param other RangeSearch model to copy.
    */
-  RangeSearch& operator=(const RangeSearch& other);
-
-  /**
-   * Take ownership of the given RangeSearch model.
-   *
-   * @param other RangeSearch model to take ownership of.
-   */
-  RangeSearch& operator=(RangeSearch&& other);
+  RangeSearch& operator=(RangeSearch other);
 
   /**
    * Destroy the RangeSearch object.  If trees were created, they will be

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -51,8 +51,8 @@ class RangeSearch
    * naive mode or single-tree mode. Additionally, an instantiated metric can be
    * given, for cases where the distance metric holds data.
    *
-   * This method will move the matrices to internal copies, which are rearranged
-   * during tree-building.  You can avoid creating an extra copy by
+   * This method will move the matrices to internal copies, which are
+   * rearranged during tree-building.  You can avoid creating an extra copy by
    * pre-constructing the trees and passing them in using std::move.
    *
    * @param referenceSet Reference dataset.
@@ -140,10 +140,10 @@ class RangeSearch
   /**
    * Set the reference set to a new reference set, and build a tree if
    * necessary.  This method is called 'Train()' in order to match the rest of
-   * the mlpack abstractions, even though calling this "training" is maybe a bit
-   * of a stretch.
+   * the mlpack abstractions, even though calling this "training" is maybe a
+   * bit of a stretch.
    *
-   * Use std::move to pass in the reference set if an the old copy is no longer
+   * Use std::move to pass in the reference set if the old copy is no longer
    * needed.
    *
    * @param referenceSet New set of reference data.

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -298,8 +298,6 @@ class RangeSearch
 
   //! If true, this object is responsible for deleting the trees.
   bool treeOwner;
-  //! If true, we own the reference set.
-  bool setOwner;
 
   //! If true, O(n^2) naive computation is used.
   bool naive;

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -125,7 +125,7 @@ class RangeSearch
 
   /**
    * Copy the given RangeSearch model.
-   * Use std::move to pass in the model if an additional copy is not needed.
+   * Use std::move to pass in the model if the old copy is no longer needed.
    *
    * @param other RangeSearch model to copy.
    */
@@ -143,7 +143,8 @@ class RangeSearch
    * the mlpack abstractions, even though calling this "training" is maybe a bit
    * of a stretch.
    *
-   * Use std::move to pass in the reference set if an additional copy is not needed.
+   * Use std::move to pass in the reference set if an the old copy is no longer
+   * needed.
    *
    * @param referenceSet New set of reference data.
    */

--- a/src/mlpack/methods/range_search/range_search_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_impl.hpp
@@ -217,42 +217,7 @@ template<typename MetricType,
                   typename TreeStatType,
                   typename TreeMatType> class TreeType>
 void RangeSearch<MetricType, MatType, TreeType>::Train(
-    const MatType& referenceSet)
-{
-  // Clean up the old tree, if we built one.
-  if (treeOwner && referenceTree)
-    delete referenceTree;
-
-  // Rebuild the tree, if necessary.
-  if (!naive)
-  {
-    referenceTree = BuildTree<Tree>(const_cast<MatType&>(referenceSet),
-        oldFromNewReferences);
-    treeOwner = true;
-  }
-  else
-  {
-    treeOwner = false;
-  }
-
-  // Delete the old reference set, if we owned it.
-  if (setOwner && this->referenceSet)
-    delete this->referenceSet;
-
-  if (!naive)
-    this->referenceSet = &referenceTree->Dataset();
-  else
-    this->referenceSet = &referenceSet;
-  setOwner = false;
-}
-
-template<typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType>
-void RangeSearch<MetricType, MatType, TreeType>::Train(
-    MatType&& referenceSet)
+    MatType referenceSet)
 {
   // Clean up the old tree, if we built one.
   if (treeOwner && referenceTree)

--- a/src/mlpack/methods/range_search/range_search_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_impl.hpp
@@ -175,37 +175,7 @@ template<typename MetricType,
                   typename TreeStatType,
                   typename TreeMatType> class TreeType>
 RangeSearch<MetricType, MatType, TreeType>&
-RangeSearch<MetricType, MatType, TreeType>::operator=(const RangeSearch& other)
-{
-  // Clean memory first.
-  if (treeOwner)
-    delete referenceTree;
-  if (setOwner)
-    delete referenceSet;
-
-  // Copy the other model.
-  oldFromNewReferences = other.oldFromNewReferences;
-  referenceTree = other.referenceTree ? new Tree(*other.referenceTree) : NULL;
-  referenceSet = other.referenceTree ? &referenceTree->Dataset() :
-      new MatType(*other.referenceSet);
-  treeOwner = other.referenceTree;
-  setOwner = !other.referenceTree;
-  naive = other.naive;
-  singleMode = other.singleMode;
-  metric = other.metric;
-  baseCases = other.baseCases;
-  scores = other.scores;
-
-  return *this;
-}
-
-template<typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType>
-RangeSearch<MetricType, MatType, TreeType>&
-RangeSearch<MetricType, MatType, TreeType>::operator=(RangeSearch&& other)
+RangeSearch<MetricType, MatType, TreeType>::operator=(RangeSearch other)
 {
   // Clean memory first.
   if (treeOwner)
@@ -224,18 +194,6 @@ RangeSearch<MetricType, MatType, TreeType>::operator=(RangeSearch&& other)
   metric = std::move(other.metric);
   baseCases = other.baseCases;
   scores = other.scores;
-
-  // Clean other model.
-  other.referenceSet = new MatType();
-  other.referenceTree =
-      BuildTree<Tree>(const_cast<MatType&>(*other.referenceSet),
-      other.oldFromNewReferences);
-  other.treeOwner = true;
-  other.setOwner = true;
-  other.naive = false;
-  other.singleMode = false;
-  other.baseCases = 0;
-  other.scores = 0;
 
   return *this;
 }

--- a/src/mlpack/methods/range_search/range_search_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_impl.hpp
@@ -48,32 +48,7 @@ template<typename MetricType,
                   typename TreeStatType,
                   typename TreeMatType> class TreeType>
 RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
-    const MatType& referenceSetIn,
-    const bool naive,
-    const bool singleMode,
-    const MetricType metric) :
-    referenceTree(naive ? NULL : BuildTree<Tree>(referenceSetIn,
-        oldFromNewReferences)),
-    referenceSet(naive ? &referenceSetIn : &referenceTree->Dataset()),
-    treeOwner(!naive), // If in naive mode, we are not building any trees.
-    setOwner(false),
-    naive(naive),
-    singleMode(!naive && singleMode), // Naive overrides single mode.
-    metric(metric),
-    baseCases(0),
-    scores(0)
-{
-  // Nothing to do.
-}
-
-// Move constructor.
-template<typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType>
-RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
-    MatType&& referenceSet,
+    MatType referenceSet,
     const bool naive,
     const bool singleMode,
     const MetricType metric) :

--- a/src/mlpack/methods/range_search/rs_model.hpp
+++ b/src/mlpack/methods/range_search/rs_model.hpp
@@ -287,16 +287,11 @@ class RSModel
   /**
    * Copy the given RSModel.
    *
+   * Use std::move to pass in the model if the old copy is no longer needed.
+   *
    * @param other RSModel to copy.
    */
-  RSModel& operator=(const RSModel& other);
-
-  /**
-   * Take ownership of the given RSModel.
-   *
-   * @param other RSModel to take ownership of.
-   */
-  RSModel& operator=(RSModel&& other);
+  RSModel& operator=(RSModel other);
 
   /**
    * Clean memory, if necessary.

--- a/src/mlpack/methods/range_search/rs_model_impl.hpp
+++ b/src/mlpack/methods/range_search/rs_model_impl.hpp
@@ -33,30 +33,15 @@ inline RSModel::RSModel(TreeTypes treeType, bool randomBasis) :
   // Nothing to do.
 }
 
-// Copy constructor.
-inline RSModel::RSModel(const RSModel& other) :
-    treeType(other.treeType),
-    leafSize(other.leafSize),
-    randomBasis(other.randomBasis),
-    q(other.q),
-    rSearch(other.rSearch)
-{
-  // Nothing to do.
-}
-
 // Move constructor.
-inline RSModel::RSModel(RSModel&& other) :
+inline RSModel::RSModel(RSModel other) :
     treeType(other.treeType),
     leafSize(other.leafSize),
     randomBasis(other.randomBasis),
     q(std::move(other.q)),
     rSearch(std::move(other.rSearch))
 {
-  // Reset other model.
-  other.treeType = TreeTypes::KD_TREE;
-  other.leafSize = 0;
-  other.randomBasis = false;
-  other.rSearch = decltype(other.rSearch)();
+  // Nothing to do.
 }
 
 // Copy operator.

--- a/src/mlpack/methods/range_search/rs_model_impl.hpp
+++ b/src/mlpack/methods/range_search/rs_model_impl.hpp
@@ -33,33 +33,33 @@ inline RSModel::RSModel(TreeTypes treeType, bool randomBasis) :
   // Nothing to do.
 }
 
+// Copy constructor.
+inline RSModel::RSModel(const RSModel& other) :
+    treeType(other.treeType),
+    leafSize(other.leafSize),
+    randomBasis(other.randomBasis),
+    q(other.q),
+    rSearch(other.rSearch)
+{
+  // Nothing to do.
+}
+
 // Move constructor.
-inline RSModel::RSModel(RSModel other) :
+inline RSModel::RSModel(RSModel&& other) :
     treeType(other.treeType),
     leafSize(other.leafSize),
     randomBasis(other.randomBasis),
     q(std::move(other.q)),
     rSearch(std::move(other.rSearch))
 {
-  // Nothing to do.
+  // Reset other model.
+  other.treeType = TreeTypes::KD_TREE;
+  other.leafSize = 0;
+  other.randomBasis = false;
+  other.rSearch = decltype(other.rSearch)();
 }
 
-// Copy operator.
-inline RSModel& RSModel::operator=(const RSModel& other)
-{
-  boost::apply_visitor(DeleteVisitor(), rSearch);
-
-  treeType = other.treeType;
-  leafSize = other.leafSize;
-  randomBasis = other.randomBasis;
-  q = other.q;
-  rSearch = other.rSearch;
-
-  return *this;
-}
-
-// Move operator.
-inline RSModel& RSModel::operator=(RSModel&& other)
+inline RSModel& RSModel::operator=(RSModel other)
 {
   boost::apply_visitor(DeleteVisitor(), rSearch);
 
@@ -68,12 +68,6 @@ inline RSModel& RSModel::operator=(RSModel&& other)
   randomBasis = other.randomBasis;
   q = std::move(other.q);
   rSearch = std::move(other.rSearch);
-
-  // Reset other model.
-  other.treeType = TreeTypes::KD_TREE;
-  other.leafSize = 0;
-  other.randomBasis = false;
-  other.rSearch = decltype(other.rSearch)();
 
   return *this;
 }


### PR DESCRIPTION
Updated the methods and constructors in `range_search` to pass-by-value instead of the 2 overload methods as suggested in #1021.