### PR TITLE
CMake installation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,15 @@ option(DOWNLOAD_ENSMALLEN "If ensmallen is not found, download it." ON)
 # set BUILD_PYTHON_BINDINGS to OFF when the platform is Windows.
 if (WIN32)
   option(BUILD_PYTHON_BINDINGS "Build Python bindings." OFF)
+  option(BUILD_SHARED_LIBS
+      "Compile shared libraries (if OFF, static libraries are compiled)." OFF)
   message(WARNING "By default Python bindings are not compiled for Windows because they are not known to work.  Set BUILD_PYTHON_BINDINGS to ON if you want them built.")
 else ()
   option(BUILD_PYTHON_BINDINGS "Build Python bindings." ON)
+  option(BUILD_SHARED_LIBS
+      "Compile shared libraries (if OFF, static libraries are compiled)." ON)
 endif()
 
-option(BUILD_SHARED_LIBS
-    "Compile shared libraries (if OFF, static libraries are compiled)." ON)
 option(BUILD_WITH_COVERAGE
     "Build with support for code coverage tools (gcc only)." OFF)
 option(MATHJAX

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -77,7 +77,7 @@ This tutorial follows the second approach for simplicity.
 - Run cmake: 
 
 @code
-cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DCMAKE_PREFIX:FILEPATH="C:/mlpack/armadillo" -DBUILD_SHARED_LIBS=OFF ..
+cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DCMAKE_PREFIX:FILEPATH="C:/mlpack/armadillo" ..
 @endcode
 
 @note If you are using different directory paths, a different configuration (e.g. Release)

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -166,18 +166,11 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE}
     OUTPUT_VARIABLE CMAKE_PYTHON_PATH)
 string(STRIP "${CMAKE_PYTHON_PATH}" CMAKE_PYTHON_PATH)
 install(CODE "set(ENV{PYTHONPATH} ${CMAKE_PYTHON_PATH})")
+install(CODE "set(PYTHON_EXECUTABLE \"${PYTHON_EXECUTABLE}\")")
+install(CODE "set(CMAKE_BINARY_DIR \"${CMAKE_BINARY_DIR}\")")
+install(CODE "set(CMAKE_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\")")
 install(CODE "execute_process(COMMAND mkdir -p $ENV{DESTDIR}${CMAKE_PYTHON_PATH})")
-if ($ENV{DESTDIR})
-  install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE}
-      \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
-      --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR}
-      WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
-else ()
-  install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE}
-      \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py\" install
-      --prefix=${CMAKE_INSTALL_PREFIX}
-      WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/\")")
-endif ()
+install(SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/PythonInstall.cmake)
 
 # Prepare __init__.py for having all of the convenience imports appended to it.
 file(COPY mlpack/__init__.py DESTINATION

--- a/src/mlpack/bindings/python/PythonInstall.cmake
+++ b/src/mlpack/bindings/python/PythonInstall.cmake
@@ -1,0 +1,21 @@
+# PythonInstall.cmake
+#
+# A utility script to install Python bindings and fail fatally if installation
+# was not successful.
+if (DEFINED ENV{DESTDIR})
+  execute_process(COMMAND ${PYTHON_EXECUTABLE}
+      "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
+          --prefix=${CMAKE_INSTALL_PREFIX} --root="$ENV{DESTDIR}"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
+      RESULT_VARIABLE setup_res)
+else ()
+  execute_process(COMMAND ${PYTHON_EXECUTABLE}
+      "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
+          --prefix=${CMAKE_INSTALL_PREFIX}
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
+      RESULT_VARIABLE setup_res)
+endif ()
+
+if (NOT ${setup_res} EQUAL "0")
+  message(FATAL_ERROR "Error installing Python bindings!")
+endif ()


### PR DESCRIPTION
This should solve #1621.  I had to refactor the CMake installation scripts for Python a bit to make it work right.

I also set BUILD_SHARED_LIBS=OFF by default on Windows as suggested in #1611.