### PR TITLE
Return the final objective of the trained model

### DIFF
--- a/src/mlpack/methods/logistic_regression/logistic_regression.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression.hpp
@@ -125,9 +125,10 @@ class LogisticRegression
    * @tparam OptimizerType Type of optimizer to use to train the model.
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
+   * @return The final objective of the trained model (NaN or Inf on error)
    */
   template<typename OptimizerType = mlpack::optimization::L_BFGS>
-  void Train(const MatType& predictors,
+  double Train(const MatType& predictors,
              const arma::Row<size_t>& responses);
 
   /**
@@ -145,9 +146,10 @@ class LogisticRegression
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
    * @param optimizer Instantiated optimizer with instantiated error function.
+   * @return The final objective of the trained model (NaN or Inf on error)
    */
   template<typename OptimizerType>
-  void Train(const MatType& predictors,
+  double Train(const MatType& predictors,
              const arma::Row<size_t>& responses,
              OptimizerType& optimizer);
 

--- a/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
@@ -68,16 +68,16 @@ LogisticRegression<MatType>::LogisticRegression(
 
 template<typename MatType>
 template<typename OptimizerType>
-void LogisticRegression<MatType>::Train(const MatType& predictors,
+double LogisticRegression<MatType>::Train(const MatType& predictors,
                                         const arma::Row<size_t>& responses)
 {
   OptimizerType optimizer;
-  Train(predictors, responses, optimizer);
+  return Train(predictors, responses, optimizer);
 }
 
 template<typename MatType>
 template<typename OptimizerType>
-void LogisticRegression<MatType>::Train(
+double LogisticRegression<MatType>::Train(
     const MatType& predictors,
     const arma::Row<size_t>& responses,
     OptimizerType& optimizer)
@@ -93,6 +93,8 @@ void LogisticRegression<MatType>::Train(
 
   Log::Info << "LogisticRegression::LogisticRegression(): final objective of "
       << "trained model is " << out << "." << std::endl;
+
+  return out;
 }
 
 template<typename MatType>


### PR DESCRIPTION
Hi,
It is sometimes useful to have the final objective of the trained model, especially if it failed to train properly.

It has been useful for me, letting you have this as it may well be useful for others.

Cheers,

Rob