### PR TITLE
Mean shift: allow single-point clusters

### DIFF
--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -68,7 +68,7 @@ EstimateRadius(const MatType& data, double ratio)
   arma::rowvec maxDistances = max(distances);
 
   // Calculate and return the radius.
-  return sum(maxDistances) / (double) data.n_cols;
+  return arma::sum(maxDistances) / (double) data.n_cols;
 }
 
 // Class to compare two vectors.
@@ -218,7 +218,7 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
     // Initial centroid is the seed itself.
     allCentroids.col(i) = pSeeds->unsafe_col(i);
     for (size_t completedIterations = 0; completedIterations < maxIterations
-      || forceConvergence; completedIterations++)
+        || forceConvergence; completedIterations++)
     {
       // Store new centroid in this.
       arma::colvec newCentroid = arma::zeros<arma::colvec>(pSeeds->n_rows);
@@ -265,8 +265,9 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
   // forcing convergence, take 1 random centroid calculated.
   if (centroids.empty())
   {
-    Log::Warn << "No clusters converge, setting 1 random centroid calculated. "
-    "Try a larger max_iterations or pass force_convergence flag." << std::endl;
+    Log::Warn << "No clusters converged; setting 1 random centroid calculated. "
+        << "Try a larger max_iterations or pass force_convergence flag."
+        << std::endl;
 
     if (maxIterations == 0)
     {

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -266,8 +266,8 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
   if (centroids.empty())
   {
     Log::Warn << "No clusters converged; setting 1 random centroid calculated. "
-        << "Try a larger max_iterations or pass force_convergence flag."
-        << std::endl;
+        << "Try increasing the maximum number of iterations or setting the "
+        << "option to force convergence." << std::endl;
 
     if (maxIterations == 0)
     {

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -225,7 +225,7 @@ inline void MeanShift<UseKernel, KernelType, MatType>::Cluster(
 
       rangeSearcher.Search(allCentroids.unsafe_col(i), validRadius,
           neighbors, distances);
-      if (neighbors[0].size() <= 1)
+      if (neighbors[0].size() == 0) // There are no points in the cluster.
         break;
 
       // Calculate new centroid.


### PR DESCRIPTION
The previous mean shift code would disallow a single cluster if it only held one point.  This fix allows single-point clusters.  @ShangtongZhang: I wouldn't mind if you could take a quick look at this and ensure it doesn't break anything unforeseen. :)

This should be a fix for issue #1526.