### PR TITLE
Created default value for ConstInitialization constructor

### DIFF
--- a/src/mlpack/methods/ann/init_rules/const_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/const_init.hpp
@@ -25,6 +25,14 @@ namespace ann /** Artificial Neural Network. */ {
 class ConstInitialization
 {
  public:
+
+  /**
+   *  Create the ConstantInitialization object.
+   *  Allow it to be used as a template argument.
+   */
+  ConstInitialization() : initVal(0.0) {};
+
+  
   /**
    *  Create the ConstantInitialization object.
    */

--- a/src/mlpack/methods/ann/init_rules/const_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/const_init.hpp
@@ -25,18 +25,10 @@ namespace ann /** Artificial Neural Network. */ {
 class ConstInitialization
 {
  public:
-
-  /**
-   *  Create the ConstantInitialization object.
-   *  Allow it to be used as a template argument.
-   */
-  ConstInitialization() : initVal(0.0) {};
-
-  
   /**
    *  Create the ConstantInitialization object.
    */
-  ConstInitialization(const double initVal) : initVal(initVal)
+  ConstInitialization(const double initVal = 0) : initVal(initVal)
   { /* Nothing to do here */ }
 
   /**


### PR DESCRIPTION
Added a default value to the ConstInitialization constructor that allows it to be used as a template argument.
Initializes the weight matrix to 0.