### PR TITLE
Use 2 neighbors for LMNNAccuracyTest because 1 is unstable.

### DIFF
--- a/src/mlpack/tests/lmnn_test.cpp
+++ b/src/mlpack/tests/lmnn_test.cpp
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(LMNNAccuracyTest)
   // Taking k = 3 as the case of k = 1 can be easily observed.
   double initAccuracy = KnnAccuracy(dataset, labels, 3);
 
-  LMNN<> lmnn(dataset, labels, 1);
+  LMNN<> lmnn(dataset, labels, 2);
 
   arma::mat outputMatrix;
   lmnn.LearnDistance(outputMatrix);


### PR DESCRIPTION
It can cause unexpected changes in the impostor, which inverts the gradient; or, by only choosing one true neighbor, the gradient will be biased towards that one neighbor.  This can cause LMNN to fail to converge to a better solution.  If we use two impostors and neighbors it is much more robust.

So, with this fix, the LMNNAccuracyTest should not randomly fail anymore.  I tested with ~200 different random seeds and saw no failures, whereas before it would fail with ~half of all random seeds.

@manish7294: let me know if I overlooked anything.