### PR TITLE
Fix/add references to Win tutorials and sample app

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -103,7 +103,8 @@ Copyright:
   Copyright 2018, Thanasis Mattas <mattasa@auth.gr>
   Copyright 2018, Shashank Shekhar <contactshashankshekhar@gmail.com>
   Copyright 2018, Yasmine Dumouchel <yasmine.dumouchel@gmail.com>
-
+  Copyright 2018, German Lancioni
+  
 License: BSD-3-clause
   All rights reserved.
   .

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -24,8 +24,7 @@ mlpack uses CMake as a build system and allows several flexible build
 configuration options.  One can consult any of numerous CMake tutorials for
 further documentation, but this tutorial should be enough to get mlpack built
 and installed on most Linux and UNIX-like systems (including OS X).  If you want
-to build mlpack on Windows, see <a
-href="https://keon.io/mlpack-on-windows/">Keon's excellent tutorial</a>.
+to build mlpack on Windows, see \ref build_windows.
 
 You can download the latest mlpack release from here:
 <a href="http://www.mlpack.org/files/mlpack-3.0.2.tar.gz">mlpack-3.0.2</a>

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -24,7 +24,9 @@ mlpack uses CMake as a build system and allows several flexible build
 configuration options.  One can consult any of numerous CMake tutorials for
 further documentation, but this tutorial should be enough to get mlpack built
 and installed on most Linux and UNIX-like systems (including OS X).  If you want
-to build mlpack on Windows, see \ref build_windows.
+to build mlpack on Windows, see \ref build_windows (alternatively, you can read 
+<a href="https://keon.io/mlpack-on-windows/">Keon's excellent tutorial</a> which
+is based on older versions).
 
 You can download the latest mlpack release from here:
 <a href="http://www.mlpack.org/files/mlpack-3.0.2.tar.gz">mlpack-3.0.2</a>

--- a/doc/tutorials/tutorials.txt
+++ b/doc/tutorials/tutorials.txt
@@ -21,11 +21,13 @@ developers who want to use and contribute to mlpack but are not sure where to
 start.
 
  - \ref build
+ - \ref build_windows
  - \ref formatdoc
  - \ref matrices
  - \ref iodoc
  - \ref timer
  - \ref sample
+ - \ref sample_ml_app
 
 @section method_tut Method-specific Tutorials
 

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -96,10 +96,12 @@
  * A few short tutorials on how to use mlpack are given below.
  *
  *  - @ref build
+ *  - @ref build_windows
  *  - @ref matrices
  *  - @ref iodoc
  *  - @ref timer
  *  - @ref sample
+ *  - @ref sample_ml_app
  *  - @ref cv
  *  - @ref hpt
  *  - @ref verinfo
@@ -247,6 +249,7 @@
  *   - Thanasis Mattas <mattasa@auth.gr>
  *   - Shashank Shekhar <contactshashankshekhar@gmail.com>
  *   - Yasmine Dumouchel <yasmine.dumouchel@gmail.com>
+ *   - German Lancioni
  */
 
 // First, include all of the prerequisites.


### PR DESCRIPTION
Minor changes to link core.hpp and tutorials.txt to the recently added Windows build tutorial and sample app.

Let me know if I missed any other ref location.