### PR TITLE
Fixed bug in the derivative of the exponential linear unit.

### DIFF
--- a/src/mlpack/methods/ann/layer/elu.hpp
+++ b/src/mlpack/methods/ann/layer/elu.hpp
@@ -210,7 +210,7 @@ class ELU
    */
   double Deriv(const double y)
   {
-    return (y > 0) ? lambda : lambda * (Fn(y) + alpha);
+    return (y > 0) ? lambda : (Fn(y) + lambda * alpha);
   }
 
   /**

--- a/src/mlpack/methods/ann/layer/elu.hpp
+++ b/src/mlpack/methods/ann/layer/elu.hpp
@@ -210,7 +210,7 @@ class ELU
    */
   double Deriv(const double y)
   {
-    return (y > 0) ? lambda : lambda * (y + alpha);
+    return (y > 0) ? lambda : lambda * (Fn(y) + alpha);
   }
 
   /**


### PR DESCRIPTION
The derivative of the exponential linear unit is discussed correctly in the comments, but the implementation had a bug.