### PR TITLE
Add JOSS paper for submission.

### DIFF
--- a/doc/joss_paper/paper.bib
+++ b/doc/joss_paper/paper.bib
@@ -1,0 +1,104 @@
+@article{halevy2009unreasonable,
+  title={The unreasonable effectiveness of data},
+  author={Halevy, A. and Norvig, P. and Pereira, F.},
+  journal={IEEE Intelligent Systems},
+  volume={24},
+  number={2},
+  pages={8--12},
+  year={2009},
+  publisher={IEEE}
+}
+
+@inproceedings{mlpack2011,
+  author={R.R. Curtin and J.R. Cline and N.P. Slagle and M.L. Amidon and A.G.
+          Gray},
+  title={{mlpack: A Scalable C++ Machine Learning Library}},
+  booktitle={{BigLearning: Algorithms, Systems, and Tools for Learning at
+              Scale}},
+  year = 2011
+}
+
+@article{mlpack2013,
+  title = {{mlpack}: A Scalable {C++} Machine Learning Library},
+  author = {Curtin, R.R. and Cline, J.R. and Slagle, N.P. and March, W.B. and
+            Ram, P. and Mehta, N.A. and Gray, A.G.},
+  journal = {Journal of Machine Learning Research},
+  volume = {14},
+  pages = {801--805},
+  year= {2013}
+}
+
+@book{alexandrescu2001modern,
+  title={Modern C++ design: generic programming and design patterns applied},
+  author={Alexandrescu, A.},
+  year={2001},
+  publisher={Addison-Wesley}
+}
+
+@article{sanderson2016armadillo,
+  title={Armadillo: a template-based C++ library for linear algebra},
+  author={Sanderson, C. and Curtin, R.R.},
+  journal={Journal of Open Source Software},
+  year={2016},
+  publisher={Journal of Open Source Software}
+}
+
+@misc{xianyi2018openblas,
+  title={{OpenBLAS: An Optimized BLAS Library}},
+  author={Xianyi, Z. and Qian, W. and Saar, W.},
+  year={2018},
+  howpublished={\url{http://www.openblas.net}}
+}
+
+@misc{nvblas,
+  title={{NVBLAS Library}},
+  author={{NVIDIA}},
+  year={2015},
+  howpublished={\ur;{http://docs.nvidia.com/cuda/nvblas}}
+}
+
+@inproceedings{curtin2013tree,
+  title={Tree-Independent Dual-Tree Algorithms},
+  author={Curtin, R.R. and March, W.B. and Ram, P. and Anderson, D.V. and Gray,
+          A.G. and Isbell Jr., C.L.},
+  booktitle={Proceedings of The 30th International Conference on Machine
+             Learning (ICML '13)},
+  pages={1435--1443},
+  year={2013}
+}
+
+@article{curtin2017generic,
+  title={A generic and fast C++ optimization framework},
+  author={Curtin, R.R. and Bhardwaj, S. and Edel, M. and Mentekidis, Y.},
+  journal={arXiv preprint arXiv:1711.06581},
+  year={2017}
+}
+
+@article{curtin2017designing,
+  title={Designing and building the mlpack open-source machine learning
+library},
+  author={Curtin, R.R. and Edel, M.},
+  journal={arXiv preprint arXiv:1708.05279},
+  year={2017}
+}
+
+@inproceedings{edel2014automatic,
+  title={An automatic benchmarking system},
+  author={Edel, M. and Soni, A. and Curtin, R.R.},
+  year={2014},
+  booktitle={Proceedings of the NIPS 2014 Workshop on Software Engineering for
+             Machine Learning}
+}
+
+@article{sonnenburg2007need,
+  title={The need for open source software in machine learning},
+  author={Sonnenburg, S. and Braun, M.L. and Ong, C.S. and Bengio, S. and
+          Bottou, L. and Holmes, G. and LeCun, Y. and M{\"u}ller, K.-R. and
+          Pereira, F. and Rasmussen, C.E. and R{\"a}tsch, G. and Sch{\"o}lkopf,
+          B. and Smola, A. and Vincent, P. and Weston, J. and Williamson, R.C.},
+  journal={Journal of Machine Learning Research},
+  volume={8},
+  number={Oct},
+  pages={2443--2466},
+  year={2007}
+}

--- a/doc/joss_paper/paper.md
+++ b/doc/joss_paper/paper.md
@@ -1,0 +1,91 @@
+---
+title: 'mlpack 3: a fast, flexible machine learning library'
+tags:
+- machine learning
+- deep learning
+- c++
+- optimization
+- template metaprogramming
+
+authors:
+- name: Ryan R. Curtin
+  orcid: 0000-0002-9903-8214
+  affiliation: 1
+
+- name: Marcus Edel
+  orcid: 0000-0001-5445-7303
+  affiliation: 2
+
+- name: Mikhail Lozhnikov
+  orcid: 0000-0002-8727-0091
+  affiliation: 3
+
+- name: Yannis Mentekidis
+  orcid: 0000-0003-3860-9885
+
+- name: Sumedh Ghaisas
+  orcid: 0000-0003-3753-9029
+
+- name: Shangtong Zhang
+  orcid: 0000-0003-4255-1364
+  affiliation: 4
+
+affiliations:
+- name: Center for Advanced Machine Learning, Symantec Corporation
+  index: 1
+- name: Institute of Computer Science, Free University of Berlin
+  index: 2
+- name: Moscow State University, Faculty of Mechanics and Mathematics
+  index: 3
+- name: University of Alberta
+  index: 4
+
+date: 5 April 2018
+bibliography: paper.bib
+---
+
+# Summary
+
+In the past several years, the field of machine learning has seen an explosion
+of interest and excitement, with hundreds or thousands of algorithms developed
+for different tasks every year.  But a primary problem faced by the field is the
+ability to scale to larger and larger data---since it is known that training on
+larger datasets typically produces better results [@halevy2009unreasonable].
+Therefore, the development of new algorithms for the continued growth of the
+field depends largely on the existence of good tooling and libraries that enable
+researchers and practitioners to quickly prototype and develop solutions
+[@sonnenburg2007need].  Simultaneously, useful libraries must also be efficient
+and well-implemented.  This has motivated our development of mlpack.
+
+mlpack is a flexible and fast machine learning library written in C++ that has
+bindings that allow use from the command-line and from Python, with support for
+other languages in active development.  mlpack has been developed actively for
+over 10 years [@mlpack2011, @mlpack2013], with over 100 contributors from
+around the world, and is a frequent mentoring organization in the Google Summer
+of Code program (\url{https://summerofcode.withgoogle.com}).  If used in C++,
+the library allows flexibility with no speed penalty through policy-based design
+and template metaprogramming [@alexandrescu2001modern]; but bindings are
+available to other languages, which allow easy use of the fast mlpack codebase.
+
+For fast linear algebra, mlpack is built on the Armadillo C++ matrix library
+[@sanderson2016armadillo], which in turn can use an optimized BLAS
+implementation such as OpenBLAS [@xianyi2018openblas] or even NVBLAS
+[@nvblas] which would allow mlpack algorithms to be run on the GPU.  In
+order to provide fast code, template metaprogramming is used throughout the
+library to reduce runtime overhead by performing any possible computations and
+optimizations at compile time.  An automatic benchmarking system is developed
+and used to test the efficiency of mlpack's algorithms [@edel2014automatic].
+
+mlpack contains a number of standard machine learning algorithms, such as
+logistic regression, random forests, and k-means clustering, and also contains
+cutting-edge techniques such as a compile-time optimized deep learning and
+reinforcement learning framework, dual-tree algorithms for nearest neighbor
+search and other tasks [@curtin2013tree], a generic optimization framework with
+numerous optimizers [@curtin2017generic], a generic hyper-parameter tuner, and
+other recently published machine learning algorithms.
+
+For a more comprehensive introduction to mlpack, see the website at
+\url{http://www.mlpack.org/} or a recent paper detailing the design and
+structure of mlpack [@curtin2017designing].
+
+# References


### PR DESCRIPTION
This adds the mlpack JOSS paper to the mlpack repository, which is required for the submission to JOSS:  https://github.com/openjournals/joss-reviews/issues/703

I think that we could either remove it or leave it in the repository after the submission is done.