### PR TITLE
It was generating in linux wrong flag options

### DIFF
--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -42,7 +42,7 @@ else:
                   library_dirs=['${CMAKE_BINARY_DIR}/lib/'],
                   # CMAKE_CXX_FLAGS seems to have an extra space.
                   extra_compile_args=('-DBINDING_TYPE=BINDING_TYPE_PYX ' + \
-                      '-std=c++11${CMAKE_CXX_FLAGS}').split(' '),
+                      '-std=c++11 ${CMAKE_CXX_FLAGS}').split(' '),
                   extra_link_args=['${OpenMP_CXX_FLAGS}'],
                   undef_macros=[] if len("${DISABLE_CFLAGS}") == 0 \
                       else '${DISABLE_CFLAGS}'.split(';')) \
@@ -61,7 +61,7 @@ else:
                   library_dirs=['${CMAKE_BINARY_DIR}/lib/'],
                   # CMAKE_CXX_FLAGS seems to have an extra space.
                   extra_compile_args=('-DBINDING_TYPE=BINDING_TYPE_PYX ' + \
-                      '-std=c++11${CMAKE_CXX_FLAGS}').split(' '),
+                      '-std=c++11 ${CMAKE_CXX_FLAGS}').split(' '),
                   extra_link_args=['${OpenMP_CXX_FLAGS}'],
                   undef_macros=[] if len("${DISABLE_CFLAGS}") == 0 \
                       else '${DISABLE_CFLAGS}'.split(';')) \


### PR DESCRIPTION
This flag without spaces was appearing in my mkaefiles. I think this fix you solve that
-std=c++11-DBOOST_MATH_DISABLE_FLOAT128

Please see,
https://circleci.com/gh/conda-forge/mlpack-feedstock/49?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link