### PR TITLE
Fix math::RandomSeed() BINDING_TYPE macro condition

### DIFF
--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -39,7 +39,8 @@ extern MLPACK_EXPORT std::normal_distribution<> randNormalDist;
  */
 inline void RandomSeed(const size_t seed)
 {
-  #if (BINDING_TYPE == NULL || BINDING_TYPE != BINDING_TYPE_TEST)
+  if (BINDING_TYPE == BINDING_TYPE_UNKNOWN ||
+      BINDING_TYPE != BINDING_TYPE_TEST)
     randGen.seed((uint32_t) seed);
     srand((unsigned int) seed);
     arma::arma_rng::set_seed(seed);
@@ -55,7 +56,7 @@ inline void RandomSeed(const size_t seed)
  * a difference to execution of CLI binding.
  * Refer to pull request #1306 for discussion on this function.
  */
-#if (BINDING_TYPE == BINDING_TYPE_TEST && BINDING_TYPE != NULL)
+#if (BINDING_TYPE == BINDING_TYPE_TEST)
 inline void FixedRandomSeed()
 {
   const static size_t seed = rand();

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -39,7 +39,7 @@ extern MLPACK_EXPORT std::normal_distribution<> randNormalDist;
  */
 inline void RandomSeed(const size_t seed)
 {
-  #if BINDING_TYPE == BINDING_TYPE_UNKNOWN || BINDING_TYPE != BINDING_TYPE_TEST
+  #if (!defined(BINDING_TYPE) || BINDING_TYPE != BINDING_TYPE_TEST)
     randGen.seed((uint32_t) seed);
     srand((unsigned int) seed);
     arma::arma_rng::set_seed(seed);

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -39,7 +39,7 @@ extern MLPACK_EXPORT std::normal_distribution<> randNormalDist;
  */
 inline void RandomSeed(const size_t seed)
 {
-  #if (BINDING_TYPE != BINDING_TYPE_TEST)
+  #if (BINDING_TYPE == NULL || BINDING_TYPE != BINDING_TYPE_TEST)
     randGen.seed((uint32_t) seed);
     srand((unsigned int) seed);
     arma::arma_rng::set_seed(seed);
@@ -55,7 +55,7 @@ inline void RandomSeed(const size_t seed)
  * a difference to execution of CLI binding.
  * Refer to pull request #1306 for discussion on this function.
  */
-#if (BINDING_TYPE == BINDING_TYPE_TEST)
+#if (BINDING_TYPE == BINDING_TYPE_TEST && BINDING_TYPE != NULL)
 inline void FixedRandomSeed()
 {
   const static size_t seed = rand();

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -39,8 +39,7 @@ extern MLPACK_EXPORT std::normal_distribution<> randNormalDist;
  */
 inline void RandomSeed(const size_t seed)
 {
-  if (BINDING_TYPE == BINDING_TYPE_UNKNOWN ||
-      BINDING_TYPE != BINDING_TYPE_TEST)
+  #if BINDING_TYPE == BINDING_TYPE_UNKNOWN || BINDING_TYPE != BINDING_TYPE_TEST
     randGen.seed((uint32_t) seed);
     srand((unsigned int) seed);
     arma::arma_rng::set_seed(seed);

--- a/src/mlpack/methods/cf/cf_main.cpp
+++ b/src/mlpack/methods/cf/cf_main.cpp
@@ -11,8 +11,8 @@
  */
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/cli.hpp>
-#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/core/math/random.hpp>
 
 #include "cf.hpp"
 

--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -11,6 +11,7 @@
  */
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/cli.hpp>
+#include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/core/math/random.hpp>
 #include <mlpack/core/kernels/kernel_traits.hpp>
 #include <mlpack/core/kernels/linear_kernel.hpp>
@@ -24,7 +25,6 @@
 #include <mlpack/core/kernels/spherical_kernel.hpp>
 #include <mlpack/core/kernels/triangular_kernel.hpp>
 #include <mlpack/methods/hoeffding_trees/hoeffding_tree.hpp>
-#include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/methods/nystroem_method/ordered_selection.hpp>
 #include <mlpack/methods/nystroem_method/random_selection.hpp>
 #include <mlpack/methods/nystroem_method/kmeans_selection.hpp>

--- a/src/mlpack/methods/lmnn/lmnn_main.cpp
+++ b/src/mlpack/methods/lmnn/lmnn_main.cpp
@@ -12,8 +12,8 @@
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/cli.hpp>
 #include <mlpack/core/data/normalize_labels.hpp>
-#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/methods/neighbor_search/neighbor_search.hpp>
 

--- a/src/mlpack/methods/nca/nca_main.cpp
+++ b/src/mlpack/methods/nca/nca_main.cpp
@@ -12,8 +12,8 @@
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/cli.hpp>
 #include <mlpack/core/data/normalize_labels.hpp>
-#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 
 #include "nca.hpp"

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -10,9 +10,9 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/core/math/random.hpp>
 #include <mlpack/core/util/cli.hpp>
-#include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/core/data/split_data.hpp>
 
 PROGRAM_INFO("Split Data", "This utility takes a dataset and optionally labels "

--- a/src/mlpack/methods/radical/radical_main.cpp
+++ b/src/mlpack/methods/radical/radical_main.cpp
@@ -11,8 +11,8 @@
  */
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/cli.hpp>
-#include <mlpack/core/math/random.hpp>
 #include <mlpack/core/util/mlpack_main.hpp>
+#include <mlpack/core/math/random.hpp>
 #include "radical.hpp"
 
 PROGRAM_INFO("RADICAL", "An implementation of RADICAL, a method for independent"


### PR DESCRIPTION
Check whether the BINDING_TYPE is NULL or not. The order of mlpack_main.cpp inclusion is also corrected all over the codebase.