### PR TITLE
JOSS documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ with the following command:
 
     $ sudo apt-get install libmlpack-dev
 
+Note: Older Ubuntu versions may not have the most recent version of mlpack
+available---for instance, at the time of this writing, Ubuntu 16.04 only has
+mlpack 2.0.1 available.  Options include upgrading your Ubuntu version, finding
+a PPA or other non-official sources, or installing with a manual build.
+
 There are some other useful pages to consult in addition to this section:
 
   - [Building mlpack From Source](http://www.mlpack.org/docs/mlpack-git/doxygen/build.html)

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -195,6 +195,27 @@ If you wish to install mlpack to the system, make sure you have root privileges
 
 You can now run the executables by name; you can link against mlpack with
 \c -lmlpack, and the mlpack headers are found in \c /usr/include or
-\c /usr/local/include (depending on the system and CMake configuration).
+\c /usr/local/include (depending on the system and CMake configuration).  If
+Python bindings were installed, they should be available when you start Python.
+
+@section build_run Using mlpack without installing
+
+If you would prefer to use mlpack after building but without installing it to
+the system, this is possible.  All of the command-line programs in the
+@c build/bin/ directory will run directly with no modification.
+
+For running the Python bindings from the build directory, the situation is a
+little bit different.  You will need to set the following environment variables:
+
+@code
+export LD_LIBRARY_PATH=/path/to/mlpack/build/lib/:${LD_LIBRARY_PATH}
+export PYTHONPATH=/path/to/mlpack/build/src/mlpack/bindings/python/:${PYTHONPATH}
+@endcode
+
+(Be sure to substitute the correct path to your build directory for
+`/path/to/mlpack/build/`.)
+
+Once those environment variables are set, you should be able to start a Python
+interpreter and `import mlpack`, then use the Python bindings.
 
 */

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -11,6 +11,12 @@ with the following command:
 $ sudo apt-get install libmlpack-dev
 @endcode
 
+@note Older Ubuntu versions may not have the most recent version of mlpack
+available---for instance, at the time of this writing, Ubuntu 16.04 only has
+mlpack 2.0.1 available.  Options include upgrading Ubuntu to a newer release,
+finding a PPA or other non-official sources, or installing with a manual build
+(below).
+
 If mlpack is not available in your system's package manager, then you can follow
 this document for how to compile and install mlpack from source.
 

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -41,6 +41,13 @@ $ sudo make install
 If the \c cmake \c .. command fails, you are probably missing a dependency, so
 check the output and install any necessary libraries.  (See \ref build_dep.)
 
+On many Linux systems, mlpack will install by default to @c /usr/local/lib and
+you may need to set the @c LD_LIBRARY_PATH environment variable:
+
+@code
+export LD_LIBRARY_PATH=/usr/local/lib
+@endcode
+
 The instructions above are the simplest way to get, build, and install mlpack.
 The sections below discuss each of those steps in further detail and show how to
 configure mlpack.

--- a/doc/guide/python_quickstart.hpp
+++ b/doc/guide/python_quickstart.hpp
@@ -37,6 +37,14 @@ mkdir -p mlpack-3.0.1/build/ && cd mlpack-3.0.1/build/
 cmake ../ && make -j4 && sudo make install
 @endcode
 
+More information on the build process and details can be found on the @ref build
+page.  You may also need to set the environment variable @c LD_LIBRARY_PATH to
+include @c /usr/local/lib/ on most Linux systems.
+
+@code
+export LD_LIBRARY_PATH=/usr/local/lib/
+@endcode
+
 You can also use the mlpack Docker image on Dockerhub, which has all of the
 Python bindings pre-installed:
 

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -142,7 +142,14 @@ template<typename... Args>
 std::string ProgramCall(const std::string& programName, Args... args)
 {
   std::ostringstream oss;
-  oss << ">>> " << programName << "(";
+  oss << ">>> ";
+
+  // Find out if we have any output options first.
+  std::ostringstream ossOutput;
+  ossOutput << PrintOutputOptions(args...);
+  if (ossOutput.str() != "")
+    oss << "output = ";
+  oss << programName << "(";
 
   // Now process each input option.
   oss << PrintInputOptions(args...);

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -79,7 +79,7 @@ PROGRAM_INFO("AdaBoost", "This program implements the AdaBoost (or Adaptive "
     "storing the trained model in " + PRINT_MODEL("model") + ", one could "
     "use the following command: "
     "\n\n" +
-    PRINT_CALL("adaboost", "training", "data", "output", "model",
+    PRINT_CALL("adaboost", "training", "data", "output_model", "model",
         "weak_learner", "perceptron") +
     "\n\n"
     "Similarly, an already-trained model in " + PRINT_MODEL("model") + " can"

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -25,7 +25,7 @@ PROGRAM_INFO("Decision tree",
     "numeric or categorical features, and associated labels for each point in "
     "the dataset, this program can train a decision tree on that data."
     "\n\n"
-    "The training file and associated labels are specified with the " +
+    "The training set and associated labels are specified with the " +
     PRINT_PARAM_STRING("training") + " and " + PRINT_PARAM_STRING("labels") +
     " parameters, respectively.  The labels should be in the range [0, "
     "num_classes - 1]. Optionally, if " +
@@ -35,7 +35,7 @@ PROGRAM_INFO("Decision tree",
     "When a model is trained, the " + PRINT_PARAM_STRING("output_model") + " "
     "output parameter may be used to save the trained model.  A model may be "
     "loaded for predictions with the " + PRINT_PARAM_STRING("input_model") +
-    "' parameter.  The " + PRINT_PARAM_STRING("input_model") + " parameter "
+    " parameter.  The " + PRINT_PARAM_STRING("input_model") + " parameter "
     "may not be specified when the " + PRINT_PARAM_STRING("training") + " "
     "parameter is specified.  The " + PRINT_PARAM_STRING("minimum_leaf_size") +
     " parameter specifies the minimum number of training points that must fall"

--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -55,17 +55,17 @@ PROGRAM_INFO("Perceptron",
     " perceptron for later classification.  The invocation below trains a "
     "perceptron on " + PRINT_DATASET("training_data") + " with labels " +
     PRINT_DATASET("training_labels") + ", and saves the model to " +
-    PRINT_MODEL("perceptron") + "."
+    PRINT_MODEL("perceptron_model") + "."
     "\n\n" +
     PRINT_CALL("perceptron", "training", "training_data", "labels",
-        "training_labels", "output_model", "perceptron") +
+        "training_labels", "output_model", "perceptron_model") +
     "\n\n"
     "Then, this model can be re-used for classification on the test data " +
     PRINT_DATASET("test_data") + ".  The example below does precisely that, "
     "saving the predicted classes to " + PRINT_DATASET("predictions") + "."
     "\n\n" +
-    PRINT_CALL("perceptron", "input_model", "perceptron", "test", "test_data",
-        "output", "predictions") +
+    PRINT_CALL("perceptron", "input_model", "perceptron_model", "test",
+        "test_data", "output", "predictions") +
     "\n\n"
     "Note that all of the options may be specified at once: predictions may be "
     "calculated right after training a model, and model training can occur even"

--- a/src/mlpack/methods/random_forest/random_forest_main.cpp
+++ b/src/mlpack/methods/random_forest/random_forest_main.cpp
@@ -25,7 +25,52 @@ PROGRAM_INFO("Random forests",
     "trained and saved for later use, or a random forest may be loaded "
     "and predictions or class probabilities for points may be generated."
     "\n\n"
-    "This documentation will be rewritten once #880 is merged.");
+    "The training set and associated labels are specified with the " +
+    PRINT_PARAM_STRING("training") + " and " + PRINT_PARAM_STRING("labels") +
+    " parameters, respectively.  The labels should be in the range [0, "
+    "num_classes - 1]. Optionally, if " +
+    PRINT_PARAM_STRING("labels") + " is not specified, the labels are assumed "
+    "to be the last dimension of the training dataset."
+    "\n\n"
+    "When a model is trained, the " + PRINT_PARAM_STRING("output_model") + " "
+    "output parameter may be used to save the trained model.  A model may be "
+    "loaded for predictions with the " + PRINT_PARAM_STRING("input_model") +
+    "parameter. The " + PRINT_PARAM_STRING("input_model") + " parameter may "
+    "not be specified when the " + PRINT_PARAM_STRING("training") + " parameter"
+    " is specified.  The " + PRINT_PARAM_STRING("minimum_leaf_size") +
+    " parameter specifies the minimum number of training points that must fall "
+    "into each leaf for it to be split.  The " +
+    PRINT_PARAM_STRING("num_trees") +
+    " controls the number of trees in the random forest. If " +
+    PRINT_PARAM_STRING("print_training_accuracy") + " is specified, the "
+    "calculated accuracy on the training set will be printed."
+    "\n\n"
+    "Test data may be specified with the " + PRINT_PARAM_STRING("test") + " "
+    "parameter, and if performance measures are desired for that test set, "
+    "labels for the test points may be specified with the " +
+    PRINT_PARAM_STRING("test_labels") + " parameter.  Predictions for each "
+    "test point may be saved via the " + PRINT_PARAM_STRING("predictions") +
+    "output parameter.  Class probabilities for each prediction may be saved "
+    "with the " + PRINT_PARAM_STRING("probabilities") + " output parameter."
+    "\n\n"
+    "For example, to train a random forest with a minimum leaf size of 20 "
+    "using 10 trees on the dataset contained in " + PRINT_DATASET("data") +
+    "with labels " + PRINT_DATASET("labels") + ", saving the output random "
+    "forest to " + PRINT_MODEL("rf_model") + " and printing the training "
+    "error, one could call"
+    "\n\n" +
+    PRINT_CALL("random_forest", "training", "data", "labels", "labels",
+        "minimum_leaf_size", 20, "num_trees", 10, "output_model", "rf_model",
+        "print_training_accuracy", true) +
+    "\n\n"
+    "Then, to use that model to classify points in " +
+    PRINT_DATASET("test_set") + " and print the test error given the labels " +
+    PRINT_DATASET("test_labels") + " using that model, while saving the "
+    "predictions for each point to " + PRINT_DATASET("predictions") + ", one "
+    "could call "
+    "\n\n" +
+    PRINT_CALL("random_forest", "input_model", "rf_model", "test", "test_set",
+        "test_labels", "test_labels", "predictions", "predictions"));
 
 PARAM_MATRIX_IN("training", "Training dataset.", "t");
 PARAM_UROW_IN("labels", "Labels for training dataset.", "l");

--- a/src/mlpack/methods/rann/krann_main.cpp
+++ b/src/mlpack/methods/rann/krann_main.cpp
@@ -37,11 +37,13 @@ PROGRAM_INFO("K-Rank-Approximate-Nearest-Neighbors (kRANN)",
     "(and optionally the success probability)."
     "\n\n"
     "For example, the following will return 5 neighbors from the top 0.1% of "
-    "the data (with probability 0.95) for each point in 'input.csv' and store "
-    "the distances in 'distances.csv' and the neighbors in the file "
-    "'neighbors.csv':"
-    "\n\n"
-    "$ allkrann -k 5 -r input.csv -d distances.csv -n neighbors.csv --tau 0.1"
+    "the data (with probability 0.95) for each point in " +
+    PRINT_DATASET("input") + " and store the distances in " +
+    PRINT_DATASET("distances") + " and the neighbors in " +
+    PRINT_DATASET("neighbors.csv") + ":"
+    "\n\n" +
+    PRINT_CALL("krann", "reference", "input", "k", 5, "distances", "distances",
+        "neighbors", "neighbors", "tau", 0.1) +
     "\n\n"
     "Note that tau must be set such that the number of points in the "
     "corresponding percentile of the data is greater than k.  Thus, if we "
@@ -49,7 +51,7 @@ PROGRAM_INFO("K-Rank-Approximate-Nearest-Neighbors (kRANN)",
     "attempting to choose 5 nearest neighbors out of the closest 1 point -- "
     "this is invalid and the program will terminate with an error message."
     "\n\n"
-    "The output files are organized such that row i and column j in the "
+    "The output matrices are organized such that row i and column j in the "
     "neighbors output file corresponds to the index of the point in the "
     "reference set which is the i'th nearest neighbor from the point in the "
     "query set with index j.  Row i and column j in the distances output file "


### PR DESCRIPTION
This is a collection of fixes for the issues brought up by @rasbt:

 * Clarify how to use the Python bindings without installation and mention when `LD_LIBRARY_PATH` might be needed. (#1416)
 * Print `output = ` before automatically-generated calls to Python bindings in documentation. (#1418)
 * Change name of `perceptron` variable in the perceptron code documentation. (#1419)
 * Rewrite the kRANN documentation since it was written specifically for command-line bindings and never updated.
 * Write the random forest documentation since it seems it never actually got written.

Since these fix some fairly important documentation issues from the Python angle, I would have no problem doing a release after this merge as mlpack 3.0.2.