### PR TITLE
Patch from aabghari to work in log-space for probabilities.

### DIFF
--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -264,6 +264,7 @@
 #include <mlpack/core/data/save.hpp>
 #include <mlpack/core/data/normalize_labels.hpp>
 #include <mlpack/core/math/clamp.hpp>
+#include <mlpack/core/math/log_add.hpp>
 #include <mlpack/core/math/random.hpp>
 #include <mlpack/core/math/random_basis.hpp>
 #include <mlpack/core/math/lin_alg.hpp>

--- a/src/mlpack/core/math/CMakeLists.txt
+++ b/src/mlpack/core/math/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SOURCES
   lin_alg.hpp
   lin_alg_impl.hpp
   lin_alg.cpp
+  log_add.hpp
+  log_add_impl.hpp
   make_alias.hpp
   random.hpp
   random.cpp

--- a/src/mlpack/methods/gmm/gmm.cpp
+++ b/src/mlpack/methods/gmm/gmm.cpp
@@ -12,6 +12,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #include "gmm.hpp"
+#include "mlpack/core/math/log_add.hpp"
 
 namespace mlpack {
 namespace gmm {
@@ -51,17 +52,40 @@ GMM& GMM::operator=(const GMM& other)
 }
 
 /**
+ * Return the log probability of the given observation being from this GMM.
+ */
+double GMM::LogProbability(const arma::vec& observation) const
+{
+  // Sum the probability for each Gaussian in our mixture (and we have to
+  // multiply by the prior for each Gaussian too).
+  double sum = -std::numeric_limits<double>::infinity();
+  for (size_t i = 0; i < gaussians; i++)
+  {
+    sum = math::LogAdd(sum, log(weights[i]) +
+        dists[i].LogProbability(observation));
+  }
+
+  return sum;
+}
+
+/**
  * Return the probability of the given observation being from this GMM.
  */
 double GMM::Probability(const arma::vec& observation) const
 {
-  // Sum the probability for each Gaussian in our mixture (and we have to
-  // multiply by the prior for each Gaussian too).
-  double sum = 0;
-  for (size_t i = 0; i < gaussians; i++)
-    sum += weights[i] * dists[i].Probability(observation);
+  return exp(LogProbability(observation));
+}
 
-  return sum;
+/**
+ * Return the log probability of the given observation being from the given
+ * component in the mixture.
+ */
+double GMM::LogProbability(const arma::vec& observation,
+                        const size_t component) const
+{
+  // We are only considering one Gaussian component -- so we only need to call
+  // Probability() once.  We do consider the prior probability!
+  return log(weights[component]) + dists[component].LogProbability(observation);
 }
 
 /**
@@ -71,9 +95,7 @@ double GMM::Probability(const arma::vec& observation) const
 double GMM::Probability(const arma::vec& observation,
                         const size_t component) const
 {
-  // We are only considering one Gaussian component -- so we only need to call
-  // Probability() once.  We do consider the prior probability!
-  return weights[component] * dists[component].Probability(observation);
+  return exp(LogProbability(observation, component));
 }
 
 /**

--- a/src/mlpack/methods/gmm/gmm.hpp
+++ b/src/mlpack/methods/gmm/gmm.hpp
@@ -165,6 +165,14 @@ class GMM
   double Probability(const arma::vec& observation) const;
 
   /**
+   * Return the log probability that the given observation came from this
+   * distribution.
+   *
+   * @param observation Observation to evaluate the probability of.
+   */
+  double LogProbability(const arma::vec& observation) const;
+
+  /**
    * Return the probability that the given observation came from the given
    * Gaussian component in this distribution.
    *
@@ -173,6 +181,16 @@ class GMM
    */
   double Probability(const arma::vec& observation,
                      const size_t component) const;
+
+  /**
+   * Return the log probability that the given observation came from the given
+   * Gaussian component in this distribution.
+   *
+   * @param observation Observation to evaluate the probability of.
+   * @param component Index of the component of the GMM to be considered.
+   */
+  double LogProbability(const arma::vec& observation,
+                        const size_t component) const;
 
   /**
    * Return a randomly generated observation according to the probability

--- a/src/mlpack/methods/gmm/gmm_impl.hpp
+++ b/src/mlpack/methods/gmm/gmm_impl.hpp
@@ -17,6 +17,8 @@
 // In case it hasn't already been included.
 #include "gmm.hpp"
 
+#include <mlpack/core/math/log_add.hpp>
+
 namespace mlpack {
 namespace gmm {
 

--- a/src/mlpack/methods/hmm/hmm.hpp
+++ b/src/mlpack/methods/hmm/hmm.hpp
@@ -211,10 +211,10 @@ class HMM
    * @return Log-likelihood of most likely state sequence.
    */
   double Estimate(const arma::mat& dataSeq,
-                  arma::mat& stateProb,
-                  arma::mat& forwardProb,
-                  arma::mat& backwardProb,
-                  arma::vec& scales) const;
+                  arma::mat& stateLogProb,
+                  arma::mat& forwardLogProb,
+                  arma::mat& backwardLogProb,
+                  arma::vec& logScales) const;
 
   /**
    * Estimate the probabilities of each hidden state at each time step of each
@@ -228,7 +228,7 @@ class HMM
    * @return Log-likelihood of most likely state sequence.
    */
   double Estimate(const arma::mat& dataSeq,
-                  arma::mat& stateProb) const;
+                  arma::mat& stateLogProb) const;
 
   /**
    * Generate a random data sequence of the given length.  The data sequence is
@@ -341,8 +341,8 @@ class HMM
    * @param forwardProb Matrix in which forward probabilities will be saved.
    */
   void Forward(const arma::mat& dataSeq,
-               arma::vec& scales,
-               arma::mat& forwardProb) const;
+               arma::vec& logScales,
+               arma::mat& forwardLogProb) const;
 
   /**
    * The Backward algorithm (part of the Forward-Backward algorithm).  Computes
@@ -356,8 +356,8 @@ class HMM
    * @param backwardProb Matrix in which backward probabilities will be saved.
    */
   void Backward(const arma::mat& dataSeq,
-                const arma::vec& scales,
-                arma::mat& backwardProb) const;
+                const arma::vec& logScales,
+                arma::mat& backwardLogProb) const;
 
   //! Set of emission probability distributions; one for each state.
   std::vector<Distribution> emission;

--- a/src/mlpack/methods/hmm/hmm_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_impl.hpp
@@ -16,6 +16,7 @@
 
 // Just in case...
 #include "hmm.hpp"
+#include <mlpack/core/math/log_add.hpp>
 
 namespace mlpack {
 namespace hmm {
@@ -115,10 +116,10 @@ void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
   for (size_t iter = 0; iter < iterations; iter++)
   {
     // Clear new transition matrix and emission probabilities.
-    arma::vec newInitial(transition.n_rows);
-    newInitial.zeros();
-    arma::mat newTransition(transition.n_rows, transition.n_cols);
-    newTransition.zeros();
+    arma::vec newLogInitial(transition.n_rows);
+    newLogInitial.fill(-std::numeric_limits<double>::infinity());
+    arma::mat newLogTransition(transition.n_rows, transition.n_cols);
+    newLogTransition.fill(-std::numeric_limits<double>::infinity());
 
     // Reset log likelihood.
     loglik = 0;
@@ -129,17 +130,18 @@ void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
     // Loop over each sequence.
     for (size_t seq = 0; seq < dataSeq.size(); seq++)
     {
-      arma::mat stateProb;
-      arma::mat forward;
-      arma::mat backward;
-      arma::vec scales;
+      arma::mat stateLogProb;
+      arma::mat forwardLog;
+      arma::mat backwardLog;
+      arma::vec logScales;
 
       // Add the log-likelihood of this sequence.  This is the E-step.
-      loglik += Estimate(dataSeq[seq], stateProb, forward, backward, scales);
+      loglik += Estimate(dataSeq[seq], stateLogProb, forwardLog, backwardLog,
+          logScales);
 
       // Add to estimate of initial probability for state j.
       for (size_t j = 0; j < transition.n_cols; ++j)
-        newInitial[j] += stateProb(j, 0);
+        newLogInitial[j] = math::LogAdd(newLogInitial[j], stateLogProb(j, 0));
 
       // Now re-estimate the parameters.  This is the M-step.
       //   pi_i = sum_d ((1 / P(seq[d])) sum_t (f(i, 0) b(i, 0))
@@ -156,14 +158,17 @@ void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
             // Estimate of T_ij (probability of transition from state j to state
             // i).  We postpone multiplication of the old T_ij until later.
             for (size_t i = 0; i < transition.n_rows; i++)
-              newTransition(i, j) += forward(j, t) * backward(i, t + 1) *
-                  emission[i].Probability(dataSeq[seq].unsafe_col(t + 1)) /
-                  scales[t + 1];
+            {
+              newLogTransition(i, j) = math::LogAdd(newLogTransition(i, j),
+                  forwardLog(j, t) + backwardLog(i, t + 1) +
+                  emission[i].LogProbability(dataSeq[seq].unsafe_col(t + 1)) -
+                  logScales[t + 1]);
+            }
           }
 
           // Add to list of emission observations, for Distribution::Train().
           emissionList.col(sumTime) = dataSeq[seq].col(t);
-          emissionProb[j][sumTime] = stateProb(j, t);
+          emissionProb[j][sumTime] = exp(stateLogProb(j, t));
         }
         sumTime++;
       }
@@ -179,15 +184,15 @@ void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
 
     // Normalize the new initial probabilities.
     if (dataSeq.size() > 1)
-      initial = newInitial / dataSeq.size();
+      initial = exp(newLogInitial) / dataSeq.size();
     else
-      initial = newInitial;
+      initial = exp(newLogInitial);
 
     // Assign the new transition matrix.  We use %= (element-wise
     // multiplication) because every element of the new transition matrix must
     // still be multiplied by the old elements (this is the multiplication we
     // earlier postponed).
-    transition %= newTransition;
+    transition %= exp(newLogTransition);
 
     // Now we normalize the transition matrix.
     for (size_t i = 0; i < transition.n_cols; i++)
@@ -309,21 +314,21 @@ void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq,
  */
 template<typename Distribution>
 double HMM<Distribution>::Estimate(const arma::mat& dataSeq,
-                                   arma::mat& stateProb,
-                                   arma::mat& forwardProb,
-                                   arma::mat& backwardProb,
-                                   arma::vec& scales) const
+                                   arma::mat& stateLogProb,
+                                   arma::mat& forwardLogProb,
+                                   arma::mat& backwardLogProb,
+                                   arma::vec& logScales) const
 {
   // First run the forward-backward algorithm.
-  Forward(dataSeq, scales, forwardProb);
-  Backward(dataSeq, scales, backwardProb);
+  Forward(dataSeq, logScales, forwardLogProb);
+  Backward(dataSeq, logScales, backwardLogProb);
 
   // Now assemble the state probability matrix based on the forward and backward
   // probabilities.
-  stateProb = forwardProb % backwardProb;
+  stateLogProb = forwardLogProb + backwardLogProb;
 
   // Finally assemble the log-likelihood and return it.
-  return accu(log(scales));
+  return accu(logScales);
 }
 
 /**
@@ -332,13 +337,14 @@ double HMM<Distribution>::Estimate(const arma::mat& dataSeq,
  */
 template<typename Distribution>
 double HMM<Distribution>::Estimate(const arma::mat& dataSeq,
-                                   arma::mat& stateProb) const
+                                   arma::mat& stateLogProb) const
 {
   // We don't need to save these.
-  arma::mat forwardProb, backwardProb;
-  arma::vec scales;
+  arma::mat forwardLogProb, backwardLogProb;
+  arma::vec logScales;
 
-  return Estimate(dataSeq, stateProb, forwardProb, backwardProb, scales);
+  return Estimate(dataSeq, stateLogProb, forwardLogProb, backwardLogProb,
+      logScales);
 }
 
 /**
@@ -417,8 +423,8 @@ double HMM<Distribution>::Predict(const arma::mat& dataSeq,
   logStateProb.col(0).zeros();
   for (size_t state = 0; state < transition.n_rows; state++)
   {
-    logStateProb(state, 0) = log(initial[state] *
-        emission[state].Probability(dataSeq.unsafe_col(0)));
+    logStateProb(state, 0) = log(initial[state]) +
+        emission[state].LogProbability(dataSeq.unsafe_col(0));
     stateSeqBack(state, 0) = state;
   }
 
@@ -433,8 +439,8 @@ double HMM<Distribution>::Predict(const arma::mat& dataSeq,
     {
       arma::vec prob = logStateProb.col(t - 1) + logTrans.col(j);
       logStateProb(j, t) = prob.max(index) +
-          log(emission[j].Probability(dataSeq.unsafe_col(t)));
-        stateSeqBack(j, t) = index;
+          emission[j].LogProbability(dataSeq.unsafe_col(t));
+      stateSeqBack(j, t) = index;
     }
   }
 
@@ -442,8 +448,10 @@ double HMM<Distribution>::Predict(const arma::mat& dataSeq,
   logStateProb.unsafe_col(dataSeq.n_cols - 1).max(index);
   stateSeq[dataSeq.n_cols - 1] = index;
   for (size_t t = 2; t <= dataSeq.n_cols; t++)
+  {
     stateSeq[dataSeq.n_cols - t] =
         stateSeqBack(stateSeq[dataSeq.n_cols - t + 1], dataSeq.n_cols - t + 1);
+  }
 
   return logStateProb(stateSeq(dataSeq.n_cols - 1), dataSeq.n_cols - 1);
 }
@@ -454,13 +462,13 @@ double HMM<Distribution>::Predict(const arma::mat& dataSeq,
 template<typename Distribution>
 double HMM<Distribution>::LogLikelihood(const arma::mat& dataSeq) const
 {
-  arma::mat forward;
-  arma::vec scales;
+  arma::mat forwardLog;
+  arma::vec logScales;
 
-  Forward(dataSeq, scales, forward);
+  Forward(dataSeq, logScales, forwardLog);
 
   // The log-likelihood is the log of the scales for each time step.
-  return accu(log(scales));
+  return accu(logScales);
 }
 
 /**
@@ -472,9 +480,11 @@ void HMM<Distribution>::Filter(const arma::mat& dataSeq,
                                size_t ahead) const
 {
   // First run the forward algorithm.
-  arma::mat forwardProb;
-  arma::vec scales;
-  Forward(dataSeq, scales, forwardProb);
+  arma::mat forwardLogProb;
+  arma::vec logScales;
+  Forward(dataSeq, logScales, forwardLogProb);
+
+  arma::mat forwardProb = exp(forwardProb);
 
   // Propagate state ahead.
   if (ahead != 0)
@@ -495,14 +505,14 @@ void HMM<Distribution>::Smooth(const arma::mat& dataSeq,
                                arma::mat& smoothSeq) const
 {
   // First run the forward algorithm.
-  arma::mat stateProb;
-  Estimate(dataSeq, stateProb);
+  arma::mat stateLogProb;
+  Estimate(dataSeq, stateLogProb);
 
   // Compute expected emissions.
   // Will not work for distributions without a Mean() function.
   smoothSeq.zeros(dimensionality, dataSeq.n_cols);
   for (size_t i = 0; i < emission.size(); i++)
-    smoothSeq += emission[i].Mean() * stateProb.row(i);
+    smoothSeq += emission[i].Mean() * exp(stateLogProb.row(i));
 }
 
 /**
@@ -510,13 +520,17 @@ void HMM<Distribution>::Smooth(const arma::mat& dataSeq,
  */
 template<typename Distribution>
 void HMM<Distribution>::Forward(const arma::mat& dataSeq,
-                                arma::vec& scales,
-                                arma::mat& forwardProb) const
+                                arma::vec& logScales,
+                                arma::mat& forwardLogProb) const
 {
   // Our goal is to calculate the forward probabilities:
   //  P(X_k | o_{1:k}) for all possible states X_k, for each time point k.
-  forwardProb.zeros(transition.n_rows, dataSeq.n_cols);
-  scales.zeros(dataSeq.n_cols);
+  forwardLogProb.resize(transition.n_rows, dataSeq.n_cols);
+  forwardLogProb.fill(-std::numeric_limits<double>::infinity());
+  logScales.resize(dataSeq.n_cols);
+  logScales.fill(-std::numeric_limits<double>::infinity());
+
+  arma::mat logTrans = trans(log(transition));
 
   // The first entry in the forward algorithm uses the initial state
   // probabilities.  Note that MATLAB assumes that the starting state (at
@@ -524,13 +538,13 @@ void HMM<Distribution>::Forward(const arma::mat& dataSeq,
   // behavior, you could append a single starting state to every single data
   // sequence and that should produce results in line with MATLAB.
   for (size_t state = 0; state < transition.n_rows; state++)
-    forwardProb(state, 0) = initial(state) *
-        emission[state].Probability(dataSeq.unsafe_col(0));
+    forwardLogProb(state, 0) = log(initial(state)) +
+        emission[state].LogProbability(dataSeq.unsafe_col(0));
 
   // Then normalize the column.
-  scales[0] = accu(forwardProb.col(0));
-  if (scales[0] > 0.0)
-    forwardProb.col(0) /= scales[0];
+  logScales[0] = math::AccuLog(forwardLogProb.unsafe_col(0));
+  if(std::isfinite(logScales[0]))
+    forwardLogProb.col(0) -= logScales[0];
 
   // Now compute the probabilities for each successive observation.
   for (size_t t = 1; t < dataSeq.n_cols; t++)
@@ -540,29 +554,31 @@ void HMM<Distribution>::Forward(const arma::mat& dataSeq,
       // The forward probability of state j at time t is the sum over all states
       // of the probability of the previous state transitioning to the current
       // state and emitting the given observation.
-      forwardProb(j, t) = accu(forwardProb.col(t - 1) %
-          trans(transition.row(j))) *
-          emission[j].Probability(dataSeq.unsafe_col(t));
+      const arma::vec probs = forwardLogProb.col(t - 1) + logTrans.col(j);
+      forwardLogProb(j, t) = math::AccuLog(probs) +
+          emission[j].LogProbability(dataSeq.unsafe_col(t));
     }
 
     // Normalize probability.
-    scales[t] = accu(forwardProb.col(t));
-    if (scales[t] > 0.0)
-      forwardProb.col(t) /= scales[t];
+    logScales[t] = math::AccuLog(forwardLogProb.unsafe_col(t));
+    if(std::isfinite(logScales[t]))
+        forwardLogProb.col(t) -= logScales[t];
   }
 }
 
 template<typename Distribution>
 void HMM<Distribution>::Backward(const arma::mat& dataSeq,
-                                 const arma::vec& scales,
-                                 arma::mat& backwardProb) const
+                                 const arma::vec& logScales,
+                                 arma::mat& backwardLogProb) const
 {
   // Our goal is to calculate the backward probabilities:
   //  P(X_k | o_{k + 1:T}) for all possible states X_k, for each time point k.
-  backwardProb.zeros(transition.n_rows, dataSeq.n_cols);
+  backwardLogProb.resize(transition.n_rows, dataSeq.n_cols);
+  backwardLogProb.fill(-std::numeric_limits<double>::infinity());
+  arma::mat logTrans = log(transition);
 
   // The last element probability is 1.
-  backwardProb.col(dataSeq.n_cols - 1).fill(1);
+  backwardLogProb.col(dataSeq.n_cols - 1).fill(0);
 
   // Now step backwards through all other observations.
   for (size_t t = dataSeq.n_cols - 2; t + 1 > 0; t--)
@@ -574,12 +590,15 @@ void HMM<Distribution>::Backward(const arma::mat& dataSeq,
       // current state multiplied by the probability of each of those states
       // emitting the given observation.
       for (size_t state = 0; state < transition.n_rows; state++)
-        backwardProb(j, t) += transition(state, j) * backwardProb(state, t + 1)
-            * emission[state].Probability(dataSeq.unsafe_col(t + 1));
+      {
+        backwardLogProb(j, t) = math::LogAdd(backwardLogProb(j, t),
+            logTrans(state, j) + backwardLogProb(state, t + 1) +
+            emission[state].LogProbability(dataSeq.unsafe_col(t + 1)));
+      }
 
       // Normalize by the weights from the forward algorithm.
-      if (scales[t + 1] > 0.0)
-        backwardProb(j, t) /= scales[t + 1];
+      if (std::isfinite(logScales[t + 1]))
+        backwardLogProb(j, t) -= logScales[t + 1];
     }
   }
 }

--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -127,13 +127,15 @@ BOOST_AUTO_TEST_CASE(ForwardBackwardTwoState)
   HMM<DiscreteDistribution> hmm(initial, transition, emis);
 
   // Now check we are getting the same results as MATLAB for this sequence.
-  arma::mat stateProb;
-  arma::mat forwardProb;
-  arma::mat backwardProb;
-  arma::vec scales;
+  arma::mat stateLogProb;
+  arma::mat forwardLogProb;
+  arma::mat backwardLogProb;
+  arma::vec logScales;
 
-  const double log = hmm.Estimate(obs, stateProb, forwardProb, backwardProb,
-      scales);
+  const double log = hmm.Estimate(obs, stateLogProb, forwardLogProb,
+      backwardLogProb, logScales);
+
+  arma::mat stateProb = arma::exp(stateLogProb);
 
   // All values obtained from MATLAB hmmdecode().
   BOOST_REQUIRE_CLOSE(log, -23.4349, 1e-3);
@@ -584,10 +586,12 @@ BOOST_AUTO_TEST_CASE(GaussianHMMSimpleTest)
 
   // Now predict the sequence.
   arma::Row<size_t> predictedClasses;
-  arma::mat stateProb;
+  arma::mat stateLogProb;
 
   hmm.Predict(observations, predictedClasses);
-  hmm.Estimate(observations, stateProb);
+  hmm.Estimate(observations, stateLogProb);
+
+  arma::mat stateProb = arma::exp(stateLogProb);
 
   // Check that each prediction is right.
   for (size_t i = 0; i < 1000; i++)
@@ -780,6 +784,111 @@ BOOST_AUTO_TEST_CASE(GaussianHMMGenerateTest)
         hmm2.Emission()[em].Covariance()(1, 0), 0.2);
     BOOST_REQUIRE_SMALL(hmm.Emission()[em].Covariance()(1, 1) -
         hmm2.Emission()[em].Covariance()(1, 1), 0.2);
+  }
+}
+
+/**
+ * Make sure that Predict() is numerically stable.
+ */
+BOOST_AUTO_TEST_CASE(GaussianHMMPredictTest)
+{
+  size_t numState = 10;
+  size_t obsDimension = 2;
+  HMM<GaussianDistribution> hmm(numState, GaussianDistribution(obsDimension));
+
+  arma::vec initial = {1.0000, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  arma::mat transition = {{0.9149, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                          {0.0851, 0.8814, 0, 0, 0, 0, 0, 0, 0, 0},
+                          {0, 0.1186, 0.9031, 0, 0, 0, 0, 0, 0, 0},
+                          {0, 0, 0.0969, 0.903, 0, 0, 0, 0, 0, 0},
+                          {0, 0, 0, 0.097, 0.8941, 0, 0, 0, 0, 0},
+                          {0, 0, 0, 0, 0.1059, 0.9024, 0, 0, 0, 0},
+                          {0, 0, 0, 0, 0, 0.0976, 0.8902, 0, 0, 0},
+                          {0, 0, 0, 0, 0, 0, 0.1098, 0.9107, 0, 0},
+                          {0, 0, 0, 0, 0, 0, 0, 0.0893, 0.8964, 0},
+                          {0, 0, 0, 0, 0, 0, 0, 0, 0.1036, 1}};
+
+  std::vector<arma::vec> mean = {{0, 0.259},
+                                 {0.0372, 0.2063},
+                                 {0.1496, -0.3075},
+                                 {-0.0366, -0.3255},
+                                 {-0.2866, -0.0202},
+                                 {0.1804, 0.1385},
+                                 {0.1922, -0.0616},
+                                 {-0.378, -0.1751},
+                                 {-0.1346, 0.1357},
+                                 {0.338, 0.183}};
+
+  std::vector<arma::mat> cov = {
+      {{3.2837e-07, 0}, {0, 0.032837}},
+      {{0.0154, -0.0093}, {-0.0093, 0.0358}},
+      {{0.1087, -0.0032}, {-0.0032, 0.0587}},
+      {{0.3185, -0.0069}, {-0.0069, 0.0396}},
+      {{0.3472, 0.0484}, {0.0484, 0.0706}},
+      {{0.39, 0.0406}, {0.0406, 0.0653}},
+      {{0.4502, 0.0718}, {0.0718, 0.0705}},
+      {{0.3253, 0.0312}, {0.0312, 0.0783}},
+      {{0.2355, 0.0195}, {0.0195, 0.0276}},
+      {{0.0818, 0.022}, {0.022, 0.0282}}};
+
+  hmm.Initial() = initial;
+  hmm.Transition() = transition;
+
+  for (size_t i = 0; i < numState; ++i)
+  {
+    GaussianDistribution &emission = hmm.Emission().at(i);
+    emission.Mean() = mean.at(i);
+    emission.Covariance(cov.at(i));
+  }
+
+  arma::mat obs = {
+      {
+          -0.0424, -0.0395, -0.0336, -0.0294, -0.0299, -0.032, -0.0289, -0.0148,
+          0.0095, 0.0416, 0.0795, 0.1173, 0.1491, 0.1751, 0.1999, 0.2277,
+          0.2586, 0.2858, 0.3019, 0.303, 0.289, 0.2632, 0.2301, 0.1923, 0.1498,
+          0.1021, 0.0471, -0.0191, -0.0969, -0.1795, -0.2559, -0.323, -0.3882,
+          -0.4582, -0.5334, -0.609, -0.6778999999999999, -0.7278, -0.7481,
+          -0.7356, -0.6953, -0.635, -0.5617, -0.478, -0.3833, -0.2721, -0.1365,
+          0.0283, 0.217, 0.4148, 0.6028, 0.7664, 0.8937, 0.9737, 1, 0.972,
+          0.8972, 0.7891, 0.6613, 0.524, 0.3847, 0.2489, 0.1187, -0.0045,
+          -0.1214, -0.2316, -0.3328, -0.4211, -0.4963, -0.5607, -0.6136,
+          -0.6532, -0.6777, -0.6867, -0.6807, -0.6612, -0.6345, -0.6075,
+          -0.5748, -0.5278, -0.4747, -0.4176, -0.33, -0.2036, -0.0597,
+          0.07240000000000001, 0.1754, 0.2471, 0.295, 0.3356, 0.3809, 0.4299,
+          0.4737, 0.4987, 0.4958, 0.4676, 0.4253, 0.3802, 0.342, 0.3183
+      },
+      {
+          0.2355, 0.2639, 0.2971, 0.3301, 0.3598, 0.3842, 0.3995, 0.4019, 0.39,
+          0.3624, 0.3201, 0.2658, 0.203, 0.1341, 0.06, -0.0179, -0.1006,
+          -0.1869, -0.2719, -0.35, -0.4176, -0.4739, -0.52, -0.5584, -0.5913,
+          -0.6196, -0.642, -0.6554, -0.6567, -0.6459, -0.6271, -0.6029, -0.5722,
+          -0.5318000000000001, -0.4802, -0.4174, -0.3449, -0.2685, -0.1927,
+          -0.1201, -0.0532, 0.008699999999999999, 0.0673, 0.1204, 0.1647,
+          0.2008, 0.2284, 0.2447, 0.2504, 0.2479, 0.2373, 0.2148, 0.1781,
+          0.1283, 0.06710000000000001, -0.0022, -0.0743, -0.1463, -0.2149,
+          -0.2784, -0.3362, -0.3867, -0.4297, -0.4651, -0.4924, -0.5101,
+          -0.5168, -0.5117, -0.496, -0.4706, -0.4358, -0.3923, -0.3419, -0.2868,
+          -0.2289, -0.1702, -0.1094, -0.0421, 0.0311, 0.1047, 0.1732, 0.2257,
+          0.254, 0.2532, 0.2308, 0.2017, 0.1724, 0.1425, 0.1195, 0.099, 0.0759,
+          0.0521, 0.0313, 0.0188, 0.0113, 0.0068, 0.0042, 0.0026, 0.0018, 0.0014
+      }
+  };
+
+  arma::Row<size_t> stateSeq;
+  auto likelihood = hmm.LogLikelihood(obs);
+  hmm.Predict(obs, stateSeq);
+
+  arma::Row<size_t> stateSeqRef = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4,
+      4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7,
+      7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9,
+      9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
+
+  BOOST_REQUIRE_CLOSE(likelihood, -2734.43, 1e-3);
+
+  for (size_t i = 0; i < stateSeqRef.n_cols; ++i)
+  {
+    BOOST_REQUIRE_EQUAL(stateSeqRef.at(i), stateSeq.at(i));
   }
 }
 


### PR DESCRIPTION
This is from #1538.  The probability computations for the HMM and GMM are now done entirely in log-space instead of the normal space, which helps with low-probability precision and correctness issues.

It seems that when using OpenMP (my system has 8 cores) this can result in a significant acceleration:

```
# OLD
$ time bin/mlpack_test -t HMMTest
Running 18 test cases...

*** No errors detected

real	0m6.463s
user	0m26.263s
sys	0m21.803s

# NEW
$ time bin/mlpack_test -t HMMTest
Running 19 test cases...

*** No errors detected

real	0m1.225s
user	0m2.020s
sys	0m2.788s
```

However, when setting the number of threads to 1, it's a slight slowdown:

```
# OLD
$ time OMP_NUM_THREADS=1 bin/mlpack_test -t HMMTest
Running 18 test cases...

*** No errors detected

real	0m0.808s
user	0m0.779s
sys	0m0.029s

# NEW
$ time OMP_NUM_THREADS=1 bin/mlpack_test -t HMMTest
Running 19 test cases...

*** No errors detected

real	0m1.050s
user	0m1.022s
sys	0m0.028s
```

It's possible that the code could be tuned so the singlethreaded performance matched the old singlethreaded performance, but I'm happy to leave it as-is because the multithreaded performance is so much better.