### PR TITLE
Allow multiple trials of MountainCarWithDQN test.

### DIFF
--- a/src/mlpack/tests/q_learning_test.cpp
+++ b/src/mlpack/tests/q_learning_test.cpp
@@ -253,67 +253,79 @@ BOOST_AUTO_TEST_CASE(AcrobotWithDQN)
 
 //! Test DQN in Mountain Car task.
 BOOST_AUTO_TEST_CASE(MountainCarWithDQN)
-{ 
-  // Set up the network.
-  FFN<MeanSquaredError<>, GaussianInitialization> model(MeanSquaredError<>(),
-      GaussianInitialization(0, 0.001));
-  model.Add<Linear<>>(2, 64);
-  model.Add<ReLULayer<>>();
-  model.Add<Linear<>>(64, 32);
-  model.Add<ReLULayer<>>();
-  model.Add<Linear<>>(32, 3);
-
-  // Set up the policy and replay method.
-  GreedyPolicy<MountainCar> policy(1.0, 1000, 0.1);
-  RandomReplay<MountainCar> replayMethod(20, 10000);
-
-  TrainingConfig config;
-  config.StepSize() = 0.0001;
-  config.Discount() = 0.9;
-  config.TargetNetworkSyncInterval() = 100;
-  config.ExplorationSteps() = 100;
-  config.DoubleQLearning() = false;
-  config.StepLimit() = 400;
-
-  // Set up DQN agent.
-  QLearning<MountainCar, decltype(model), AdamUpdate, decltype(policy)>
-      agent(std::move(config), std::move(model), std::move(policy),
-      std::move(replayMethod));
-
-  arma::running_stat<double> averageReturn;
-  size_t episodes = 0;
-  bool converged = true;
-  while (true)
+{
+  // We will allow three trials total.
+  bool success = false;
+  for (size_t trial = 0; trial < 3; trial++)
   {
-    double episodeReturn = agent.Episode();
-    averageReturn(episodeReturn);
-    episodes += 1;
+    // Set up the network.
+    FFN<MeanSquaredError<>, GaussianInitialization> model(MeanSquaredError<>(),
+        GaussianInitialization(0, 0.001));
+    model.Add<Linear<>>(2, 64);
+    model.Add<ReLULayer<>>();
+    model.Add<Linear<>>(64, 32);
+    model.Add<ReLULayer<>>();
+    model.Add<Linear<>>(32, 3);
 
-    if (episodes > 1000)
+    // Set up the policy and replay method.
+    GreedyPolicy<MountainCar> policy(1.0, 1000, 0.1);
+    RandomReplay<MountainCar> replayMethod(20, 10000);
+
+    TrainingConfig config;
+    config.StepSize() = 0.0001;
+    config.Discount() = 0.9;
+    config.TargetNetworkSyncInterval() = 100;
+    config.ExplorationSteps() = 100;
+    config.DoubleQLearning() = false;
+    config.StepLimit() = 400;
+
+    // Set up DQN agent.
+    QLearning<MountainCar, decltype(model), AdamUpdate, decltype(policy)>
+        agent(std::move(config), std::move(model), std::move(policy),
+        std::move(replayMethod));
+
+    arma::running_stat<double> averageReturn;
+    size_t episodes = 0;
+    bool converged = true;
+    while (true)
     {
-      Log::Debug << "Mountain Car with DQN failed." << std::endl;
-      converged = false;
-      break;
+      double episodeReturn = agent.Episode();
+      averageReturn(episodeReturn);
+      episodes += 1;
+
+      if (episodes > 1000)
+      {
+        Log::Debug << "Mountain Car with DQN failed." << std::endl;
+        converged = false;
+        break;
+      }
+
+      /**
+       * Set a threshold of -370 to check convergence.
+       */
+      Log::Debug << "Average return: " << averageReturn.mean()
+          << " Episode return: " << episodeReturn << std::endl;
+      if (averageReturn.mean() > -370)
+      {
+        agent.Deterministic() = true;
+        arma::running_stat<double> testReturn;
+        for (size_t i = 0; i < 10; ++i)
+          testReturn(agent.Episode());
+
+        Log::Debug << "Average return in deterministic test: "
+            << testReturn.mean() << std::endl;
+        break;
+      }
     }
 
-    /**
-     * Set a threshold of -370 to check convergence.
-     */
-    Log::Debug << "Average return: " << averageReturn.mean()
-        << " Episode return: " << episodeReturn << std::endl;
-    if (averageReturn.mean() > -370)
+    if (converged)
     {
-      agent.Deterministic() = true;
-      arma::running_stat<double> testReturn;
-      for (size_t i = 0; i < 10; ++i)
-        testReturn(agent.Episode());
-
-      Log::Debug << "Average return in deterministic test: "
-          << testReturn.mean() << std::endl;
+      success = true;
       break;
     }
   }
-  BOOST_REQUIRE(converged);
+
+  BOOST_REQUIRE_EQUAL(success, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
I noticed that the test `QLearningTest/MountainCarWithDQN` occasionally fails.  Some of the other tests in `q_learning_test.cpp` have been adapted to run with multiple trials, and I believe that the mountain car test is suffering from random failures much in the way the other tests did.  So the change here simply runs the test up to three times if it fails, which should reduce the failure probability so that it is insignificant.