### PR TITLE
Adjust tolerances to fix failing matrix build tests.

### DIFF
--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -202,10 +202,10 @@ BOOST_AUTO_TEST_CASE(GMMTrainEMMultipleGaussians)
     CheckMatrices(gmm.Component(sortTry[i]).Mean(), means[sortRef[i]], 1e-3);
     // Check the covariance.
     CheckMatrices(gmm.Component(sortTry[i]).Covariance(), covars[sortRef[i]],
-                  0.05);
+                  0.15);
     // Check the weight.
     BOOST_REQUIRE_CLOSE(gmm.Weights()[sortTry[i]], weights[sortRef[i]],
-        0.001);
+        0.005);
   }
 }
 

--- a/src/mlpack/tests/nesterov_momentum_sgd_test.cpp
+++ b/src/mlpack/tests/nesterov_momentum_sgd_test.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(NesterovMomentumSGDSpeedUpTestFunction)
   arma::mat coordinates = f.GetInitialPoint();
   double result = s.Optimize(f, coordinates);
 
-  BOOST_REQUIRE_CLOSE(result, -1.0, 0.15);
+  BOOST_REQUIRE_CLOSE(result, -1.0, 0.20);
   BOOST_REQUIRE_SMALL(coordinates[0], 1e-3);
   BOOST_REQUIRE_SMALL(coordinates[1], 1e-7);
   BOOST_REQUIRE_SMALL(coordinates[2], 1e-7);

--- a/src/mlpack/tests/svd_incremental_test.cpp
+++ b/src/mlpack/tests/svd_incremental_test.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(SVDIncompleteIncrementalRegularizationTest)
   mat m3, m4;
   double regularizedRMSE = amf2.Apply(cleanedData2, 2, m3, m4);
 
-  BOOST_REQUIRE_LT(regularizedRMSE, regularRMSE + 0.075);
+  BOOST_REQUIRE_LT(regularizedRMSE, regularRMSE + 0.085);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
After watching the nightly and weekly docker matrix builds, I adjusted tolerances for three tests:

 * NesterovMomentumSGDSpeedUpTest
 * SVDIncompleteIncrementalRegularizationTest
 * GMMTrainEMMultipleGaussians

Once I merge this I'll start those builds again, as well as the monthly build, and hopefully everything should pass for once. :)