### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-bug.md
+++ b/.github/ISSUE_TEMPLATE/0-bug.md
@@ -1,6 +1,7 @@
 ---
 name: bug report
 about: Use this template for reporting a bug that you have found in mlpack.
+labels: "t: bug report", "s: unanswered"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/0-bug.md
+++ b/.github/ISSUE_TEMPLATE/0-bug.md
@@ -1,0 +1,37 @@
+---
+name: bug report
+about: Use this template for reporting a bug that you have found in mlpack.
+
+---
+
+<!--
+
+Welcome!  Please fill out the template below; that makes it easier for us to 
+quickly figure out what the issue is and solve it.  Thanks!
+
+-->
+
+#### Issue description
+
+<!-- Describe your issue here. -->
+
+#### Your environment
+
+ * version of mlpack:
+ * operating system:
+ * compiler:
+ * version of dependencies (Boost/Armadillo):
+ * any other environment information you think is relevant:
+
+#### Steps to reproduce
+
+<!-- Tell us how to reproduce the issue; please provide a working example if
+possible! -->
+
+#### Expected behavior
+
+<!-- Tell us what should happen. -->
+
+#### Actual behavior
+
+<!-- Tell us what happened instead. -->

--- a/.github/ISSUE_TEMPLATE/1-documentation.md
+++ b/.github/ISSUE_TEMPLATE/1-documentation.md
@@ -1,0 +1,24 @@
+---
+name: documentation issue
+about: Use this template to report an issue you've found with the documentation.
+
+---
+
+<!--
+
+Welcome!  Unfortunately not all documentation is perfect, and if you're opening
+a documentation issue we are interested in fixing it.  Please fill out the
+template below so that we can solve the problem more quickly; or, alternately,
+open a PR with a fix, if you like.
+
+-->
+
+#### Problem location
+
+<!-- Link to incorrect website or location of source file with bad
+documentation. -->
+
+#### Description of problem
+
+<!-- Tell us what is wrong with the documentation so we can fix it. -->
+

--- a/.github/ISSUE_TEMPLATE/1-documentation.md
+++ b/.github/ISSUE_TEMPLATE/1-documentation.md
@@ -1,6 +1,7 @@
 ---
 name: documentation issue
 about: Use this template to report an issue you've found with the documentation.
+labels: "t: bug report", "c: documentation", "s: unanswered"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/2-question.md
+++ b/.github/ISSUE_TEMPLATE/2-question.md
@@ -1,0 +1,15 @@
+---
+name: question
+about: Use this template for other problems, requests, or questions.
+
+---
+
+<!--
+
+Welcome!  If you have a question you'd like to ask, you can do it here or on the
+mlpack mailing list; see also http://mlpack.org/help.html.
+
+If you're looking for how to get involved and contribute, there's no need to
+open an issue---you can see http://www.mlpack.org/involved.html instead.
+
+-->


### PR DESCRIPTION
Here is a basic idea for issue templates.  This should help us classify issues that people open more quickly, and hopefully help get the information we need to take care of the issues more quickly.

It seems like we can automatically apply labels to some of these, which is great, so I have done that where applicable (but the "question" template could be a feature request or a question or something else, so we can just let mlpack-bot label it as `unlabeled`).