### PR TITLE
Truncated Normal Initialization of Weights

### DIFF
--- a/src/mlpack/methods/ann/init_rules/CMakeLists.txt
+++ b/src/mlpack/methods/ann/init_rules/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(SOURCES
   const_init.hpp
   gaussian_init.hpp
+  glorot_init.hpp
   init_rules_traits.hpp
   kathirvalavakumar_subavathi_init.hpp
   network_init.hpp
@@ -10,7 +11,7 @@ set(SOURCES
   oivs_init.hpp
   orthogonal_init.hpp
   random_init.hpp
-  glorot_init.hpp
+  truncated_gaussian_init.hpp
 )
 
 # Add directory name to sources.

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -102,6 +102,58 @@ class GaussianInitialization
   double stddev;
 }; // class GaussianInitialization
 
+/**
+ * This class initializes a given weight matrix with values sampled from a
+ * Gaussian Distribution of given mean and variance. It ensures that none of
+ * the sampled values are more than two standard deviations away from the mean.
+ */
+class TruncatedGaussianInitialization
+{
+ public:
+  /**
+   * Initialize the gaussian with given mean and variance.
+   *
+   * @param mean Mean of the gaussian.
+   * @param variance Variance of the gaussian.
+   */
+  TruncatedGaussianInitialization(const double mean = 0,
+                                  const double variance = 1.0) :
+     g(new GaussianInitialization(mean, variance))
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements weight matrix using a Gaussian distribution.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   */
+  void Initialize(arma::mat& W,
+                  const size_t rows,
+                  const size_t cols)
+  {
+    g->Initialize(W, rows, cols, true);
+  }
+
+  void Initialize(arma::cube& W,
+                  const size_t rows,
+                  const size_t cols,
+                  const size_t slices)
+  {
+    g->Initialize(W, rows, cols, slices, true);
+  }
+
+  ~TruncatedGaussianInitialization()
+  {
+    delete g;
+  }
+
+ private:
+  GaussianInitialization* g;
+};
+
 } // namespace ann
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -118,7 +118,7 @@ class TruncatedGaussianInitialization
    */
   TruncatedGaussianInitialization(const double mean = 0,
                                   const double variance = 1.0) :
-     g(new GaussianInitialization(mean, variance))
+     g(GaussianInitialization(mean, variance))
   {
     // Nothing to do here.
   }
@@ -134,7 +134,7 @@ class TruncatedGaussianInitialization
                   const size_t rows,
                   const size_t cols)
   {
-    g->Initialize(W, rows, cols, true);
+    g.Initialize(W, rows, cols, true);
   }
 
   void Initialize(arma::cube& W,
@@ -142,16 +142,11 @@ class TruncatedGaussianInitialization
                   const size_t cols,
                   const size_t slices)
   {
-    g->Initialize(W, rows, cols, slices, true);
-  }
-
-  ~TruncatedGaussianInitialization()
-  {
-    delete g;
+    g.Initialize(W, rows, cols, slices, true);
   }
 
  private:
-  GaussianInitialization* g;
+  GaussianInitialization g;
 };
 
 } // namespace ann

--- a/src/mlpack/methods/ann/init_rules/truncated_gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/truncated_gaussian_init.hpp
@@ -36,7 +36,8 @@ class TruncatedGaussianInitialization
    * @param mean Mean of the gaussian.
    * @param variance Variance of the gaussian.
    */
-  TruncatedGaussianInitialization(const double mean = 0, const double variance = 1) :
+  TruncatedGaussianInitialization(const double mean = 0,
+                                  const double variance = 1) :
       mean(mean), variance(variance), stddev(sqrt(variance))
   {
     // Nothing to do here.

--- a/src/mlpack/methods/ann/init_rules/truncated_gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/truncated_gaussian_init.hpp
@@ -83,7 +83,7 @@ class TruncatedGaussianInitialization
     W = arma::cube(rows, cols, slices);
 
     for (size_t i = 0; i < slices; i++)
-      Initialize(W.slice(i), rows, cols, truncated);
+      Initialize(W.slice(i), rows, cols);
   }
 
  private:

--- a/src/mlpack/tests/init_rules_test.cpp
+++ b/src/mlpack/tests/init_rules_test.cpp
@@ -199,6 +199,39 @@ BOOST_AUTO_TEST_CASE(GaussianInitTest)
 }
 
 /**
+ * Simple test of the GaussianInitialization class with truncated flag set.
+ * Generated random values must lie within two standard deviations of the mean.
+ */
+BOOST_AUTO_TEST_CASE(TruncatedGaussianInitTest)
+{
+  const size_t rows = 7;
+  const size_t cols = 8;
+  const size_t slices = 2;
+
+  arma::mat weights;
+  arma::cube weights3d;
+
+  GaussianInitialization t(0, 0.2);
+
+  t.Initialize(weights, rows, cols, true);
+  t.Initialize(weights3d, rows, cols, slices, true);
+
+  BOOST_REQUIRE_EQUAL(weights.n_rows, rows);
+  BOOST_REQUIRE_EQUAL(weights.n_cols, cols);
+
+  BOOST_REQUIRE_EQUAL(weights3d.n_rows, rows);
+  BOOST_REQUIRE_EQUAL(weights3d.n_cols, cols);
+  BOOST_REQUIRE_EQUAL(weights3d.n_slices, slices);
+
+  double stddev = sqrt(0.2);
+
+  for (size_t i=0; i < weights.n_elem; i++)
+    BOOST_REQUIRE_LE(std::abs(weights[i]), 2.0 * stddev);
+  for (size_t i=0; i < weights3d.n_elem; i++)
+    BOOST_REQUIRE_LE(std::abs(weights3d[i]), 2.0 * stddev);
+}
+
+/**
  * Simple test of the NetworkInitialization class, we test it with every
  * implemented initialization rule and make sure the output is reasonable.
  */

--- a/src/mlpack/tests/init_rules_test.cpp
+++ b/src/mlpack/tests/init_rules_test.cpp
@@ -199,8 +199,10 @@ BOOST_AUTO_TEST_CASE(GaussianInitTest)
 }
 
 /**
- * Simple test of the GaussianInitialization class with truncated flag set.
- * Generated random values must lie within two standard deviations of the mean.
+ * Simple test of the TruncatedGaussianInitialization class.
+ * Generated random values are sampled from a Gaussian distribution of given
+ * mean and variance. Random values must lie within two standard deviations
+ * of the mean.
  */
 BOOST_AUTO_TEST_CASE(TruncatedGaussianInitTest)
 {
@@ -211,10 +213,10 @@ BOOST_AUTO_TEST_CASE(TruncatedGaussianInitTest)
   arma::mat weights;
   arma::cube weights3d;
 
-  GaussianInitialization t(0, 0.2);
+  TruncatedGaussianInitialization t(0, 0.2);
 
-  t.Initialize(weights, rows, cols, true);
-  t.Initialize(weights3d, rows, cols, slices, true);
+  t.Initialize(weights, rows, cols);
+  t.Initialize(weights3d, rows, cols, slices);
 
   BOOST_REQUIRE_EQUAL(weights.n_rows, rows);
   BOOST_REQUIRE_EQUAL(weights.n_cols, cols);
@@ -317,6 +319,17 @@ BOOST_AUTO_TEST_CASE(NetworkInitTest)
   gaussianModel.Predict(input, response);
 
   BOOST_REQUIRE_EQUAL(gaussianModel.Parameters().n_elem, 42);
+
+  // Create a simple network and use the TruncatedGaussianInitialization rule to
+  // initialize the network parameters.
+  FFN<NegativeLogLikelihood<>, TruncatedGaussianInitialization> truncatedModel;
+  truncatedModel.Add<IdentityLayer<> >();
+  truncatedModel.Add<Linear<> >(5, 5);
+  truncatedModel.Add<Linear<> >(5, 2);
+  truncatedModel.Add<LogSoftMax<> >();
+  truncatedModel.Predict(input, response);
+
+  BOOST_REQUIRE_EQUAL(truncatedModel.Parameters().n_elem, 42);
 }
 
 /**

--- a/src/mlpack/tests/init_rules_test.cpp
+++ b/src/mlpack/tests/init_rules_test.cpp
@@ -24,6 +24,7 @@
 #include <mlpack/methods/ann/init_rules/const_init.hpp>
 #include <mlpack/methods/ann/init_rules/gaussian_init.hpp>
 #include <mlpack/methods/ann/init_rules/glorot_init.hpp>
+#include <mlpack/methods/ann/init_rules/truncated_gaussian_init.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"


### PR DESCRIPTION
#1228 

[Keras implementation](https://github.com/keras-team/keras/blob/af804d0a5db9a8f20fbb083b48655b2687ce89d9/keras/initializers.py#L122) creates a separate initialization class. I have only added an option in the existing implementation of Gaussian initialization.

Please close this PR if this is not required/too simple.