### PR TITLE
Resolve gcc parameter reorder warning for clean build.

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -55,8 +55,8 @@ AdaBoost<WeakLearnerType, MatType>::AdaBoost(
 // Empty constructor.
 template<typename WeakLearnerType, typename MatType>
 AdaBoost<WeakLearnerType, MatType>::AdaBoost(const double tolerance) :
-    tolerance(tolerance),
     numClasses(0),
+    tolerance(tolerance),
     ztProduct(1.0)
 {
   // Nothing to do.

--- a/src/mlpack/methods/ann/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm_impl.hpp
@@ -35,7 +35,7 @@ RBM<InitializationRuleType, DataType, PolicyType>::RBM(
     const size_t poolSize,
     const ElemType slabPenalty,
     const ElemType radius,
-    const bool persistence):
+    const bool persistence) :
     predictors(std::move(predictors)),
     initializeRule(initializeRule),
     visibleSize(visibleSize),
@@ -44,11 +44,11 @@ RBM<InitializationRuleType, DataType, PolicyType>::RBM(
     numSteps(numSteps),
     negSteps(negSteps),
     poolSize(poolSize),
+    steps(0),
     slabPenalty(slabPenalty),
     radius(2 * radius),
     persistence(persistence),
-    reset(false),
-    steps(0)
+    reset(false)
 {
   numFunctions = this->predictors.n_cols;
 }


### PR DESCRIPTION
I noticed gcc -Wreorder warning, because the parameters were unordered when initializing.