### PR TITLE
Add shuffle parameter to KFoldCV constructor

### DIFF
--- a/src/mlpack/core/cv/k_fold_cv.hpp
+++ b/src/mlpack/core/cv/k_fold_cv.hpp
@@ -40,6 +40,10 @@ namespace cv {
  * double softmaxAccuracy = cv.Evaluate(lambda);
  * @endcode
  *
+ * Before calling @c Evaluate(), it is possible to shuffle the data by calling
+ * the @c Shuffle() function.  Shuffling is performed at construction time if
+ * the parameter @c shuffle is set to @c true in the constructor.
+ *
  * @tparam MLAlgorithm A machine learning algorithm.
  * @tparam Metric A metric to assess the quality of a trained model.
  * @tparam MatType The type of data.
@@ -69,9 +73,7 @@ class KFoldCV
    * @param xs Data points to cross-validate on.
    * @param ys Predictions (labels for classification algorithms and responses
    *     for regression algorithms) for each data point.
-   * @param shuffle Whether or not to shuffle the data and predictions before
-   *     performing cross-validation.  Shuffling will be performed before every
-   *     call to Evaluate().
+   * @param shuffle Whether or not to shuffle the data during construction.
    */
   KFoldCV(const size_t k,
           const MatType& xs,
@@ -85,9 +87,7 @@ class KFoldCV
    * @param xs Data points to cross-validate on.
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
-   * @param shuffle Whether or not to shuffle the data and predictions before
-   *     performing cross-validation.  Shuffling will be performed before every
-   *     call to Evaluate().
+   * @param shuffle Whether or not to shuffle the data during construction.
    */
   KFoldCV(const size_t k,
           const MatType& xs,
@@ -104,9 +104,7 @@ class KFoldCV
    * @param datasetInfo Type information for each dimension of the dataset.
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
-   * @param shuffle Whether or not to shuffle the data and predictions before
-   *     performing cross-validation.  Shuffling will be performed before every
-   *     call to Evaluate().
+   * @param shuffle Whether or not to shuffle the data during construction.
    */
   KFoldCV(const size_t k,
           const MatType& xs,
@@ -124,9 +122,7 @@ class KFoldCV
    * @param ys Predictions (labels for classification algorithms and responses
    *     for regression algorithms) for each data point.
    * @param weights Observation weights (for boosting).
-   * @param shuffle Whether or not to shuffle the data and predictions before
-   *     performing cross-validation.  Shuffling will be performed before every
-   *     call to Evaluate().
+   * @param shuffle Whether or not to shuffle the data during construction.
    */
   KFoldCV(const size_t k,
           const MatType& xs,
@@ -143,9 +139,7 @@ class KFoldCV
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
    * @param weights Observation weights (for boosting).
-   * @param shuffle Whether or not to shuffle the data and predictions before
-   *     performing cross-validation.  Shuffling will be performed before every
-   *     call to Evaluate().
+   * @param shuffle Whether or not to shuffle the data during construction.
    */
   KFoldCV(const size_t k,
           const MatType& xs,
@@ -164,9 +158,7 @@ class KFoldCV
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
    * @param weights Observation weights (for boosting).
-   * @param shuffle Whether or not to shuffle the data and predictions before
-   *     performing cross-validation.  Shuffling will be performed before every
-   *     call to Evaluate().
+   * @param shuffle Whether or not to shuffle the data during construction.
    */
   KFoldCV(const size_t k,
           const MatType& xs,

--- a/src/mlpack/core/cv/k_fold_cv.hpp
+++ b/src/mlpack/core/cv/k_fold_cv.hpp
@@ -181,6 +181,9 @@ class KFoldCV
   //! The extended (by repeating the first k - 2 bins) weights.
   WeightsType weights;
 
+  //! The original size of the dataset.
+  size_t lastBinSize;
+
   //! The size of each bin in terms of data points.
   size_t binSize;
 
@@ -219,7 +222,7 @@ class KFoldCV
   /**
    * Train and run evaluation in the case of non-weighted learning.
    */
-  template<typename...MLAlgorithmArgs,
+  template<typename... MLAlgorithmArgs,
            bool Enabled = !Base::MIE::SupportsWeights,
            typename = typename std::enable_if<Enabled>::type>
   double TrainAndEvaluate(const MLAlgorithmArgs& ...mlAlgorithmArgs);

--- a/src/mlpack/core/cv/k_fold_cv.hpp
+++ b/src/mlpack/core/cv/k_fold_cv.hpp
@@ -221,9 +221,6 @@ class KFoldCV
   //! The size of each bin in terms of data points.
   size_t binSize;
 
-  //! The size of each training subset in terms of data points.
-  size_t trainingSubsetSize;
-
   //! A pointer to a model from the last run of k-fold cross-validation.
   std::unique_ptr<MLAlgorithm> modelPtr;
 

--- a/src/mlpack/core/cv/k_fold_cv.hpp
+++ b/src/mlpack/core/cv/k_fold_cv.hpp
@@ -69,10 +69,14 @@ class KFoldCV
    * @param xs Data points to cross-validate on.
    * @param ys Predictions (labels for classification algorithms and responses
    *     for regression algorithms) for each data point.
+   * @param shuffle Whether or not to shuffle the data and predictions before
+   *     performing cross-validation.  Shuffling will be performed before every
+   *     call to Evaluate().
    */
   KFoldCV(const size_t k,
           const MatType& xs,
-          const PredictionsType& ys);
+          const PredictionsType& ys,
+          const bool shuffle = true);
 
   /**
    * This constructor can be used for multiclass classification algorithms.
@@ -81,11 +85,15 @@ class KFoldCV
    * @param xs Data points to cross-validate on.
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
+   * @param shuffle Whether or not to shuffle the data and predictions before
+   *     performing cross-validation.  Shuffling will be performed before every
+   *     call to Evaluate().
    */
   KFoldCV(const size_t k,
           const MatType& xs,
           const PredictionsType& ys,
-          const size_t numClasses);
+          const size_t numClasses,
+          const bool shuffle = true);
 
   /**
    * This constructor can be used for multiclass classification algorithms that
@@ -96,12 +104,16 @@ class KFoldCV
    * @param datasetInfo Type information for each dimension of the dataset.
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
+   * @param shuffle Whether or not to shuffle the data and predictions before
+   *     performing cross-validation.  Shuffling will be performed before every
+   *     call to Evaluate().
    */
   KFoldCV(const size_t k,
           const MatType& xs,
           const data::DatasetInfo& datasetInfo,
           const PredictionsType& ys,
-          const size_t numClasses);
+          const size_t numClasses,
+          const bool shuffle = true);
 
   /**
    * This constructor can be used for regression and binary classification
@@ -112,11 +124,15 @@ class KFoldCV
    * @param ys Predictions (labels for classification algorithms and responses
    *     for regression algorithms) for each data point.
    * @param weights Observation weights (for boosting).
+   * @param shuffle Whether or not to shuffle the data and predictions before
+   *     performing cross-validation.  Shuffling will be performed before every
+   *     call to Evaluate().
    */
   KFoldCV(const size_t k,
           const MatType& xs,
           const PredictionsType& ys,
-          const WeightsType& weights);
+          const WeightsType& weights,
+          const bool shuffle = true);
 
   /**
    * This constructor can be used for multiclass classification algorithms that
@@ -127,12 +143,16 @@ class KFoldCV
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
    * @param weights Observation weights (for boosting).
+   * @param shuffle Whether or not to shuffle the data and predictions before
+   *     performing cross-validation.  Shuffling will be performed before every
+   *     call to Evaluate().
    */
   KFoldCV(const size_t k,
           const MatType& xs,
           const PredictionsType& ys,
           const size_t numClasses,
-          const WeightsType& weights);
+          const WeightsType& weights,
+          const bool shuffle = true);
 
   /**
    * This constructor can be used for multiclass classification algorithms that
@@ -144,13 +164,17 @@ class KFoldCV
    * @param ys Labels for each data point.
    * @param numClasses Number of classes in the dataset.
    * @param weights Observation weights (for boosting).
+   * @param shuffle Whether or not to shuffle the data and predictions before
+   *     performing cross-validation.  Shuffling will be performed before every
+   *     call to Evaluate().
    */
   KFoldCV(const size_t k,
           const MatType& xs,
           const data::DatasetInfo& datasetInfo,
           const PredictionsType& ys,
           const size_t numClasses,
-          const WeightsType& weights);
+          const WeightsType& weights,
+          const bool shuffle = true);
 
   /**
    * Run k-fold cross-validation.
@@ -163,6 +187,13 @@ class KFoldCV
 
   //! Access and modify a model from the last run of k-fold cross-validation.
   MLAlgorithm& Model();
+
+  //! Access whether or not shuffling will be performed before k-fold
+  //! cross-validation.
+  bool Shuffle() const { return shuffle; }
+  //! Modify whether or not shuffling will be performed before k-fold
+  //! cross-validation.
+  bool& Shuffle() { return shuffle; }
 
  private:
   //! A short alias for CVBase.
@@ -180,6 +211,9 @@ class KFoldCV
   PredictionsType ys;
   //! The extended (by repeating the first k - 2 bins) weights.
   WeightsType weights;
+
+  //! Whether or not to shuffle when calling Evaluate().
+  bool shuffle;
 
   //! The original size of the dataset.
   size_t lastBinSize;
@@ -200,7 +234,8 @@ class KFoldCV
   KFoldCV(Base&& base,
           const size_t k,
           const MatType& xs,
-          const PredictionsType& ys);
+          const PredictionsType& ys,
+          const bool shuffle);
 
   /**
    * Assert the k parameter and data consistency and initialize fields required
@@ -210,7 +245,8 @@ class KFoldCV
           const size_t k,
           const MatType& xs,
           const PredictionsType& ys,
-          const WeightsType& weights);
+          const WeightsType& weights,
+          const bool shuffle);
 
   /**
    * Initialize the given destination matrix with the given source joined with
@@ -230,11 +266,26 @@ class KFoldCV
   /**
    * Train and run evaluation in the case of supporting weighted learning.
    */
-  template<typename...MLAlgorithmArgs,
+  template<typename... MLAlgorithmArgs,
            bool Enabled = Base::MIE::SupportsWeights,
            typename = typename std::enable_if<Enabled>::type,
            typename = void>
   double TrainAndEvaluate(const MLAlgorithmArgs& ...mlAlgorithmArgs);
+
+  /**
+   * Shuffle data if weights are not supported.
+   */
+  template<bool Enabled = !Base::MIE::SupportsWeights,
+           typename = typename std::enable_if<Enabled>::type>
+  void ShuffleData();
+
+  /**
+   * Shuffle data if weights are supported.
+   */
+  template<bool Enabled = Base::MIE::SupportsWeights,
+           typename = typename std::enable_if<Enabled>::type,
+           typename = void>
+  void ShuffleData();
 
   /**
    * Calculate the index of the first column of the ith validation subset.

--- a/src/mlpack/core/cv/k_fold_cv.hpp
+++ b/src/mlpack/core/cv/k_fold_cv.hpp
@@ -188,17 +188,29 @@ class KFoldCV
   //! Access and modify a model from the last run of k-fold cross-validation.
   MLAlgorithm& Model();
 
-  //! Access whether or not shuffling will be performed before k-fold
-  //! cross-validation.
-  bool Shuffle() const { return shuffle; }
-  //! Modify whether or not shuffling will be performed before k-fold
-  //! cross-validation.
-  bool& Shuffle() { return shuffle; }
-
  private:
   //! A short alias for CVBase.
   using Base = CVBase<MLAlgorithm, MatType, PredictionsType, WeightsType>;
 
+ public:
+  /**
+   * Shuffle the data.  This overload is called if weights are not supported by
+   * the model type.
+   */
+  template<bool Enabled = !Base::MIE::SupportsWeights,
+           typename = typename std::enable_if<Enabled>::type>
+  void Shuffle();
+
+  /**
+   * Shuffle the data.  This overload is called if weights are supported by the
+   * model type.
+   */
+  template<bool Enabled = Base::MIE::SupportsWeights,
+           typename = typename std::enable_if<Enabled>::type,
+           typename = void>
+  void Shuffle();
+
+ private:
   //! An auxiliary object.
   Base base;
 
@@ -211,9 +223,6 @@ class KFoldCV
   PredictionsType ys;
   //! The extended (by repeating the first k - 2 bins) weights.
   WeightsType weights;
-
-  //! Whether or not to shuffle when calling Evaluate().
-  bool shuffle;
 
   //! The original size of the dataset.
   size_t lastBinSize;
@@ -268,21 +277,6 @@ class KFoldCV
            typename = typename std::enable_if<Enabled>::type,
            typename = void>
   double TrainAndEvaluate(const MLAlgorithmArgs& ...mlAlgorithmArgs);
-
-  /**
-   * Shuffle data if weights are not supported.
-   */
-  template<bool Enabled = !Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type>
-  void ShuffleData();
-
-  /**
-   * Shuffle data if weights are supported.
-   */
-  template<bool Enabled = Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type,
-           typename = void>
-  void ShuffleData();
 
   /**
    * Calculate the index of the first column of the ith validation subset.

--- a/src/mlpack/core/cv/k_fold_cv_impl.hpp
+++ b/src/mlpack/core/cv/k_fold_cv_impl.hpp
@@ -220,11 +220,10 @@ void KFoldCV<MLAlgorithm,
                                           DataType& destination)
 {
   binSize = source.n_cols / k;
-  trainingSubsetSize = binSize * (k - 1);
   lastBinSize = source.n_cols - ((k - 1) * binSize);
 
   destination = (k == 2) ? source : arma::join_rows(source,
-      source.cols(0, trainingSubsetSize - binSize - 1));
+      source.cols(0, source.n_cols - lastBinSize - 1));
 }
 
 template<typename MLAlgorithm,
@@ -348,7 +347,7 @@ size_t KFoldCV<MLAlgorithm,
                WeightsType>::ValidationSubsetFirstCol(const size_t i)
 {
   // Use as close to the beginning of the dataset as we can.
-  return (i == 0) ? trainingSubsetSize : binSize * (i - 1);
+  return (i == 0) ? binSize * (k - 1) : binSize * (i - 1);
 }
 
 template<typename MLAlgorithm,
@@ -366,9 +365,9 @@ arma::Mat<ElementType> KFoldCV<MLAlgorithm,
     const size_t i)
 {
   // If this is the last fold, we have to handle it a little bit differently,
-  // since the last fold may not contain 'binSize' points.
+  // since the last fold may contain slightly more than 'binSize' points.
   const size_t subsetSize = (i == k - 1) ? lastBinSize + (k - 2) * binSize :
-      trainingSubsetSize;
+      (k - 1) * binSize;
 
   return arma::Mat<ElementType>(m.colptr(binSize * i), m.n_rows, subsetSize,
       false, true);
@@ -391,7 +390,7 @@ arma::Row<ElementType> KFoldCV<MLAlgorithm,
   // If this is the last fold, we have to handle it a little bit differently,
   // since the last fold may not contain 'binSize' points.
   const size_t subsetSize = (i == k - 1) ? lastBinSize + (k - 2) * binSize :
-      trainingSubsetSize;
+      (k - 1) * binSize;
 
   return arma::Row<ElementType>(r.colptr(binSize * i), subsetSize, false, true);
 }

--- a/src/mlpack/core/cv/k_fold_cv_impl.hpp
+++ b/src/mlpack/core/cv/k_fold_cv_impl.hpp
@@ -295,14 +295,14 @@ void KFoldCV<MLAlgorithm,
              PredictionsType,
              WeightsType>::ShuffleData()
 {
-  MatType data = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
-  PredictionsType labels = ys.subvec(0, (k - 1) * binSize + lastBinSize - 1);
+  MatType xsOrig = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
+  PredictionsType ysOrig = ys.cols(0, (k - 1) * binSize + lastBinSize - 1);
 
   // Now shuffle the data.
-  math::ShuffleData(data, labels, data, labels);
+  math::ShuffleData(xsOrig, ysOrig, xsOrig, ysOrig);
 
-  InitKFoldCVMat(data, xs);
-  InitKFoldCVMat(labels, ys);
+  InitKFoldCVMat(xsOrig, xs);
+  InitKFoldCVMat(ysOrig, ys);
 }
 
 template<typename MLAlgorithm,
@@ -317,22 +317,22 @@ void KFoldCV<MLAlgorithm,
              PredictionsType,
              WeightsType>::ShuffleData()
 {
-  MatType data = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
-  PredictionsType labels = ys.cols(0, (k - 1) * binSize + lastBinSize - 1);
-  WeightsType newWeights;
+  MatType xsOrig = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
+  PredictionsType ysOrig = ys.cols(0, (k - 1) * binSize + lastBinSize - 1);
+  WeightsType weightsOrig;
   if (weights.n_elem > 0)
-    newWeights = weights.cols(0, (k - 1) * binSize + lastBinSize - 1);
+    weightsOrig = weights.cols(0, (k - 1) * binSize + lastBinSize - 1);
 
   // Now shuffle the data.
   if (weights.n_elem > 0)
-    math::ShuffleData(data, labels, newWeights, data, labels, newWeights);
+    math::ShuffleData(xsOrig, ysOrig, weightsOrig, xsOrig, ysOrig, weightsOrig);
   else
-    math::ShuffleData(data, labels, data, labels);
+    math::ShuffleData(xsOrig, ysOrig, xsOrig, ysOrig);
 
-  InitKFoldCVMat(data, xs);
-  InitKFoldCVMat(labels, ys);
+  InitKFoldCVMat(xsOrig, xs);
+  InitKFoldCVMat(ysOrig, ys);
   if (weights.n_elem > 0)
-    InitKFoldCVMat(newWeights, weights);
+    InitKFoldCVMat(weightsOrig, weights);
 }
 
 template<typename MLAlgorithm,

--- a/src/mlpack/core/cv/k_fold_cv_impl.hpp
+++ b/src/mlpack/core/cv/k_fold_cv_impl.hpp
@@ -26,57 +26,9 @@ KFoldCV<MLAlgorithm,
         PredictionsType,
         WeightsType>::KFoldCV(const size_t k,
                               const MatType& xs,
-                              const PredictionsType& ys) :
-    KFoldCV(Base(), k, xs, ys)
-{ /* Nothing left to do. */ }
-
-template<typename MLAlgorithm,
-         typename Metric,
-         typename MatType,
-         typename PredictionsType,
-         typename WeightsType>
-KFoldCV<MLAlgorithm,
-        Metric,
-        MatType,
-        PredictionsType,
-        WeightsType>::KFoldCV(const size_t k,
-                              const MatType& xs,
                               const PredictionsType& ys,
-                              const size_t numClasses) :
-    KFoldCV(Base(numClasses), k, xs, ys)
-{ /* Nothing left to do. */ }
-
-template<typename MLAlgorithm,
-         typename Metric,
-         typename MatType,
-         typename PredictionsType,
-         typename WeightsType>
-KFoldCV<MLAlgorithm,
-        Metric,
-        MatType,
-        PredictionsType,
-        WeightsType>::KFoldCV(const size_t k,
-                              const MatType& xs,
-                              const data::DatasetInfo& datasetInfo,
-                              const PredictionsType& ys,
-                              const size_t numClasses) :
-    KFoldCV(Base(datasetInfo, numClasses), k, xs, ys)
-{ /* Nothing left to do. */ }
-
-template<typename MLAlgorithm,
-         typename Metric,
-         typename MatType,
-         typename PredictionsType,
-         typename WeightsType>
-KFoldCV<MLAlgorithm,
-        Metric,
-        MatType,
-        PredictionsType,
-        WeightsType>::KFoldCV(const size_t k,
-                              const MatType& xs,
-                              const PredictionsType& ys,
-                              const WeightsType& weights) :
-    KFoldCV(Base(), k, xs, ys, weights)
+                              const bool shuffle) :
+    KFoldCV(Base(), k, xs, ys, shuffle)
 { /* Nothing left to do. */ }
 
 template<typename MLAlgorithm,
@@ -92,8 +44,8 @@ KFoldCV<MLAlgorithm,
                               const MatType& xs,
                               const PredictionsType& ys,
                               const size_t numClasses,
-                              const WeightsType& weights) :
-    KFoldCV(Base(numClasses), k, xs, ys, weights)
+                              const bool shuffle) :
+    KFoldCV(Base(numClasses), k, xs, ys, shuffle)
 { /* Nothing left to do. */ }
 
 template<typename MLAlgorithm,
@@ -110,8 +62,62 @@ KFoldCV<MLAlgorithm,
                               const data::DatasetInfo& datasetInfo,
                               const PredictionsType& ys,
                               const size_t numClasses,
-                              const WeightsType& weights) :
-    KFoldCV(Base(datasetInfo, numClasses), k, xs, ys, weights)
+                              const bool shuffle) :
+    KFoldCV(Base(datasetInfo, numClasses), k, xs, ys, shuffle)
+{ /* Nothing left to do. */ }
+
+template<typename MLAlgorithm,
+         typename Metric,
+         typename MatType,
+         typename PredictionsType,
+         typename WeightsType>
+KFoldCV<MLAlgorithm,
+        Metric,
+        MatType,
+        PredictionsType,
+        WeightsType>::KFoldCV(const size_t k,
+                              const MatType& xs,
+                              const PredictionsType& ys,
+                              const WeightsType& weights,
+                              const bool shuffle) :
+    KFoldCV(Base(), k, xs, ys, weights, shuffle)
+{ /* Nothing left to do. */ }
+
+template<typename MLAlgorithm,
+         typename Metric,
+         typename MatType,
+         typename PredictionsType,
+         typename WeightsType>
+KFoldCV<MLAlgorithm,
+        Metric,
+        MatType,
+        PredictionsType,
+        WeightsType>::KFoldCV(const size_t k,
+                              const MatType& xs,
+                              const PredictionsType& ys,
+                              const size_t numClasses,
+                              const WeightsType& weights,
+                              const bool shuffle) :
+    KFoldCV(Base(numClasses), k, xs, ys, weights, shuffle)
+{ /* Nothing left to do. */ }
+
+template<typename MLAlgorithm,
+         typename Metric,
+         typename MatType,
+         typename PredictionsType,
+         typename WeightsType>
+KFoldCV<MLAlgorithm,
+        Metric,
+        MatType,
+        PredictionsType,
+        WeightsType>::KFoldCV(const size_t k,
+                              const MatType& xs,
+                              const data::DatasetInfo& datasetInfo,
+                              const PredictionsType& ys,
+                              const size_t numClasses,
+                              const WeightsType& weights,
+                              const bool shuffle) :
+    KFoldCV(Base(datasetInfo, numClasses), k, xs, ys, weights, shuffle)
 { /* Nothing left to do. */ }
 
 template<typename MLAlgorithm,
@@ -126,8 +132,11 @@ KFoldCV<MLAlgorithm,
         WeightsType>::KFoldCV(Base&& base,
                               const size_t k,
                               const MatType& xs,
-                              const PredictionsType& ys) :
-  base(std::move(base)), k(k)
+                              const PredictionsType& ys,
+                              const bool shuffle) :
+    base(std::move(base)),
+    k(k),
+    shuffle(shuffle)
 {
   if (k < 2)
     throw std::invalid_argument("KFoldCV: k should not be less than 2");
@@ -151,8 +160,9 @@ KFoldCV<MLAlgorithm,
                               const size_t k,
                               const MatType& xs,
                               const PredictionsType& ys,
-                              const WeightsType& weights) :
-    KFoldCV(std::move(base), k, xs, ys)
+                              const WeightsType& weights,
+                              const bool shuffle) :
+    KFoldCV(std::move(base), k, xs, ys, shuffle)
 {
   Base::AssertWeightsConsistency(xs, weights);
 
@@ -171,6 +181,10 @@ double KFoldCV<MLAlgorithm,
                PredictionsType,
                WeightsType>::Evaluate(const MLAlgorithmArgs&... args)
 {
+  // Do we need to shuffle the dataset?
+  if (shuffle)
+    ShuffleData();
+
   return TrainAndEvaluate(args...);
 }
 
@@ -268,6 +282,58 @@ double KFoldCV<MLAlgorithm,
   }
 
   return arma::mean(evaluations);
+}
+
+template<typename MLAlgorithm,
+         typename Metric,
+         typename MatType,
+         typename PredictionsType,
+         typename WeightsType>
+template<bool Enabled, typename>
+void KFoldCV<MLAlgorithm,
+             Metric,
+             MatType,
+             PredictionsType,
+             WeightsType>::ShuffleData()
+{
+  MatType data = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
+  PredictionsType labels = ys.subvec(0, (k - 1) * binSize + lastBinSize - 1);
+
+  // Now shuffle the data.
+  math::ShuffleData(data, labels, data, labels);
+
+  InitKFoldCVMat(data, xs);
+  InitKFoldCVMat(labels, ys);
+}
+
+template<typename MLAlgorithm,
+         typename Metric,
+         typename MatType,
+         typename PredictionsType,
+         typename WeightsType>
+template<bool Enabled, typename, typename>
+void KFoldCV<MLAlgorithm,
+             Metric,
+             MatType,
+             PredictionsType,
+             WeightsType>::ShuffleData()
+{
+  MatType data = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
+  PredictionsType labels = ys.cols(0, (k - 1) * binSize + lastBinSize - 1);
+  WeightsType newWeights;
+  if (weights.n_elem > 0)
+    newWeights = weights.cols(0, (k - 1) * binSize + lastBinSize - 1);
+
+  // Now shuffle the data.
+  if (weights.n_elem > 0)
+    math::ShuffleData(data, labels, newWeights, data, labels, newWeights);
+  else
+    math::ShuffleData(data, labels, data, labels);
+
+  InitKFoldCVMat(data, xs);
+  InitKFoldCVMat(labels, ys);
+  if (weights.n_elem > 0)
+    InitKFoldCVMat(newWeights, weights);
 }
 
 template<typename MLAlgorithm,

--- a/src/mlpack/core/cv/k_fold_cv_impl.hpp
+++ b/src/mlpack/core/cv/k_fold_cv_impl.hpp
@@ -370,9 +370,10 @@ arma::Mat<ElementType> KFoldCV<MLAlgorithm,
     arma::Mat<ElementType>& m,
     const size_t i)
 {
-  // If this is the last fold, we have to handle it a little bit differently,
-  // since the last fold may contain slightly more than 'binSize' points.
-  const size_t subsetSize = (i == k - 1) ? lastBinSize + (k - 2) * binSize :
+  // If this is not the first fold, we have to handle it a little bit
+  // differently, since the last fold may contain slightly more than 'binSize'
+  // points.
+  const size_t subsetSize = (i != 0) ? lastBinSize + (k - 2) * binSize :
       (k - 1) * binSize;
 
   return arma::Mat<ElementType>(m.colptr(binSize * i), m.n_rows, subsetSize,
@@ -393,9 +394,10 @@ arma::Row<ElementType> KFoldCV<MLAlgorithm,
     arma::Row<ElementType>& r,
     const size_t i)
 {
-  // If this is the last fold, we have to handle it a little bit differently,
-  // since the last fold may not contain 'binSize' points.
-  const size_t subsetSize = (i == k - 1) ? lastBinSize + (k - 2) * binSize :
+  // If this is not the first fold, we have to handle it a little bit
+  // differently, since the last fold may contain slightly more than 'binSize'
+  // points.
+  const size_t subsetSize = (i != 0) ? lastBinSize + (k - 2) * binSize :
       (k - 1) * binSize;
 
   return arma::Row<ElementType>(r.colptr(binSize * i), subsetSize, false, true);

--- a/src/mlpack/core/cv/k_fold_cv_impl.hpp
+++ b/src/mlpack/core/cv/k_fold_cv_impl.hpp
@@ -135,8 +135,7 @@ KFoldCV<MLAlgorithm,
                               const PredictionsType& ys,
                               const bool shuffle) :
     base(std::move(base)),
-    k(k),
-    shuffle(shuffle)
+    k(k)
 {
   if (k < 2)
     throw std::invalid_argument("KFoldCV: k should not be less than 2");
@@ -145,6 +144,10 @@ KFoldCV<MLAlgorithm,
 
   InitKFoldCVMat(xs, this->xs);
   InitKFoldCVMat(ys, this->ys);
+
+  // Do we need to shuffle the dataset?
+  if (shuffle)
+    Shuffle();
 }
 
 template<typename MLAlgorithm,
@@ -162,11 +165,18 @@ KFoldCV<MLAlgorithm,
                               const PredictionsType& ys,
                               const WeightsType& weights,
                               const bool shuffle) :
-    KFoldCV(std::move(base), k, xs, ys, shuffle)
+    base(std::move(base)),
+    k(k)
 {
   Base::AssertWeightsConsistency(xs, weights);
 
+  InitKFoldCVMat(xs, this->xs);
+  InitKFoldCVMat(ys, this->ys);
   InitKFoldCVMat(weights, this->weights);
+
+  // Do we need to shuffle the dataset?
+  if (shuffle)
+    Shuffle();
 }
 
 template<typename MLAlgorithm,
@@ -181,10 +191,6 @@ double KFoldCV<MLAlgorithm,
                PredictionsType,
                WeightsType>::Evaluate(const MLAlgorithmArgs&... args)
 {
-  // Do we need to shuffle the dataset?
-  if (shuffle)
-    ShuffleData();
-
   return TrainAndEvaluate(args...);
 }
 
@@ -293,7 +299,7 @@ void KFoldCV<MLAlgorithm,
              Metric,
              MatType,
              PredictionsType,
-             WeightsType>::ShuffleData()
+             WeightsType>::Shuffle()
 {
   MatType xsOrig = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
   PredictionsType ysOrig = ys.cols(0, (k - 1) * binSize + lastBinSize - 1);
@@ -315,7 +321,7 @@ void KFoldCV<MLAlgorithm,
              Metric,
              MatType,
              PredictionsType,
-             WeightsType>::ShuffleData()
+             WeightsType>::Shuffle()
 {
   MatType xsOrig = xs.cols(0, (k - 1) * binSize + lastBinSize - 1);
   PredictionsType ysOrig = ys.cols(0, (k - 1) * binSize + lastBinSize - 1);

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -148,6 +148,97 @@ void ShuffleData(const MatType& inputPoints,
   }
 }
 
+/**
+ * Shuffle a dataset and associated labels (or responses) and weights.  It is
+ * expected that inputPoints and inputLabels and inputWeights have the same
+ * number of columns (so, be sure that inputLabels, if it is a vector, is a row
+ * vector).
+ *
+ * Shuffled data will be output into outputPoints and outputLabels and
+ * outputWeights.
+ */
+template<typename MatType, typename LabelsType, typename WeightsType>
+void ShuffleData(const MatType& inputPoints,
+                 const LabelsType& inputLabels,
+                 const WeightsType& inputWeights,
+                 MatType& outputPoints,
+                 LabelsType& outputLabels,
+                 WeightsType& outputWeights,
+                 const std::enable_if_t<!arma::is_SpMat<MatType>::value>* = 0,
+                 const std::enable_if_t<!arma::is_Cube<MatType>::value>* = 0)
+{
+  // Generate ordering.
+  arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
+      inputPoints.n_cols - 1, inputPoints.n_cols));
+
+  outputPoints = inputPoints.cols(ordering);
+  outputLabels = inputLabels.cols(ordering);
+  outputWeights = inputWeights.cols(ordering);
+}
+
+/**
+ * Shuffle a sparse dataset and associated labels (or responses) and weights.
+ * It is expected that inputPoints and inputLabels and inputWeights have the
+ * same number of columns (so, be sure that inputLabels, if it is a vector, is a
+ * row vector).
+ *
+ * Shuffled data will be output into outputPoints and outputLabels and
+ * outputWeights.
+ */
+template<typename MatType, typename LabelsType, typename WeightsType>
+void ShuffleData(const MatType& inputPoints,
+                 const LabelsType& inputLabels,
+                 const WeightsType& inputWeights,
+                 MatType& outputPoints,
+                 LabelsType& outputLabels,
+                 WeightsType& outputWeights,
+                 const std::enable_if_t<arma::is_SpMat<MatType>::value>* = 0,
+                 const std::enable_if_t<!arma::is_Cube<MatType>::value>* = 0)
+{
+  // Generate ordering.
+  arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
+      inputPoints.n_cols - 1, inputPoints.n_cols));
+
+  // Extract coordinate list representation.
+  arma::umat locations(2, inputPoints.n_nonzero);
+  arma::Col<typename MatType::elem_type> values(
+      const_cast<typename MatType::elem_type*>(inputPoints.values),
+      inputPoints.n_nonzero, false, true);
+  typename MatType::const_iterator it = inputPoints.begin();
+  size_t index = 0;
+  while (it != inputPoints.end())
+  {
+    locations(0, index) = it.row();
+    locations(1, index) = ordering[it.col()];
+    ++it;
+    ++index;
+  }
+
+  if (&inputPoints == &outputPoints || &inputLabels == &outputLabels ||
+      &inputWeights == &outputWeights)
+  {
+    MatType newOutputPoints(locations, values, inputPoints.n_rows,
+        inputPoints.n_cols, true);
+    LabelsType newOutputLabels(inputLabels.n_elem);
+    WeightsType newOutputWeights(inputWeights.n_elem);
+    newOutputLabels.cols(ordering) = inputLabels;
+    newOutputWeights.cols(ordering) = inputWeights;
+
+    outputPoints = std::move(newOutputPoints);
+    outputLabels = std::move(newOutputLabels);
+    outputWeights = std::move(newOutputWeights);
+  }
+  else
+  {
+    outputPoints = MatType(locations, values, inputPoints.n_rows,
+        inputPoints.n_cols, true);
+    outputLabels.set_size(inputLabels.n_elem);
+    outputLabels.cols(ordering) = inputLabels;
+    outputWeights.set_size(inputWeights.n_elem);
+    outputWeights.cols(ordering) = inputWeights;
+  }
+}
+
 } // namespace math
 } // namespace mlpack
 

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -61,15 +61,14 @@ void ShuffleData(const MatType& inputPoints,
 
   // Extract coordinate list representation.
   arma::umat locations(2, inputPoints.n_nonzero);
-  arma::Col<typename MatType::elem_type> values(
-      const_cast<typename MatType::elem_type*>(inputPoints.values),
-      inputPoints.n_nonzero, false, true);
+  arma::Col<typename MatType::elem_type> values(inputPoints.n_nonzero);
   typename MatType::const_iterator it = inputPoints.begin();
   size_t index = 0;
   while (it != inputPoints.end())
   {
     locations(0, index) = it.row();
     locations(1, index) = ordering[it.col()];
+    values(index) = (*it);
     ++it;
     ++index;
   }
@@ -201,15 +200,14 @@ void ShuffleData(const MatType& inputPoints,
 
   // Extract coordinate list representation.
   arma::umat locations(2, inputPoints.n_nonzero);
-  arma::Col<typename MatType::elem_type> values(
-      const_cast<typename MatType::elem_type*>(inputPoints.values),
-      inputPoints.n_nonzero, false, true);
+  arma::Col<typename MatType::elem_type> values(inputPoints.n_nonzero);
   typename MatType::const_iterator it = inputPoints.begin();
   size_t index = 0;
   while (it != inputPoints.end())
   {
     locations(0, index) = it.row();
     locations(1, index) = ordering[it.col()];
+    values(index) = (*it);
     ++it;
     ++index;
   }

--- a/src/mlpack/methods/softmax_regression/softmax_regression_function.cpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_function.cpp
@@ -53,14 +53,14 @@ void SoftmaxRegressionFunction::Shuffle()
     reverseOrdering[ordering[i]] = i;
 
   arma::umat newLocations(2, groundTruth.n_nonzero);
-  arma::vec values(const_cast<double*>(groundTruth.values),
-      groundTruth.n_nonzero, false, true);
+  arma::vec values(groundTruth.n_nonzero);
   arma::sp_mat::const_iterator it = groundTruth.begin();
   size_t loc = 0;
   while (it != groundTruth.end())
   {
     newLocations(0, loc) = reverseOrdering(it.col());
     newLocations(1, loc) = it.row();
+    values(loc) = (*it);
 
     ++it;
     ++loc;

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -520,6 +520,10 @@ BOOST_AUTO_TEST_CASE(SerializationTest)
       cBinary.CleanedData().n_nonzero);
   BOOST_REQUIRE_EQUAL(c.CleanedData().n_nonzero, cText.CleanedData().n_nonzero);
 
+#if ARMA_VERSION_MAJOR >= 8
+  c.CleanedData().sync();
+#endif
+
   for (size_t i = 0; i <= c.CleanedData().n_cols; ++i)
   {
     BOOST_REQUIRE_EQUAL(c.CleanedData().col_ptrs[i],


### PR DESCRIPTION
I've modified the KFoldCV class so that there is an optional 'shuffle' parameter, and made a few other changes also:

 * Better handling of sparse matrices to fix #1411 throughout the codebase.

 * Better handling of datasets where the number of points is not evenly divisible by `k` in `KFoldCV`.  @micyril, if you like, you can take a look at what I did and see if there are any issues.  Basically the modification amounts to holding a `lastBinSize`, since the last cross-validation bin may hold fewer points than the others, and then modifying the `GetTrainingSubset()` and `GetValidationSubset()` functions.

The shuffling is done at the beginning of any call to `KFoldCV::Evaluate()`.

This fixes #1409.