### PR TITLE
Fix NMF saving and loading of matrices.

### DIFF
--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -29,6 +29,9 @@
 
 #if (BINDING_TYPE == BINDING_TYPE_CLI) // This is a command-line executable.
 
+// Matrices are transposed on load/save.
+#define BINDING_MATRIX_TRANSPOSED
+
 #include <mlpack/bindings/cli/cli_option.hpp>
 #include <mlpack/bindings/cli/print_doc_functions.hpp>
 
@@ -74,6 +77,9 @@ int main(int argc, char** argv)
 
 #elif(BINDING_TYPE == BINDING_TYPE_TEST) // This is a unit test.
 
+// Matrices are not transposed on load/save, so we don't define
+// BINDING_MATRIX_TRANSPOSED.
+
 #include <mlpack/bindings/tests/test_option.hpp>
 #include <mlpack/bindings/tests/ignore_check.hpp>
 #include <mlpack/bindings/tests/clean_memory.hpp>
@@ -104,6 +110,9 @@ using Option = mlpack::bindings::tests::TestOption<T>;
         []() { return DESC; });
 
 #elif(BINDING_TYPE == BINDING_TYPE_PYX) // This is a Python binding.
+
+// Matrices are transposed on load/save.
+#define BINDING_MATRIX_TRANSPOSED
 
 #include <mlpack/bindings/python/py_option.hpp>
 #include <mlpack/bindings/python/print_doc_functions.hpp>

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -30,7 +30,7 @@
 #if (BINDING_TYPE == BINDING_TYPE_CLI) // This is a command-line executable.
 
 // Matrices are transposed on load/save.
-#define BINDING_MATRIX_TRANSPOSED
+#define BINDING_MATRIX_TRANSPOSED true
 
 #include <mlpack/bindings/cli/cli_option.hpp>
 #include <mlpack/bindings/cli/print_doc_functions.hpp>
@@ -77,8 +77,8 @@ int main(int argc, char** argv)
 
 #elif(BINDING_TYPE == BINDING_TYPE_TEST) // This is a unit test.
 
-// Matrices are not transposed on load/save, so we don't define
-// BINDING_MATRIX_TRANSPOSED.
+// Matrices are not transposed on load/save.
+#define BINDING_MATRIX_TRANSPOSED false
 
 #include <mlpack/bindings/tests/test_option.hpp>
 #include <mlpack/bindings/tests/ignore_check.hpp>
@@ -112,7 +112,7 @@ using Option = mlpack::bindings::tests::TestOption<T>;
 #elif(BINDING_TYPE == BINDING_TYPE_PYX) // This is a Python binding.
 
 // Matrices are transposed on load/save.
-#define BINDING_MATRIX_TRANSPOSED
+#define BINDING_MATRIX_TRANSPOSED true
 
 #include <mlpack/bindings/python/py_option.hpp>
 #include <mlpack/bindings/python/print_doc_functions.hpp>

--- a/src/mlpack/methods/nmf/nmf_main.cpp
+++ b/src/mlpack/methods/nmf/nmf_main.cpp
@@ -105,7 +105,13 @@ static void mlpackMain()
   RequireAtLeastOnePassed({ "h", "w" }, false, "no output will be saved");
   RequireNoneOrAllPassed({"initial_w", "initial_h"}, true);
 
-  // Load input dataset.
+  // Load input dataset.  Note that this dataset will typically be transposed on
+  // load, since we are likely receiving it from a row-major language, but we
+  // get it in a column-major form.  Therefore, we're actually decomposing V^T =
+  // W^T * H^T.  Effectively this means we are solving, for the user, V = H*W.
+  // Therefore, we actually have to switch what we are saving, so we will save
+  // the W we get from amf.Apply() as H, and vice versa.  We know if the data is
+  // transposed based on the BINDING_MATRIX_TRANSPOSED macro.
   arma::mat V = std::move(CLI::GetParam<arma::mat>("input"));
 
   arma::mat W;
@@ -121,9 +127,15 @@ static void mlpackMain()
     if (CLI::HasParam("initial_w"))
     {
       // Initialization with given W, H matrices.
+#ifdef BINDING_MATRIX_TRANSPOSED
+      GivenInitialization ginit = GivenInitialization(
+          std::move(CLI::GetParam<arma::mat>("initial_h")),
+          std::move(CLI::GetParam<arma::mat>("initial_w")));
+#else
       GivenInitialization ginit = GivenInitialization(
           std::move(CLI::GetParam<arma::mat>("initial_w")),
           std::move(CLI::GetParam<arma::mat>("initial_h")));
+#endif
       AMF<SimpleResidueTermination,
           GivenInitialization> amf(srt, ginit);
       amf.Apply(V, r, W, H);
@@ -143,9 +155,15 @@ static void mlpackMain()
     if (CLI::HasParam("initial_w"))
     {
       // Initialization with given W, H matrices.
+#ifdef BINDING_MATRIX_TRANSPOSED
+      GivenInitialization ginit = GivenInitialization(
+          std::move(CLI::GetParam<arma::mat>("initial_h")),
+          std::move(CLI::GetParam<arma::mat>("initial_w")));
+#else
       GivenInitialization ginit = GivenInitialization(
           std::move(CLI::GetParam<arma::mat>("initial_w")),
           std::move(CLI::GetParam<arma::mat>("initial_h")));
+#endif
       AMF<SimpleResidueTermination,
           GivenInitialization,
           NMFMultiplicativeDivergenceUpdate> amf(srt, ginit);
@@ -168,9 +186,15 @@ static void mlpackMain()
     if (CLI::HasParam("initial_w"))
     {
       // Initialization with given W, H matrices.
+#ifdef BINDING_MATRIX_TRANSPOSED
+      GivenInitialization ginit = GivenInitialization(
+          std::move(CLI::GetParam<arma::mat>("initial_h")),
+          std::move(CLI::GetParam<arma::mat>("initial_w")));
+#else
       GivenInitialization ginit = GivenInitialization(
           std::move(CLI::GetParam<arma::mat>("initial_w")),
           std::move(CLI::GetParam<arma::mat>("initial_h")));
+#endif
       AMF<SimpleResidueTermination,
           GivenInitialization,
           NMFALSUpdate> amf(srt, ginit);
@@ -185,9 +209,17 @@ static void mlpackMain()
     }
   }
 
-  // Save results.
+  // Save results.  Remember from our discussion in the comments earlier that we
+  // may need to switch the names of the outputs.
+#ifdef BINDING_MATRIX_TRANSPOSED
+  if (CLI::HasParam("w"))
+    CLI::GetParam<arma::mat>("w") = std::move(H);
+  if (CLI::HasParam("h"))
+    CLI::GetParam<arma::mat>("h") = std::move(W);
+#else
   if (CLI::HasParam("w"))
     CLI::GetParam<arma::mat>("w") = std::move(W);
   if (CLI::HasParam("h"))
     CLI::GetParam<arma::mat>("h") = std::move(H);
+#endif
 }

--- a/src/mlpack/methods/nmf/nmf_main.cpp
+++ b/src/mlpack/methods/nmf/nmf_main.cpp
@@ -80,6 +80,41 @@ PARAM_STRING_IN("update_rules", "Update rules for each iteration; ( multdist | "
 PARAM_MATRIX_IN("initial_w", "Initial W matrix.", "p");
 PARAM_MATRIX_IN("initial_h", "Initial H matrix.", "q");
 
+void LoadInitialWH(const bool bindingTransposed, arma::mat& w, arma::mat& h)
+{
+  // Note that these datasets will typically be transposed on load, since we are
+  // likely receiving it from a row-major language, but we get it in a
+  // column-major form.  Therefore, we're actually decomposing V^T = W^T * H^T.
+  // Effectively this means we are solving, for the user, V = H*W.  Therefore,
+  // we actually have to switch what we are saving, so we will save the W we get
+  // from amf.Apply() as H, and vice versa.
+  if (bindingTransposed)
+  {
+    w = CLI::GetParam<arma::mat>("initial_h");
+    h = CLI::GetParam<arma::mat>("initial_w");
+  }
+  else
+  {
+    h = CLI::GetParam<arma::mat>("initial_h");
+    w = CLI::GetParam<arma::mat>("initial_w");
+  }
+}
+
+void SaveWH(const bool bindingTransposed, arma::mat&& w, arma::mat&& h)
+{
+  // The same transposition applies when saving.
+  if (bindingTransposed)
+  {
+    CLI::GetParam<arma::mat>("w") = std::move(h);
+    CLI::GetParam<arma::mat>("h") = std::move(w);
+  }
+  else
+  {
+    CLI::GetParam<arma::mat>("h") = std::move(h);
+    CLI::GetParam<arma::mat>("w") = std::move(w);
+  }
+}
+
 static void mlpackMain()
 {
   // Initialize random seed.
@@ -105,13 +140,8 @@ static void mlpackMain()
   RequireAtLeastOnePassed({ "h", "w" }, false, "no output will be saved");
   RequireNoneOrAllPassed({"initial_w", "initial_h"}, true);
 
-  // Load input dataset.  Note that this dataset will typically be transposed on
-  // load, since we are likely receiving it from a row-major language, but we
-  // get it in a column-major form.  Therefore, we're actually decomposing V^T =
-  // W^T * H^T.  Effectively this means we are solving, for the user, V = H*W.
-  // Therefore, we actually have to switch what we are saving, so we will save
-  // the W we get from amf.Apply() as H, and vice versa.  We know if the data is
-  // transposed based on the BINDING_MATRIX_TRANSPOSED macro.
+  // Load input dataset.  We know if the data is transposed based on the
+  // BINDING_MATRIX_TRANSPOSED macro, which will be 'true' or 'false'.
   arma::mat V = std::move(CLI::GetParam<arma::mat>("input"));
 
   arma::mat W;
@@ -127,15 +157,10 @@ static void mlpackMain()
     if (CLI::HasParam("initial_w"))
     {
       // Initialization with given W, H matrices.
-#ifdef BINDING_MATRIX_TRANSPOSED
-      GivenInitialization ginit = GivenInitialization(
-          std::move(CLI::GetParam<arma::mat>("initial_h")),
-          std::move(CLI::GetParam<arma::mat>("initial_w")));
-#else
-      GivenInitialization ginit = GivenInitialization(
-          std::move(CLI::GetParam<arma::mat>("initial_w")),
-          std::move(CLI::GetParam<arma::mat>("initial_h")));
-#endif
+      arma::mat initialW, initialH;
+      LoadInitialWH(BINDING_MATRIX_TRANSPOSED, initialW, initialH);
+      GivenInitialization ginit = GivenInitialization(initialW, initialH);
+
       AMF<SimpleResidueTermination,
           GivenInitialization> amf(srt, ginit);
       amf.Apply(V, r, W, H);
@@ -155,15 +180,10 @@ static void mlpackMain()
     if (CLI::HasParam("initial_w"))
     {
       // Initialization with given W, H matrices.
-#ifdef BINDING_MATRIX_TRANSPOSED
-      GivenInitialization ginit = GivenInitialization(
-          std::move(CLI::GetParam<arma::mat>("initial_h")),
-          std::move(CLI::GetParam<arma::mat>("initial_w")));
-#else
-      GivenInitialization ginit = GivenInitialization(
-          std::move(CLI::GetParam<arma::mat>("initial_w")),
-          std::move(CLI::GetParam<arma::mat>("initial_h")));
-#endif
+      arma::mat initialW, initialH;
+      LoadInitialWH(BINDING_MATRIX_TRANSPOSED, initialW, initialH);
+      GivenInitialization ginit = GivenInitialization(initialW, initialH);
+
       AMF<SimpleResidueTermination,
           GivenInitialization,
           NMFMultiplicativeDivergenceUpdate> amf(srt, ginit);
@@ -186,15 +206,10 @@ static void mlpackMain()
     if (CLI::HasParam("initial_w"))
     {
       // Initialization with given W, H matrices.
-#ifdef BINDING_MATRIX_TRANSPOSED
-      GivenInitialization ginit = GivenInitialization(
-          std::move(CLI::GetParam<arma::mat>("initial_h")),
-          std::move(CLI::GetParam<arma::mat>("initial_w")));
-#else
-      GivenInitialization ginit = GivenInitialization(
-          std::move(CLI::GetParam<arma::mat>("initial_w")),
-          std::move(CLI::GetParam<arma::mat>("initial_h")));
-#endif
+      arma::mat initialW, initialH;
+      LoadInitialWH(BINDING_MATRIX_TRANSPOSED, initialW, initialH);
+      GivenInitialization ginit = GivenInitialization(initialW, initialH);
+
       AMF<SimpleResidueTermination,
           GivenInitialization,
           NMFALSUpdate> amf(srt, ginit);
@@ -211,15 +226,5 @@ static void mlpackMain()
 
   // Save results.  Remember from our discussion in the comments earlier that we
   // may need to switch the names of the outputs.
-#ifdef BINDING_MATRIX_TRANSPOSED
-  if (CLI::HasParam("w"))
-    CLI::GetParam<arma::mat>("w") = std::move(H);
-  if (CLI::HasParam("h"))
-    CLI::GetParam<arma::mat>("h") = std::move(W);
-#else
-  if (CLI::HasParam("w"))
-    CLI::GetParam<arma::mat>("w") = std::move(W);
-  if (CLI::HasParam("h"))
-    CLI::GetParam<arma::mat>("h") = std::move(H);
-#endif
+  SaveWH(BINDING_MATRIX_TRANSPOSED, std::move(W), std::move(H));
 }

--- a/src/mlpack/tests/main_tests/nmf_test.cpp
+++ b/src/mlpack/tests/main_tests/nmf_test.cpp
@@ -58,7 +58,7 @@ BOOST_FIXTURE_TEST_SUITE(NMFMainTest, NMFTestFixture);
  */
 BOOST_AUTO_TEST_CASE(NMFMultdistShapeTest)
 {
-  mat v = randu<mat>(10, 10);
+  mat v = randu<mat>(8, 10);
   int r = 5;
 
   SetInputParam("update_rules", std::string("multdist"));
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(NMFMultdistShapeTest)
   const mat& h = CLI::GetParam<mat>("h");
 
   // Check the shapes of W and H.
-  BOOST_REQUIRE_EQUAL(w.n_rows, 10);
+  BOOST_REQUIRE_EQUAL(w.n_rows, 8);
   BOOST_REQUIRE_EQUAL(w.n_cols, 5);
   BOOST_REQUIRE_EQUAL(h.n_rows, 5);
   BOOST_REQUIRE_EQUAL(h.n_cols, 10);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(NMFMultdistShapeTest)
  */
 BOOST_AUTO_TEST_CASE(NMFMultdivShapeTest)
 {
-  mat v = randu<mat>(10, 10);
+  mat v = randu<mat>(8, 10);
   int r = 5;
 
   SetInputParam("update_rules", std::string("multdiv"));
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(NMFMultdivShapeTest)
   const mat& h = CLI::GetParam<mat>("h");
 
   // Check the shapes of W and H.
-  BOOST_REQUIRE_EQUAL(w.n_rows, 10);
+  BOOST_REQUIRE_EQUAL(w.n_rows, 8);
   BOOST_REQUIRE_EQUAL(w.n_cols, 5);
   BOOST_REQUIRE_EQUAL(h.n_rows, 5);
   BOOST_REQUIRE_EQUAL(h.n_cols, 10);
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(NMFMultdivShapeTest)
  */
 BOOST_AUTO_TEST_CASE(NMFAlsShapeTest)
 {
-  mat v = randu<mat>(10, 10);
+  mat v = randu<mat>(8, 10);
   int r = 5;
 
   SetInputParam("update_rules", std::string("als"));
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(NMFAlsShapeTest)
   const mat& h = CLI::GetParam<mat>("h");
 
   // Check the shapes of W and H.
-  BOOST_REQUIRE_EQUAL(w.n_rows, 10);
+  BOOST_REQUIRE_EQUAL(w.n_rows, 8);
   BOOST_REQUIRE_EQUAL(w.n_cols, 5);
   BOOST_REQUIRE_EQUAL(h.n_rows, 5);
   BOOST_REQUIRE_EQUAL(h.n_cols, 10);


### PR DESCRIPTION
This fixes #1646, which pointed out that NMF returns transposed W/H matrices from the Python bindings (and this is true of the command-line bindings too).  The solution was to detect whether or not the binding type is going to transpose the matrices (via the new macro BINDING_MATRIX_TRANSPOSED) and use that to control the behavior in `nmf_main.cpp`.

I also made the `NMFMainTest` a little more robust by using non-square matrices for decomposition.