### PR TITLE
Add control of Reset Policy to Adam optimizers

### DIFF
--- a/src/mlpack/core/optimizers/adam/adam.hpp
+++ b/src/mlpack/core/optimizers/adam/adam.hpp
@@ -172,6 +172,13 @@ class AdamType
   //! Modify whether or not the individual functions are shuffled.
   bool& Shuffle() { return optimizer.Shuffle(); }
 
+  //! Get whether or not the update policy parameters
+  //! are reset before Optimize call.
+  bool ResetPolicy() const { return optimizer.ResetPolicy(); }
+  //! Modify whether or not the update policy parameters
+  //! are reset before Optimize call.
+  bool& ResetPolicy() { return optimizer.ResetPolicy(); }
+
  private:
   //! The Stochastic Gradient Descent object with Adam policy.
   SGD<UpdateRule> optimizer;


### PR DESCRIPTION
Seems to be needed to do "single-epoch loop" training (see issue #1455) without resetting each time.