### PR TITLE
Make use of OpenMP optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(MATHJAX
     "Use MathJax for HTML Doxygen output (disabled by default)." OFF)
 option(FORCE_CXX11
     "Don't check that the compiler supports C++11, just assume it.  Make sure to specify any necessary flag to enable C++11 as part of CXXFLAGS." OFF)
+option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
 enable_testing()
 
 # Currently Python bindings aren't known to build successfully on Windows, so
@@ -348,7 +349,10 @@ add_definitions(-DBOOST_TEST_DYN_LINK)
 #   ... openMP code here ...
 # }
 # #endif
-find_package(OpenMP)
+if (USE_OPENMP)
+  find_package(OpenMP)
+endif ()
+
 if (OPENMP_FOUND)
   add_definitions(-DHAS_OPENMP)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ a PPA or other non-official sources, or installing with a manual build.
 There are some other useful pages to consult in addition to this section:
 
   - [Building mlpack From Source](http://www.mlpack.org/docs/mlpack-git/doxygen/build.html)
-  - [Building mlpack Under Windows](https://github.com/mlpack/mlpack/wiki/WindowsBuild)
+  - [Building mlpack From Source on Windows](http://www.mlpack.org/docs/mlpack-git/doxygen/build_windows.html)
 
 mlpack uses CMake as a build system and allows several flexible build
 configuration options. One can consult any of numerous CMake tutorials for

--- a/README.md
+++ b/README.md
@@ -61,15 +61,18 @@ documentation. The website should be consulted for further information:
 If you use mlpack in your research or software, please cite mlpack using the
 citation below (given in BiBTeX format):
 
-    @article{mlpack2013,
-      title     = {{mlpack}: A Scalable {C++} Machine Learning Library},
-      author    = {Curtin, Ryan R. and Cline, James R. and Slagle, Neil P. and
-                   March, William B. and Ram, P. and Mehta, Nishant A. and Gray,
-                   Alexander G.},
-      journal   = {Journal of Machine Learning Research},
-      volume    = {14},
-      pages     = {801--805},
-      year      = {2013}
+    @article{mlpack2018,
+        title     = {mlpack 3: a fast, flexible machine learning library},
+        author    = {Curtin, Ryan R. and Edel, Marcus and Lozhnikov, Mikhail and
+                     Mentekidis, Yannis and Ghaisas, Sumedh and Zhang,
+                     Shangtong},
+        journal   = {Journal of Open Source Software},
+        volume    = {3},
+        issue     = {26},
+        pages     = {726},
+        year      = {2018},
+        doi       = {10.21105/joss.00726},
+        url       = {https://doi.org/10.21105/joss.00726}
     }
 
 Citations are beneficial for the growth and improvement of mlpack.

--- a/README.md
+++ b/README.md
@@ -155,13 +155,17 @@ Options are specified with the -D flag.  A list of options allowed:
     ARMADILLO_LIBRARY=(/path/to/armadillo/libarmadillo.so): Armadillo library
     BUILD_CLI_EXECUTABLES=(ON/OFF): whether or not to build command-line programs
     BUILD_PYTHON_BINDINGS=(ON/OFF): whether or not to build Python bindings
+    BUILD_TESTS=(ON/OFF): whether or not to build tests
+    USE_OPENMP=(ON/OFF): whether or not to use OpenMP if available
 
 Other tools can also be used to configure CMake, but those are not documented
-here.
+here.  See [this section of the build guide](http://www.mlpack.org/docs/mlpack-git/doxygen/build.html#build_config)
+for more details.
 
 By default, command-line programs will be built, and if the Python dependencies
 (Cython, setuptools, numpy, pandas) are available, then Python bindings will
-also be built.
+also be built.  OpenMP will be used for parallelization when possible by
+default.
 
 Once CMake is configured, building the library is as simple as typing 'make'.
 This will build all library components as well as 'mlpack_test'.

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -147,6 +147,8 @@ The full list of options mlpack allows:
  - FORCE_CXX11=(ON/OFF): assume that the compiler supports C++11 instead of
        checking; be sure to specify any necessary flag to enable C++11 as part
        of CXXFLAGS (default OFF)
+ - USE_OPENMP=(ON/OFF): if ON, then use OpenMP if the compiler supports it; if
+       OFF, OpenMP support is manually disabled (default ON)
 
 Each option can be specified to CMake with the '-D' flag.  Other tools can also
 be used to configure CMake, but those are not documented here.

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -6,8 +6,15 @@
 
 @section build_windows_intro Introduction
 
-This document discusses how to build mlpack for Windows from source, so you can later
-create your own C++ applications.
+This document discusses how to build mlpack for Windows from source, so you can
+later create your own C++ applications.  There are a couple of other tutorials
+for Windows, but they may be out of date:
+
+ * <a href="https://github.com/mlpack/mlpack/wiki/WindowsBuild">Github wiki Windows Build page</a>
+ * <a href="http://keon.io/mlpack-on-windows">Keon's tutorial for mlpack 2.0.3</a>
+ * <a href="https://overdosedblog.wordpress.com/2016/08/15/once_again/">Kirizaki's tutorial for mlpack 2</a>
+
+Those guides could be used in addition to this tutorial.
 
 @section build_windows_env Environment
 


### PR DESCRIPTION
This fixes #1473, and I'll release mlpack 3.0.3 with this and some other fixes once this is merged.

Basically this just adds a CMake configuration option `USE_OPENMP` that allows the user to specify whether or not to use OpenMP.

So you can now configure as

```
$ cmake -DUSE_OPENMP=OFF ..
```

and OpenMP won't be used.

I also noticed the mlpack paper citation in the readme is out of date, so I updated that too. :)