### PR TITLE
Implement Flexible ReLU 

### DIFF
--- a/src/mlpack/methods/ann/layer/CMakeLists.txt
+++ b/src/mlpack/methods/ann/layer/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SOURCES
   elu_impl.hpp
   fast_lstm.hpp
   fast_lstm_impl.hpp
+  flexible_relu.hpp
+  flexible_relu_impl.hpp
   glimpse.hpp
   glimpse_impl.hpp
   gru.hpp

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -1,6 +1,7 @@
 /**
  * @file flexible_relu.hpp
  * @author Aarush Gupta
+ * @author Manthan-R-Sheth
  *
  * Definition of FlexibleReLU layer as described by
  * Suo Qiu, Xiangmin Xu and Bolun Cai in
@@ -15,6 +16,7 @@
  *  title   = {FReLU: Flexible Rectified Linear Units for Improving
  *             Convolutional Neural Networks}
  *  journal = {arxiv preprint},
+ *  URL     = {https://arxiv.org/pdf/1706.08098.pdf},
  *  year    = {2018}
  * }
  * @endcode

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -1,0 +1,194 @@
+/**
+ * @file flexible_relu.hpp
+ * @author Aarush Gupta
+ *
+ * Definition of FlexibleReLU layer as described by
+ * Suo Qiu, Xiangmin Xu and Bolun Cai in
+ * "FReLU: Flexible Rectified Linear Units for Improving Convolutional
+ *   Neural Networks", 2018
+ *
+ * For more information, read the following paper:
+ *
+ * @code
+ * @article{
+ *  author  = {Suo Qiu, Xiangmin Xu and Bolun Cai},
+ *  title   = {FReLU: Flexible Rectified Linear Units for Improving
+ *             Convolutional Neural Networks}
+ *  journal = {arxiv preprint},
+ *  year    = {2018}
+ * }
+ * @endcode
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LAYER_FLEXIBLERELU_HPP
+#define MLPACK_METHODS_ANN_LAYER_FLEXIBLERELU_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /**Artificial Neural Network*/ {
+
+/**
+ *The FlexibleReLU activation function, defined by
+ *
+ * @f{eqnarray*}{
+ * f(x) &=& \max(0,x)+alpha \\
+ * f'(x) &=& \left\{
+ * 	 \begin(array){lr}
+ * 	   1 & : x > 0 \\
+ * 	   0 & : x \le 0
+ * 	 \end{array}
+ * \right
+ *@f}
+ *
+ *@tparam InputDataType Type of the input data ( arma::colvec, arma::mar,
+ *        arma::sp_mat or arma::cube)
+ *
+ *@tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *        arma::sp_mat or arma::cube)
+ *
+ */
+
+
+template <
+	     typename InputDataType = arma::mat,
+	     typename OutputDataType = arma::mat
+>
+class FlexibleReLU
+{
+public:
+  /**
+   *
+   * Create the FlexibleReLU object using the specified parameters.
+   * The non zero parameter can be adjusted by specifying the parameter
+   * alpha which controls the range of the relu function. ( Default alpha = 0)
+   * This parameter is trainable. 
+   *@param alpha Parameter for adjusting the range of the relu function.
+   *
+   */
+  FlexibleReLU(const double alpha = 0);
+
+  /**
+   * Ordinary feed forward pass of a neural network, evaluating the function
+   * f(x) by propagating the activity forward through f.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param output Resulting output activation.
+   */
+  template<typename InputType, typename OutputType>
+  void Forward(const InputType&& input, OutputType&& output);
+
+  /**
+   * Ordinary feed backward pass of a neural network, calculating the function
+   * f(x) by propagating x backwards through f. Using the results from the feed
+   * forward pass.
+   *
+   * @param input The propagated input activation.
+   * @param gy The backpropagated error.
+   * @param g The calculated gradient.
+   */
+  template<typename DataType>
+  void Backward(const DataType&& input, DataType&& gy, DataType&& g);
+
+  //! Get the input parameter.
+  InputDataType const& InputParameter() const { return inputParameter; }
+  //!Modify the input parameter.
+  InputDataType& InputParameter() { return inputParameter; }
+
+  //!Get the output parameter.
+  OutputDataType const& OutputParameter() const { return outputParameter; }
+  //Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  //!Get the delta.
+  OutputDataType const& Delta() const { return delta; }
+  //!Modify the delta.
+  OutputDataType& Delta() { return delta;}
+  
+  //!Get the parameter controlling the range of the relu function.
+  double const& Alpha() const { return alpha; }
+  //!Modify the parameter controlling the range of the relu function.
+  double& Alpha() { return alpha; }
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version*/);
+
+private:
+  /**
+   * Computes the FlexibleReLU function
+   *
+   * @param x Input data.
+   * @return f(x).
+   */
+ doubel Fn(const double x)
+ {
+ 	return (std::max(x,0) + alpha);
+ }
+
+ /**
+   * Computes the FlexibleReLU function using a dense matrix as input.
+   *
+   * @param x Input data.
+   * @param y The resulting output activation.
+   */
+ template<typename eT>
+ void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
+ {
+ 	y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
+ }
+ 
+ /**
+  * Computes the first derivative of the LeakyReLU function.
+  *
+  * @param x Input data.
+  * @return f'(x)
+  */
+ double Deriv(const double x)
+ {
+   return x > 0;
+ }
+
+ /**
+   * Computes the first derivative of the FlexibleReLU function.
+   *
+   * @param y Input activations.
+   * @param The resulting dreivatives
+   */
+ template<typename InputType, typename, OutputType>
+ void Deriv(const InputParameter& x, OutputType& y)
+ {
+ 	y = x
+
+ 	for (size_t i = 0; i < x.n_elem; i++)
+	{
+	  y(i) = Deriv(x(i));
+	}
+ }
+
+ //! Locally-stored delta object.
+ OutputDataType delta;
+
+ //! Locally-stored input parameter object.
+ InputDataType inputParameter;
+
+ //! Locally-stored output parameter object.
+ OutputDataType outputParameter;
+
+ //! Parameter controlling the range of the rectifier function
+ double alpha;
+}; // class FlexibleReLU
+
+} // namespace ann
+} // namespace mlpack
+
+// Include implementation
+#include "flexible_relu_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -96,22 +96,22 @@ class FlexibleReLU
 
   //! Get the input parameter.
   InputDataType const& InputParameter() const { return inputParameter; }
-  //!Modify the input parameter.
+  //! Modify the input parameter.
   InputDataType& InputParameter() { return inputParameter; }
 
-  //!Get the output parameter.
+  //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }
-  //Modify the output parameter.
+  //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //!Get the delta.
+  //! Get the delta.
   OutputDataType const& Delta() const { return delta; }
-  //!Modify the delta.
+  //! Modify the delta.
   OutputDataType& Delta() { return delta;}
-  
-  //!Get the parameter controlling the range of the relu function.
+
+  //! Get the parameter controlling the range of the relu function.
   double const& Alpha() const { return alpha; }
-  //!Modify the parameter controlling the range of the relu function.
+  //! Modify the parameter controlling the range of the relu function.
   double& Alpha() { return alpha; }
 
   /**
@@ -143,7 +143,7 @@ class FlexibleReLU
   {
     y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
   }
- 
+
   /**
    * Computes the first derivative of the LeakyReLU function.
    *
@@ -161,7 +161,7 @@ class FlexibleReLU
    * @param y Input activations.
    * @param The resulting dreivatives
    */
-  
+
   template<typename InputType, typename OutputType>
   void Deriv(const InputType& x, OutputType& y)
   {

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -60,7 +60,7 @@ template <
 >
 class FlexibleReLU
 {
-public:
+ public:
   /**
    *
    * Create the FlexibleReLU object using the specified parameters.
@@ -120,69 +120,70 @@ public:
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version*/);
 
-private:
+ private:
   /**
    * Computes the FlexibleReLU function
    *
    * @param x Input data.
    * @return f(x).
    */
- doubel Fn(const double x)
- {
- 	return (std::max(x,0) + alpha);
- }
+  double Fn(const double x)
+  {
+ 	  return (std::max(x,0) + alpha);
+  }
 
- /**
+  /**
    * Computes the FlexibleReLU function using a dense matrix as input.
    *
    * @param x Input data.
    * @param y The resulting output activation.
    */
- template<typename eT>
- void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
- {
- 	y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
- }
+  template<typename eT>
+  void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
+  {
+ 	  y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
+  }
  
- /**
-  * Computes the first derivative of the LeakyReLU function.
-  *
-  * @param x Input data.
-  * @return f'(x)
-  */
- double Deriv(const double x)
- {
-   return x > 0;
- }
+  /**
+   * Computes the first derivative of the LeakyReLU function.
+   *
+   * @param x Input data.
+   * @return f'(x)
+   */
+  double Deriv(const double x)
+  {
+    return x > 0;
+  }
 
- /**
+  /**
    * Computes the first derivative of the FlexibleReLU function.
    *
    * @param y Input activations.
    * @param The resulting dreivatives
    */
- template<typename InputType, typename, OutputType>
- void Deriv(const InputParameter& x, OutputType& y)
- {
- 	y = x
+  
+  template<typename InputType, typename, OutputType>
+  void Deriv(const InputParameter& x, OutputType& y)
+  {
+ 	  y = x
 
- 	for (size_t i = 0; i < x.n_elem; i++)
-	{
-	  y(i) = Deriv(x(i));
-	}
- }
+ 	  for (size_t i = 0; i < x.n_elem; i++)
+	  {
+	    y(i) = Deriv(x(i));
+	  }
+  }
 
- //! Locally-stored delta object.
- OutputDataType delta;
+  //! Locally-stored delta object.
+  OutputDataType delta;
 
- //! Locally-stored input parameter object.
- InputDataType inputParameter;
+  //! Locally-stored input parameter object.
+  InputDataType inputParameter;
 
- //! Locally-stored output parameter object.
- OutputDataType outputParameter;
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
 
- //! Parameter controlling the range of the rectifier function
- double alpha;
+  //! Parameter controlling the range of the rectifier function
+  double alpha;
 }; // class FlexibleReLU
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -129,7 +129,7 @@ class FlexibleReLU
    */
   double Fn(const double x)
   {
-    return (std::max(x,0) + alpha);
+    return (std::max(x, 0 * x) + alpha);
   }
 
   /**
@@ -162,10 +162,10 @@ class FlexibleReLU
    * @param The resulting dreivatives
    */
   
-  template<typename InputType, typename, OutputType>
-  void Deriv(const InputParameter& x, OutputType& y)
+  template<typename InputType, typename OutputType>
+  void Deriv(const InputType& x, OutputType& y)
   {
-    y = x
+    y = x;
 
     for (size_t i = 0; i < x.n_elem; i++)
     {

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -121,57 +121,6 @@ class FlexibleReLU
   void serialize(Archive& ar, const unsigned int /* version*/);
 
  private:
-  /**
-   * Computes the FlexibleReLU function
-   *
-   * @param x Input data.
-   * @return f(x).
-   */
-  double Fn(const double x)
-  {
-    return (std::max(x, 0 * x) + alpha);
-  }
-
-  /**
-   * Computes the FlexibleReLU function using a dense matrix as input.
-   *
-   * @param x Input data.
-   * @param y The resulting output activation.
-   */
-  template<typename eT>
-  void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
-  {
-    y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
-  }
-
-  /**
-   * Computes the first derivative of the LeakyReLU function.
-   *
-   * @param x Input data.
-   * @return f'(x)
-   */
-  double Deriv(const double x)
-  {
-    return x > 0? 1 : 0;
-  }
-
-  /**
-   * Computes the first derivative of the FlexibleReLU function.
-   *
-   * @param y Input activations.
-   * @param The resulting dreivatives
-   */
-
-  template<typename InputType, typename OutputType>
-  void Deriv(const InputType& x, OutputType& y)
-  {
-    y = x;
-
-    for (size_t i = 0; i < x.n_elem; i++)
-    {
-      y(i) = Deriv(x(i));
-    }
-  }
 
   //! Locally-stored delta object.
   OutputDataType delta;

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -152,7 +152,7 @@ class FlexibleReLU
    */
   double Deriv(const double x)
   {
-    return x > 0;
+    return x > 0? 1 : 0;
   }
 
   /**

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -55,8 +55,8 @@ namespace ann /**Artificial Neural Network*/ {
 
 
 template <
-	     typename InputDataType = arma::mat,
-	     typename OutputDataType = arma::mat
+    typename InputDataType = arma::mat,
+    typename OutputDataType = arma::mat
 >
 class FlexibleReLU
 {
@@ -129,7 +129,7 @@ class FlexibleReLU
    */
   double Fn(const double x)
   {
- 	  return (std::max(x,0) + alpha);
+    return (std::max(x,0) + alpha);
   }
 
   /**
@@ -141,7 +141,7 @@ class FlexibleReLU
   template<typename eT>
   void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
   {
- 	  y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
+    y = arma::max(arma::zeros<arma::Mat<eT> >(x.n_rows, x.n_cols), x)+alpha;
   }
  
   /**
@@ -165,12 +165,12 @@ class FlexibleReLU
   template<typename InputType, typename, OutputType>
   void Deriv(const InputParameter& x, OutputType& y)
   {
- 	  y = x
+    y = x
 
- 	  for (size_t i = 0; i < x.n_elem; i++)
-	  {
-	    y(i) = Deriv(x(i));
-	  }
+    for (size_t i = 0; i < x.n_elem; i++)
+    {
+      y(i) = Deriv(x(i));
+    }
   }
 
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -157,7 +157,7 @@ class FlexibleReLU
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Leakyness Parameter object.
+  //! Parameter object.
   OutputDataType alpha;
 
   //! Locally-stored gradient object.

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -120,7 +120,6 @@ class FlexibleReLU
   void serialize(Archive& ar, const unsigned int /* version*/);
 
  private:
-
   //! Locally-stored delta object.
   OutputDataType delta;
 

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -65,11 +65,17 @@ class FlexibleReLU
    * Create the FlexibleReLU object using the specified parameters.
    * The non zero parameter can be adjusted by specifying the parameter
    * alpha which controls the range of the relu function. ( Default alpha = 0)
-   * This parameter is trainable. 
+   * This parameter is trainable.
+   *
    *@param alpha Parameter for adjusting the range of the relu function.
    *
    */
-  FlexibleReLU(const double alpha = 0);
+  FlexibleReLU(const double userAlpha = 0);
+
+  /*
+   * Reset the layer parameter.
+   */
+  void Reset();
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -93,6 +99,23 @@ class FlexibleReLU
   template<typename DataType>
   void Backward(const DataType&& input, DataType&& gy, DataType&& g);
 
+  /**
+   * Calculate the gradient using the output delta and the input activation.
+   *
+   * @param input The input parameter used for calculating the gradient.
+   * @param error The calculated error.
+   * @param gradient The calculated gradient.
+   */
+  template<typename eT>
+  void Gradient(const arma::Mat<eT>&& input,
+                arma::Mat<eT>&& error,
+                arma::Mat<eT>&& gradient);
+
+  //! Get the parameters.
+  OutputDataType const& Parameters() const { return alpha; }
+  //! Modify the parameters.
+  OutputDataType& Parameters() { return alpha; }
+
   //! Get the input parameter.
   InputDataType const& InputParameter() const { return inputParameter; }
   //! Modify the input parameter.
@@ -107,6 +130,11 @@ class FlexibleReLU
   OutputDataType const& Delta() const { return delta; }
   //! Modify the delta.
   OutputDataType& Delta() { return delta;}
+
+  //! Get the gradient.
+  OutputDataType const& Gradient() const { return gradient; }
+  //! Modify the gradient.
+  OutputDataType& Gradient() { return gradient; }
 
   //! Get the parameter controlling the range of the relu function.
   double const& Alpha() const { return alpha; }
@@ -129,8 +157,14 @@ class FlexibleReLU
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
+  //! Leakyness Parameter object.
+  OutputDataType alpha;
+
+  //! Locally-stored gradient object.
+  OutputDataType gradient;
+
   //! Parameter controlling the range of the rectifier function
-  double alpha;
+  double userAlpha;
 }; // class FlexibleReLU
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -8,19 +8,6 @@
  * "FReLU: Flexible Rectified Linear Units for Improving Convolutional
  *   Neural Networks", 2018
  *
- * For more information, read the following paper:
- *
- * @code
- * @article{
- *  author  = {Suo Qiu, Xiangmin Xu and Bolun Cai},
- *  title   = {FReLU: Flexible Rectified Linear Units for Improving
- *             Convolutional Neural Networks}
- *  journal = {arxiv preprint},
- *  URL     = {https://arxiv.org/pdf/1706.08098.pdf},
- *  year    = {2018}
- * }
- * @endcode
- *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
  * 3-clause BSD license along with mlpack.  If not, see
@@ -47,15 +34,25 @@ namespace ann /**Artificial Neural Network*/ {
  * \right
  *@f}
  *
- *@tparam InputDataType Type of the input data ( arma::colvec, arma::mar,
- *        arma::sp_mat or arma::cube)
+ * For more information, read the following paper:
  *
+ * @code
+ * @article{Qiu2018,
+ *  author  = {Suo Qiu, Xiangmin Xu and Bolun Cai},
+ *  title   = {FReLU: Flexible Rectified Linear Units for Improving
+ *             Convolutional Neural Networks}
+ *  journal = {arxiv preprint},
+ *  URL     = {https://arxiv.org/abs/1706.08098},
+ *  year    = {2018}
+ * }
+ * @endcode
+ *
+ *@tparam InputDataType Type of the input data (arma::colvec, arma::mar,
+ *        arma::sp_mat or arma::cube)
  *@tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
  *        arma::sp_mat or arma::cube)
  *
  */
-
-
 template <
     typename InputDataType = arma::mat,
     typename OutputDataType = arma::mat

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -1,0 +1,61 @@
+/**
+ * @file flexible_relu_impl.hpp
+ * @author Aarush Gupta
+ *
+ * Implementation of FlexibleReLU layer as described by
+ * Suo Qiu, Xiangmin Xu and Bolun Cai in
+ * "FReLU: Flexible Rectified Linear Units for Improving Convolutional 
+ *  Neural Networks", 2018
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_LAYER_FLEXIBLERELU_IMPL_HPP
+#define MLPACK_METHODS_ANN_LAYER_FLEXIBLERELU_IMPL_HPP
+
+#include "flexible_relu.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+FlexibleReLU<InputDataType, OutputDataType>::FlexibleReLU(
+	const double alpha) : aplha(alpha)
+{
+	//Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename OutputType>
+void FlexibleReLU<InputDataType, OutputDataType>::Forward(
+        const InputType&& input, OutputType&& output)
+{
+  Fn(input, output);
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename DataType>
+void FlexibleReLU<InputDataType, OutputDataType>::Backward(
+	const DataType&& input, DataType&& gy, DataType&& g)
+{
+	DataType derivative;
+	Deriv(input, derivative);
+	g = gy % derivative;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void FlexibleReLU<InputDataType, OutputDataType>::serialize(
+	Archive& ar,
+	const unsigned int /* version*/)
+{
+  ar & BOOST_SERIALIZATION_NVP(alpha);
+}
+
+} // napespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -25,7 +25,7 @@ template<typename InputDataType, typename OutputDataType>
 FlexibleReLU<InputDataType, OutputDataType>::FlexibleReLU(
     const double alpha) : aplha(alpha)
 {
-	//Nothing to do here.
+  //Nothing to do here.
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -41,9 +41,9 @@ template<typename DataType>
 void FlexibleReLU<InputDataType, OutputDataType>::Backward(
     const DataType&& input, DataType&& gy, DataType&& g)
 {
-    DataType derivative;
-    Deriv(input, derivative);
-    g = gy % derivative;
+  DataType derivative;
+  Deriv(input, derivative);
+  g = gy % derivative;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -25,7 +25,7 @@ template<typename InputDataType, typename OutputDataType>
 FlexibleReLU<InputDataType, OutputDataType>::FlexibleReLU(
     const double alpha) : alpha(alpha)
 {
-  //Nothing to do here.
+  // Nothing to do here.
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -55,7 +55,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(alpha);
 }
 
-} // napespace ann
+} // namespace ann
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -45,7 +45,8 @@ template<typename InputType, typename OutputType>
 void FlexibleReLU<InputDataType, OutputDataType>::Forward(
     const InputType&& input, OutputType&& output)
 {
-  Fn(input, output);
+  output = arma::max(arma::zeros<InputType>(input.n_rows, input.n_cols), input)
+    + alpha;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -54,7 +55,15 @@ void FlexibleReLU<InputDataType, OutputDataType>::Backward(
     const DataType&& input, DataType&& gy, DataType&& g)
 {
   DataType derivative;
-  Deriv(input, derivative);
+
+  //! Compute the first derivative of FlexibleReLU function.
+  derivative = input;
+
+  for (size_t i = 0; i < input.n_elem; i++)
+  {
+    derivative(i) = input(i) > 0? 1 : 0;
+  }
+
   g = gy % derivative;
 }
 

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -1,6 +1,7 @@
 /**
  * @file flexible_relu_impl.hpp
  * @author Aarush Gupta
+ * @author Manthan-R-Sheth
  *
  * Implementation of FlexibleReLU layer as described by
  * Suo Qiu, Xiangmin Xu and Bolun Cai in
@@ -15,6 +16,7 @@
  *  title   = {FReLU: Flexible Rectified Linear Units for Improving
  *             Convolutional Neural Networks}
  *  journal = {arxiv preprint},
+ *  URL     = {https://arxiv.org/pdf/1706.08098.pdf},
  *  year    = {2018}
  * }
  * @endcode

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -23,7 +23,7 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
 FlexibleReLU<InputDataType, OutputDataType>::FlexibleReLU(
-	const double alpha) : aplha(alpha)
+    const double alpha) : aplha(alpha)
 {
 	//Nothing to do here.
 }
@@ -31,7 +31,7 @@ FlexibleReLU<InputDataType, OutputDataType>::FlexibleReLU(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void FlexibleReLU<InputDataType, OutputDataType>::Forward(
-        const InputType&& input, OutputType&& output)
+    const InputType&& input, OutputType&& output)
 {
   Fn(input, output);
 }
@@ -39,18 +39,18 @@ void FlexibleReLU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void FlexibleReLU<InputDataType, OutputDataType>::Backward(
-	const DataType&& input, DataType&& gy, DataType&& g)
+    const DataType&& input, DataType&& gy, DataType&& g)
 {
-	DataType derivative;
-	Deriv(input, derivative);
-	g = gy % derivative;
+    DataType derivative;
+    Deriv(input, derivative);
+    g = gy % derivative;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void FlexibleReLU<InputDataType, OutputDataType>::serialize(
-	Archive& ar,
-	const unsigned int /* version*/)
+    Archive& ar,
+    const unsigned int /* version*/)
 {
   ar & BOOST_SERIALIZATION_NVP(alpha);
 }

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -7,6 +7,18 @@
  * "FReLU: Flexible Rectified Linear Units for Improving Convolutional 
  *  Neural Networks", 2018
  *
+ * For more information, read the following paper:
+ *
+ * @code
+ * @article{
+ *  author  = {Suo Qiu, Xiangmin Xu and Bolun Cai},
+ *  title   = {FReLU: Flexible Rectified Linear Units for Improving
+ *             Convolutional Neural Networks}
+ *  journal = {arxiv preprint},
+ *  year    = {2018}
+ * }
+ * @endcode
+ *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
  * 3-clause BSD license along with mlpack.  If not, see

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -23,7 +23,7 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
 FlexibleReLU<InputDataType, OutputDataType>::FlexibleReLU(
-    const double alpha) : aplha(alpha)
+    const double alpha) : alpha(alpha)
 {
   //Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -66,7 +66,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Gradient(
 {
   if (gradient.n_elem == 0)
   {
-    gradient = arma::zeros<arma::Mat<eT>>(1, 1);
+    gradient.set_size(1, 1);
   }
   gradient(0) = arma::accu(error) / input.n_cols;
 }

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -7,20 +7,7 @@
  * Suo Qiu, Xiangmin Xu and Bolun Cai in
  * "FReLU: Flexible Rectified Linear Units for Improving Convolutional 
  *  Neural Networks", 2018
- *
- * For more information, read the following paper:
- *
- * @code
- * @article{
- *  author  = {Suo Qiu, Xiangmin Xu and Bolun Cai},
- *  title   = {FReLU: Flexible Rectified Linear Units for Improving
- *             Convolutional Neural Networks}
- *  journal = {arxiv preprint},
- *  URL     = {https://arxiv.org/pdf/1706.08098.pdf},
- *  year    = {2018}
- * }
- * @endcode
- *
+ *  
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
  * 3-clause BSD license along with mlpack.  If not, see

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -45,8 +45,8 @@ void FlexibleReLU<InputDataType, OutputDataType>::Forward(
 {
   int i = -1;
   output = arma::zeros<InputType>(input.n_rows, input.n_cols);
-  output.transform([input, &i](double val) { ++i;
-      return (std::max(input(i), 0.0) + alpha); } );
+  output.transform([input, &i, alpha](double val) { ++i;
+      return (std::max(input(i), 0.0) + alpha(0)); } );
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -68,7 +68,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Gradient(
   {
     gradient = arma::zeros<arma::Mat<eT>>(1, 1);
   }
-  gradient(0) = 1.0;
+  gradient(0) = arma::accu(error) / input.n_cols;
 }
 
 

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -45,9 +45,8 @@ void FlexibleReLU<InputDataType, OutputDataType>::Forward(
 {
   int i = -1;
   output = arma::zeros<InputType>(input.n_rows, input.n_cols);
-  output.transform( [input, &i](double val) { ++i;
+  output.transform([input, &i](double val) { ++i;
       return (std::max(input(i), 0.0) + alpha); } );
-
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -59,7 +58,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Backward(
   //! Compute the first derivative of FlexibleReLU function.
   derivative.set_size(input.n_rows, input.n_cols);
   int i = -1;
-  derivative.transform( [input, &i](double val) { ++i;
+  derivative.transform([input, &i](double val) { ++i;
     return (input(i) > 0? 1 : 0); } );
 
   g = gy % derivative;

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -68,8 +68,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Gradient(
   {
     gradient = arma::zeros<arma::Mat<eT>>(1, 1);
   }
-  gradient(0) = arma::accu(error % arma::clamp(input, -DBL_MAX, 0.0))
-      / input.n_cols;
+  gradient(0) = 1.0;
 }
 
 

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -53,8 +53,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Backward(
 {
   DataType derivative;
   //! Compute the first derivative of FlexibleReLU function.
-  derivative = arma::sign(input);
-  derivative.elem(arma::find(derivative < 0.0)) += 1;
+  derivative = arma::clamp(arma::sign(input), 0.0, 1.0);
   g = gy % derivative;
 }
 

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -45,7 +45,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Forward(
 {
   int i = -1;
   output = arma::zeros<InputType>(input.n_rows, input.n_cols);
-  output.transform([input, &i, alpha](double val) { ++i;
+  output.transform([input, &i, this](double val) { ++i;
       return (std::max(input(i), 0.0) + alpha(0)); } );
 }
 

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -26,6 +26,7 @@
 #include <mlpack/methods/ann/layer/hard_tanh.hpp>
 #include <mlpack/methods/ann/layer/join.hpp>
 #include <mlpack/methods/ann/layer/leaky_relu.hpp>
+#include <mlpack/methods/ann/layer/flexible_relu.hpp>
 #include <mlpack/methods/ann/layer/log_softmax.hpp>
 #include <mlpack/methods/ann/layer/lookup.hpp>
 #include <mlpack/methods/ann/layer/mean_squared_error.hpp>
@@ -124,6 +125,7 @@ using LayerTypes = boost::variant<
     DropConnect<arma::mat, arma::mat>*,
     Dropout<arma::mat, arma::mat>*,
     ELU<arma::mat, arma::mat>*,
+    FlexibleReLU<arma::mat, arma::mat>*,
     Glimpse<arma::mat, arma::mat>*,
     HardTanH<arma::mat, arma::mat>*,
     Join<arma::mat, arma::mat>*,

--- a/src/mlpack/methods/ann/layer/leaky_relu.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu.hpp
@@ -103,7 +103,7 @@ class LeakyReLU
 
  private:
   /**
-   * Computes the LeakReLU function
+   * Computes the LeakyReLU function
    *
    * @param x Input data.
    * @return f(x).
@@ -114,7 +114,7 @@ class LeakyReLU
   }
 
   /**
-   * Computes the Leaky ReLU function using a dense matrix as input.
+   * Computes the LeakyReLU function using a dense matrix as input.
    *
    * @param x Input data.
    * @param y The resulting output activation.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -620,18 +620,18 @@ BOOST_AUTO_TEST_CASE(JacobianLeakyReLULayerTest)
  */
 BOOST_AUTO_TEST_CASE(JacobianFlexibleReLULayerTest)
 {
-   for (size_t i = 0; i < 5; i++)
-   {
-   	const size_t inputElements = math::RandInt(2, 1000);
+  for (size_t i = 0; i < 5; i++)
+  {
+    const size_t inputElements = math::RandInt(2, 1000);
 
-   	arma::mat input;
-   	input.set_size(inputElements, 1);
+    arma::mat input;
+    input.set_size(inputElements, 1);
 
-   	FlexibleReLU<> module;
+    FlexibleReLU<> module;
 
-   	double error = JacobianTest(module, input);
-   	BOOST_REQUIRE_LE(error, 1e-5);
-   }
+    double error = JacobianTest(module, input);
+    BOOST_REQUIRE_LE(error, 1e-5);
+  }
 }
 
 /**

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -616,6 +616,25 @@ BOOST_AUTO_TEST_CASE(JacobianLeakyReLULayerTest)
 }
 
 /**
+ * Jacobian FlexibleReLU module test.
+ */
+BOOST_AUTO_TEST_CASE(JacobianFlexibleReLULayerTest)
+{
+   for (size_t i = 0; i < 5; i++)
+   {
+   	const size_t inputElements = math::RandInt(2, 1000);
+
+   	arma::mat input;
+   	input.set_size(inputElements, 1);
+
+   	FlexibleReLU<> module;
+
+   	double error = JacobianTest(module, input);
+   	BOOST_REQUIRE_LE(error, 1e-5);
+   }
+}
+
+/**
  * Jacobian MultiplyConstant module test.
  */
 BOOST_AUTO_TEST_CASE(JacobianMultiplyConstantLayerTest)

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -647,8 +647,9 @@ BOOST_AUTO_TEST_CASE(GradientFlexibleReLULayerTest)
       input = arma::randn(10, 1);
       target = arma::mat("1");
 
-      model = new FFN<NegativeLogLikelihood<>, NguyenWidrowInitialization>(
-        input, target);
+      model = new FFN<NegativeLogLikelihood<>, NguyenWidrowInitialization>();
+      model->Predictors() = input;
+      model->Responses() = target;
       model->Add<Linear<> >(10, 2);
       model->Add<FlexibleReLU<> >(0.05);
       model->Add<LogSoftMax<> >();

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -644,13 +644,15 @@ BOOST_AUTO_TEST_CASE(GradientFlexibleReLULayerTest)
   {
     GradientFunction()
     {
-      input = arma::randu(10, 1);
+      input = arma::randu(2, 1);
       target = arma::mat("1");
 
-      model = new FFN<NegativeLogLikelihood<>, NguyenWidrowInitialization>();
+      model = new FFN<NegativeLogLikelihood<>, RandomInitialization>(
+        NegativeLogLikelihood<>(), RandomInitialization(0.1, 0.5));
+
       model->Predictors() = input;
       model->Responses() = target;
-      model->Add<Linear<> >(10, 2);
+      model->Add<LinearNoBias<> >(2, 5);
       model->Add<FlexibleReLU<> >(0.05);
       model->Add<LogSoftMax<> >();
     }
@@ -670,7 +672,7 @@ BOOST_AUTO_TEST_CASE(GradientFlexibleReLULayerTest)
 
     arma::mat& Parameters() { return model->Parameters(); }
 
-    FFN<NegativeLogLikelihood<>, NguyenWidrowInitialization>* model;
+    FFN<NegativeLogLikelihood<>, RandomInitialization>* model;
     arma::mat input, target;
   } function;
 

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE(GradientFlexibleReLULayerTest)
   {
     GradientFunction()
     {
-      input = arma::randn(10, 1);
+      input = arma::randu(10, 1);
       target = arma::mat("1");
 
       model = new FFN<NegativeLogLikelihood<>, NguyenWidrowInitialization>();


### PR DESCRIPTION
This is in continuity to #1281.
Function call overheads have been removed and code is simplified to include the calculation in `Forward() `and `Backward()`. 