### PR TITLE
Decision tree pass by value

### DIFF
--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -56,6 +56,8 @@ class DecisionTree :
    * minimumGainSplit too small may cause the tree to overfit, but setting them
    * too large may cause it to underfit.
    *
+   * Use std::move if data or labels are no longer needed to avoid copies.
+   *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension of the dataset.
    * @param labels Labels for each training point.
@@ -77,6 +79,8 @@ class DecisionTree :
    * minimumGainSplit too small may cause the tree to overfit, but setting them
    * too large may cause it to underfit.
    *
+   * Use std::move if data or labels are no longer needed to avoid copies.
+   *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
@@ -95,6 +99,9 @@ class DecisionTree :
    * where the data can be both numeric and categorical. Setting minimumLeafSize
    * and minimumGainSplit too small may cause the tree to overfit, but setting
    * them too large may cause it to underfit.
+   *
+   * Use std::move if data, labels or weights are no longer needed to avoid
+   * copies.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension of the dataset.
@@ -121,6 +128,9 @@ class DecisionTree :
    * assuming that the data is all of the numeric type. Setting minimumLeafSize
    * and minimumGainSplit too small may cause the tree to overfit, but setting
    * them too large may cause it to underfit.
+   *
+   * Use std::move if data, labels or weights are no longer needed to avoid
+   * copies.
    *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
@@ -191,6 +201,8 @@ class DecisionTree :
    * minimumGainSplit too small may cause the tree to overfit, but setting them
    * too large may cause it to underfit.
    *
+   * Use std::move if data or labels are no longer needed to avoid copies.
+   *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension.
    * @param labels Labels for each training point.
@@ -213,6 +225,8 @@ class DecisionTree :
    * minimumGainSplit too small may cause the tree to overfit, but setting them
    * too large may cause it to underfit.
    *
+   * Use std::move if data or labels are no longer needed to avoid copies.
+   *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.
    * @param numClasses Number of classes in the dataset.
@@ -233,6 +247,9 @@ class DecisionTree :
    * specified by the datasetInfo parameter.  Setting minimumLeafSize and
    * minimumGainSplit too small may cause the tree to overfit, but setting them
    * too large may cause it to underfit.
+   *
+   * Use std::move if data, labels or weights are no longer needed to avoid
+   * copies.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Type information for each dimension.
@@ -258,6 +275,9 @@ class DecisionTree :
    * dimensions are numeric.  This will overwrite the given model. Setting
    * minimumLeafSize and minimumGainSplit too small may cause the tree to
    * overfit, but setting them too large may cause it to underfit.
+   *
+   * Use std::move if data, labels or weights are no longer needed to avoid
+   * copies.
    *
    * @param data Dataset to train on.
    * @param labels Labels for each training point.

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -64,9 +64,9 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
-  DecisionTree(MatType&& data,
+  DecisionTree(MatType data,
                const data::DatasetInfo& datasetInfo,
-               LabelsType&& labels,
+               LabelsType labels,
                const size_t numClasses,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7);
@@ -84,8 +84,8 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
-  DecisionTree(MatType&& data,
-               LabelsType&& labels,
+  DecisionTree(MatType data,
+               LabelsType labels,
                const size_t numClasses,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7);
@@ -105,11 +105,11 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
-  DecisionTree(MatType&& data,
+  DecisionTree(MatType data,
                const data::DatasetInfo& datasetInfo,
-               LabelsType&& labels,
+               LabelsType labels,
                const size_t numClasses,
-               WeightsType&& weights,
+               WeightsType weights,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7,
                const std::enable_if_t<arma::is_arma_type<
@@ -130,10 +130,10 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
-  DecisionTree(MatType&& data,
-               LabelsType&& labels,
+  DecisionTree(MatType data,
+               LabelsType labels,
                const size_t numClasses,
-               WeightsType&& weights,
+               WeightsType weights,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7,
                const std::enable_if_t<arma::is_arma_type<
@@ -200,9 +200,9 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
-  void Train(MatType&& data,
+  void Train(MatType data,
              const data::DatasetInfo& datasetInfo,
-             LabelsType&& labels,
+             LabelsType labels,
              const size_t numClasses,
              const size_t minimumLeafSize = 10,
              const double minimumGainSplit = 1e-7);
@@ -221,8 +221,8 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
-  void Train(MatType&& data,
-             LabelsType&& labels,
+  void Train(MatType data,
+             LabelsType labels,
              const size_t numClasses,
              const size_t minimumLeafSize = 10,
              const double minimumGainSplit = 1e-7);
@@ -243,11 +243,11 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
-  void Train(MatType&& data,
+  void Train(MatType data,
              const data::DatasetInfo& datasetInfo,
-             LabelsType&& labels,
+             LabelsType labels,
              const size_t numClasses,
-             WeightsType&& weights,
+             WeightsType weights,
              const size_t minimumLeafSize = 10,
              const double minimumGainSplit = 1e-7,
              const std::enable_if_t<arma::is_arma_type<typename
@@ -267,10 +267,10 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
-  void Train(MatType&& data,
-             LabelsType&& labels,
+  void Train(MatType data,
+             LabelsType labels,
              const size_t numClasses,
-             WeightsType&& weights,
+             WeightsType weights,
              const size_t minimumLeafSize = 10,
              const double minimumGainSplit = 1e-7,
              const std::enable_if_t<arma::is_arma_type<typename

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -28,9 +28,9 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType&& data,
+             NoRecursion>::DecisionTree(MatType data,
                                         const data::DatasetInfo& datasetInfo,
-                                        LabelsType&& labels,
+                                        LabelsType labels,
                                         const size_t numClasses,
                                         const size_t minimumLeafSize,
                                         const double minimumGainSplit)
@@ -39,8 +39,8 @@ DecisionTree<FitnessFunction,
   using TrueLabelsType = typename std::decay<LabelsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
 
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
@@ -61,8 +61,8 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType&& data,
-                                        LabelsType&& labels,
+             NoRecursion>::DecisionTree(MatType data,
+                                        LabelsType labels,
                                         const size_t numClasses,
                                         const size_t minimumLeafSize,
                                         const double minimumGainSplit)
@@ -71,8 +71,8 @@ DecisionTree<FitnessFunction,
   using TrueLabelsType = typename std::decay<LabelsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
 
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
@@ -93,11 +93,11 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType&& data,
+             NoRecursion>::DecisionTree(MatType data,
                                         const data::DatasetInfo& datasetInfo,
-                                        LabelsType&& labels,
+                                        LabelsType labels,
                                         const size_t numClasses,
-                                        WeightsType&& weights,
+                                        WeightsType weights,
                                         const size_t minimumLeafSize,
                                         const double minimumGainSplit,
                                         const std::enable_if_t<
@@ -110,9 +110,9 @@ DecisionTree<FitnessFunction,
   using TrueWeightsType = typename std::decay<WeightsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
-  TrueWeightsType tmpWeights(std::forward<WeightsType>(weights));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
+  TrueWeightsType tmpWeights(std::move(weights));
 
   // Pass off work to the weighted Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
@@ -132,10 +132,10 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType&& data,
-                                        LabelsType&& labels,
+             NoRecursion>::DecisionTree(MatType data,
+                                        LabelsType labels,
                                         const size_t numClasses,
-                                        WeightsType&& weights,
+                                        WeightsType weights,
                                         const size_t minimumLeafSize,
                                         const double minimumGainSplit,
                                         const std::enable_if_t<
@@ -148,9 +148,9 @@ DecisionTree<FitnessFunction,
   using TrueWeightsType = typename std::decay<WeightsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
-  TrueWeightsType tmpWeights(std::forward<WeightsType>(weights));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
+  TrueWeightsType tmpWeights(std::move(weights));
 
   // Pass off work to the weighted Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, tmpWeights,
@@ -345,9 +345,9 @@ void DecisionTree<FitnessFunction,
                   CategoricalSplitType,
                   DimensionSelectionType,
                   ElemType,
-                  NoRecursion>::Train(MatType&& data,
+                  NoRecursion>::Train(MatType data,
                                       const data::DatasetInfo& datasetInfo,
-                                      LabelsType&& labels,
+                                      LabelsType labels,
                                       const size_t numClasses,
                                       const size_t minimumLeafSize,
                                       const double minimumGainSplit)
@@ -366,8 +366,8 @@ void DecisionTree<FitnessFunction,
   using TrueLabelsType = typename std::decay<LabelsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
 
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
@@ -388,8 +388,8 @@ void DecisionTree<FitnessFunction,
                   CategoricalSplitType,
                   DimensionSelectionType,
                   ElemType,
-                  NoRecursion>::Train(MatType&& data,
-                                      LabelsType&& labels,
+                  NoRecursion>::Train(MatType data,
+                                      LabelsType labels,
                                       const size_t numClasses,
                                       const size_t minimumLeafSize,
                                       const double minimumGainSplit)
@@ -408,8 +408,8 @@ void DecisionTree<FitnessFunction,
   using TrueLabelsType = typename std::decay<LabelsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
 
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
@@ -430,11 +430,11 @@ void DecisionTree<FitnessFunction,
                   CategoricalSplitType,
                   DimensionSelectionType,
                   ElemType,
-                  NoRecursion>::Train(MatType&& data,
+                  NoRecursion>::Train(MatType data,
                                       const data::DatasetInfo& datasetInfo,
-                                      LabelsType&& labels,
+                                      LabelsType labels,
                                       const size_t numClasses,
-                                      WeightsType&& weights,
+                                      WeightsType weights,
                                       const size_t minimumLeafSize,
                                       const double minimumGainSplit,
                                       const std::enable_if_t<arma::is_arma_type<
@@ -456,9 +456,9 @@ void DecisionTree<FitnessFunction,
   using TrueWeightsType = typename std::decay<WeightsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
-  TrueWeightsType tmpWeights(std::forward<WeightsType>(weights));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
+  TrueWeightsType tmpWeights(std::move(weights));
 
   // Pass off work to the Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
@@ -478,10 +478,10 @@ void DecisionTree<FitnessFunction,
                   CategoricalSplitType,
                   DimensionSelectionType,
                   ElemType,
-                  NoRecursion>::Train(MatType&& data,
-                                      LabelsType&& labels,
+                  NoRecursion>::Train(MatType data,
+                                      LabelsType labels,
                                       const size_t numClasses,
-                                      WeightsType&& weights,
+                                      WeightsType weights,
                                       const size_t minimumLeafSize,
                                       const double minimumGainSplit,
                                       const std::enable_if_t<arma::is_arma_type<
@@ -503,9 +503,9 @@ void DecisionTree<FitnessFunction,
   using TrueWeightsType = typename std::decay<WeightsType>::type;
 
   // Copy or move data.
-  TrueMatType tmpData(std::forward<MatType>(data));
-  TrueLabelsType tmpLabels(std::forward<LabelsType>(labels));
-  TrueWeightsType tmpWeights(std::forward<WeightsType>(weights));
+  TrueMatType tmpData(std::move(data));
+  TrueLabelsType tmpLabels(std::move(labels));
+  TrueWeightsType tmpWeights(std::move(weights));
 
   // Pass off work to the Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, tmpWeights,

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -181,21 +181,29 @@ static void mlpackMain()
       arma::Row<double> weights =
           std::move(CLI::GetParam<arma::Mat<double>>("weights"));
       if (CLI::HasParam("print_training_error"))
+      {
         model->tree = DecisionTree<>(trainingSet, model->info, labels,
             numClasses, std::move(weights), minLeafSize, minimumGainSplit);
+      }
       else
+      {
         model->tree = DecisionTree<>(std::move(trainingSet), model->info,
             std::move(labels), numClasses, std::move(weights), minLeafSize,
             minimumGainSplit);
+      }
     }
     else
     {
       if (CLI::HasParam("print_training_error"))
+      {
         model->tree = DecisionTree<>(trainingSet, model->info, labels,
             numClasses, minLeafSize, minimumGainSplit);
+      }
       else
+      {
         model->tree = DecisionTree<>(std::move(trainingSet), model->info,
             std::move(labels), numClasses, minLeafSize, minimumGainSplit);
+      }
     }
 
     // Do we need to print training error?

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -180,13 +180,22 @@ static void mlpackMain()
     {
       arma::Row<double> weights =
           std::move(CLI::GetParam<arma::Mat<double>>("weights"));
-      model->tree = DecisionTree<>(trainingSet, model->info, labels,
-          numClasses, weights, minLeafSize, minimumGainSplit);
+      if (CLI::HasParam("print_training_error"))
+        model->tree = DecisionTree<>(trainingSet, model->info, labels,
+            numClasses, std::move(weights), minLeafSize, minimumGainSplit);
+      else
+        model->tree = DecisionTree<>(std::move(trainingSet), model->info,
+            std::move(labels), numClasses, std::move(weights), minLeafSize,
+            minimumGainSplit);
     }
     else
     {
-      model->tree = DecisionTree<>(trainingSet, model->info, labels,
-          numClasses, minLeafSize, minimumGainSplit);
+      if (CLI::HasParam("print_training_error"))
+        model->tree = DecisionTree<>(trainingSet, model->info, labels,
+            numClasses, minLeafSize, minimumGainSplit);
+      else
+        model->tree = DecisionTree<>(std::move(trainingSet), model->info,
+            std::move(labels), numClasses, minLeafSize, minimumGainSplit);
     }
 
     // Do we need to print training error?


### PR DESCRIPTION
Replace arguments of decision trees with pass by value arguments so the user can choose whether to copy or move the data. This makes reference to #1021.