### PR TITLE
NMF: allow user to specify one of initial W/H matrices

### DIFF
--- a/src/mlpack/methods/amf/init_rules/given_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/given_init.hpp
@@ -3,7 +3,7 @@
  * @author Ryan Curtin
  *
  * Initialization rule for alternating matrix factorization (AMF). This simple
- * initialization is performed by assigning a given matrix to W and H.
+ * initialization is performed by assigning a given matrix to W and/or H.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -19,10 +19,12 @@ namespace mlpack {
 namespace amf {
 
 /**
- * This initialization rule for AMF simply fills the W and H matrices with the
- * matrices given to the constructor of this object.  Note that this object does
- * not use std::move() during the Initialize() method, so it can be reused for
- * multiple AMF objects, but will incur copies of the W and H matrices.
+ * This initialization rule for AMF simply fills the W and/or H matrices with
+ * the matrices given to the constructor of this object. If only one initial
+ * matrix is given, the other matrix will be initialized with random noise.
+ * Note that this object does not use std::move() during the Initialize()
+ * method, so it can be reused for multiple AMF objects, but will incur copies
+ * of the W and H matrices.
  */
 class GivenInitialization
 {

--- a/src/mlpack/methods/amf/init_rules/given_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/given_init.hpp
@@ -21,8 +21,8 @@ namespace amf {
 /**
  * This initialization rule for AMF simply fills the W and/or H matrices with
  * the matrices given to the constructor of this object. If only one initial
- * matrix is given, the other matrix will be initialized with random noise.
- * Note that this object does not use std::move() during the Initialize()
+ * matrix is given, the other matrix will be initialized with random uniform 
+ * noise. Note that this object does not use std::move() during Initialize()
  * method, so it can be reused for multiple AMF objects, but will incur copies
  * of the W and H matrices.
  */
@@ -46,7 +46,7 @@ class GivenInitialization
   { }
 
   // Initialize either H or W with the given matrix. The other matrix will
-  // be initialized with random noise in Initialize().
+  // be initialized with random uniform noise in Initialize().
   GivenInitialization(const char whichMatrix, const arma::mat& m)
   {
     if (whichMatrix == 'W' || whichMatrix == 'w')
@@ -69,7 +69,7 @@ class GivenInitialization
   }
 
   // Initialize either H or W, taking control of the given matrix. The other
-  // matrix will be initialized with random noise in Initialize().
+  // matrix will be initialized with random uniform noise in Initialize().
   GivenInitialization(const char whichMatrix, const arma::mat&& m)
   {
     if (whichMatrix == 'W' || whichMatrix == 'w')

--- a/src/mlpack/methods/nmf/nmf_main.cpp
+++ b/src/mlpack/methods/nmf/nmf_main.cpp
@@ -92,6 +92,7 @@ void ApplyFactorization(const arma::mat& V,
   SimpleResidueTermination srt(minResidue, maxIterations);
   if (CLI::HasParam("initial_w") && CLI::HasParam("initial_h"))
   {
+    // Initialize W and H with given matrices.
     GivenInitialization ginit = GivenInitialization(
         std::move(CLI::GetParam<arma::mat>("initial_w")),
         std::move(CLI::GetParam<arma::mat>("initial_h")));
@@ -102,6 +103,7 @@ void ApplyFactorization(const arma::mat& V,
   }
   else if (CLI::HasParam("initial_w"))
   {
+    // Initialize W with the given matrix, and H with random noise.
     GivenInitialization ginit = GivenInitialization(
         'W', std::move(CLI::GetParam<arma::mat>("initial_w")));
     AMF<SimpleResidueTermination,
@@ -111,6 +113,7 @@ void ApplyFactorization(const arma::mat& V,
   }
   else if (CLI::HasParam("initial_h"))
   {
+    // Initialize H with the given matrix, and W with random noise.
     GivenInitialization ginit = GivenInitialization(
         'H', std::move(CLI::GetParam<arma::mat>("initial_h")));
     AMF<SimpleResidueTermination,
@@ -120,6 +123,7 @@ void ApplyFactorization(const arma::mat& V,
   }
   else
   {
+    // Use random initialization.
     AMF<SimpleResidueTermination,
         RandomInitialization,
         UpdateRuleType> amf(srt);

--- a/src/mlpack/tests/main_tests/nmf_test.cpp
+++ b/src/mlpack/tests/main_tests/nmf_test.cpp
@@ -284,4 +284,81 @@ BOOST_AUTO_TEST_CASE(NMFMaxIterationTest)
   BOOST_REQUIRE_GT(arma::norm(h1 - h2), 1e-5);
 }
 
+/**
+ * Test NMF with given initial_w and inital_h.
+ */
+BOOST_AUTO_TEST_CASE(NMFWHGivenInitTest)
+{
+  mat v = arma::randu(10, 10);
+  mat initialW = arma::randu(10, 5);
+  mat initialH = arma::randu(5, 10);
+  int r = 5;
+
+  SetInputParam("input", v);
+  SetInputParam("rank", r);
+  SetInputParam("initial_w", initialW);
+  SetInputParam("initial_h", initialH);
+
+  mlpackMain();
+
+  const mat w = CLI::GetParam<mat>("w");
+  const mat h = CLI::GetParam<mat>("h");
+
+  // Check the shapes of W and H.
+  BOOST_REQUIRE_EQUAL(w.n_rows, 10);
+  BOOST_REQUIRE_EQUAL(w.n_cols, 5);
+  BOOST_REQUIRE_EQUAL(h.n_rows, 5);
+  BOOST_REQUIRE_EQUAL(h.n_cols, 10);
+}
+
+/**
+ * Test NMF with given initial_w.
+ */
+BOOST_AUTO_TEST_CASE(NMFWGivenInitTest)
+{
+  mat v = arma::randu(10, 10);
+  mat initialW = arma::randu(10, 5);
+  int r = 5;
+
+  SetInputParam("input", v);
+  SetInputParam("rank", r);
+  SetInputParam("initial_w", initialW);
+
+  mlpackMain();
+
+  const mat w = CLI::GetParam<mat>("w");
+  const mat h = CLI::GetParam<mat>("h");
+
+  // Check the shapes of W and H.
+  BOOST_REQUIRE_EQUAL(w.n_rows, 10);
+  BOOST_REQUIRE_EQUAL(w.n_cols, 5);
+  BOOST_REQUIRE_EQUAL(h.n_rows, 5);
+  BOOST_REQUIRE_EQUAL(h.n_cols, 10);
+}
+
+/**
+ * Test NMF with given initial_h
+ */
+BOOST_AUTO_TEST_CASE(NMFHGivenInitTest)
+{
+  mat v = arma::randu(10, 10);
+  mat initialH = arma::randu(5, 10);
+  int r = 5;
+
+  SetInputParam("input", v);
+  SetInputParam("rank", r);
+  SetInputParam("initial_h", initialH);
+
+  mlpackMain();
+
+  const mat w = CLI::GetParam<mat>("w");
+  const mat h = CLI::GetParam<mat>("h");
+
+  // Check the shapes of W and H.
+  BOOST_REQUIRE_EQUAL(w.n_rows, 10);
+  BOOST_REQUIRE_EQUAL(w.n_cols, 5);
+  BOOST_REQUIRE_EQUAL(h.n_rows, 5);
+  BOOST_REQUIRE_EQUAL(h.n_cols, 10);
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This PR is follow-up of the discussion in #1261. It adds support to allow user to specify one of initial H/W matrices, and to randomly initialize the other one.