### PR TITLE
Add missing check to suppress compiler warning

### DIFF
--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
@@ -159,6 +159,10 @@ static void mlpackMain()
       model = new HoeffdingTreeModel(HoeffdingTreeModel::INFO_HOEFFDING);
     else if (CLI::HasParam("info_gain") && (numericSplitStrategy == "binary"))
       model = new HoeffdingTreeModel(HoeffdingTreeModel::INFO_BINARY);
+    else {
+      Log::Fatal << "model is not initialized" << std::endl;
+      return;
+    }
   }
 
   // Now, do we need to train?

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
@@ -157,12 +157,8 @@ static void mlpackMain()
       model = new HoeffdingTreeModel(HoeffdingTreeModel::GINI_BINARY);
     else if (CLI::HasParam("info_gain") && (numericSplitStrategy == "domingos"))
       model = new HoeffdingTreeModel(HoeffdingTreeModel::INFO_HOEFFDING);
-    else if (CLI::HasParam("info_gain") && (numericSplitStrategy == "binary"))
+    else
       model = new HoeffdingTreeModel(HoeffdingTreeModel::INFO_BINARY);
-    else {
-      Log::Fatal << "model is not initialized" << std::endl;
-      return;
-    }
   }
 
   // Now, do we need to train?


### PR DESCRIPTION
The variable 'model' may not be initialized, thus causing a compile warning in
src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp:251