### PR TITLE
Adapted Classifiers

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -109,7 +109,8 @@ Copyright:
   Copyright 2018, Tommi Laivamaa <tommi.laivamaa@protonmail.com>
   Copyright 2019, Kim SangYeon <sy0814k@gmail.com>
   Copyright 2019, Niteya Shah <niteya.56@gmail.com>
-  
+  Copyright 2019, Toshal Agrawal <tagrawal1339@gmail.com>
+
 License: BSD-3-clause
   All rights reserved.
   .

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,11 +2,14 @@
 ###### ????-??-??
   * Add kernel density estimation (KDE) implementation with bindings to other
     languages (#1301).
+  * Where relevant, all models with a `Train()` method now return a `double`
+    value representing the goodness of fit
+    (i.e. final objective value, error, etc.) (#1678).  
 
 ### mlpack 3.0.5
 ###### ????-??-??
   * Change DBSCAN to use PointSelectionPolicy and add OrderedPointSelection (#1625).
-  
+
 ### mlpack 3.0.4
 ###### 2018-11-13
   * Bump minimum CMake version to 3.3.2.

--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -255,6 +255,7 @@
  *   - Tommi Laivamaa <tommi.laivamaa@protonmail.com>
  *   - Kim SangYeon <sy0814k@gmail.com>
  *   - Niteya Shah <niteya.56@gmail.com>
+ *   - Toshal Agrawal <tagrawal1339@gmail.com>
  */
 
 // First, include all of the prerequisites.

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -140,6 +140,7 @@ class AdaBoost
    * @param data Dataset to train on.
    * @param labels Labels for each point in the dataset.
    * @param learner Learner to use for training.
+   * @return ztProduct an upper bound for training error.
    */
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -140,7 +140,7 @@ class AdaBoost
    * @param data Dataset to train on.
    * @param labels Labels for each point in the dataset.
    * @param learner Learner to use for training.
-   * @return ztProduct an upper bound for training error.
+   * @return The upper bound for training error.
    */
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -141,7 +141,7 @@ class AdaBoost
    * @param labels Labels for each point in the dataset.
    * @param learner Learner to use for training.
    */
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const size_t numClasses,
              const WeakLearnerType& learner,

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -142,11 +142,11 @@ class AdaBoost
    * @param learner Learner to use for training.
    */
   double Train(const MatType& data,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const WeakLearnerType& learner,
-             const size_t iterations = 100,
-             const double tolerance = 1e-6);
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const WeakLearnerType& learner,
+               const size_t iterations = 100,
+               const double tolerance = 1e-6);
 
   /**
    * Classify the given test points.

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -62,7 +62,7 @@ AdaBoost<WeakLearnerType, MatType>::AdaBoost(const double tolerance) :
 
 // Train AdaBoost.
 template<typename WeakLearnerType, typename MatType>
-void AdaBoost<WeakLearnerType, MatType>::Train(
+double AdaBoost<WeakLearnerType, MatType>::Train(
     const MatType& data,
     const arma::Row<size_t>& labels,
     const size_t numClasses,
@@ -198,6 +198,7 @@ void AdaBoost<WeakLearnerType, MatType>::Train(
     // Accumulate the value of zt for the Hamming loss bound.
     ztProduct *= zt;
   }
+  return ztProduct;
 }
 
 /**

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -57,7 +57,8 @@ template<typename WeakLearnerType, typename MatType>
 AdaBoost<WeakLearnerType, MatType>::AdaBoost(const double tolerance) :
     tolerance(tolerance)
 {
-  // Nothing to do.
+  numClasses = 0;
+  ztProduct = 1.0;
 }
 
 // Train AdaBoost.

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -55,10 +55,11 @@ AdaBoost<WeakLearnerType, MatType>::AdaBoost(
 // Empty constructor.
 template<typename WeakLearnerType, typename MatType>
 AdaBoost<WeakLearnerType, MatType>::AdaBoost(const double tolerance) :
-    tolerance(tolerance)
+    tolerance(tolerance),
+    numClasses(0),
+    ztProduct(1.0)
 {
-  numClasses = 0;
-  ztProduct = 1.0;
+  // Nothing to do.
 }
 
 // Train AdaBoost.

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -97,6 +97,7 @@ class FFN
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
    * @param optimizer Instantiated optimizer used to train the model.
+   * @return final objective value.
    */
   template<typename OptimizerType>
   double Train(arma::mat predictors,
@@ -118,6 +119,7 @@ class FFN
    * @tparam OptimizerType Type of optimizer to use to train the model.
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
+   * @return final objective value.
    */
   template<typename OptimizerType = ens::RMSProp>
   double Train(arma::mat predictors, arma::mat responses);

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -100,8 +100,8 @@ class FFN
    */
   template<typename OptimizerType>
   double Train(arma::mat predictors,
-             arma::mat responses,
-             OptimizerType& optimizer);
+               arma::mat responses,
+               OptimizerType& optimizer);
 
   /**
    * Train the feedforward network on the given input data. By default, the

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -97,7 +97,7 @@ class FFN
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
    * @param optimizer Instantiated optimizer used to train the model.
-   * @return final objective value.
+   * @return The final objective of the trained model (NaN or Inf on error).
    */
   template<typename OptimizerType>
   double Train(arma::mat predictors,
@@ -119,7 +119,7 @@ class FFN
    * @tparam OptimizerType Type of optimizer to use to train the model.
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
-   * @return final objective value.
+   * @return The final objective of the trained model (NaN or Inf on error).
    */
   template<typename OptimizerType = ens::RMSProp>
   double Train(arma::mat predictors, arma::mat responses);

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -99,7 +99,7 @@ class FFN
    * @param optimizer Instantiated optimizer used to train the model.
    */
   template<typename OptimizerType>
-  void Train(arma::mat predictors,
+  double Train(arma::mat predictors,
              arma::mat responses,
              OptimizerType& optimizer);
 
@@ -120,7 +120,7 @@ class FFN
    * @param responses Outputs results from input training variables.
    */
   template<typename OptimizerType = ens::RMSProp>
-  void Train(arma::mat predictors, arma::mat responses);
+  double Train(arma::mat predictors, arma::mat responses);
 
   /**
    * Predict the responses to a given set of predictors. The responses will

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -70,7 +70,7 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::ResetData(
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename OptimizerType>
-void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
+double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
       arma::mat predictors,
       arma::mat responses,
       OptimizerType& optimizer)
@@ -84,12 +84,13 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   Log::Info << "FFN::FFN(): final objective of trained model is " << out
       << "." << std::endl;
+  return out;    
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename OptimizerType>
-void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
+double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
     arma::mat predictors, arma::mat responses)
 {
   ResetData(std::move(predictors), std::move(responses));
@@ -103,6 +104,7 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   Log::Info << "FFN::FFN(): final objective of trained model is " << out
       << "." << std::endl;
+  return out;
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -84,7 +84,7 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   Log::Info << "FFN::FFN(): final objective of trained model is " << out
       << "." << std::endl;
-  return out;    
+  return out;
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,

--- a/src/mlpack/methods/ann/gan/gan.hpp
+++ b/src/mlpack/methods/ann/gan/gan.hpp
@@ -100,7 +100,8 @@ class GAN
 
   /**
    * Train function.
-   * @return final objective value.
+   *
+   * @return The final objective of the trained model (NaN or Inf on error).
    */
   template<typename OptimizerType>
   double Train(OptimizerType& Optimizer);

--- a/src/mlpack/methods/ann/gan/gan.hpp
+++ b/src/mlpack/methods/ann/gan/gan.hpp
@@ -98,7 +98,10 @@ class GAN
   // Reset function.
   void Reset();
 
-  // Train function.
+  /**
+   * Train function.
+   * @return final objective value.
+   */
   template<typename OptimizerType>
   double Train(OptimizerType& Optimizer);
 

--- a/src/mlpack/methods/ann/gan/gan.hpp
+++ b/src/mlpack/methods/ann/gan/gan.hpp
@@ -100,7 +100,7 @@ class GAN
 
   // Train function.
   template<typename OptimizerType>
-  void Train(OptimizerType& Optimizer);
+  double Train(OptimizerType& Optimizer);
 
   /**
    * Evaluate function for the Standard GAN and DCGAN.

--- a/src/mlpack/methods/ann/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/gan_impl.hpp
@@ -193,12 +193,12 @@ template<
   typename PolicyType
 >
 template<typename OptimizerType>
-void GAN<Model, InitializationRuleType, Noise, PolicyType>::Train(
+double GAN<Model, InitializationRuleType, Noise, PolicyType>::Train(
     OptimizerType& Optimizer)
 {
   if (!reset)
     Reset();
-  Optimizer.Optimize(*this, parameter);
+  return Optimizer.Optimize(*this, parameter);
 }
 
 template<

--- a/src/mlpack/methods/ann/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm.hpp
@@ -89,7 +89,7 @@ class RBM
    * @param optimizer Optimizer type.
    */
   template<typename OptimizerType>
-  void Train(OptimizerType& optimizer);
+  double Train(OptimizerType& optimizer);
 
   /**
    * Evaluate the RBM network with the given parameters.

--- a/src/mlpack/methods/ann/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm.hpp
@@ -87,7 +87,7 @@ class RBM
    * parameters vector directly with Parameters() and modify it as desired.
    *
    * @param optimizer Optimizer type.
-   * @return final objective value.
+   * @return The final objective of the trained model (NaN or Inf on error).
    */
   template<typename OptimizerType>
   double Train(OptimizerType& optimizer);

--- a/src/mlpack/methods/ann/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm.hpp
@@ -87,6 +87,7 @@ class RBM
    * parameters vector directly with Parameters() and modify it as desired.
    *
    * @param optimizer Optimizer type.
+   * @return final objective value.
    */
   template<typename OptimizerType>
   double Train(OptimizerType& optimizer);

--- a/src/mlpack/methods/ann/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm_impl.hpp
@@ -91,7 +91,7 @@ template<
   typename PolicyType
 >
 template<typename OptimizerType>
-void RBM<InitializationRuleType, DataType, PolicyType>::Train(
+double RBM<InitializationRuleType, DataType, PolicyType>::Train(
     OptimizerType& optimizer)
 {
   if (!reset)
@@ -99,7 +99,7 @@ void RBM<InitializationRuleType, DataType, PolicyType>::Train(
     Reset();
   }
 
-  optimizer.Optimize(*this, parameter);
+  return optimizer.Optimize(*this, parameter);
 }
 
 template<

--- a/src/mlpack/methods/ann/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm_impl.hpp
@@ -47,10 +47,10 @@ RBM<InitializationRuleType, DataType, PolicyType>::RBM(
     slabPenalty(slabPenalty),
     radius(2 * radius),
     persistence(persistence),
-    reset(false)
+    reset(false),
+    steps(0)
 {
   numFunctions = this->predictors.n_cols;
-  steps = 0;
 }
 
 template<

--- a/src/mlpack/methods/ann/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm_impl.hpp
@@ -50,6 +50,7 @@ RBM<InitializationRuleType, DataType, PolicyType>::RBM(
     reset(false)
 {
   numFunctions = this->predictors.n_cols;
+  steps = 0;
 }
 
 template<
@@ -135,12 +136,8 @@ RBM<InitializationRuleType, DataType, PolicyType>::Phase(
   DataType hiddenBiasGrad = DataType(gradient.memptr() + weightGrad.n_elem,
       hiddenSize, 1, false, false);
 
-  DataType visibleBiasGrad = DataType(gradient.memptr() + weightGrad.n_elem +
-      hiddenBiasGrad.n_elem, visibleSize, 1, false, false);
-
   HiddenMean(std::move(input), std::move(hiddenBiasGrad));
   weightGrad.slice(0) = hiddenBiasGrad * input.t();
-  visibleBiasGrad = input;
 }
 
 template<

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -97,8 +97,8 @@ class RNN
    */
   template<typename OptimizerType>
   double Train(arma::cube predictors,
-             arma::cube responses,
-             OptimizerType& optimizer);
+               arma::cube responses,
+               OptimizerType& optimizer);
 
   /**
    * Train the recurrent neural network on the given input data. By default, the

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -94,7 +94,7 @@ class RNN
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
    * @param optimizer Instantiated optimizer used to train the model.
-   * @return final objective value.
+   * @return The final objective of the trained model (NaN or Inf on error).
    */
   template<typename OptimizerType>
   double Train(arma::cube predictors,
@@ -123,7 +123,7 @@ class RNN
    * @tparam OptimizerType Type of optimizer to use to train the model.
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
-   * @return final objective value.
+   * @return The final objective of the trained model (NaN or Inf on error).
    */
   template<typename OptimizerType = ens::StandardSGD>
   double Train(arma::cube predictors, arma::cube responses);

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -94,6 +94,7 @@ class RNN
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
    * @param optimizer Instantiated optimizer used to train the model.
+   * @return final objective value.
    */
   template<typename OptimizerType>
   double Train(arma::cube predictors,
@@ -122,6 +123,7 @@ class RNN
    * @tparam OptimizerType Type of optimizer to use to train the model.
    * @param predictors Input training variables.
    * @param responses Outputs results from input training variables.
+   * @return final objective value.
    */
   template<typename OptimizerType = ens::StandardSGD>
   double Train(arma::cube predictors, arma::cube responses);

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -96,7 +96,7 @@ class RNN
    * @param optimizer Instantiated optimizer used to train the model.
    */
   template<typename OptimizerType>
-  void Train(arma::cube predictors,
+  double Train(arma::cube predictors,
              arma::cube responses,
              OptimizerType& optimizer);
 
@@ -124,7 +124,7 @@ class RNN
    * @param responses Outputs results from input training variables.
    */
   template<typename OptimizerType = ens::StandardSGD>
-  void Train(arma::cube predictors, arma::cube responses);
+  double Train(arma::cube predictors, arma::cube responses);
 
   /**
    * Predict the responses to a given set of predictors. The responses will

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -64,7 +64,7 @@ RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::~RNN()
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename OptimizerType>
-void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
+double RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
     arma::cube predictors,
     arma::cube responses,
     OptimizerType& optimizer)
@@ -89,6 +89,7 @@ void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   Log::Info << "RNN::RNN(): final objective of trained model is " << out
       << "." << std::endl;
+  return out;
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
@@ -105,7 +106,7 @@ void RNN<OutputLayerType, InitializationRuleType,
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename OptimizerType>
-void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
+double RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
     arma::cube predictors,
     arma::cube responses)
 {
@@ -131,6 +132,7 @@ void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   Log::Info << "RNN::RNN(): final objective of trained model is " << out
       << "." << std::endl;
+  return out;
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,

--- a/src/mlpack/methods/decision_stump/decision_stump.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump.hpp
@@ -82,7 +82,7 @@ class DecisionStump
    * @param numClasses Number of classes in the dataset.
    * @param bucketSize Minimum size of bucket when splitting.
    */
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const size_t numClasses,
              const size_t bucketSize);
@@ -98,7 +98,7 @@ class DecisionStump
    * @param numClasses Number of classes in the dataset.
    * @param bucketSize Minimum size of bucket when splitting.
    */
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const arma::rowvec& weights,
              const size_t numClasses,
@@ -216,7 +216,7 @@ class DecisionStump
    *      (otherwise they are ignored).
    */
   template<bool UseWeights>
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const arma::rowvec& weights);
 };

--- a/src/mlpack/methods/decision_stump/decision_stump.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump.hpp
@@ -81,6 +81,7 @@ class DecisionStump
    * @param labels Labels for each point in the dataset.
    * @param numClasses Number of classes in the dataset.
    * @param bucketSize Minimum size of bucket when splitting.
+   * @return final entropy after splitting.
    */
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
@@ -97,6 +98,7 @@ class DecisionStump
    * @param weights Weights for each point in the dataset.
    * @param numClasses Number of classes in the dataset.
    * @param bucketSize Minimum size of bucket when splitting.
+   * @return final entropy after splitting.
    */
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
@@ -214,6 +216,7 @@ class DecisionStump
    * @param weights Weights for this set of labels.
    * @tparam UseWeights If true, the weights in the weight vector will be used
    *      (otherwise they are ignored).
+   * @return final entropy after splitting.
    */
   template<bool UseWeights>
   double Train(const MatType& data,

--- a/src/mlpack/methods/decision_stump/decision_stump.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump.hpp
@@ -81,7 +81,7 @@ class DecisionStump
    * @param labels Labels for each point in the dataset.
    * @param numClasses Number of classes in the dataset.
    * @param bucketSize Minimum size of bucket when splitting.
-   * @return final entropy after splitting.
+   * @return The final entropy after splitting.
    */
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
@@ -98,7 +98,7 @@ class DecisionStump
    * @param weights Weights for each point in the dataset.
    * @param numClasses Number of classes in the dataset.
    * @param bucketSize Minimum size of bucket when splitting.
-   * @return final entropy after splitting.
+   * @return The final entropy after splitting.
    */
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
@@ -216,7 +216,7 @@ class DecisionStump
    * @param weights Weights for this set of labels.
    * @tparam UseWeights If true, the weights in the weight vector will be used
    *      (otherwise they are ignored).
-   * @return final entropy after splitting.
+   * @return The final entropy after splitting.
    */
   template<bool UseWeights>
   double Train(const MatType& data,

--- a/src/mlpack/methods/decision_stump/decision_stump.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump.hpp
@@ -83,9 +83,9 @@ class DecisionStump
    * @param bucketSize Minimum size of bucket when splitting.
    */
   double Train(const MatType& data,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const size_t bucketSize);
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const size_t bucketSize);
 
   /**
    * Train the decision stump on the given data, with the given weights.  This
@@ -99,10 +99,10 @@ class DecisionStump
    * @param bucketSize Minimum size of bucket when splitting.
    */
   double Train(const MatType& data,
-             const arma::Row<size_t>& labels,
-             const arma::rowvec& weights,
-             const size_t numClasses,
-             const size_t bucketSize);
+               const arma::Row<size_t>& labels,
+               const arma::rowvec& weights,
+               const size_t numClasses,
+               const size_t bucketSize);
 
   /**
    * Classification function. After training, classify test, and put the
@@ -217,8 +217,8 @@ class DecisionStump
    */
   template<bool UseWeights>
   double Train(const MatType& data,
-             const arma::Row<size_t>& labels,
-             const arma::rowvec& weights);
+               const arma::Row<size_t>& labels,
+               const arma::rowvec& weights);
 };
 
 } // namespace decision_stump

--- a/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
@@ -58,9 +58,9 @@ DecisionStump<MatType>::DecisionStump() :
  */
 template<typename MatType>
 double DecisionStump<MatType>::Train(const MatType& data,
-                                   const arma::Row<size_t>& labels,
-                                   const size_t numClasses,
-                                   const size_t bucketSize)
+                                     const arma::Row<size_t>& labels,
+                                     const size_t numClasses,
+                                     const size_t bucketSize)
 {
   this->numClasses = numClasses;
   this->bucketSize = bucketSize;
@@ -77,10 +77,10 @@ double DecisionStump<MatType>::Train(const MatType& data,
  */
 template<typename MatType>
 double DecisionStump<MatType>::Train(const MatType& data,
-                                   const arma::Row<size_t>& labels,
-                                   const arma::rowvec& weights,
-                                   const size_t numClasses,
-                                   const size_t bucketSize)
+                                     const arma::Row<size_t>& labels,
+                                     const arma::rowvec& weights,
+                                     const size_t numClasses,
+                                     const size_t bucketSize)
 {
   this->numClasses = numClasses;
   this->bucketSize = bucketSize;
@@ -99,8 +99,8 @@ double DecisionStump<MatType>::Train(const MatType& data,
 template<typename MatType>
 template<bool UseWeights>
 double DecisionStump<MatType>::Train(const MatType& data,
-                                   const arma::Row<size_t>& labels,
-                                   const arma::rowvec& weights)
+                                     const arma::Row<size_t>& labels,
+                                     const arma::rowvec& weights)
 {
   // If classLabels are not all identical, proceed with training.
   size_t bestDim = 0;

--- a/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
@@ -57,7 +57,7 @@ DecisionStump<MatType>::DecisionStump() :
  * Train on the given data and labels.
  */
 template<typename MatType>
-void DecisionStump<MatType>::Train(const MatType& data,
+double DecisionStump<MatType>::Train(const MatType& data,
                                    const arma::Row<size_t>& labels,
                                    const size_t numClasses,
                                    const size_t bucketSize)
@@ -67,7 +67,7 @@ void DecisionStump<MatType>::Train(const MatType& data,
 
   // Pass to unweighted training function.
   arma::rowvec weights;
-  Train<false>(data, labels, weights);
+  return Train<false>(data, labels, weights);
 }
 
 /**
@@ -76,7 +76,7 @@ void DecisionStump<MatType>::Train(const MatType& data,
  * stump may be completely different.
  */
 template<typename MatType>
-void DecisionStump<MatType>::Train(const MatType& data,
+double DecisionStump<MatType>::Train(const MatType& data,
                                    const arma::Row<size_t>& labels,
                                    const arma::rowvec& weights,
                                    const size_t numClasses,
@@ -86,7 +86,7 @@ void DecisionStump<MatType>::Train(const MatType& data,
   this->bucketSize = bucketSize;
 
   // Pass to weighted training function.
-  Train<true>(data, labels, weights);
+  return Train<true>(data, labels, weights);
 }
 
 /**
@@ -98,7 +98,7 @@ void DecisionStump<MatType>::Train(const MatType& data,
  */
 template<typename MatType>
 template<bool UseWeights>
-void DecisionStump<MatType>::Train(const MatType& data,
+double DecisionStump<MatType>::Train(const MatType& data,
                                    const arma::Row<size_t>& labels,
                                    const arma::rowvec& weights)
 {
@@ -134,6 +134,7 @@ void DecisionStump<MatType>::Train(const MatType& data,
 
   // Once the splitting column/dimension has been decided, train on it.
   TrainOnDim(data.row(splitDimension), labels);
+  return -bestGain;
 }
 
 /**

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -212,7 +212,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
-  void Train(MatType data,
+  double Train(MatType data,
              const data::DatasetInfo& datasetInfo,
              LabelsType labels,
              const size_t numClasses,
@@ -235,7 +235,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType>
-  void Train(MatType data,
+  double Train(MatType data,
              LabelsType labels,
              const size_t numClasses,
              const size_t minimumLeafSize = 10,
@@ -260,7 +260,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
-  void Train(MatType data,
+  double Train(MatType data,
              const data::DatasetInfo& datasetInfo,
              LabelsType labels,
              const size_t numClasses,
@@ -287,7 +287,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
-  void Train(MatType data,
+  double Train(MatType data,
              LabelsType labels,
              const size_t numClasses,
              WeightsType weights,
@@ -423,7 +423,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<bool UseWeights, typename MatType>
-  void Train(MatType& data,
+  double Train(MatType& data,
              const size_t begin,
              const size_t count,
              const data::DatasetInfo& datasetInfo,
@@ -448,7 +448,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    */
   template<bool UseWeights, typename MatType>
-  void Train(MatType& data,
+  double Train(MatType& data,
              const size_t begin,
              const size_t count,
              arma::Row<size_t>& labels,

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -210,6 +210,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @return final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
   double Train(MatType data,
@@ -233,6 +234,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @return final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
   double Train(MatType data,
@@ -258,6 +260,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @return final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   double Train(MatType data,
@@ -285,6 +288,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @return final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   double Train(MatType data,
@@ -421,6 +425,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @return final entropy of decision tree.
    */
   template<bool UseWeights, typename MatType>
   double Train(MatType& data,
@@ -446,6 +451,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @return final entropy of decision tree.
    */
   template<bool UseWeights, typename MatType>
   double Train(MatType& data,

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -213,11 +213,11 @@ class DecisionTree :
    */
   template<typename MatType, typename LabelsType>
   double Train(MatType data,
-             const data::DatasetInfo& datasetInfo,
-             LabelsType labels,
-             const size_t numClasses,
-             const size_t minimumLeafSize = 10,
-             const double minimumGainSplit = 1e-7);
+               const data::DatasetInfo& datasetInfo,
+               LabelsType labels,
+               const size_t numClasses,
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7);
 
   /**
    * Train the decision tree on the given data, assuming that all dimensions are
@@ -236,10 +236,10 @@ class DecisionTree :
    */
   template<typename MatType, typename LabelsType>
   double Train(MatType data,
-             LabelsType labels,
-             const size_t numClasses,
-             const size_t minimumLeafSize = 10,
-             const double minimumGainSplit = 1e-7);
+               LabelsType labels,
+               const size_t numClasses,
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7);
 
   /**
    * Train the decision tree on the given weighted data.  This will overwrite
@@ -261,14 +261,14 @@ class DecisionTree :
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   double Train(MatType data,
-             const data::DatasetInfo& datasetInfo,
-             LabelsType labels,
-             const size_t numClasses,
-             WeightsType weights,
-             const size_t minimumLeafSize = 10,
-             const double minimumGainSplit = 1e-7,
-             const std::enable_if_t<arma::is_arma_type<typename
-                 std::remove_reference<WeightsType>::type>::value>* = 0);
+               const data::DatasetInfo& datasetInfo,
+               LabelsType labels,
+               const size_t numClasses,
+               WeightsType weights,
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7,
+               const std::enable_if_t<arma::is_arma_type<typename
+                   std::remove_reference<WeightsType>::type>::value>* = 0);
 
   /**
    * Train the decision tree on the given weighted data, assuming that all
@@ -288,13 +288,13 @@ class DecisionTree :
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   double Train(MatType data,
-             LabelsType labels,
-             const size_t numClasses,
-             WeightsType weights,
-             const size_t minimumLeafSize = 10,
-             const double minimumGainSplit = 1e-7,
-             const std::enable_if_t<arma::is_arma_type<typename
-                 std::remove_reference<WeightsType>::type>::value>* = 0);
+               LabelsType labels,
+               const size_t numClasses,
+               WeightsType weights,
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7,
+               const std::enable_if_t<arma::is_arma_type<typename
+                   std::remove_reference<WeightsType>::type>::value>* = 0);
 
   /**
    * Classify the given point, using the entire tree.  The predicted label is

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -424,14 +424,14 @@ class DecisionTree :
    */
   template<bool UseWeights, typename MatType>
   double Train(MatType& data,
-             const size_t begin,
-             const size_t count,
-             const data::DatasetInfo& datasetInfo,
-             arma::Row<size_t>& labels,
-             const size_t numClasses,
-             arma::rowvec& weights,
-             const size_t minimumLeafSize = 10,
-             const double minimumGainSplit = 1e-7);
+               const size_t begin,
+               const size_t count,
+               const data::DatasetInfo& datasetInfo,
+               arma::Row<size_t>& labels,
+               const size_t numClasses,
+               arma::rowvec& weights,
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7);
 
   /**
    * Corresponding to the public Train() method, this method is designed for
@@ -449,13 +449,13 @@ class DecisionTree :
    */
   template<bool UseWeights, typename MatType>
   double Train(MatType& data,
-             const size_t begin,
-             const size_t count,
-             arma::Row<size_t>& labels,
-             const size_t numClasses,
-             arma::rowvec& weights,
-             const size_t minimumLeafSize = 10,
-             const double minimumGainSplit = 1e-7);
+               const size_t begin,
+               const size_t count,
+               arma::Row<size_t>& labels,
+               const size_t numClasses,
+               arma::rowvec& weights,
+               const size_t minimumLeafSize = 10,
+               const double minimumGainSplit = 1e-7);
 };
 
 /**

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -210,7 +210,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
-   * @return final entropy of decision tree.
+   * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
   double Train(MatType data,
@@ -234,7 +234,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
-   * @return final entropy of decision tree.
+   * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
   double Train(MatType data,
@@ -260,7 +260,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
-   * @return final entropy of decision tree.
+   * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   double Train(MatType data,
@@ -288,7 +288,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
-   * @return final entropy of decision tree.
+   * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   double Train(MatType data,
@@ -425,7 +425,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
-   * @return final entropy of decision tree.
+   * @return The final entropy of decision tree.
    */
   template<bool UseWeights, typename MatType>
   double Train(MatType& data,
@@ -451,7 +451,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
-   * @return final entropy of decision tree.
+   * @return The final entropy of decision tree.
    */
   template<bool UseWeights, typename MatType>
   double Train(MatType& data,

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -341,16 +341,16 @@ template<typename FitnessFunction,
          bool NoRecursion>
 template<typename MatType, typename LabelsType>
 double DecisionTree<FitnessFunction,
-                  NumericSplitType,
-                  CategoricalSplitType,
-                  DimensionSelectionType,
-                  ElemType,
-                  NoRecursion>::Train(MatType data,
-                                      const data::DatasetInfo& datasetInfo,
-                                      LabelsType labels,
-                                      const size_t numClasses,
-                                      const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                    NumericSplitType,
+                    CategoricalSplitType,
+                    DimensionSelectionType,
+                    ElemType,
+                    NoRecursion>::Train(MatType data,
+                                        const data::DatasetInfo& datasetInfo,
+                                        LabelsType labels,
+                                        const size_t numClasses,
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -384,15 +384,15 @@ template<typename FitnessFunction,
          bool NoRecursion>
 template<typename MatType, typename LabelsType>
 double DecisionTree<FitnessFunction,
-                  NumericSplitType,
-                  CategoricalSplitType,
-                  DimensionSelectionType,
-                  ElemType,
-                  NoRecursion>::Train(MatType data,
-                                      LabelsType labels,
-                                      const size_t numClasses,
-                                      const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                    NumericSplitType,
+                    CategoricalSplitType,
+                    DimensionSelectionType,
+                    ElemType,
+                    NoRecursion>::Train(MatType data,
+                                        LabelsType labels,
+                                        const size_t numClasses,
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -426,20 +426,21 @@ template<typename FitnessFunction,
          bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 double DecisionTree<FitnessFunction,
-                  NumericSplitType,
-                  CategoricalSplitType,
-                  DimensionSelectionType,
-                  ElemType,
-                  NoRecursion>::Train(MatType data,
-                                      const data::DatasetInfo& datasetInfo,
-                                      LabelsType labels,
-                                      const size_t numClasses,
-                                      WeightsType weights,
-                                      const size_t minimumLeafSize,
-                                      const double minimumGainSplit,
-                                      const std::enable_if_t<arma::is_arma_type<
-                                          typename std::remove_reference<
-                                          WeightsType>::type>::value>*)
+                    NumericSplitType,
+                    CategoricalSplitType,
+                    DimensionSelectionType,
+                    ElemType,
+                    NoRecursion>::Train(MatType data,
+                                        const data::DatasetInfo& datasetInfo,
+                                        LabelsType labels,
+                                        const size_t numClasses,
+                                        WeightsType weights,
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit,
+                                        const std::enable_if_t<
+                                            arma::is_arma_type<
+                                            typename std::remove_reference<
+                                            WeightsType>::type>::value>*)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -474,19 +475,20 @@ template<typename FitnessFunction,
          bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 double DecisionTree<FitnessFunction,
-                  NumericSplitType,
-                  CategoricalSplitType,
-                  DimensionSelectionType,
-                  ElemType,
-                  NoRecursion>::Train(MatType data,
-                                      LabelsType labels,
-                                      const size_t numClasses,
-                                      WeightsType weights,
-                                      const size_t minimumLeafSize,
-                                      const double minimumGainSplit,
-                                      const std::enable_if_t<arma::is_arma_type<
-                                          typename std::remove_reference<
-                                          WeightsType>::type>::value>*)
+                    NumericSplitType,
+                    CategoricalSplitType,
+                    DimensionSelectionType,
+                    ElemType,
+                    NoRecursion>::Train(MatType data,
+                                        LabelsType labels,
+                                        const size_t numClasses,
+                                        WeightsType weights,
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit,
+                                        const std::enable_if_t<
+                                            arma::is_arma_type<
+                                            typename std::remove_reference<
+                                            WeightsType>::type>::value>*)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -521,19 +523,19 @@ template<typename FitnessFunction,
          bool NoRecursion>
 template<bool UseWeights, typename MatType>
 double DecisionTree<FitnessFunction,
-                  NumericSplitType,
-                  CategoricalSplitType,
-                  DimensionSelectionType,
-                  ElemType,
-                  NoRecursion>::Train(MatType& data,
-                                      const size_t begin,
-                                      const size_t count,
-                                      const data::DatasetInfo& datasetInfo,
-                                      arma::Row<size_t>& labels,
-                                      const size_t numClasses,
-                                      arma::rowvec& weights,
-                                      const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                    NumericSplitType,
+                    CategoricalSplitType,
+                    DimensionSelectionType,
+                    ElemType,
+                    NoRecursion>::Train(MatType& data,
+                                        const size_t begin,
+                                        const size_t count,
+                                        const data::DatasetInfo& datasetInfo,
+                                        arma::Row<size_t>& labels,
+                                        const size_t numClasses,
+                                        arma::rowvec& weights,
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -695,18 +697,18 @@ template<typename FitnessFunction,
          bool NoRecursion>
 template<bool UseWeights, typename MatType>
 double DecisionTree<FitnessFunction,
-                  NumericSplitType,
-                  CategoricalSplitType,
-                  DimensionSelectionType,
-                  ElemType,
-                  NoRecursion>::Train(MatType& data,
-                                      const size_t begin,
-                                      const size_t count,
-                                      arma::Row<size_t>& labels,
-                                      const size_t numClasses,
-                                      arma::rowvec& weights,
-                                      const size_t minimumLeafSize,
-                                      const double minimumGainSplit)
+                    NumericSplitType,
+                    CategoricalSplitType,
+                    DimensionSelectionType,
+                    ElemType,
+                    NoRecursion>::Train(MatType& data,
+                                        const size_t begin,
+                                        const size_t count,
+                                        arma::Row<size_t>& labels,
+                                        const size_t numClasses,
+                                        arma::rowvec& weights,
+                                        const size_t minimumLeafSize,
+                                        const double minimumGainSplit)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -630,8 +630,8 @@ double DecisionTree<FitnessFunction,
     for (size_t i = begin; i < begin + count; ++i)
       childCounts[childAssignments[i - begin]]++;
 
-    //Initialize bestGain if recursive split is allowed
-    if(!NoRecursion)
+    // Initialize bestGain if recursive split is allowed.
+    if (!NoRecursion)
     {
       bestGain = 0.0;
     }
@@ -664,7 +664,7 @@ double DecisionTree<FitnessFunction,
       }
       else
       {
-        // During recursion entropy of child node may change
+        // During recursion entropy of child node may change.
         double childGain = child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, datasetInfo, labels, numClasses,
             weights, minimumLeafSize, minimumGainSplit);
@@ -777,8 +777,8 @@ double DecisionTree<FitnessFunction,
     for (size_t j = begin; j < begin + count; ++j)
       childCounts[childAssignments[j - begin]]++;
 
-    //Initialize bestGain if recursive split is allowed
-    if(!NoRecursion)
+    // Initialize bestGain if recursive split is allowed.
+    if (!NoRecursion)
     {
       bestGain = 0.0;
     }
@@ -810,7 +810,7 @@ double DecisionTree<FitnessFunction,
       }
       else
       {
-        // During recursion entropy of child node may change
+        // During recursion entropy of child node may change.
         double childGain = child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, labels, numClasses, weights,
             minimumLeafSize, minimumGainSplit);

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -628,6 +628,12 @@ double DecisionTree<FitnessFunction,
     for (size_t i = begin; i < begin + count; ++i)
       childCounts[childAssignments[i - begin]]++;
 
+    //Initialize bestGain if recursive split is allowed
+    if(!NoRecursion)
+    {
+      bestGain = 0.0;
+    }
+
     // Split into children.
     size_t currentCol = begin;
     for (size_t i = 0; i < numChildren; ++i)
@@ -656,24 +662,11 @@ double DecisionTree<FitnessFunction,
       }
       else
       {
-        double prevChildGain = FitnessFunction::template Evaluate<UseWeights>(
-            labels.subvec(currentChildBegin, currentCol - 1),
-            numClasses,
-            UseWeights ? weights.subvec(currentChildBegin, currentCol - 1) :
-                weights);
         // During recursion entropy of child node may change
-        double newChildGain = child->Train<UseWeights>(data, currentChildBegin,
+        double childGain = child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, datasetInfo, labels, numClasses,
             weights, minimumLeafSize, minimumGainSplit);
-        newChildGain = -newChildGain;
-        if(newChildGain>prevChildGain)
-        {
-          double prevContribute = prevChildGain * childCounts[i] / count ;
-          double newBestGain = bestGain - prevContribute;
-          double newContribute = newChildGain * childCounts[i] / count;
-          newBestGain = newBestGain + newContribute;
-          bestGain = std::max(bestGain,newBestGain);
-        }
+        bestGain += double(childCounts[i]) / double(count) * (-childGain);
       }
       children.push_back(child);
     }
@@ -782,6 +775,12 @@ double DecisionTree<FitnessFunction,
     for (size_t j = begin; j < begin + count; ++j)
       childCounts[childAssignments[j - begin]]++;
 
+    //Initialize bestGain if recursive split is allowed
+    if(!NoRecursion)
+    {
+      bestGain = 0.0;
+    }
+
     size_t currentCol = begin;
     for (size_t i = 0; i < numChildren; ++i)
     {
@@ -809,24 +808,11 @@ double DecisionTree<FitnessFunction,
       }
       else
       {
-        double prevChildGain = FitnessFunction::template Evaluate<UseWeights>(
-            labels.subvec(currentChildBegin, currentCol - 1),
-            numClasses,
-            UseWeights ? weights.subvec(currentChildBegin, currentCol - 1) :
-                weights);
         // During recursion entropy of child node may change
-        double newChildGain = child->Train<UseWeights>(data, currentChildBegin,
+        double childGain = child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, labels, numClasses, weights,
             minimumLeafSize, minimumGainSplit);
-        newChildGain = -newChildGain;
-        if(newChildGain>prevChildGain)
-        {
-          double prevContribute = prevChildGain * childCounts[i] / count ;
-          double newBestGain = bestGain - prevContribute;
-          double newContribute = newChildGain * childCounts[i] / count;
-          newBestGain = newBestGain + newContribute;
-          bestGain = std::max(bestGain,newBestGain);
-        }
+        bestGain += double(childCounts[i]) / double(count) * (-childGain);
       }
       children.push_back(child);
     }

--- a/src/mlpack/methods/hmm/hmm.hpp
+++ b/src/mlpack/methods/hmm/hmm.hpp
@@ -166,7 +166,7 @@ class HMM
    *
    * @param dataSeq Vector of observation sequences.
    */
-  void Train(const std::vector<arma::mat>& dataSeq);
+  double Train(const std::vector<arma::mat>& dataSeq);
 
   /**
    * Train the model using the given labeled observations; the transition and

--- a/src/mlpack/methods/hmm/hmm.hpp
+++ b/src/mlpack/methods/hmm/hmm.hpp
@@ -165,7 +165,7 @@ class HMM
    * @endnote
    *
    * @param dataSeq Vector of observation sequences.
-   * @return final log likelihood after training.
+   * @return Log-likelihood of state sequence.
    */
   double Train(const std::vector<arma::mat>& dataSeq);
 

--- a/src/mlpack/methods/hmm/hmm.hpp
+++ b/src/mlpack/methods/hmm/hmm.hpp
@@ -41,12 +41,12 @@ namespace hmm /** Hidden Markov Models. */ {
  *   double Probability(const DataType& observation) const;
  *
  *   // Estimate the distribution based on the given observations.
- *   void Train(const std::vector<DataType>& observations);
+ *   double Train(const std::vector<DataType>& observations);
  *
  *   // Estimate the distribution based on the given observations, given also
  *   // the probability of each observation coming from this distribution.
- *   void Train(const std::vector<DataType>& observations,
- *              const std::vector<double>& probabilities);
+ *   double Train(const std::vector<DataType>& observations,
+ *                const std::vector<double>& probabilities);
  * };
  * @endcode
  *
@@ -165,6 +165,7 @@ class HMM
    * @endnote
    *
    * @param dataSeq Vector of observation sequences.
+   * @return final log likelihood after training.
    */
   double Train(const std::vector<arma::mat>& dataSeq);
 

--- a/src/mlpack/methods/hmm/hmm_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_impl.hpp
@@ -83,7 +83,7 @@ HMM<Distribution>::HMM(const arma::vec& initial,
  * @param dataSeq Set of data sequences to train on.
  */
 template<typename Distribution>
-void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
+double HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
 {
   // We should allow a guess at the transition and emission matrices.
   double loglik = 0;
@@ -211,6 +211,7 @@ void HMM<Distribution>::Train(const std::vector<arma::mat>& dataSeq)
     Log::Debug << "Iteration " << iter << ": log-likelihood " << loglik
         << "." << std::endl;
   }
+  return loglik;
 }
 
 /**

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -69,9 +69,9 @@ LARS::LARS(const arma::mat& data,
 }
 
 double LARS::Train(const arma::mat& matX,
-                 const arma::rowvec& y,
-                 arma::vec& beta,
-                 const bool transposeData)
+                   const arma::rowvec& y,
+                   arma::vec& beta,
+                   const bool transposeData)
 {
   Timer::Start("lars_regression");
 
@@ -365,8 +365,8 @@ double LARS::Train(const arma::mat& matX,
 }
 
 double LARS::Train(const arma::mat& data,
-                 const arma::rowvec& responses,
-                 const bool transposeData)
+                   const arma::rowvec& responses,
+                   const bool transposeData)
 {
   arma::vec beta;
   return Train(data, responses, beta, transposeData);

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -68,7 +68,7 @@ LARS::LARS(const arma::mat& data,
   Train(data, responses, transposeData);
 }
 
-void LARS::Train(const arma::mat& matX,
+double LARS::Train(const arma::mat& matX,
                  const arma::rowvec& y,
                  arma::vec& beta,
                  const bool transposeData)
@@ -129,7 +129,7 @@ void LARS::Train(const arma::mat& matX,
   {
     lambdaPath[0] = lambda1;
     Timer::Stop("lars_regression");
-    return;
+    return maxCorr;
   }
 
   // Compute the Gram matrix.  If this is the elastic net problem, we will add
@@ -361,14 +361,15 @@ void LARS::Train(const arma::mat& matX,
   beta = betaPath.back();
 
   Timer::Stop("lars_regression");
+  return maxCorr;
 }
 
-void LARS::Train(const arma::mat& data,
+double LARS::Train(const arma::mat& data,
                  const arma::rowvec& responses,
                  const bool transposeData)
 {
   arma::vec beta;
-  Train(data, responses, beta, transposeData);
+  return Train(data, responses, beta, transposeData);
 }
 
 void LARS::Predict(const arma::mat& points,

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -183,7 +183,7 @@ class LARS
    * @param responses A vector of targets.
    * @param beta Vector to store the solution (the coefficients) in.
    * @param transposeData Set to false if the data is row-major.
-   * @return final absolute maximum correlation.
+   * @return The final absolute maximum correlation.
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,
@@ -202,7 +202,7 @@ class LARS
    * @param responses A vector of targets.
    * @param transposeData Should be true if the input data is column-major and
    *     false otherwise.
-   * @return final absolute maximum correlation.
+   * @return The final absolute maximum correlation.
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -183,6 +183,7 @@ class LARS
    * @param responses A vector of targets.
    * @param beta Vector to store the solution (the coefficients) in.
    * @param transposeData Set to false if the data is row-major.
+   * @return final absolute maximum correlation.
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,
@@ -201,6 +202,7 @@ class LARS
    * @param responses A vector of targets.
    * @param transposeData Should be true if the input data is column-major and
    *     false otherwise.
+   * @return final absolute maximum correlation.
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -185,9 +185,9 @@ class LARS
    * @param transposeData Set to false if the data is row-major.
    */
   double Train(const arma::mat& data,
-             const arma::rowvec& responses,
-             arma::vec& beta,
-             const bool transposeData = true);
+               const arma::rowvec& responses,
+               arma::vec& beta,
+               const bool transposeData = true);
 
   /**
    * Run LARS.  The input matrix (like all mlpack matrices) should be
@@ -203,8 +203,8 @@ class LARS
    *     false otherwise.
    */
   double Train(const arma::mat& data,
-             const arma::rowvec& responses,
-             const bool transposeData = true);
+               const arma::rowvec& responses,
+               const bool transposeData = true);
 
   /**
    * Predict y_i for each data point in the given data matrix using the

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -184,7 +184,7 @@ class LARS
    * @param beta Vector to store the solution (the coefficients) in.
    * @param transposeData Set to false if the data is row-major.
    */
-  void Train(const arma::mat& data,
+  double Train(const arma::mat& data,
              const arma::rowvec& responses,
              arma::vec& beta,
              const bool transposeData = true);
@@ -202,7 +202,7 @@ class LARS
    * @param transposeData Should be true if the input data is column-major and
    *     false otherwise.
    */
-  void Train(const arma::mat& data,
+  double Train(const arma::mat& data,
              const arma::rowvec& responses,
              const bool transposeData = true);
 

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -34,14 +34,14 @@ LinearRegression::LinearRegression(const arma::mat& predictors,
   Train(predictors, responses, weights, intercept);
 }
 
-void LinearRegression::Train(const arma::mat& predictors,
+double LinearRegression::Train(const arma::mat& predictors,
                              const arma::rowvec& responses,
                              const bool intercept)
 {
-  Train(predictors, responses, arma::rowvec(), intercept);
+  return Train(predictors, responses, arma::rowvec(), intercept);
 }
 
-void LinearRegression::Train(const arma::mat& predictors,
+double LinearRegression::Train(const arma::mat& predictors,
                              const arma::rowvec& responses,
                              const arma::rowvec& weights,
                              const bool intercept)
@@ -85,6 +85,7 @@ void LinearRegression::Train(const arma::mat& predictors,
       lambda * arma::eye<arma::mat>(p.n_rows, p.n_rows);
 
   parameters = arma::solve(cov, p * r.t());
+  return ComputeError(predictors,responses);
 }
 
 void LinearRegression::Predict(const arma::mat& points,

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -85,7 +85,7 @@ double LinearRegression::Train(const arma::mat& predictors,
       lambda * arma::eye<arma::mat>(p.n_rows, p.n_rows);
 
   parameters = arma::solve(cov, p * r.t());
-  return ComputeError(predictors,responses);
+  return ComputeError(predictors, responses);
 }
 
 void LinearRegression::Predict(const arma::mat& points,

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -35,16 +35,16 @@ LinearRegression::LinearRegression(const arma::mat& predictors,
 }
 
 double LinearRegression::Train(const arma::mat& predictors,
-                             const arma::rowvec& responses,
-                             const bool intercept)
+                               const arma::rowvec& responses,
+                               const bool intercept)
 {
   return Train(predictors, responses, arma::rowvec(), intercept);
 }
 
 double LinearRegression::Train(const arma::mat& predictors,
-                             const arma::rowvec& responses,
-                             const arma::rowvec& weights,
-                             const bool intercept)
+                               const arma::rowvec& responses,
+                               const arma::rowvec& weights,
+                               const bool intercept)
 {
   this->intercept = intercept;
 

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -73,8 +73,8 @@ class LinearRegression
    * @param intercept Whether or not to fit an intercept term.
    */
   double Train(const arma::mat& predictors,
-             const arma::rowvec& responses,
-             const bool intercept = true);
+               const arma::rowvec& responses,
+               const bool intercept = true);
 
   /**
    * Train the LinearRegression model on the given data and weights. Careful!
@@ -89,9 +89,9 @@ class LinearRegression
    * @param weights Observation weights (for boosting).
    */
   double Train(const arma::mat& predictors,
-             const arma::rowvec& responses,
-             const arma::rowvec& weights,
-             const bool intercept = true);
+               const arma::rowvec& responses,
+               const arma::rowvec& weights,
+               const bool intercept = true);
 
   /**
    * Calculate y_i for each data point in points.

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -71,7 +71,7 @@ class LinearRegression
    * @param predictors X, the matrix of data points to train the model on.
    * @param responses y, the responses to the data points.
    * @param intercept Whether or not to fit an intercept term.
-   * @return least squares error after training.
+   * @return The least squares error after training.
    */
   double Train(const arma::mat& predictors,
                const arma::rowvec& responses,

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -72,7 +72,7 @@ class LinearRegression
    * @param responses y, the responses to the data points.
    * @param intercept Whether or not to fit an intercept term.
    */
-  void Train(const arma::mat& predictors,
+  double Train(const arma::mat& predictors,
              const arma::rowvec& responses,
              const bool intercept = true);
 
@@ -88,7 +88,7 @@ class LinearRegression
    * @param intercept Whether or not to fit an intercept term.
    * @param weights Observation weights (for boosting).
    */
-  void Train(const arma::mat& predictors,
+  double Train(const arma::mat& predictors,
              const arma::rowvec& responses,
              const arma::rowvec& weights,
              const bool intercept = true);

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -71,6 +71,7 @@ class LinearRegression
    * @param predictors X, the matrix of data points to train the model on.
    * @param responses y, the responses to the data points.
    * @param intercept Whether or not to fit an intercept term.
+   * @return least squares error after training.
    */
   double Train(const arma::mat& predictors,
                const arma::rowvec& responses,
@@ -87,6 +88,7 @@ class LinearRegression
    * @param responses y, the responses to the data points.
    * @param intercept Whether or not to fit an intercept term.
    * @param weights Observation weights (for boosting).
+   * @return ordinary least squares error.
    */
   double Train(const arma::mat& predictors,
                const arma::rowvec& responses,

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -88,7 +88,7 @@ class LinearRegression
    * @param responses y, the responses to the data points.
    * @param intercept Whether or not to fit an intercept term.
    * @param weights Observation weights (for boosting).
-   * @return ordinary least squares error.
+   * @return The least squares error after training.
    */
   double Train(const arma::mat& predictors,
                const arma::rowvec& responses,

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -140,9 +140,9 @@ class LocalCoordinateCoding
       typename DictionaryInitializer =
           sparse_coding::DataDependentRandomInitializer
   >
-  void Train(const arma::mat& data,
-             const DictionaryInitializer& initializer =
-                 DictionaryInitializer());
+  double Train(const arma::mat& data,
+               const DictionaryInitializer& initializer =
+                   DictionaryInitializer());
 
   /**
    * Code each point via distance-weighted LARS.

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -135,7 +135,7 @@ class LocalCoordinateCoding
    * @param objTolerance Tolerance of objective function.  When the objective
    *     function changes by a value lower than this tolerance, the optimization
    *     terminates.
-   * @return final objective value.
+   * @return The final objective value.
    */
   template<
       typename DictionaryInitializer =

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -135,6 +135,7 @@ class LocalCoordinateCoding
    * @param objTolerance Tolerance of objective function.  When the objective
    *     function changes by a value lower than this tolerance, the optimization
    *     terminates.
+   * @return final objective value.
    */
   template<
       typename DictionaryInitializer =

--- a/src/mlpack/methods/local_coordinate_coding/lcc_impl.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc_impl.hpp
@@ -36,7 +36,7 @@ LocalCoordinateCoding::LocalCoordinateCoding(
 }
 
 template<typename DictionaryInitializer>
-void LocalCoordinateCoding::Train(
+double LocalCoordinateCoding::Train(
     const arma::mat& data,
     const DictionaryInitializer& initializer)
 {
@@ -103,6 +103,7 @@ void LocalCoordinateCoding::Train(
   }
 
   Timer::Stop("local_coordinate_coding");
+  return lastObjVal;
 }
 
 template<typename Archive>

--- a/src/mlpack/methods/logistic_regression/logistic_regression.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression.hpp
@@ -129,7 +129,7 @@ class LogisticRegression
    */
   template<typename OptimizerType = ens::L_BFGS>
   double Train(const MatType& predictors,
-             const arma::Row<size_t>& responses);
+               const arma::Row<size_t>& responses);
 
   /**
    * Train the LogisticRegression model with the given instantiated optimizer.
@@ -150,8 +150,8 @@ class LogisticRegression
    */
   template<typename OptimizerType>
   double Train(const MatType& predictors,
-             const arma::Row<size_t>& responses,
-             OptimizerType& optimizer);
+               const arma::Row<size_t>& responses,
+               OptimizerType& optimizer);
 
   //! Return the parameters (the b vector).
   const arma::rowvec& Parameters() const { return parameters; }

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -129,6 +129,7 @@ class RandomForest
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @return average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -149,6 +150,7 @@ class RandomForest
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @return average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -169,6 +171,7 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @return average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -191,6 +194,7 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @return average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -279,6 +283,7 @@ class RandomForest
    * @tparam UseWeights Whether or not to use the weights parameter.
    * @tparam UseDatasetInfo Whether or not to use the datasetInfo parameter.
    * @tparam MatType The type of data matrix (i.e. arma::mat).
+   * @return average entropy of all the decision trees trained under forest.
    */
   template<bool UseWeights, bool UseDatasetInfo, typename MatType>
   double Train(const MatType& data,

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -129,7 +129,7 @@ class RandomForest
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
-   * @return average entropy of all the decision trees trained under forest.
+   * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -150,7 +150,7 @@ class RandomForest
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
-   * @return average entropy of all the decision trees trained under forest.
+   * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -171,7 +171,7 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
-   * @return average entropy of all the decision trees trained under forest.
+   * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -194,7 +194,7 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
-   * @return average entropy of all the decision trees trained under forest.
+   * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
@@ -283,7 +283,7 @@ class RandomForest
    * @tparam UseWeights Whether or not to use the weights parameter.
    * @tparam UseDatasetInfo Whether or not to use the datasetInfo parameter.
    * @tparam MatType The type of data matrix (i.e. arma::mat).
-   * @return average entropy of all the decision trees trained under forest.
+   * @return The average entropy of all the decision trees trained under forest.
    */
   template<bool UseWeights, bool UseDatasetInfo, typename MatType>
   double Train(const MatType& data,

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -132,10 +132,10 @@ class RandomForest
    */
   template<typename MatType>
   double Train(const MatType& data,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const size_t numTrees = 50,
-             const size_t minimumLeafSize = 20);
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const size_t numTrees = 50,
+               const size_t minimumLeafSize = 20);
 
   /**
    * Train the random forest on the given labeled training data with the given
@@ -152,11 +152,11 @@ class RandomForest
    */
   template<typename MatType>
   double Train(const MatType& data,
-             const data::DatasetInfo& datasetInfo,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const size_t numTrees = 50,
-             const size_t minimumLeafSize = 20);
+               const data::DatasetInfo& datasetInfo,
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const size_t numTrees = 50,
+               const size_t minimumLeafSize = 20);
 
   /**
    * Train the random forest on the given weighted labeled training data with
@@ -172,11 +172,11 @@ class RandomForest
    */
   template<typename MatType>
   double Train(const MatType& data,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const arma::rowvec& weights,
-             const size_t numTrees = 50,
-             const size_t minimumLeafSize = 20);
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const arma::rowvec& weights,
+               const size_t numTrees = 50,
+               const size_t minimumLeafSize = 20);
 
   /**
    * Train the random forest on the given weighted labeled training data with
@@ -194,12 +194,12 @@ class RandomForest
    */
   template<typename MatType>
   double Train(const MatType& data,
-             const data::DatasetInfo& datasetInfo,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const arma::rowvec& weights,
-             const size_t numTrees = 50,
-             const size_t minimumLeafSize = 20);
+               const data::DatasetInfo& datasetInfo,
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const arma::rowvec& weights,
+               const size_t numTrees = 50,
+               const size_t minimumLeafSize = 20);
 
   /**
    * Predict the class of the given point.  If the random forest has not been
@@ -282,12 +282,12 @@ class RandomForest
    */
   template<bool UseWeights, bool UseDatasetInfo, typename MatType>
   double Train(const MatType& data,
-             const data::DatasetInfo& datasetInfo,
-             const arma::Row<size_t>& labels,
-             const size_t numClasses,
-             const arma::rowvec& weights,
-             const size_t numTrees,
-             const size_t minimumLeafSize);
+               const data::DatasetInfo& datasetInfo,
+               const arma::Row<size_t>& labels,
+               const size_t numClasses,
+               const arma::rowvec& weights,
+               const size_t numTrees,
+               const size_t minimumLeafSize);
 
   //! The trees in the forest.
   std::vector<DecisionTreeType> trees;

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -131,7 +131,7 @@ class RandomForest
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
    */
   template<typename MatType>
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const size_t numClasses,
              const size_t numTrees = 50,
@@ -151,7 +151,7 @@ class RandomForest
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
    */
   template<typename MatType>
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const data::DatasetInfo& datasetInfo,
              const arma::Row<size_t>& labels,
              const size_t numClasses,
@@ -171,7 +171,7 @@ class RandomForest
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
    */
   template<typename MatType>
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const size_t numClasses,
              const arma::rowvec& weights,
@@ -193,7 +193,7 @@ class RandomForest
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
    */
   template<typename MatType>
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const data::DatasetInfo& datasetInfo,
              const arma::Row<size_t>& labels,
              const size_t numClasses,
@@ -281,7 +281,7 @@ class RandomForest
    * @tparam MatType The type of data matrix (i.e. arma::mat).
    */
   template<bool UseWeights, bool UseDatasetInfo, typename MatType>
-  void Train(const MatType& data,
+  double Train(const MatType& data,
              const data::DatasetInfo& datasetInfo,
              const arma::Row<size_t>& labels,
              const size_t numClasses,

--- a/src/mlpack/methods/random_forest/random_forest_impl.hpp
+++ b/src/mlpack/methods/random_forest/random_forest_impl.hpp
@@ -433,7 +433,7 @@ double RandomForest<
   trees.resize(numTrees); // This will fill the vector with untrained trees.
   double avgGain = 0.0;
 
-  #pragma omp parallel for
+  #pragma omp parallel for reduction( + : avgGain)
   for (omp_size_t i = 0; i < numTrees; ++i)
   {
     MatType bootstrapDataset;

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -179,7 +179,7 @@ class SparseCoding
    * Train the sparse coding model on the given dataset.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
-  void Train(const arma::mat& data,
+  double Train(const arma::mat& data,
              const DictionaryInitializer& initializer =
                  DictionaryInitializer());
 

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -177,7 +177,7 @@ class SparseCoding
 
   /**
    * Train the sparse coding model on the given dataset.
-   * @return final objective value.
+   * @return The final objective value.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
   double Train(const arma::mat& data,

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -177,6 +177,7 @@ class SparseCoding
 
   /**
    * Train the sparse coding model on the given dataset.
+   * @return final objective value.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
   double Train(const arma::mat& data,

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -180,8 +180,8 @@ class SparseCoding
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
   double Train(const arma::mat& data,
-             const DictionaryInitializer& initializer =
-                 DictionaryInitializer());
+               const DictionaryInitializer& initializer =
+                   DictionaryInitializer());
 
   /**
    * Sparse code each point in the given dataset via LARS, using the current

--- a/src/mlpack/methods/sparse_coding/sparse_coding_impl.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding_impl.hpp
@@ -40,7 +40,7 @@ SparseCoding::SparseCoding(
 }
 
 template<typename DictionaryInitializer>
-void SparseCoding::Train(
+double SparseCoding::Train(
     const arma::mat& data,
     const DictionaryInitializer& initializer)
 {
@@ -106,6 +106,7 @@ void SparseCoding::Train(
   }
 
   Timer::Stop("sparse_coding");
+  return lastObjVal;
 }
 
 template<typename Archive>

--- a/src/mlpack/methods/sparse_coding/sparse_coding_impl.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding_impl.hpp
@@ -95,14 +95,14 @@ double SparseCoding::Train(
     Log::Info << "  Objective value: " << curObjVal << " (improvement "
         << std::scientific << improvement << ")." << std::endl;
 
+    lastObjVal = curObjVal;
+
     // Have we converged?
     if (improvement < objTolerance)
     {
       Log::Info << "Converged within tolerance " << objTolerance << ".\n";
       break;
     }
-
-    lastObjVal = curObjVal;
   }
 
   Timer::Stop("sparse_coding");


### PR DESCRIPTION
Hi, 
This is pull Request for #1483 Issue.
I have changed three classifiers 
1) adaboost - returning ztProduct as it's upper bound for training error
2) decision stump - returning the entropy after splitting.
3) decision tree - returning final entropy of the tree . Added some code to get final entropy in recursive decision   tree.
Let me know if I have returned something wrong.

Update One:
Changed Two Classifiers 
1) HMM - In this returning final log likelihood obtained after training using data sequences.
2) Random Forest  - Returning average entropy of all the decision trees trained under the forest
                                 (Not Sure of this)

Update Two:
1) LARS : Returning final absolute maximum correlation after training
2) Linear_regression : Returning least squares error after training.
3) sparse_coding : Returning final minmized objective function value.
4) ANN : Returning objective function from GANS, FNN, RNN, RBM.  

Update Three:
1) local_coordinate_coding : returning final objective value

Also I went through some other classifiers and drawn following conclusions
1) Hoeffding Trees : In this we are using gain to find best split hence returning entropy is not good.
2) Naive Bayes Classifier : In this we are updating the probability and distribution curve and thus we don't need to return anything in this.
3) Perceptron : In this we are doing simple weight update without any objective function hence no need to return anything from it.
4) Softmax Regression : Train function is already modified.
5) GMM : Train function is already modified


I am quite new to these algorithms, please correct me if I have made a mistake .  