### PR TITLE
Replace copy and move overloads with pass-by-value for NeighborSearch

### DIFF
--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -342,11 +342,6 @@ class NeighborSearch
   //! Reference dataset.  In some situations we may be the owner of this.
   const MatType* referenceSet;
 
-  //! If true, this object created the trees and is responsible for them.
-  bool treeOwner;
-  //! If true, we own the reference set.
-  bool setOwner;
-
   //! Indicates the neighbor search mode.
   NeighborSearchMode searchMode;
   //! Indicates the relative error to be considered in approximate search.

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -187,42 +187,25 @@ class NeighborSearch
 
   /**
    * Set the reference set to a new reference set, and build a tree if
-   * necessary.  This method is called 'Train()' in order to match the rest of
-   * the mlpack abstractions, even though calling this "training" is maybe a bit
-   * of a stretch.
+   * necessary. The dataset is copied by default, but the copy can be avoided by
+   * transferring the ownership of the dataset using std::move().  This method
+   * is called 'Train()' in order to match the rest of the mlpack abstractions,
+   * even though calling this "training" is maybe a bit of a stretch.
    *
    * @param referenceSet New set of reference data.
    */
-  void Train(const MatType& referenceSet);
+  void Train(MatType referenceSet);
 
   /**
-   * Set the reference set to a new reference set, taking ownership of the set,
-   * and build a tree if necessary.  This method is called 'Train()' in order to
-   * match the rest of the mlpack abstractions, even though calling this
-   * "training" is maybe a bit of a stretch.
-   *
-   * @param referenceSet New set of reference data.
-   */
-  void Train(MatType&& referenceSet);
-
-  /**
-   * Set the reference tree as a copy of the given reference tree.
-   *
-   * This method will copy the given tree.  You can avoid this copy by using the
-   * Train() method that takes a rvalue reference to the tree.
+   * Set the reference tree to a new reference tree.  The tree is copied by
+   * default, but the copy can be avoided by using std::move() to transfer the
+   * ownership of the tree.  This method is called 'Train()' in order to match
+   * the rest of the mlpack abstractions, even though calling this "training" is
+   * maybe a bit of a stretch.
    *
    * @param referenceTree Pre-built tree for reference points.
    */
-  void Train(const Tree& referenceTree);
-
-  /**
-   * Set the reference tree to a new reference tree.
-   *
-   * This method will take ownership of the given tree.
-   *
-   * @param referenceTree Pre-built tree for reference points.
-   */
-  void Train(Tree&& referenceTree);
+  void Train(Tree referenceTree);
 
   /**
    * For each point in the query set, compute the nearest neighbors and store

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -331,46 +331,7 @@ template<typename SortPolicy,
          template<typename> class DualTreeTraversalType,
          template<typename> class SingleTreeTraversalType>
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::Train(
-    const MatType& referenceSet)
-{
-  // Clean up the old tree, if we built one.
-  if (treeOwner && referenceTree)
-  {
-    oldFromNewReferences.clear();
-    delete referenceTree;
-  }
-
-  // Delete the old reference set, if we owned it.
-  if (setOwner && this->referenceSet)
-    delete this->referenceSet;
-
-  // We may need to rebuild the tree.
-  if (searchMode != NAIVE_MODE)
-  {
-    referenceTree = BuildTree<Tree>(referenceSet, oldFromNewReferences);
-    treeOwner = true;
-    this->referenceSet = &referenceTree->Dataset();
-  }
-  else
-  {
-    treeOwner = false;
-    this->referenceSet = &referenceSet;
-  }
-
-  setOwner = false; // We don't own the set in either case.
-}
-
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::Train(MatType&& referenceSetIn)
+DualTreeTraversalType, SingleTreeTraversalType>::Train(MatType referenceSetIn)
 {
   // Clean up the old tree, if we built one.
   if (treeOwner && referenceTree)
@@ -409,38 +370,7 @@ template<typename SortPolicy,
          template<typename> class DualTreeTraversalType,
          template<typename> class SingleTreeTraversalType>
 void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::Train(
-    const Tree& referenceTree)
-{
-  if (searchMode == NAIVE_MODE)
-    throw std::invalid_argument("cannot train on given reference tree when "
-        "naive search (without trees) is desired");
-
-  if (treeOwner && this->referenceTree)
-  {
-    oldFromNewReferences.clear();
-    delete this->referenceTree;
-  }
-
-  if (setOwner && referenceSet)
-    delete this->referenceSet;
-
-  this->referenceTree = new Tree(referenceTree);
-  this->referenceSet = &this->referenceTree->Dataset();
-  treeOwner = true;
-  setOwner = false;
-}
-
-template<typename SortPolicy,
-         typename MetricType,
-         typename MatType,
-         template<typename TreeMetricType,
-                  typename TreeStatType,
-                  typename TreeMatType> class TreeType,
-         template<typename> class DualTreeTraversalType,
-         template<typename> class SingleTreeTraversalType>
-void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
-DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree&& referenceTree)
+DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree referenceTree)
 {
   if (searchMode == NAIVE_MODE)
     throw std::invalid_argument("cannot train on given reference tree when "

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -63,8 +63,6 @@ SingleTreeTraversalType>::NeighborSearch(MatType referenceSetIn,
         BuildTree<Tree>(std::move(referenceSetIn), oldFromNewReferences)),
     referenceSet(mode == NAIVE_MODE ?  new MatType(std::move(referenceSetIn)) :
         &referenceTree->Dataset()),
-    treeOwner(mode != NAIVE_MODE),
-    setOwner(mode == NAIVE_MODE),
     searchMode(mode),
     epsilon(epsilon),
     metric(metric),
@@ -92,8 +90,6 @@ SingleTreeTraversalType>::NeighborSearch(Tree referenceTree,
                                          const MetricType metric) :
     referenceTree(new Tree(std::move(referenceTree))),
     referenceSet(&this->referenceTree->Dataset()),
-    treeOwner(true),
-    setOwner(false),
     searchMode(mode),
     epsilon(epsilon),
     metric(metric),
@@ -120,8 +116,6 @@ SingleTreeTraversalType>::NeighborSearch(const NeighborSearchMode mode,
                                          const MetricType metric) :
     referenceTree(NULL),
     referenceSet(new MatType()), // Empty matrix.
-    treeOwner(false),
-    setOwner(true),
     searchMode(mode),
     epsilon(epsilon),
     metric(metric),
@@ -136,7 +130,7 @@ SingleTreeTraversalType>::NeighborSearch(const NeighborSearchMode mode,
   if (mode != NAIVE_MODE)
   {
     referenceTree = BuildTree<Tree>(*referenceSet, oldFromNewReferences);
-    treeOwner = true;
+    referenceSet = &referenceTree->Dataset();
   }
 }
 
@@ -155,8 +149,6 @@ SingleTreeTraversalType>::NeighborSearch(const NeighborSearch& other) :
     referenceTree(other.referenceTree ? new Tree(*other.referenceTree) : NULL),
     referenceSet(other.referenceTree ? &referenceTree->Dataset() :
         new MatType(*other.referenceSet)),
-    treeOwner(other.referenceTree),
-    setOwner(!other.referenceTree),
     searchMode(other.searchMode),
     epsilon(other.epsilon),
     metric(other.metric),
@@ -181,8 +173,6 @@ SingleTreeTraversalType>::NeighborSearch(NeighborSearch&& other) :
     oldFromNewReferences(std::move(other.oldFromNewReferences)),
     referenceTree(other.referenceTree),
     referenceSet(other.referenceSet),
-    treeOwner(other.treeOwner),
-    setOwner(other.setOwner),
     searchMode(other.searchMode),
     epsilon(other.epsilon),
     metric(std::move(other.metric)),
@@ -194,8 +184,7 @@ SingleTreeTraversalType>::NeighborSearch(NeighborSearch&& other) :
   other.referenceSet = new MatType();
   other.referenceTree = BuildTree<Tree>(*other.referenceSet,
       other.oldFromNewReferences);
-  other.treeOwner = true;
-  other.setOwner = true;
+  other.referenceSet = &other.referenceTree->Dataset();
   other.searchMode = DUAL_TREE_MODE,
   other.epsilon = 0.0;
   other.baseCases = 0;
@@ -229,17 +218,21 @@ NeighborSearch<SortPolicy,
     return *this; // Nothing to do.
 
   // Clean memory first.
-  if (treeOwner && referenceTree)
+  if (referenceTree)
+  {
     delete referenceTree;
-  if (setOwner && referenceSet)
+    referenceTree = NULL;
+  }
+  else
+  {
     delete referenceSet;
+    referenceSet = NULL;
+  }
 
   oldFromNewReferences = other.oldFromNewReferences;
   referenceTree = other.referenceTree ? new Tree(*other.referenceTree) : NULL;
   referenceSet = other.referenceTree ? &referenceTree->Dataset() :
       new MatType(*other.referenceSet);
-  treeOwner = (other.referenceTree != NULL);
-  setOwner = (other.referenceTree == NULL);
   searchMode = other.searchMode;
   epsilon = other.epsilon;
   metric = other.metric;
@@ -274,16 +267,20 @@ NeighborSearch<SortPolicy,
     return *this; // Nothing to do.
 
   // Clean memory first.
-  if (treeOwner && referenceTree)
+  if (referenceTree)
+  {
     delete referenceTree;
-  if (setOwner && referenceSet)
+    referenceTree = NULL;
+  }
+  else
+  {
     delete referenceSet;
+    referenceSet = NULL;
+  }
 
   oldFromNewReferences = std::move(other.oldFromNewReferences);
   referenceTree = other.referenceTree;
   referenceSet = other.referenceSet;
-  treeOwner = other.treeOwner;
-  setOwner = other.setOwner;
   searchMode = other.searchMode;
   epsilon = other.epsilon;
   metric = other.metric;
@@ -292,11 +289,9 @@ NeighborSearch<SortPolicy,
   treeNeedsReset = other.treeNeedsReset;
 
   // Reset the other object.
-  other.referenceSet = new MatType();
   other.referenceTree = BuildTree<Tree>(*other.referenceSet,
       other.oldFromNewReferences);
-  other.treeOwner = true;
-  other.setOwner = true;
+  other.referenceSet = &other.referenceTree->Dataset();
   other.searchMode = DUAL_TREE_MODE,
   other.epsilon = 0.0;
   other.baseCases = 0;
@@ -316,10 +311,16 @@ template<typename SortPolicy,
 NeighborSearch<SortPolicy, MetricType, MatType, TreeType, DualTreeTraversalType,
 SingleTreeTraversalType>::~NeighborSearch()
 {
-  if (treeOwner && referenceTree)
+  if (referenceTree)
+  {
     delete referenceTree;
-  if (setOwner && referenceSet)
+    referenceTree = NULL;
+  }
+  else
+  {
     delete referenceSet;
+    referenceSet = NULL;
+  }
 }
 
 template<typename SortPolicy,
@@ -334,30 +335,28 @@ void NeighborSearch<SortPolicy, MetricType, MatType, TreeType,
 DualTreeTraversalType, SingleTreeTraversalType>::Train(MatType referenceSetIn)
 {
   // Clean up the old tree, if we built one.
-  if (treeOwner && referenceTree)
+  if (referenceTree)
   {
     oldFromNewReferences.clear();
     delete referenceTree;
+    referenceTree = NULL;
   }
-
-  // Delete the old reference set, if we owned it.
-  if (setOwner && referenceSet)
+  else
+  {
     delete referenceSet;
+    referenceSet = NULL;
+  }
 
   // We may need to rebuild the tree.
   if (searchMode != NAIVE_MODE)
   {
     referenceTree = BuildTree<Tree>(std::move(referenceSetIn),
         oldFromNewReferences);
-    treeOwner = true;
     referenceSet = &referenceTree->Dataset();
-    setOwner = false;
   }
   else
   {
-    treeOwner = false;
     referenceSet = new MatType(std::move(referenceSetIn));
-    setOwner = true;
   }
 }
 
@@ -376,19 +375,20 @@ DualTreeTraversalType, SingleTreeTraversalType>::Train(Tree referenceTree)
     throw std::invalid_argument("cannot train on given reference tree when "
         "naive search (without trees) is desired");
 
-  if (treeOwner && this->referenceTree)
+  if (this->referenceTree)
   {
     oldFromNewReferences.clear();
     delete this->referenceTree;
+    this->referenceTree = NULL;
   }
-
-  if (setOwner && referenceSet)
+  else
+  {
     delete this->referenceSet;
+    this->referenceSet = NULL;
+  }
 
   this->referenceTree = new Tree(std::move(referenceTree));
   this->referenceSet = &this->referenceTree->Dataset();
-  treeOwner = true;
-  setOwner = false;
 }
 
 /**
@@ -976,12 +976,10 @@ DualTreeTraversalType, SingleTreeTraversalType>::serialize(
   if (searchMode == NAIVE_MODE)
   {
     // Delete the current reference set, if necessary and if we are loading.
-    if (Archive::is_loading::value)
+    if (Archive::is_loading::value && referenceSet)
     {
-      if (setOwner && referenceSet)
-        delete referenceSet;
-
-      setOwner = true; // We will own the reference set when we load it.
+      delete referenceSet;
+      referenceSet = NULL;
     }
 
     ar & BOOST_SERIALIZATION_NVP(referenceSet);
@@ -990,24 +988,20 @@ DualTreeTraversalType, SingleTreeTraversalType>::serialize(
     // If we are loading, set the tree to NULL and clean up memory if necessary.
     if (Archive::is_loading::value)
     {
-      if (treeOwner && referenceTree)
+      if (referenceTree)
         delete referenceTree;
 
       referenceTree = NULL;
       oldFromNewReferences.clear();
-      treeOwner = false;
     }
   }
   else
   {
     // Delete the current reference tree, if necessary and if we are loading.
-    if (Archive::is_loading::value)
+    if (Archive::is_loading::value && referenceTree)
     {
-      if (treeOwner && referenceTree)
-        delete referenceTree;
-
-      // After we load the tree, we will own it.
-      treeOwner = true;
+      delete referenceTree;
+      referenceTree = NULL;
     }
 
     ar & BOOST_SERIALIZATION_NVP(referenceTree);
@@ -1017,12 +1011,8 @@ DualTreeTraversalType, SingleTreeTraversalType>::serialize(
     // necessary.
     if (Archive::is_loading::value)
     {
-      if (setOwner && referenceSet)
-        delete referenceSet;
-
       referenceSet = &referenceTree->Dataset();
       metric = referenceTree->Metric(); // Get the metric from the tree.
-      setOwner = false;
     }
   }
 


### PR DESCRIPTION
Replace copy and move overloads of the method Train in class NeighborSearch with pass-by-value. This pull request implements the guidelines suggested in #1021.