### PR TITLE
Fixes for intermittently failing tests

### DIFF
--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -107,9 +107,9 @@ PARAM_INT_IN("new_dimensionality", "If not 0, reduce the dimensionality of "
 PARAM_FLAG("center", "If set, the transformed data will be centered about the "
     "origin.", "c");
 
-PARAM_FLAG("nystroem_method", "If set, the nystroem method will be used.", "n");
+PARAM_FLAG("nystroem_method", "If set, the Nystroem method will be used.", "n");
 
-PARAM_STRING_IN("sampling", "Sampling scheme to use for the nystroem method: "
+PARAM_STRING_IN("sampling", "Sampling scheme to use for the Nystroem method: "
     "'kmeans', 'random', 'ordered'", "s", "kmeans");
 
 PARAM_DOUBLE_IN("kernel_scale", "Scale, for 'hyptan' kernel.", "S", 1.0);

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -667,11 +667,11 @@ BOOST_AUTO_TEST_CASE(GammaDistributionTrainWithProbabilitiesTest)
   BOOST_REQUIRE_CLOSE(gDist2.Alpha(1), gDist.Alpha(1), 1.5);
   BOOST_REQUIRE_CLOSE(gDist2.Beta(1), gDist.Beta(1), 1.5);
 
-  BOOST_REQUIRE_CLOSE(alphaReal, gDist.Alpha(0), 2.5);
-  BOOST_REQUIRE_CLOSE(betaReal, gDist.Beta(0), 2.5);
+  BOOST_REQUIRE_CLOSE(alphaReal, gDist.Alpha(0), 3.0);
+  BOOST_REQUIRE_CLOSE(betaReal, gDist.Beta(0), 3.0);
 
-  BOOST_REQUIRE_CLOSE(alphaReal, gDist.Alpha(1), 2.5);
-  BOOST_REQUIRE_CLOSE(betaReal, gDist.Beta(1), 2.5);
+  BOOST_REQUIRE_CLOSE(alphaReal, gDist.Alpha(1), 3.0);
+  BOOST_REQUIRE_CLOSE(betaReal, gDist.Beta(1), 3.0);
 }
 
 /**

--- a/src/mlpack/tests/main_tests/kernel_pca_test.cpp
+++ b/src/mlpack/tests/main_tests/kernel_pca_test.cpp
@@ -245,18 +245,18 @@ BOOST_AUTO_TEST_CASE(KernelPCAOffsetTest)
   for (std::string& kernel: kernels)
   {
     ResetSettings();
-    arma::mat x = arma::randu<arma::mat>(5, 5);
+    arma::mat x = arma::randu<arma::mat>(5, 100);
 
     SetInputParam("input", x);
     SetInputParam("new_dimensionality", (int) 3);
     SetInputParam("kernel", kernel);
-    SetInputParam("offset", (double) 1);
+    SetInputParam("offset", (double) 0.01);
 
     mlpackMain();
     arma::mat output1 = CLI::GetParam<arma::mat>("output");
 
     SetInputParam("input", std::move(x));
-    SetInputParam("offset", (double) 2);
+    SetInputParam("offset", (double) 0.1);
 
     mlpackMain();
     arma::mat output2 = CLI::GetParam<arma::mat>("output");
@@ -323,10 +323,10 @@ BOOST_AUTO_TEST_CASE(KernelPCASamplingSchemeTest)
 {
   ResetSettings();
 
-  arma::mat x = arma::randu<arma::mat>(5, 5);
+  arma::mat x = arma::randu<arma::mat>(5, 500);
 
   SetInputParam("input", x);
-  SetInputParam("new_dimensionality", (int) 1);
+  SetInputParam("new_dimensionality", (int) 3);
   SetInputParam("kernel", (std::string) "gaussian");
   SetInputParam("nystroem_method", true);
   SetInputParam("sampling", (std::string) "kmeans");

--- a/src/mlpack/tests/nmf_test.cpp
+++ b/src/mlpack/tests/nmf_test.cpp
@@ -124,11 +124,11 @@ BOOST_AUTO_TEST_CASE(NMFALSTest)
 
   const mat wh = w * h;
 
-  // Make sure reconstruction error is not too high.  8% tolerance.  It seems
+  // Make sure reconstruction error is not too high.  9% tolerance.  It seems
   // like ALS doesn't converge to results that are as good.  It also seems to be
   // particularly sensitive to initial conditions.
   BOOST_REQUIRE_SMALL(arma::norm(v - wh, "fro") / arma::norm(v, "fro"),
-      0.08);
+      0.09);
 }
 
 /**

--- a/src/mlpack/tests/recurrent_network_test.cpp
+++ b/src/mlpack/tests/recurrent_network_test.cpp
@@ -452,7 +452,8 @@ void ReberGrammarTestNetwork(const size_t hiddenSize = 4,
                              const bool recursive = false,
                              const size_t averageRecursion = 3,
                              const size_t maxRecursion = 5,
-                             const size_t iterations = 10)
+                             const size_t iterations = 10,
+                             const size_t trials = 5)
 {
   const size_t trainReberGrammarCount = 700;
   const size_t testReberGrammarCount = 250;
@@ -493,7 +494,7 @@ void ReberGrammarTestNetwork(const size_t hiddenSize = 4,
   // to escape from local minima and to solve the task.
   size_t successes = 0;
   size_t offset = 0;
-  for (size_t trial = 0; trial < 5; ++trial)
+  for (size_t trial = 0; trial < trials; ++trial)
   {
     const size_t outputSize = 7;
     const size_t inputSize = 7;
@@ -601,7 +602,7 @@ BOOST_AUTO_TEST_CASE(FastLSTMReberGrammarTest)
  */
 BOOST_AUTO_TEST_CASE(GRURecursiveReberGrammarTest)
 {
-  ReberGrammarTestNetwork<GRU<> >(16, true);
+  ReberGrammarTestNetwork<GRU<> >(16, true, 3, 5, 10, 7);
 }
 
 /*
@@ -988,12 +989,12 @@ void ReberGrammarTestCustomNetwork(const size_t hiddenSize = 4,
    *            .......
    */
   // It isn't guaranteed that the recurrent network will converge in the
-  // specified number of iterations using random weights. If this works 1 of 5
+  // specified number of iterations using random weights. If this works 1 of 10
   // times, I'm fine with that. All I want to know is that the network is able
   // to escape from local minima and to solve the task.
   size_t successes = 0;
   size_t offset = 0;
-  for (size_t trial = 0; trial < 5; ++trial)
+  for (size_t trial = 0; trial < 10; ++trial)
   {
     const size_t outputSize = 7;
     const size_t inputSize = 7;
@@ -1068,7 +1069,7 @@ void ReberGrammarTestCustomNetwork(const size_t hiddenSize = 4,
     }
 
     error /= testReberGrammarCount;
-    if (error <= 0.3)
+    if (error <= 0.35)
     {
       ++successes;
       break;


### PR DESCRIPTION
Looking through the jobs on ci.mlpack.org, I took a list of tests that were failing and tried to adjust tolerances on each of them to reduce the failure probability.

@saksham189: some of the kernel PCA main tests were failing intermittently.  For instance, the sampling scheme test would fail because the new dimensionality was only 1, meaning that the Nystroem method would select only one point.  Since the dataset only had 5 points, the probability of failure was the probability that the random sampling scheme would select the same point as the ordered sampling scheme, which in this case was 20%.  A larger dataset and a higher new dimensionality appear to have fixed the problem.  One other test needed a bit of changes too.  Take a look at the changes and let me know if I broke anything (or if I missed anything) please. :)