### PR TITLE
Explicitly serialize the 'reset' parameter.

### DIFF
--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -462,6 +462,24 @@ class FFN
 
 } // namespace ann
 } // namespace mlpack
+
+//! Set the serialization version of the FFN class.  Multiple template arguments
+//! makes this ugly...
+namespace boost {
+namespace serialization {
+
+template<typename OutputLayerType,
+         typename InitializationRuleType,
+         typename... CustomLayer>
+struct version<
+    mlpack::ann::FFN<OutputLayerType, InitializationRuleType, CustomLayer...>>
+{
+  BOOST_STATIC_CONSTANT(unsigned int, value = 1);
+};
+
+} // namespace serialization
+} // namespace boost
+
 // Include implementation.
 #include "ffn_impl.hpp"
 

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -474,7 +474,7 @@ template<typename OutputLayerType,
 struct version<
     mlpack::ann::FFN<OutputLayerType, InitializationRuleType, CustomLayer...>>
 {
-  BOOST_STATIC_CONSTANT(unsigned int, value = 1);
+  BOOST_STATIC_CONSTANT(int, value = 1);
 };
 
 } // namespace serialization

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -495,12 +495,19 @@ template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename Archive>
 void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::serialize(
-    Archive& ar, const unsigned int /* version */)
+    Archive& ar, const unsigned int version)
 {
   ar & BOOST_SERIALIZATION_NVP(parameter);
   ar & BOOST_SERIALIZATION_NVP(width);
   ar & BOOST_SERIALIZATION_NVP(height);
   ar & BOOST_SERIALIZATION_NVP(currentInput);
+
+  // Earlier versions of the FFN code did not serialize whether or not the model
+  // was reset.
+  if (version > 0)
+  {
+    ar & BOOST_SERIALIZATION_NVP(reset);
+  }
 
   // Be sure to clear other layers before loading.
   if (Archive::is_loading::value)
@@ -515,7 +522,10 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::serialize(
   // If we are loading, we need to initialize the weights.
   if (Archive::is_loading::value)
   {
-    reset = false;
+    // The behavior in earlier versions was to always assume the weights needed
+    // to be reset.
+    if (version == 0)
+      reset = false;
 
     size_t offset = 0;
     for (size_t i = 0; i < network.size(); ++i)

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -396,7 +396,7 @@ template<typename OutputLayerType,
 struct version<
     mlpack::ann::RNN<OutputLayerType, InitializationRuleType, CustomLayer...>>
 {
-  BOOST_STATIC_CONSTANT(unsigned int, value = 1);
+  BOOST_STATIC_CONSTANT(int, value = 1);
 };
 
 } // namespace serialization

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -385,6 +385,23 @@ class RNN
 } // namespace ann
 } // namespace mlpack
 
+//! Set the serialization version of the RNN class.  Multiple template arguments
+//! makes this ugly...
+namespace boost {
+namespace serialization {
+
+template<typename OutputLayerType,
+         typename InitializationRuleType,
+         typename... CustomLayer>
+struct version<
+    mlpack::ann::RNN<OutputLayerType, InitializationRuleType, CustomLayer...>>
+{
+  BOOST_STATIC_CONSTANT(unsigned int, value = 1);
+};
+
+} // namespace serialization
+} // namespace boost
+
 // Include implementation.
 #include "rnn_impl.hpp"
 


### PR DESCRIPTION
Previously, models would always re-initialize their weights after loading.  But we have to increment the serialization version for backwards compatibility.  I opened this because a user sent me an email that pointed out the problem.

@ShikharJ: does the GAN code need to be correspondingly updated?  I see that there is a serialize function there, but it seems very different in its behavior.