### PR TITLE
Replace linear regression implementation with something faster.

### DIFF
--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -82,7 +82,7 @@ void LinearRegression::Train(const arma::mat& predictors,
   // The total runtime of this should be O(d^2 N) + O(d^3) + O(dN).
   // (assuming the SVD is used to solve it)
   arma::mat cov = p * p.t() +
-      lambda * arma::eye<arma::mat>(predictors.n_rows, predictors.n_rows);
+      lambda * arma::eye<arma::mat>(p.n_rows, p.n_rows);
 
   parameters = arma::solve(cov, p * r.t());
 }

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -76,34 +76,15 @@ void LinearRegression::Train(const arma::mat& predictors,
     r = sqrt(weights) % responses;
   }
 
-  if (lambda != 0.0)
-  {
-    // Add the identity matrix to the predictors (this is equivalent to ridge
-    // regression).  See http://math.stackexchange.com/questions/299481/ for
-    // more information.
-    p.insert_cols(nCols, predictors.n_rows);
-    p.submat(p.n_rows - predictors.n_rows, nCols, p.n_rows - 1, nCols +
-    predictors.n_rows - 1) = sqrt(lambda) *
-        arma::eye<arma::mat>(predictors.n_rows, predictors.n_rows);
-  }
+  // Convert to this form:
+  // a * (X X^T) = y X^T.
+  // Then we'll use Armadillo to solve it.
+  // The total runtime of this should be O(d^2 N) + O(d^3) + O(dN).
+  // (assuming the SVD is used to solve it)
+  arma::mat cov = p * p.t() +
+      lambda * arma::eye<arma::mat>(predictors.n_rows, predictors.n_rows);
 
-  // We compute the QR decomposition of the predictors.
-  // We transpose the predictors because they are in column major order.
-  arma::mat Q, R;
-  arma::qr(Q, R, arma::trans(p));
-
-  // We compute the parameters, B, like so:
-  // R * B = Q^T * responses
-  // B = Q^T * responses * R^-1
-  // If lambda > 0, then we must add a bunch of empty responses.
-  if (lambda == 0.0)
-    arma::solve(parameters, R, arma::trans(r * Q));
-  else
-  {
-    // Copy responses into larger vector.
-    r.insert_cols(nCols, p.n_cols - nCols);
-    arma::solve(parameters, R, arma::trans(r * Q));
-  }
+  parameters = arma::solve(cov, p * r.t());
 }
 
 void LinearRegression::Predict(const arma::mat& points,


### PR DESCRIPTION
Basically what I have done here is that following Anisa's email, I identified that linear regression actually creates an NxN matrix.  I think the old implementation scaled as O(N^2 d).  I then spent a little time at a whiteboard thinking about how to avoid that, and only use O(d^2) memory.  That resulted in this implementation, which scales as O(Nd^2 + d^3) where the O(Nd^2) comes from the covariance matrix computation and the O(d^3) comes from the `arma::solve()` call.

On a simple low-dimensional example with lots of points, the implementation scales much better.  I tested with a 200k point subset of the higgs dataset (28d), and the actual computation was 0.04s (whereas the loading time was like 1.4s).

Maybe for very high-dimensional datasets this implementation could be somewhat problematic, but at that point I think that using the optimization framework to do SGD would be better, or something like that.