### PR TITLE
CMake fixes and GNUInstallDirs

### DIFF
--- a/CMake/allexec2man.sh
+++ b/CMake/allexec2man.sh
@@ -18,7 +18,7 @@ exec2man="$1"
 outdir="$2"
 
 mkdir -p "$outdir"
-for program in $(find . -type f -executable -iname 'mlpack_*' | \
+for program in $(find . -type f -perm -u+x -iname 'mlpack_*' | \
                 grep -v '[.]$' | \
                 grep -v '_test$'); do
   echo "Generating man page for $program...";

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(FORCE_CXX11
 option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
 enable_testing()
 
-# Set required standard to c++11
+# Set required standard to C++11.
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ else ()
   set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
   set(CMAKE_INSTALL_MANDIR ${CMAKE_INSTALL_PREFIX}/man)
   set(CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_PREFIX}/share/doc/mlpack)
+  set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
 endif ()
 
 # This is as of yet unused.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Include modules in the CMake directory.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 
+# If we are on a Unix-like system, use the GNU install directories module.
+# Otherwise set the values manually.
+if (UNIX)
+  include(GNUInstallDirs)
+else ()
+  set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_PREFIX}/bin)
+  set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
+  set(CMAKE_INSTALL_MANDIR ${CMAKE_INSTALL_PREFIX}/man)
+  set(CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_PREFIX}/share/doc/mlpack)
+endif ()
+
 # This is as of yet unused.
 #option(PGO "Use profile-guided optimization if not a debug build" ON)
 
@@ -436,7 +447,7 @@ if (BUILD_CLI_EXECUTABLES AND UNIX)
 
     # Set the rules to install the documentation.
     install(DIRECTORY ${CMAKE_BINARY_DIR}/share/man/
-        DESTINATION share/man/man1/)
+        DESTINATION ${CMAKE_INSTALL_MANDIR})
   endif ()
 endif ()
 
@@ -488,7 +499,7 @@ if (DOXYGEN_FOUND)
   )
 
   install(DIRECTORY ${CMAKE_BINARY_DIR}/doc/html
-      DESTINATION share/doc/mlpack
+      DESTINATION ${CMAKE_INSTALL_DOCDIR}
       COMPONENT doc
       OPTIONAL
   )
@@ -567,7 +578,6 @@ if (PKG_CONFIG_FOUND)
       DEPENDS mlpack_headers
       COMMENT "Generating mlpack.pc (pkg-config) file.")
 
-  # Do we need a different directory?
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig/mlpack.pc
-      DESTINATION lib/pkgconfig/)
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
 endif ()

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -90,14 +90,15 @@ endforeach()
 
 # At install time, we simply install that directory of header files we
 # collected to include/.
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include/mlpack DESTINATION include)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/mlpack DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Set generated executables to be installed.  Unfortunately they must manually
 # be entered...
 install(TARGETS mlpack
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 add_dependencies(mlpack mlpack_headers)
 

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -14,7 +14,7 @@ set(DIRS
 )
 
 foreach(dir ${DIRS})
-    add_subdirectory(${dir})
+  add_subdirectory(${dir})
 endforeach()
 
 # MLPACK_SRCS is set in the subdirectories.  The dependencies (MLPACK_LIBRARIES)
@@ -40,8 +40,7 @@ if (NOT BUILD_SHARED_LIBS)
   add_definitions(-DMLPACK_STATIC_DEFINE)
 endif ()
 
-target_link_libraries(mlpack
-  ${MLPACK_LIBRARIES})
+target_link_libraries(mlpack ${MLPACK_LIBRARIES})
 
 set_target_properties(mlpack
   PROPERTIES

--- a/src/mlpack/bindings/cli/CMakeLists.txt
+++ b/src/mlpack/bindings/cli/CMakeLists.txt
@@ -56,7 +56,7 @@ if (BUILD_CLI_EXECUTABLES)
   # compiled with the correct int main() call.
   set_target_properties(mlpack_${name} PROPERTIES COMPILE_FLAGS
       -DBINDING_TYPE=BINDING_TYPE_CLI)
-  install(TARGETS mlpack_${name} RUNTIME DESTINATION bin)
+  install(TARGETS mlpack_${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   # If man documentation is being generated, make sure this is a dependency.
   if (TXT2MAN)

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -163,13 +163,21 @@ add_dependencies(python python_copy)
 # Configure installation script file.
 execute_process(COMMAND ${PYTHON_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/print_python_version.py" "${CMAKE_INSTALL_PREFIX}"
-    OUTPUT_VARIABLE NEW_PYTHONPATH)
-install(CODE "set(ENV{PYTHONPATH} ${NEW_PYTHONPATH})")
-install(CODE "execute_process(COMMAND mkdir -p $ENV{DESTDIR}${NEW_PYTHONPATH})")
-install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE}
-    \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
-    --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR}
-    WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
+    OUTPUT_VARIABLE CMAKE_PYTHON_PATH)
+string(STRIP "${CMAKE_PYTHON_PATH}" CMAKE_PYTHON_PATH)
+install(CODE "set(ENV{PYTHONPATH} ${CMAKE_PYTHON_PATH})")
+install(CODE "execute_process(COMMAND mkdir -p $ENV{DESTDIR}${CMAKE_PYTHON_PATH})")
+if ($ENV{DESTDIR})
+  install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE}
+      \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
+      --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR}
+      WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
+else ()
+  install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE}
+      \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
+      --prefix=${CMAKE_INSTALL_PREFIX}
+      WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
+endif ()
 
 # Prepare __init__.py for having all of the convenience imports appended to it.
 file(COPY mlpack/__init__.py DESTINATION

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -116,7 +116,7 @@ add_custom_command(TARGET python_copy PRE_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy
         ${CMAKE_CURRENT_SOURCE_DIR}/setup.cfg
         ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/
-	BYPRODUCTS ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/${cython_file})
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/${cython_file})
 add_custom_command(TARGET python_copy PRE_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy
         ${CMAKE_CURRENT_SOURCE_DIR}/copy_artifacts.py
@@ -128,7 +128,7 @@ if (BUILD_TESTS)
         COMMAND ${CMAKE_COMMAND} ARGS -E copy
             ${CMAKE_CURRENT_SOURCE_DIR}/${test_file}
             ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/tests/
-	BYPRODUCTS ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/tests/${test_file})
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/tests/${test_file})
   endforeach ()
 endif ()
 

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -14,7 +14,6 @@ if (NOT BUILD_PYTHON_BINDINGS)
 endif ()
 
 # Generate Python setuptools file.
-# We can probably use FindPythonInterp when we require CMake 3.0.
 find_package(PythonInterp)
 if (NOT PYTHON_EXECUTABLE)
   not_found_return("Python not found; not building Python bindings.")


### PR DESCRIPTION
These changes are for #1578 and #1576:

 * Use `GNUInstallDirs` from CMake, which lets the user configure things like LIBDIR, INCLUDEDIR, etc.  On Windows, we just set these to their existing defaults, but they can be configured there also.
 * A few minor formatting fixes.
 * Fix another Linux-ism for the `find` call in `allexec2man.sh`.