### PR TITLE
Fix inappropriate warning Barak pointed out in #1564.

### DIFF
--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -130,7 +130,7 @@ static void mlpackMain()
   // should issue a warning.
   RequireAtLeastOnePassed({ "output_model", "output" }, false,
       "no output will be saved");
-  ReportIgnoredParam({{ "test", true }}, "output");
+  ReportIgnoredParam({{ "test", false }}, "output");
 
   // Check parameter validity.
   RequireParamValue<int>("max_iterations", [](int x) { return x >= 0; },


### PR DESCRIPTION
The warning should be issued if `output` is specified but `test` is not... not the other way around.