### PR TITLE
Fixes from marcespie

### DIFF
--- a/CMake/allexec2man.sh
+++ b/CMake/allexec2man.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -23,5 +23,4 @@ for program in $(find . -type f -executable -iname 'mlpack_*' | \
                 grep -v '_test$'); do
   echo "Generating man page for $program...";
   "$exec2man" "$program" "$outdir/$program.1"
-  gzip -f "$outdir/$program.1"
 done

--- a/CMake/exec2man.sh
+++ b/CMake/exec2man.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/sh
+#
 # Convert the output of an mlpack executable into a man page.  This assumes that
 # the CLI subsystem is used to output help, that the executable is properly
 # documented, and that the program is run in the directory that the executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,11 +150,6 @@ if(BUILD_WITH_COVERAGE)
   endif()
 endif()
 
-# For clock_gettime().
-if (UNIX AND NOT APPLE AND NOT HAIKU)
-  set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} "rt")
-endif ()
-
 # Debugging CFLAGS.  Turn optimizations off; turn debugging symbols on.
 if(DEBUG)
   if (NOT MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,7 @@ if (OPENMP_FOUND)
 else ()
   # Disable warnings for all the unknown OpenMP pragmas.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+  set(OpenMP_CXX_FLAGS "")
 endif ()
 
 # Create a 'distclean' target in case the user is using an in-source build for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,31 @@ add_custom_target(mlpack_arma_config ALL
 set(MLPACK_SRCS ${MLPACK_SRCS}
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mlpack/core/util/arma_config.hpp")
 
+# Make a target to generate the man page documentation, but only if we are on a
+# UNIX-like system.
+if (BUILD_CLI_EXECUTABLES AND UNIX)
+  find_program(TXT2MAN txt2man)
+
+  # It's not a requirement that we make man pages.
+  if (NOT TXT2MAN)
+    message(WARNING "txt2man not found; man pages will not be generated.")
+  else ()
+    # We have the tools.  We can make them.
+    add_custom_target(man ALL
+        ${CMAKE_CURRENT_SOURCE_DIR}/CMake/allexec2man.sh
+            ${CMAKE_CURRENT_SOURCE_DIR}/CMake/exec2man.sh
+            ${CMAKE_BINARY_DIR}/share/man
+        WORKING_DIRECTORY
+          ${CMAKE_BINARY_DIR}/bin
+        COMMENT "Generating man pages from built executables."
+    )
+
+    # Set the rules to install the documentation.
+    install(DIRECTORY ${CMAKE_BINARY_DIR}/share/man/
+        DESTINATION share/man/man1/)
+  endif ()
+endif ()
+
 # Recurse into the rest of the project.
 add_subdirectory(src/mlpack)
 
@@ -474,69 +499,6 @@ if (DOXYGEN_FOUND)
       COMPONENT doc
       OPTIONAL
   )
-endif ()
-
-# Make a target to generate the man page documentation, but only if we are on a
-# UNIX-like system.
-if (BUILD_CLI_EXECUTABLES AND UNIX)
-  find_program(TXT2MAN txt2man)
-
-  # It's not a requirement that we make man pages.
-  if (NOT TXT2MAN)
-    message(WARNING "txt2man not found; man pages will not be generated.")
-  else ()
-    # We have the tools.  We can make them.
-    add_custom_target(man ALL
-        ${CMAKE_CURRENT_SOURCE_DIR}/CMake/allexec2man.sh
-            ${CMAKE_CURRENT_SOURCE_DIR}/CMake/exec2man.sh
-            ${CMAKE_BINARY_DIR}/share/man
-        WORKING_DIRECTORY
-          ${CMAKE_BINARY_DIR}/bin
-        DEPENDS
-          mlpack_adaboost
-          mlpack_approx_kfn
-          mlpack_kfn
-          mlpack_knn
-          mlpack_krann
-          mlpack_cf
-          mlpack_dbscan
-          mlpack_decision_stump
-          mlpack_decision_tree
-          mlpack_det
-          mlpack_emst
-          mlpack_fastmks
-          mlpack_gmm_train
-          mlpack_gmm_probability
-          mlpack_gmm_generate
-          mlpack_hmm_generate
-          mlpack_hmm_loglik
-          mlpack_hmm_train
-          mlpack_hmm_viterbi
-          mlpack_hoeffding_tree
-          mlpack_kernel_pca
-          mlpack_kmeans
-          mlpack_lars
-          mlpack_linear_regression
-          mlpack_local_coordinate_coding
-          mlpack_logistic_regression
-          mlpack_lsh
-          mlpack_mean_shift
-          mlpack_nbc
-          mlpack_nca
-          mlpack_nmf
-          mlpack_pca
-          mlpack_perceptron
-          mlpack_radical
-          mlpack_range_search
-          mlpack_softmax_regression
-          mlpack_sparse_coding
-        COMMENT "Generating man pages from built executables."
-    )
-
-    # Set the rules to install the documentation.
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/share/man/
-        DESTINATION share/man/man1/)
-  endif ()
 endif ()
 
 # Create the pkg-config file, if we have pkg-config.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,14 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   endif ()
 endif()
 
+# If we're using gcc, then we need to link against pthreads to use std::thread,
+# which we do in the tests.
+if(CMAKE_COMPILER_IS_GNUCC)
+  find_package(Threads)
+  set(COMPILER_SUPPORT_LIBRARIES ${COMPILER_SUPPORT_LIBRARIES}
+      ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 # Setup build for test coverage
 if(BUILD_WITH_COVERAGE)
   # Currently coverage only works with GNU g++

--- a/src/mlpack/bindings/cli/CMakeLists.txt
+++ b/src/mlpack/bindings/cli/CMakeLists.txt
@@ -38,3 +38,29 @@ endforeach()
 # Append source (with directory name) to list of all mlpack sources (used at the
 # parent scope).
 set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)
+
+# This macro adds a command-line executable with the given name.  It assumes
+# that the file with main() is in <name>_main.cpp, and produces an output
+# program with the name mlpack_<name>.
+macro (add_cli_executable name)
+if (BUILD_CLI_EXECUTABLES)
+  add_executable(mlpack_${name}
+    ${name}_main.cpp
+  )
+  target_link_libraries(mlpack_${name}
+    mlpack
+    ${Boost_LIBRARIES}
+    ${COMPILER_SUPPORT_LIBRARIES}
+  )
+  # Make sure that we set BINDING_TYPE to cli so the command-line program is
+  # compiled with the correct int main() call.
+  set_target_properties(mlpack_${name} PROPERTIES COMPILE_FLAGS
+      -DBINDING_TYPE=BINDING_TYPE_CLI)
+  install(TARGETS mlpack_${name} RUNTIME DESTINATION bin)
+
+  # If man documentation is being generated, make sure this is a dependency.
+  if (TXT2MAN)
+    add_dependencies(man mlpack_${name})
+  endif ()
+endif ()
+endmacro ()

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -164,10 +164,10 @@ execute_process(COMMAND ${PYTHON}
     "${CMAKE_CURRENT_SOURCE_DIR}/print_python_version.py" "${CMAKE_INSTALL_PREFIX}"
     OUTPUT_VARIABLE NEW_PYTHONPATH)
 install(CODE "set(ENV{PYTHONPATH} ${NEW_PYTHONPATH})")
-install(CODE "execute_process(COMMAND mkdir -p ${NEW_PYTHONPATH})")
+install(CODE "execute_process(COMMAND mkdir -p $ENV{DESTDIR}${NEW_PYTHONPATH})")
 install(CODE "execute_process(COMMAND ${PYTHON}
     \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
-    --prefix=${CMAKE_INSTALL_PREFIX}
+    --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR}
     WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
 
 # Prepare __init__.py for having all of the convenience imports appended to it.

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -24,6 +24,11 @@ from Cython.Distutils import build_ext
 
 pyxs='${MLPACK_PYXS}'.split(';')
 
+if not '${OpenMP_CXX_FLAGS}':
+  extra_link_args=[]
+else:
+  extra_link_args=['${OpenMP_CXX_FLAGS}']
+
 # Only build the extensions if we are asked to.
 if os.getenv('NO_BUILD') == '1':
   modules = []
@@ -47,7 +52,7 @@ else:
                   library_dirs=['${CMAKE_BINARY_DIR}/lib/'],
                   # CMAKE_CXX_FLAGS seems to have an extra space.
                   extra_compile_args=extra_args,
-                  extra_link_args=['${OpenMP_CXX_FLAGS}'],
+                  extra_link_args=extra_link_args,
                   undef_macros=[] if len("${DISABLE_CFLAGS}") == 0 \
                       else '${DISABLE_CFLAGS}'.split(';')) \
         for name in pyxs if name == module]
@@ -65,7 +70,7 @@ else:
                   library_dirs=['${CMAKE_BINARY_DIR}/lib/'],
                   # CMAKE_CXX_FLAGS seems to have an extra space.
                   extra_compile_args=extra_args,
-                  extra_link_args=['${OpenMP_CXX_FLAGS}'],
+                  extra_link_args=extra_link_args,
                   undef_macros=[] if len("${DISABLE_CFLAGS}") == 0 \
                       else '${DISABLE_CFLAGS}'.split(';')) \
         for name in pyxs]

--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -1,24 +1,3 @@
-# This macro adds a command-line executable with the given name.  It assumes
-# that the file with main() is in <name>_main.cpp, and produces an output
-# program with the name mlpack_<name>.
-macro (add_cli_executable name)
-if (BUILD_CLI_EXECUTABLES)
-  add_executable(mlpack_${name}
-    ${name}_main.cpp
-  )
-  target_link_libraries(mlpack_${name}
-    mlpack
-    ${Boost_LIBRARIES}
-    ${COMPILER_SUPPORT_LIBRARIES}
-  )
-  # Make sure that we set BINDING_TYPE to cli so the command-line program is
-  # compiled with the correct int main() call.
-  set_target_properties(mlpack_${name} PROPERTIES COMPILE_FLAGS
-      -DBINDING_TYPE=BINDING_TYPE_CLI)
-  install(TARGETS mlpack_${name} RUNTIME DESTINATION bin)
-endif ()
-endmacro ()
-
 # Recurse into each method mlpack provides.
 set(DIRS
   # mvu # Note: this implementation of MVU does not work.  See #189.

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ add_executable(mlpack_test
 target_link_libraries(mlpack_test
   mlpack
   ${BOOST_unit_test_framework_LIBRARY}
+  ${COMPILER_SUPPORT_LIBRARIES}
 )
 
 set_target_properties(mlpack_test PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "../core.hpp")


### PR DESCRIPTION
This is a collection of fixes for issues @marcespie has opened recently.  It includes the following changes:

 * (#1516) stop using -lrt since it isn't needed
 * add linking against -pthread for std::thread usage when using g++
 * (#1518) use /bin/sh not /bin/bash
 * (#1518) don't gzip man pages
 * (#1520) refactor dependencies on `man` target so they're automatically added when `add_cli_executable()` is called
 * (#1521, #1478) fix bad handling of spaces in CXXFLAGS in Python `setup.py`
 * (#1521, #1425?) fix bad usage of `OpenMP_CXX_FLAGS` in Python `setup.py`
 * (#1522) handle DESTDIR correctly for Python bindings (the CMake glue previously didn't)

@marcelotrevisani I'm not sure why you closed #1478, but I've pulled that branch in here and we can merge it as part of this one.  In my basic testing it seems to work.

@marcespie---if you'd like to test and see if this fixes the problems that you had, it would be great.  If it works, we can get it merged. :)