### PR TITLE
Convolution invalid memory access fix

### DIFF
--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -312,9 +312,6 @@ class Convolution
   //! Locally-stored transformed output parameter.
   arma::cube outputTemp;
 
-  //! Locally-stored transformed input parameter.
-  arma::cube inputTemp;
-
   //! Locally-stored transformed padded input parameter.
   arma::cube inputPaddedTemp;
 

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -312,9 +312,6 @@ class Convolution
   //! Locally-stored transformed output parameter.
   arma::cube outputTemp;
 
-  //! Locally-stored transformed padded input parameter.
-  arma::cube inputPaddedTemp;
-
   //! Locally-stored transformed error parameter.
   arma::cube gTemp;
 

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -91,10 +91,10 @@ void Convolution<
     OutputDataType
 >::Reset()
 {
-    weight = arma::cube(weights.memptr(), kW, kH,
-        outSize * inSize, false, false);
-    bias = arma::mat(weights.memptr() + weight.n_elem,
-        outSize, 1, false, false);
+  weight = arma::cube(weights.memptr(), kW, kH,
+      outSize * inSize, false, false);
+  bias = arma::mat(weights.memptr() + weight.n_elem,
+      outSize, 1, false, false);
 }
 
 template<
@@ -116,6 +116,7 @@ void Convolution<
   batchSize = input.n_cols;
   arma::cube inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
+  arma::cube inputPaddedTemp;
 
   if (padW != 0 || padH != 0)
   {
@@ -243,6 +244,7 @@ void Convolution<
 {
   arma::cube inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
+  arma::cube inputPaddedTemp;
   arma::cube mappedError(error.memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -246,6 +246,12 @@ void Convolution<
   arma::cube mappedError(error.memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 
+  // Pad again if we need...
+  if (padW != 0 || padH != 0)
+  {
+    Pad(inputTemp, padW, padH, inputPaddedTemp);
+  }
+
   gradient.set_size(weights.n_elem, 1);
   gradientTemp = arma::Cube<eT>(gradient.memptr(), weight.n_rows,
       weight.n_cols, weight.n_slices, false, false);

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -114,7 +114,7 @@ void Convolution<
 >::Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  arma::cube inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (padW != 0 || padH != 0)
@@ -179,8 +179,10 @@ void Convolution<
     InputDataType,
     OutputDataType
 >::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
 {
+  arma::cube inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+      inputWidth, inputHeight, inSize * batchSize, false, false);
   arma::cube mappedError(gy.memptr(), outputWidth, outputHeight,
       outSize * batchSize, false, false);
 
@@ -235,10 +237,12 @@ void Convolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>&& /* input */,
+    const arma::Mat<eT>&& input,
     arma::Mat<eT>&& error,
     arma::Mat<eT>&& gradient)
 {
+  arma::cube inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+      inputWidth, inputHeight, inSize * batchSize, false, false);
   arma::cube mappedError(error.memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 

--- a/src/mlpack/tests/augmented_rnns_tasks_test.cpp
+++ b/src/mlpack/tests/augmented_rnns_tasks_test.cpp
@@ -92,10 +92,10 @@ class HardCodedSortModel
  public:
   HardCodedSortModel(size_t bitLen) : bitLen(bitLen) {}
 
-  void Train(arma::field<arma::mat>& predictors,
-             arma::field<arma::mat>& labels)
+  void Train(arma::field<arma::mat>& /* predictors */,
+             arma::field<arma::mat>& /* labels */)
   {
-    assert(predictors.n_elem == labels.n_elem);
+    return;
   }
 
   void Predict(arma::mat& predictors,


### PR DESCRIPTION
I was investigating #1549 and when I used the `DigitRecognizerCNN` program from the models repository with `valgrind`, I got quite a lot of output.  Quickly I was able to trace this to the use of the `inputTemp` parameter in the `Convolution` class.  It looks to me like `inputTemp` is used, along with `inputPaddedTemp`, to keep from having to compute the padded input in both `Forward()` and `Gradient()`.

But based on the valgrind output, it looks like `inputTemp`'s memory is either being freed or changed between the calls to `Forward()` and `Backward()` and `Gradient()`, so I adapted the code to use the given `input` parameter at each time step, even though this may mean recomputation of the padded input in `Gradient()`.

This seems to produce the results that are expected for the `DigitRecognizerCNN`, although I also noticed that with a batch size of 50, I get the following worse performance:

```
Reading data ...
Training ...
Epoch 0:        Training Accuracy = 49.7196%,   Validation Accuracy = 48.7143%
Epoch 1:        Training Accuracy = 65.381%,    Validation Accuracy = 65.4048%
Epoch 2:        Training Accuracy = 73.1772%,   Validation Accuracy = 73.4048%
Epoch 3:        Training Accuracy = 78.0079%,   Validation Accuracy = 77.619%
Epoch 4:        Training Accuracy = 81.0899%,   Validation Accuracy = 80.619%
Epoch 5:        Training Accuracy = 83.3016%,   Validation Accuracy = 82.7857%
Epoch 6:        Training Accuracy = 84.9683%,   Validation Accuracy = 84.4048%
Epoch 7:        Training Accuracy = 86.2778%,   Validation Accuracy = 85.8095%
Epoch 8:        Training Accuracy = 87.3175%,   Validation Accuracy = 86.8333%
Epoch 9:        Training Accuracy = 87.9974%,   Validation Accuracy = 87.5238%
Epoch 10:       Training Accuracy = 88.4815%,   Validation Accuracy = 87.881%
Epoch 11:       Training Accuracy = 89.2698%,   Validation Accuracy = 88.7381%
Epoch 12:       Training Accuracy = 89.5873%,   Validation Accuracy = 88.9286%
Epoch 13:       Training Accuracy = 90.1296%,   Validation Accuracy = 89.5952%
Epoch 14:       Training Accuracy = 90.4153%,   Validation Accuracy = 89.6905%
Epoch 15:       Training Accuracy = 90.8757%,   Validation Accuracy = 89.9524%
Epoch 16:       Training Accuracy = 91.1958%,   Validation Accuracy = 90.2381%
Epoch 17:       Training Accuracy = 91.5%,      Validation Accuracy = 90.5714%
Epoch 18:       Training Accuracy = 91.7407%,   Validation Accuracy = 90.5476%
Epoch 19:       Training Accuracy = 91.9021%,   Validation Accuracy = 90.881%
Epoch 20:       Training Accuracy = 92.0608%,   Validation Accuracy = 90.7857%
Epoch 21:       Training Accuracy = 92.4524%,   Validation Accuracy = 91.381%
Epoch 22:       Training Accuracy = 92.4392%,   Validation Accuracy = 91.3095%
Epoch 23:       Training Accuracy = 92.627%,    Validation Accuracy = 91.5952%
Epoch 24:       Training Accuracy = 92.8307%,   Validation Accuracy = 91.5952%
Epoch 25:       Training Accuracy = 92.6138%,   Validation Accuracy = 91.7143%
Epoch 26:       Training Accuracy = 92.6085%,   Validation Accuracy = 91.7857%
Epoch 27:       Training Accuracy = 92.8148%,   Validation Accuracy = 91.7143%
Epoch 28:       Training Accuracy = 92.754%,    Validation Accuracy = 92%
Epoch 29:       Training Accuracy = 93.037%,    Validation Accuracy = 92.381%
Epoch 30:       Training Accuracy = 93.1323%,   Validation Accuracy = 92.2381%
Epoch 31:       Training Accuracy = 93.3095%,   Validation Accuracy = 92.5476%
Epoch 32:       Training Accuracy = 93.5582%,   Validation Accuracy = 92.7619%
Epoch 33:       Training Accuracy = 93.6878%,   Validation Accuracy = 93.0238%
Epoch 34:       Training Accuracy = 93.7063%,   Validation Accuracy = 92.9048%
Epoch 35:       Training Accuracy = 93.8307%,   Validation Accuracy = 93%
Epoch 36:       Training Accuracy = 93.6825%,   Validation Accuracy = 92.619%
Epoch 37:       Training Accuracy = 94.2222%,   Validation Accuracy = 93.1905%
Epoch 38:       Training Accuracy = 93.7963%,   Validation Accuracy = 92.9286%
Epoch 39:       Training Accuracy = 94.3333%,   Validation Accuracy = 93.381%
Epoch 40:       Training Accuracy = 94.3016%,   Validation Accuracy = 93.4048%
```

But when I run with a batch size of 1 the performance is much better:

```
Reading data ...
Training ...
Epoch 0:        Training Accuracy = 86.2143%,   Validation Accuracy = 86.5%
Epoch 1:        Training Accuracy = 90.2857%,   Validation Accuracy = 90.0714%
Epoch 2:        Training Accuracy = 91.2778%,   Validation Accuracy = 90.8095%
Epoch 3:        Training Accuracy = 92.7566%,   Validation Accuracy = 92.119%
Epoch 4:        Training Accuracy = 91.8386%,   Validation Accuracy = 91.5476%
Epoch 5:        Training Accuracy = 92.5847%,   Validation Accuracy = 92.2619%
Epoch 6:        Training Accuracy = 93.8862%,   Validation Accuracy = 93.381%
Epoch 7:        Training Accuracy = 94.5397%,   Validation Accuracy = 93.8333%
Epoch 8:        Training Accuracy = 93.836%,    Validation Accuracy = 93.9524%
Epoch 9:        Training Accuracy = 94.6878%,   Validation Accuracy = 94.4286%
Epoch 10:       Training Accuracy = 94.7302%,   Validation Accuracy = 94.2143%
Epoch 11:       Training Accuracy = 95.7857%,   Validation Accuracy = 95.4048%
Epoch 12:       Training Accuracy = 94.8016%,   Validation Accuracy = 94.3095%
Epoch 13:       Training Accuracy = 94.3624%,   Validation Accuracy = 94.381%
Epoch 14:       Training Accuracy = 95.6164%,   Validation Accuracy = 95.3095%
Epoch 15:       Training Accuracy = 93.0873%,   Validation Accuracy = 92.9762%
Epoch 16:       Training Accuracy = 96.2513%,   Validation Accuracy = 96.1667%
Epoch 17:       Training Accuracy = 95.7169%,   Validation Accuracy = 95.5714%
Epoch 18:       Training Accuracy = 96.5529%,   Validation Accuracy = 96%
... (I ctrl+c'ed it out of impatience)
```

It seems strange that the batch size would make such a difference, but I still think this is the right solution for this code.  I can't actually run it with a larger batch size with the bug, because the program crashes---so I can't compare to see that the performance is the same (it is with a batch size of 1 though).

I also tested with a batch size of 2, and the performance was slightly degraded.  So it may be that just a batch size of 50 isn't optimal for this problem, but in any case, I point all this out just in case I have introduced a bug somehow.