### PR TITLE
mlpack_preprocess_describe CLI binding tests

### DIFF
--- a/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
@@ -246,7 +246,7 @@ static void mlpackMain()
         Skewness(feature, fStd, fMean, population),
         Kurtosis(feature, fStd, fMean, population),
         StandardError(feature.n_elem, fStd)
-    });
+    }).t();
   };
 
   // If the user specified dimension, describe statistics of the given

--- a/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
@@ -172,11 +172,13 @@ static void mlpackMain()
   error << "dimension must be less than the number of dimensions "
       << "of the input data (" << dimensions << ")";
   RequireParamValue<int>("dimension",
-      [dimensions](int x) { return size_t(x) < dimensions; }, true, error.str());
+      [dimensions](int x) { return size_t(x) < dimensions; },
+      true,
+      error.str());
 
   RequireParamValue<int>("precision", [](int x) { return x >= 0; }, true,
       "precision must be nonnegative");
-  
+
   RequireParamValue<int>("width", [](int x) { return x >= 0; }, true,
       "width must be nonnegative");
 

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -143,6 +143,7 @@ add_executable(mlpack_test
   main_tests/pca_test.cpp
   main_tests/perceptron_test.cpp
   main_tests/preprocess_binarize_test.cpp
+  main_tests/preprocess_describe_test.cpp
   main_tests/preprocess_imputer_test.cpp
   main_tests/preprocess_split_test.cpp
   main_tests/random_forest_test.cpp

--- a/src/mlpack/tests/main_tests/preprocess_describe_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_describe_test.cpp
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(PreprocessDescribePopulationSampleTest)
   bool equal = true;
   for (size_t i=0; i < sampleOutput.n_elem; i++)
   {
-    if (sampleOutput[i] != populationOutput(i))
+    if (sampleOutput[i] != populationOutput[i])
     {
       equal = false;
       break;

--- a/src/mlpack/tests/main_tests/preprocess_describe_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_describe_test.cpp
@@ -1,0 +1,147 @@
+/**
+ * @file preprocess_describe_test.cpp
+ * @author Daivik Nema
+ *
+ * Test mlpackMain() of preprocess_describe_main.cpp.
+ */
+
+#define BINDING_TYPE BINDING_TYPE_TEST
+static const std::string testName = "PreprocessDescribe";
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/util/mlpack_main.hpp>
+#include "test_helper.hpp"
+#include <mlpack/methods/preprocess/preprocess_describe_main.cpp>
+
+#include <boost/test/unit_test.hpp>
+#include "../test_tools.hpp"
+
+using namespace mlpack;
+
+struct PreprocessDescribeTestFixture
+{
+ public:
+  PreprocessDescribeTestFixture()
+  {
+    // Cache in the options for this program.
+    CLI::RestoreSettings(testName);
+  }
+
+  ~PreprocessDescribeTestFixture()
+  {
+    // Clear the settings.
+    bindings::tests::CleanMemory();
+    CLI::ClearSettings();
+  }
+};
+
+BOOST_FIXTURE_TEST_SUITE(PreprocessDescribeMainTest,
+                         PreprocessDescribeTestFixture);
+
+BOOST_AUTO_TEST_CASE(PreprocessDescribeDimensionInRangeCheck)
+{
+  // We will use the dataset trainSet.csv - which is already present in the data/
+  // directory. The dataset has 1000 rows and 24 columns. Invalid dimensions are
+  // -1, -2 .. and so on
+  // 1000, 1001 .. and so on
+  int dimension = -1; // Invalid.
+  arma::mat dataset;
+  data::Load("trainSet.csv", dataset);
+
+  SetInputParam("input", std::move(dataset));
+  SetInputParam("dimension", dimension);
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+
+  // Now test with some value of dimension greater than max value.
+  dimension = 1000; // Invalid.
+  SetInputParam("dimension", dimension);
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+BOOST_AUTO_TEST_CASE(PreprocessDescribePrecisionNonNegativeCheck)
+{
+  int precision = -1; // Invalid.
+  arma::mat dataset;
+  data::Load("trainSet.csv", dataset);
+
+  SetInputParam("input", std::move(dataset));
+  SetInputParam("precision", precision);
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+BOOST_AUTO_TEST_CASE(PreprocessDescribeWidthNonNegativeTest)
+{
+  int width = -1; // Invalid.
+  arma::mat dataset;
+  data::Load("trainSet.csv", dataset);
+
+  SetInputParam("input", std::move(dataset));
+  SetInputParam("width", width);
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
+BOOST_AUTO_TEST_CASE(PreprocessDescribePopulationSampleTest)
+{
+  arma::mat dataset;
+  data::Load("trainSet.csv", dataset);
+
+  SetInputParam("input", std::move(dataset));
+  mlpackMain();
+
+  arma::mat sampleOutput = CLI::GetParam<arma::mat>("output");
+
+  SetInputParam("population", true);
+  mlpackMain();
+
+  arma::mat populationOutput = CLI::GetParam<arma::mat>("output");
+
+  BOOST_REQUIRE_EQUAL(sampleOutput.n_rows, populationOutput.n_rows);
+  BOOST_REQUIRE_EQUAL(sampleOutput.n_cols, populationOutput.n_cols);
+  BOOST_REQUIRE_EQUAL(sampleOutput.n_elem, populationOutput.n_elem);
+  bool equal = true;
+  for (size_t i=0; i < sampleOutput.n_elem; i++)
+  {
+    if (sampleOutput[i] != populationOutput(i))
+    {
+      equal = false;
+      break;
+    }
+  }
+  BOOST_REQUIRE_EQUAL(equal, false);
+}
+
+BOOST_AUTO_TEST_CASE(ProprocessDescribeRowMajorTest)
+{
+  arma::mat dataset;
+  data::Load("trainSet.csv", dataset);
+
+  SetInputParam("input", std::move(dataset));
+  mlpackMain();
+
+  arma::mat colMajorOutput = CLI::GetParam<arma::mat>("output");
+
+  SetInputParam("row_major", true);
+  mlpackMain();
+
+  arma::mat rowMajorOutput = CLI::GetParam<arma::mat>("output");
+
+  BOOST_REQUIRE_EQUAL(colMajorOutput.n_rows,
+                      CLI::GetParam<arma::mat>("input").n_rows);
+  BOOST_REQUIRE_EQUAL(rowMajorOutput.n_rows,
+                      CLI::GetParam<arma::mat>("input").n_cols);
+  BOOST_REQUIRE_EQUAL(colMajorOutput.n_cols, rowMajorOutput.n_cols);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/preprocess_describe_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_describe_test.cpp
@@ -40,7 +40,7 @@ BOOST_FIXTURE_TEST_SUITE(PreprocessDescribeMainTest,
 
 BOOST_AUTO_TEST_CASE(PreprocessDescribeDimensionInRangeCheck)
 {
-  // We will use the dataset trainSet.csv - which is already present in the data/
+  // We will use the dataset trainSet.csv - which is already present in the data
   // directory. The dataset has 1000 rows and 24 columns. Invalid dimensions are
   // -1, -2 .. and so on
   // 1000, 1001 .. and so on


### PR DESCRIPTION
Added tests for `mlpack_preprocess_describe` ( #1152 ) 

Currently, the `mlpack_preprocess_describe` utility prints output to console and doesn't give back a "results" matrix - I've added a `PARAM_MATRIX_OUT` in `preprocess_describe_main.cpp` for the same.

Also, checks for the input parameters were missing - those have been added in `preprocess_describe_main.cpp` as well.

Please let me know if I've missed important tests.