### PR TITLE
CMake doesn't allow overloading of an option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,16 @@ option(MATLAB_BINDINGS "Compile MATLAB bindings if MATLAB is found." OFF)
 option(TEST_VERBOSE "Run test cases with verbose output." OFF)
 option(BUILD_TESTS "Build tests." ON)
 option(BUILD_CLI_EXECUTABLES "Build command-line executables." ON)
-option(BUILD_PYTHON_BINDINGS "Build Python bindings." ON)
+
+# Currently Python bindings aren't known to build successfully on Windows, so
+# set BUILD_PYTHON_BINDINGS to OFF when the platform is Windows.
+if (WIN32)
+  option(BUILD_PYTHON_BINDINGS "Build Python bindings." OFF)
+  message(WARNING "By default Python bindings are not compiled for Windows because they are not known to work.  Set BUILD_PYTHON_BINDINGS to ON if you want them built.")
+else ()
+  option(BUILD_PYTHON_BINDINGS "Build Python bindings." ON)
+endif()
+
 option(BUILD_SHARED_LIBS
     "Compile shared libraries (if OFF, static libraries are compiled)." ON)
 option(BUILD_WITH_COVERAGE
@@ -23,13 +32,6 @@ option(FORCE_CXX11
     "Don't check that the compiler supports C++11, just assume it.  Make sure to specify any necessary flag to enable C++11 as part of CXXFLAGS." OFF)
 option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
 enable_testing()
-
-# Currently Python bindings aren't known to build successfully on Windows, so
-# set BUILD_PYTHON_BINDINGS to OFF when the platform is Windows.
-if (WIN32)
-  option(BUILD_PYTHON_BINDINGS "Build Python bindings." OFF)
-  message(WARNING "By default Python bindings are not compiled for Windows because they are not known to work.  Set BUILD_PYTHON_BINDINGS to ON if you want them built.")
-endif()
 
 # Set required standard to c++11
 set(CMAKE_CXX_STANDARD 11)

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -15,7 +15,7 @@ endif ()
 
 # Generate Python setuptools file.
 # We can probably use FindPythonInterp when we require CMake 3.0.
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp)
 if (NOT PYTHON_EXECUTABLE)
   not_found_return("Python not found; not building Python bindings.")
 else ()


### PR DESCRIPTION
So we can't "re-set" the default value.  This change makes the option defined with its default conditionally.  No actual functionality change here, other than that now Python bindings are properly disabled on Windows.