### PR TITLE
Various test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp
 
 install:
-  - mkdir build && cd build && cmake $CMAKE_OPTIONS .. && make -j2
+  - mkdir build && cd build && cmake $CMAKE_OPTIONS .. && travis_wait 30 make -j2
 
 script:
   - CTEST_OUTPUT_ON_FAILURE=1 travis_wait 30 ctest -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp
 
 install:
-  - mkdir build && cd build && cmake $CMAKE_OPTIONS .. && travis_wait 30 make -j2
+  - mkdir build && cd build && cmake $CMAKE_OPTIONS .. && travis_wait 60 make -j2
 
 script:
   - CTEST_OUTPUT_ON_FAILURE=1 travis_wait 30 ctest -j2

--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -111,10 +111,11 @@ BOOST_AUTO_TEST_CASE(GMMTrainEMOneGaussian)
     arma::mat actualCovar = ccov(data, 1 /* biased estimator */);
 
     // Check the model to see that it is correct.
-    CheckMatrices(gmm.Component(0).Mean(), actualMean);
-    CheckMatrices(gmm.Component(0).Covariance(), actualCovar);
+    BOOST_REQUIRE_LT(arma::norm(gmm.Component(0).Mean() - actualMean), 1e-5);
+    BOOST_REQUIRE_LT(arma::norm(gmm.Component(0).Covariance() - actualCovar),
+        1e-4);
 
-    BOOST_REQUIRE_CLOSE(gmm.Weights()[0], 1.0, 1e-5);
+    BOOST_REQUIRE_CLOSE(gmm.Weights()[0], 1.0, 1e-4);
   }
 }
 

--- a/src/mlpack/tests/gmm_test.cpp
+++ b/src/mlpack/tests/gmm_test.cpp
@@ -131,83 +131,120 @@ BOOST_AUTO_TEST_CASE(GMMTrainEMMultipleGaussians)
   size_t dims = 8;
   size_t gaussians = 3;
 
-  // Generate dataset.
-  arma::mat data;
-  data.zeros(dims, 500);
-
-  std::vector<arma::vec> means(gaussians);
-  std::vector<arma::mat> covars(gaussians);
-  arma::vec weights(gaussians);
-  arma::Col<size_t> counts(gaussians);
-
-  // Choose weights randomly.
-  weights.zeros();
-  while (weights.min() < 0.02)
+  // We'll run three trials, and it needs to pass during at least one trial.
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
   {
-    weights.randu(gaussians);
-    weights /= accu(weights);
+    // Generate dataset.
+    arma::mat data;
+    data.zeros(dims, 500);
+
+    std::vector<arma::vec> means(gaussians);
+    std::vector<arma::mat> covars(gaussians);
+    arma::vec weights(gaussians);
+    arma::Col<size_t> counts(gaussians);
+
+    // Choose weights randomly.  We want each component to have somewhat
+    // significant weight, but we also need to make sure that no weights are too
+    // close.
+    double minDiff = DBL_MAX;
+    do
+    {
+      weights.zeros();
+      weights.randu(gaussians);
+      weights /= accu(weights);
+      weights *= 0.4;
+      weights += (0.6 / double(gaussians));
+      weights /= accu(weights); // Paranoia, just to be sure they sum to 1.
+
+      // Compute minimum element difference.
+      minDiff = DBL_MAX;
+      for (size_t i = 0; i < weights.n_elem; ++i)
+        for (size_t j = (i + 1); j < weights.n_elem; ++j)
+          if (std::abs(weights[i] - weights[j]) < minDiff)
+            minDiff = std::abs(weights[i] - weights[j]);
+    } while (minDiff < 0.02);
+
+    for (size_t i = 0; i < gaussians; i++)
+      counts[i] = round(weights[i] * (data.n_cols - gaussians));
+    // Ensure one point minimum in each.
+    counts += 1;
+
+    // Account for rounding errors (possibly necessary).
+    counts[gaussians - 1] += (data.n_cols - arma::accu(counts));
+
+    // Build each Gaussian individually.
+    size_t point = 0;
+    for (size_t i = 0; i < gaussians; i++)
+    {
+      arma::mat gaussian;
+      gaussian.randn(dims, counts[i]);
+
+      // Randomly generate mean and covariance.
+      means[i].randu(dims);
+      means[i] -= 0.5;
+      means[i] *= 50;
+
+      // We need to make sure the covariance is positive definite.  We will take
+      // a random matrix C and then set our covariance to 4 * C * C', which will
+      // be positive semidefinite.
+      covars[i].randu(dims, dims);
+      covars[i] *= 4 * trans(covars[i]);
+
+      data.cols(point, point + counts[i] - 1) = (covars[i] * gaussian + means[i]
+          * arma::ones<arma::rowvec>(counts[i]));
+
+      // Calculate the actual means and covariances because they will probably
+      // be different (this is easier to do before we shuffle the points).
+      means[i] = arma::mean(data.cols(point, point + counts[i] - 1), 1);
+      covars[i] = ccov(data.cols(point, point + counts[i] - 1), 1 /* biased */);
+
+      point += counts[i];
+    }
+
+    // Calculate actual weights.
+    for (size_t i = 0; i < gaussians; i++)
+      weights[i] = (double) counts[i] / data.n_cols;
+
+    // Now train the model.
+    GMM gmm(gaussians, dims);
+    gmm.Train(data, 10);
+
+    arma::uvec sortRef = sort_index(weights);
+    arma::uvec sortTry = sort_index(gmm.Weights());
+
+    // If it's a bad match, try training again with a different seed.  We
+    // probably just fell into some bad local minimum or had a bad starting
+    // point.
+    gmm = GMM(gaussians, dims);
+    gmm.Train(data, 10);
+
+    sortTry = sort_index(gmm.Weights());
+
+    if (arma::norm(weights.elem(sortRef) - gmm.Weights().elem(sortTry)) > 0.1)
+      continue;
+
+    // Check the model to see that it is correct.
+    for (size_t i = 0; i < gaussians; i++)
+    {
+      // Check the mean.
+      BOOST_REQUIRE_LT(
+          arma::norm(gmm.Component(sortTry[i]).Mean() - means[sortRef[i]]),
+          0.05);
+      // Check the covariance.
+      BOOST_REQUIRE_LT(
+          arma::norm(gmm.Component(sortTry[i]).Covariance() -
+                                   covars[sortRef[i]]), 0.2);
+      // Check the weight.
+      BOOST_REQUIRE_CLOSE(gmm.Weights()[sortTry[i]], weights[sortRef[i]],
+          0.005);
+    }
+
+    success = true;
+    break; // No need for multiple iterations.
   }
 
-  for (size_t i = 0; i < gaussians; i++)
-    counts[i] = round(weights[i] * (data.n_cols - gaussians));
-  // Ensure one point minimum in each.
-  counts += 1;
-
-  // Account for rounding errors (possibly necessary).
-  counts[gaussians - 1] += (data.n_cols - arma::accu(counts));
-
-  // Build each Gaussian individually.
-  size_t point = 0;
-  for (size_t i = 0; i < gaussians; i++)
-  {
-    arma::mat gaussian;
-    gaussian.randn(dims, counts[i]);
-
-    // Randomly generate mean and covariance.
-    means[i].randu(dims);
-    means[i] -= 0.5;
-    means[i] *= 50;
-
-    // We need to make sure the covariance is positive definite.  We will take a
-    // random matrix C and then set our covariance to 4 * C * C', which will be
-    // positive semidefinite.
-    covars[i].randu(dims, dims);
-    covars[i] *= 4 * trans(covars[i]);
-
-    data.cols(point, point + counts[i] - 1) = (covars[i] * gaussian + means[i]
-        * arma::ones<arma::rowvec>(counts[i]));
-
-    // Calculate the actual means and covariances because they will probably
-    // be different (this is easier to do before we shuffle the points).
-    means[i] = arma::mean(data.cols(point, point + counts[i] - 1), 1);
-    covars[i] = ccov(data.cols(point, point + counts[i] - 1), 1 /* biased */);
-
-    point += counts[i];
-  }
-
-  // Calculate actual weights.
-  for (size_t i = 0; i < gaussians; i++)
-    weights[i] = (double) counts[i] / data.n_cols;
-
-  // Now train the model.
-  GMM gmm(gaussians, dims);
-  gmm.Train(data, 10);
-
-  arma::uvec sortRef = sort_index(weights);
-  arma::uvec sortTry = sort_index(gmm.Weights());
-
-  // Check the model to see that it is correct.
-  for (size_t i = 0; i < gaussians; i++)
-  {
-    // Check the mean.
-    CheckMatrices(gmm.Component(sortTry[i]).Mean(), means[sortRef[i]], 1e-3);
-    // Check the covariance.
-    CheckMatrices(gmm.Component(sortTry[i]).Covariance(), covars[sortRef[i]],
-                  0.15);
-    // Check the weight.
-    BOOST_REQUIRE_CLOSE(gmm.Weights()[sortTry[i]], weights[sortRef[i]],
-        0.005);
-  }
+  BOOST_REQUIRE_EQUAL(success, true);
 }
 
 /**

--- a/src/mlpack/tests/random_forest_test.cpp
+++ b/src/mlpack/tests/random_forest_test.cpp
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(UnweightedCategoricalLearningTest)
   size_t rfCorrect = arma::accu(rfPredictions == testLabels);
   size_t dtCorrect = arma::accu(dtPredictions == testLabels);
 
-  BOOST_REQUIRE_GE(rfCorrect, dtCorrect - 30);
+  BOOST_REQUIRE_GE(rfCorrect, dtCorrect - 50);
   BOOST_REQUIRE_GE(rfCorrect, size_t(0.7 * testData.n_cols));
 }
 
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(WeightedCategoricalLearningTest)
   size_t rfCorrect = arma::accu(rfPredictions == testLabels);
   size_t dtCorrect = arma::accu(dtPredictions == testLabels);
 
-  BOOST_REQUIRE_GE(rfCorrect, dtCorrect - 30);
+  BOOST_REQUIRE_GE(rfCorrect, dtCorrect - 50);
   BOOST_REQUIRE_GE(rfCorrect, size_t(0.7 * testData.n_cols));
 }
 


### PR DESCRIPTION
I saw the Jenkins build was unstable so I decided to debug the tests.  This contains fixes for five intermittently failing tests:

 * `GMMTrainEMOneGaussian`: instead of checking each element of the trained mean and covariances, we can just check the l2-norm of the differences.
 * `GMMTrainEMMultipleGaussians`: I overhauled this test so that (1) Gaussians in the mixture have a minimum weight of roughly 0.2; (2) multiple trials are allowed to prevent failures due to GMM converging to some local minimum.
 * `WeightedCategoricalLearningTest` and `UnweightedCategoricalLearningTest`: random forests aren't always guaranteed to be better than decision trees, so adjust the tolerance more.
 * `KernelPCASamplingSchemeTest`: here I actually found an issue in `NystreomMethod`, where we divide by the square root of the singular values.  But the singular values can sometimes be zero, giving `nan`s everywhere.