### PR TITLE
Update contribution policy.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,4 +20,7 @@ mlpack's Contributors team, to ensure that (if applicable):
  * any new functionality is tested and working
 
 Once the pull request is approved by one member of the Contributors team, it can
-be merged.
+be merged.  Members of the Contributors team are encouraged to review pull
+requests that have already been reviewed, and pull request contributors are
+encouraged to seek multiple reviews.  Reviews from anyone not on the
+Contributors team are always appreciated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,5 @@ mlpack's Contributors team, to ensure that (if applicable):
    [Style Guide](http://github.com/mlpack/mlpack/wiki/DesignGuidelines)
  * any new functionality is tested and working
 
-Once the pull request is approved by one member of the Contributors team, it may
-be merged between 3 and 7 days after approval.  This allows other contributors
-and maintainers to have time to also review the PR.  If a pull request has at
-least two approvals from members of the Contributors team, then the pull
-request may be immediately merged.  This applies even if the submitter of the
-PR is a member of the Contributors team.
+Once the pull request is approved by one member of the Contributors team, it can
+be merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ interested in participating in Google Summer of Code, see
 
 ## Pull request process
 
-Once a pull request is submitted, it must be reviewed by at least one member of
+Once a pull request is submitted, it must be approved by at least one member of
 mlpack's Contributors team, to ensure that (if applicable):
 
  * the design meshes with the rest of mlpack
@@ -19,8 +19,11 @@ mlpack's Contributors team, to ensure that (if applicable):
    [Style Guide](http://github.com/mlpack/mlpack/wiki/DesignGuidelines)
  * any new functionality is tested and working
 
-Once the pull request is approved by one member of the Contributors team, it can
-be merged.  Members of the Contributors team are encouraged to review pull
-requests that have already been reviewed, and pull request contributors are
-encouraged to seek multiple reviews.  Reviews from anyone not on the
-Contributors team are always appreciated.
+The pull request can be merged as soon as it receives two approvals; 24 hours
+after the first approval, mlpack-bot will provide a second approval.  This is to
+leave time for anyone to comment on the PR before it is merged.
+
+Members of the Contributors team are encouraged to review pull requests that
+have already been reviewed, and pull request contributors are encouraged to seek
+multiple reviews.  Reviews from anyone not on the Contributors team are always
+appreciated and encouraged!


### PR DESCRIPTION
Previously, we used to say that we would merge after one approval and a few days, or after two approvals immediately.  This was to ensure high code quality.  But as time has gone on, it's become kind of clear that this has also made merges pretty slow.

So, I think that we should change the policy so that as soon as something has one approval from someone on the Contributors team it can be merged.  And if others want to review it before it gets merged, it seems like the best idea would just be to post a comment asking to wait until they can review it before merge.

I sent an email about this to some in the contributors team and there was no objection (actually there was not much response at all), so I'll take that to mean that basically everyone would be okay with this. :)

I'll let this sit for a week or two to gather any discussion, and if there's no discussion (or we all agree we should make the change), I'll merge this in and change the repository settings so that one approving review is needed before merge. :+1: