### PR TITLE
Update Windows tutorial and build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,14 @@ find_package(Boost 1.49
 
 link_directories(${Boost_LIBRARY_DIRS})
 
+# In Visual Studio, automatic linking is performed, so we don't need to worry
+# about it.  Clear the list of libraries to link against and let Visual Studio
+# handle it.
+if (MSVC)
+  link_directories(${Boost_LIBRARY_DIRS})
+  set(Boost_LIBRARIES "")
+endif ()
+
 set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${Boost_LIBRARIES})
 set(MLPACK_LIBRARY_DIRS ${MLPACK_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,12 +325,10 @@ find_package(Boost 1.49
 
 link_directories(${Boost_LIBRARY_DIRS})
 
-# In Visual Studio, automatic linking is performed, so we don't need to worry
-# about it.  Clear the list of libraries to link against and let Visual Studio
-# handle it.
+# Disable automatic linking in Visual Studio.
 if (MSVC)
   link_directories(${Boost_LIBRARY_DIRS})
-  set(Boost_LIBRARIES "")
+  add_definitions(-DBOOST_ALL_NO_LIB)
 endif ()
 
 set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,12 +327,6 @@ find_package(Boost 1.49
 
 link_directories(${Boost_LIBRARY_DIRS})
 
-# Disable automatic linking in Visual Studio.
-if (MSVC)
-  link_directories(${Boost_LIBRARY_DIRS})
-  add_definitions(-DBOOST_ALL_NO_LIB)
-endif ()
-
 set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${Boost_LIBRARIES})
 set(MLPACK_LIBRARY_DIRS ${MLPACK_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,8 @@ set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${ARMADILLO_LIBRARIES})
 # Unfortunately this configuration variable is necessary and will need to be
 # updated as time goes on and new versions are released.
 set(Boost_ADDITIONAL_VERSIONS
+  "1.68.0" "1.68"
+  "1.67.0" "1.67"
   "1.66.0" "1.66"
   "1.65.1" "1.65.0" "1.65"
   "1.64.1" "1.64.0" "1.64"

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -90,14 +90,40 @@ or a different VS version, update the cmake command accordingly.
 @section build_windows_mlpack Building mlpack
 
 - Create a "build" directory into "C:\mlpack\mlpack-3.0.3\"
-- Open the Command Prompt and navigate to "C:\mlpack\mlpack-3.0.3\build"
-- Run cmake:
+- Use either the CMake GUI or the CMake command line to configure Armadillo.
+  - To use the CMake GUI, open "CMake".
+    - For "Where is the source code:" set `C:\mlpack\mlpack-3.0.3\`
+    - For "Where to build the binaries:" set `C:\mlpack\mlpack-3.0.3\build`
+    - Click `Configure`
+    - If there is an error and Armadillo is not found, try "Add Entry" with the
+      following variables and reconfigure:
+      - Name: `ARMADILLO_INCLUDE_DIR`; type `PATH`; value `C:/mlpack/armadillo-8.500.1/include/`
+      - Name: `ARMADILLO_LIBRARY`; type `FILEPATH`; value `C:/mlpack/armadillo-8.500.1/build/Debug/armadillo.lib`
+      - Name: `BLAS_LIBRARY`; type `FILEPATH`; value `C:/mlpack/mlpack-3.0.3/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a`
+      - Name: `LAPACK_LIBRARY`; type `FILEPATH`; value `C:/mlpack/mlpack-3.0.3/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a`
+    - If there is an error and Boost is not found, try "Add Entry" with the
+      following variables and reconfigure:
+      - Name: `BOOST_INCLUDEDIR`; type `PATH`; value `C:/boost/boost_1_66_0/`
+      - Name: `BOOST_LIBRARYDIR`; type `PATH`; value `C:/boost/boost_1_66_0/lib64-msvc-14.1`
+    - If Boost is still not found, try adding the following variables and
+      reconfigure:
+      - Name: `Boost_INCLUDE_DIR`; type `PATH`; value `C:/boost/boost_1_66_0/`
+      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_program_options-vc141-mt-gd-x64-1_66.lib`
+      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
+      - Name: `Boost_SERIALIZATION_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_serialization-vc141-mt-gd-x64-1_66.lib`
+      - Name: `Boost_SERIALIZATION_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
+      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-gd-x64-1_66.lib`
+      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-x64-1_66.lib`
+    - Once CMake has configured successfully, hit "Generate" to create the `.sln` file.
+  - To use the CMake command line prompt:
+    - Open the Command Prompt and navigate to "C:\mlpack\mlpack-3.0.3\build"
+    - Run cmake:
 
 @code
 cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.3/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.3/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DARMADILLO_INCLUDE_DIR="C:/mlpack/armadillo-8.500.1/include" -DARMADILLO_LIBRARY:FILEPATH="C:/mlpack/armadillo-8.500.1/build/Debug/armadillo.lib" -DBOOST_INCLUDEDIR:PATH="C:/boost/boost_1_66_0/" -DBOOST_LIBRARYDIR:PATH="C:/boost/boost_1_66_0/lib64-msvc-14.1" -DDEBUG=OFF -DPROFILE=OFF ..
 @endcode
 
-- Once it has successfully finished, open "C:\mlpack\mlpack-3.0.3\build\mlpack.sln"
+- Once CMake configuration has successfully finished, open "C:\mlpack\mlpack-3.0.3\build\mlpack.sln"
 - Build > Build Solution (this may be by default in Debug mode)
 - Once it has sucessfully finished, you will find the library files you need in: "C:\mlpack\mlpack-3.0.3\build\Debug" (or "C:\mlpack\mlpack-3.0.3\build\Release" if you changed to Release mode)
 

--- a/src/mlpack/bindings/cli/CMakeLists.txt
+++ b/src/mlpack/bindings/cli/CMakeLists.txt
@@ -49,6 +49,7 @@ if (BUILD_CLI_EXECUTABLES)
   )
   target_link_libraries(mlpack_${name}
     mlpack
+    ${ARMADILLO_LIBRARIES}
     ${Boost_LIBRARIES}
     ${COMPILER_SUPPORT_LIBRARIES}
   )

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ add_executable(mlpack_test
 target_link_libraries(mlpack_test
   mlpack
   ${BOOST_unit_test_framework_LIBRARY}
+  ${BOOST_program_options_LIBRARY}
   ${COMPILER_SUPPORT_LIBRARIES}
 )
 

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -180,7 +180,7 @@ add_executable(mlpack_test
 target_link_libraries(mlpack_test
   mlpack
   ${ARMADILLO_LIBRARIES}
-  ${Boost_LIBRARIES}
+  ${BOOST_unit_test_framework_LIBRARY}
   ${COMPILER_SUPPORT_LIBRARIES}
 )
 

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -179,8 +179,8 @@ add_executable(mlpack_test
 # Link dependencies of test executable.
 target_link_libraries(mlpack_test
   mlpack
-  ${BOOST_unit_test_framework_LIBRARY}
-  ${BOOST_program_options_LIBRARY}
+  ${ARMADILLO_LIBRARIES}
+  ${Boost_LIBRARIES}
   ${COMPILER_SUPPORT_LIBRARIES}
 )
 

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -180,7 +180,7 @@ add_executable(mlpack_test
 target_link_libraries(mlpack_test
   mlpack
   ${ARMADILLO_LIBRARIES}
-  ${BOOST_unit_test_framework_LIBRARY}
+  ${BOOST_LIBRARIES}
   ${COMPILER_SUPPORT_LIBRARIES}
 )
 


### PR DESCRIPTION
This is to improve on the issues encountered in #1524.  It adds some description on debugging Boost configuration failures, and also disables autolinking with Boost which apparently causes some problems.

I have not tried these steps directly on Windows but instead on Linux and they seem to work.  If someone would like to verify (and update if needed on what's wrong), I can update the Boost configuration steps.