### PR TITLE
Fix #1443 by specifying namespace

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Fix Visual Studio compilation issue (#1443).
 
 ### mlpack 3.0.2
 ###### 2018-06-08

--- a/src/mlpack/methods/radical/radical.cpp
+++ b/src/mlpack/methods/radical/radical.cpp
@@ -187,7 +187,7 @@ void mlpack::radical::WhitenFeatureMajorMatrix(const mat& matX,
 {
   mat matU, matV;
   vec s;
-  svd(matU, s, matV, cov(matX));
+  arma::svd(matU, s, matV, cov(matX));
   matWhitening = matU * diagmat(1 / sqrt(s)) * trans(matV);
   matXWhitened = matX * matWhitening;
 }


### PR DESCRIPTION
Looks like the Visual Studio compiler gets confused since `svd` is a namespace name and also a function name out of the `arma` namespace, so like @kilasuelika pointed out, we can just specify the namespace to fix it.