### PR TITLE
Handle instantiated metrics for BinarySpaceTree.

### DIFF
--- a/src/mlpack/core/metrics/mahalanobis_distance.hpp
+++ b/src/mlpack/core/metrics/mahalanobis_distance.hpp
@@ -1,5 +1,5 @@
 /***
- * @file mahalanobis_dstance.hpp
+ * @file mahalanobis_distance.hpp
  * @author Ryan Curtin
  *
  * The Mahalanobis distance.

--- a/src/mlpack/core/metrics/mahalanobis_distance.hpp
+++ b/src/mlpack/core/metrics/mahalanobis_distance.hpp
@@ -1,5 +1,5 @@
 /***
- * @file mahalanobis_dstance.h
+ * @file mahalanobis_dstance.hpp
  * @author Ryan Curtin
  *
  * The Mahalanobis distance.
@@ -81,7 +81,8 @@ class MahalanobisDistance
    *
    * @param covariance The covariance matrix to use for this distance.
    */
-  MahalanobisDistance(const arma::mat& covariance) : covariance(covariance) { }
+  MahalanobisDistance(arma::mat covariance) :
+      covariance(std::move(covariance)) { }
 
   /**
    * Evaluate the distance between the two given points using this Mahalanobis

--- a/src/mlpack/core/metrics/mahalanobis_distance_impl.hpp
+++ b/src/mlpack/core/metrics/mahalanobis_distance_impl.hpp
@@ -1,5 +1,5 @@
 /***
- * @file mahalanobis_distance.cpp
+ * @file mahalanobis_distance_impl.hpp
  * @author Ryan Curtin
  *
  * Implementation of the Mahalanobis distance.

--- a/src/mlpack/core/metrics/mahalanobis_distance_impl.hpp
+++ b/src/mlpack/core/metrics/mahalanobis_distance_impl.hpp
@@ -1,5 +1,5 @@
 /***
- * @file mahalanobis_distance.cc
+ * @file mahalanobis_distance.cpp
  * @author Ryan Curtin
  *
  * Implementation of the Mahalanobis distance.

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
@@ -794,8 +794,9 @@ void BinarySpaceTree<MetricType, StatisticType, MatType, BoundType, SplitType>::
   left->Center(leftCenter);
   right->Center(rightCenter);
 
-  const ElemType leftParentDistance = MetricType::Evaluate(center, leftCenter);
-  const ElemType rightParentDistance = MetricType::Evaluate(center,
+  const ElemType leftParentDistance = bound.Metric().Evaluate(center,
+      leftCenter);
+  const ElemType rightParentDistance = bound.Metric().Evaluate(center,
       rightCenter);
 
   left->ParentDistance() = leftParentDistance;
@@ -861,8 +862,9 @@ SplitNode(std::vector<size_t>& oldFromNew,
   left->Center(leftCenter);
   right->Center(rightCenter);
 
-  const ElemType leftParentDistance = MetricType::Evaluate(center, leftCenter);
-  const ElemType rightParentDistance = MetricType::Evaluate(center,
+  const ElemType leftParentDistance = bound.Metric().Evaluate(center,
+      leftCenter);
+  const ElemType rightParentDistance = bound.Metric().Evaluate(center,
       rightCenter);
 
   left->ParentDistance() = leftParentDistance;

--- a/src/mlpack/core/tree/cellbound.hpp
+++ b/src/mlpack/core/tree/cellbound.hpp
@@ -142,6 +142,11 @@ class CellBound
   //! Modify the minimum width of the bound.
   ElemType& MinWidth() { return minWidth; }
 
+  //! Get the metric associated with this bound.
+  const MetricType& Metric() const { return metric; }
+  //! Modify the metric associated with this bound.
+  MetricType& Metric() { return metric; }
+
   /**
    * Calculates the center of the range, placing it into the given vector.
    *
@@ -264,6 +269,8 @@ class CellBound
   arma::Col<AddressElemType> hiAddress;
   //! The minimal width of the outer rectangle.
   ElemType minWidth;
+  //! The instantiated metric (likely has size 0).
+  MetricType metric;
 
   /**
    * Add a subrectangle to the bound.

--- a/src/mlpack/core/tree/cellbound_impl.hpp
+++ b/src/mlpack/core/tree/cellbound_impl.hpp
@@ -993,6 +993,7 @@ void CellBound<MetricType, ElemType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(numBounds);
   ar & BOOST_SERIALIZATION_NVP(loAddress);
   ar & BOOST_SERIALIZATION_NVP(hiAddress);
+  ar & BOOST_SERIALIZATION_NVP(metric);
 }
 
 } // namespace bound

--- a/src/mlpack/core/tree/hrectbound.hpp
+++ b/src/mlpack/core/tree/hrectbound.hpp
@@ -101,6 +101,11 @@ class HRectBound
   //! Modify the minimum width of the bound.
   ElemType& MinWidth() { return minWidth; }
 
+  //! Get the instantiated metric associated with the bound.
+  const MetricType& Metric() const { return metric; }
+  //! Modify the instantiated metric associated with the bound.
+  MetricType& Metric() { return metric; }
+
   /**
    * Calculates the center of the range, placing it into the given vector.
    *
@@ -227,6 +232,8 @@ class HRectBound
   math::RangeType<ElemType>* bounds;
   //! Cached minimum width of bound.
   ElemType minWidth;
+  //! Instantiated metric (likely has size 0).
+  MetricType metric;
 };
 
 // A specialization of BoundTraits for this class.

--- a/src/mlpack/core/tree/hrectbound_impl.hpp
+++ b/src/mlpack/core/tree/hrectbound_impl.hpp
@@ -677,6 +677,7 @@ void HRectBound<MetricType, ElemType>::serialize(
   auto boundsArray = boost::serialization::make_array(bounds, dim);
   ar & BOOST_SERIALIZATION_NVP(boundsArray);
   ar & BOOST_SERIALIZATION_NVP(minWidth);
+  ar & BOOST_SERIALIZATION_NVP(metric);
 }
 
 } // namespace bound


### PR DESCRIPTION
This fixes #1579.

@reverendbedford: sorry, the patch was just a little more complex than I thought.  You can use this branch to fix the issue, or wait until it is merged.  Thanks again for pointing out the issue. :+1: