### PR TITLE
Warn differences in OpenMP settings.

### DIFF
--- a/CMake/CreateArmaConfigInfo.cmake
+++ b/CMake/CreateArmaConfigInfo.cmake
@@ -47,6 +47,15 @@ else()
   set(ARMA_64BIT_WORD_DEFINE "#define MLPACK_ARMA_64BIT_WORD")
 endif()
 
+# Next we need to know if we are compiling with OpenMP support.
+# Other places in the CMake configuration should have already done the
+# find(OpenMP).
+if (OPENMP_FOUND)
+  set(ARMA_HAS_OPENMP_DEFINE "#define MLPACK_ARMA_USE_OPENMP")
+else ()
+  set(ARMA_HAS_OPENMP_DEFINE "#define MLPACK_ARMA_DONT_USE_OPENMP")
+endif ()
+
 set(NEW_FILE_CONTENTS
 "/**
  * @file arma_config.hpp
@@ -66,6 +75,8 @@ set(NEW_FILE_CONTENTS
 #define MLPACK_CORE_UTIL_ARMA_CONFIG_HPP
 
 ${ARMA_64BIT_WORD_DEFINE}
+
+${ARMA_HAS_OPENMP_DEFINE}
 
 #endif
 ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ add_custom_target(mlpack_arma_config ALL
     COMMAND ${CMAKE_COMMAND}
         -D ARMADILLO_INCLUDE_DIR="${ARMADILLO_INCLUDE_DIR}"
         -D ARMADILLO_VERSION_MAJOR="${ARMADILLO_VERSION_MAJOR}"
+        -D OPENMP_FOUND="${OPENMP_FOUND}"
         -P CMake/CreateArmaConfigInfo.cmake
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Updating arma_config.hpp (if necessary)")

--- a/src/mlpack/core/util/arma_config_check.hpp
+++ b/src/mlpack/core/util/arma_config_check.hpp
@@ -36,4 +36,29 @@ ARMA_64BIT_WORD disabled."
   #endif
 #endif
 
+// Check if OpenMP was enabled when mlpack was built.  This only matters for
+// Armadillo 8.300.1 and newer.
+#if (ARMA_VERSION_MAJOR > 8) || \
+    ((ARMA_VERSION_MAJOR == 8) && (ARMA_VERSION_MINOR > 300)) || \
+    ((ARMA_VERSION_MAJOR == 8) && (ARMA_VERSION_MINOR == 300) && \
+     (ARMA_VERSION_PATCH >= 1))
+  #ifdef ARMA_USE_OPENMP
+    #ifdef MLPACK_ARMA_DONT_USE_OPENMP
+      #pragma message "mlpack was compiled without OpenMP support, but you are \
+compiling with OpenMP support (either -fopenmp or another option).  This will \
+almost certainly cause irreparable disaster.  Either compile your application \
+*without* OpenMP support (i.e. remove -fopenmp or another flag), or, recompile \
+mlpack with OpenMP support."
+    #endif
+  #else
+    #ifdef MLPACK_ARMA_USE_OPENMP
+      #pragma message "mlpack was compiled with OpenMP support, but you are \
+compiling without OpenMP support.  This will almost certainly cause \
+irreparable disaster.  Either enable OpenMP support in your application (e.g., \
+add -fopenmp to your compiler command line), or, recompile mlpack *without* \
+OpenMP support."
+    #endif
+  #endif
+#endif
+
 #endif


### PR DESCRIPTION
If the user is compiling their application with OpenMP but mlpack was not compiled with OpenMP (or vice versa) we issue a warning.  This situation can cause disaster with recent versions of Armadillo.

This solves #1358.  (Or, at least, it tells the user what is wrong in situations that can lead to #1358.)