### PR TITLE
fix unused result warning

### DIFF
--- a/src/mlpack/tests/arma_extend_test.cpp
+++ b/src/mlpack/tests/arma_extend_test.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(MatRowColIteratorDecrementOperatorTest)
 
   // Check that postfix-- does not decrement the position when position is
   // pointing to the beginning.
-  (void) it2--;
+  auto junk = it2--; (void)(junk);
   BOOST_REQUIRE_EQUAL(it1.row(), it2.row());
   BOOST_REQUIRE_EQUAL(it1.col(), it2.col());
 


### PR DESCRIPTION
Recent versions of armadillo emit warnings when the result of iterator postfix increment/decrement is not used.  The void statement by itself isn't sufficient to suppress these warnings.
