### PR TITLE
Fix invalid error in local_coordinate_coding

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 ###### ????-??-??
   * Fix Visual Studio compilation issue (#1443).
 
+  * Allow running local_coordinate_coding binding with no initial_dictionary
+    parameter when input_model is not specified (#1457).
+
 ### mlpack 3.0.2
 ###### 2018-06-08
   * Documentation generation fixes for Python bindings (#1421).

--- a/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
+++ b/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
@@ -101,7 +101,6 @@ static void mlpackMain()
     RandomSeed((size_t) std::time(NULL));
 
   // Check for parameter validity.
-  RequireOnlyOnePassed({ "input_model", "initial_dictionary" }, true);
   RequireOnlyOnePassed({ "training", "input_model" }, true);
 
   if (CLI::HasParam("training"))


### PR DESCRIPTION
I have removed a check that would mean that the user must pass either 'initial_dictionary' or 'input_model' to any call of the program.  This makes it impossible to run LCC with a random initial dictionary.

I think this would be sufficient for releasing 3.0.3 as a bugfix, but we can also wait a little if there are more fixes or functionality.