### PR TITLE
Synchronize parameter's name with @param in `dists` and `gmm` directory.

### DIFF
--- a/src/mlpack/core/dists/discrete_distribution.cpp
+++ b/src/mlpack/core/dists/discrete_distribution.cpp
@@ -69,7 +69,7 @@ void DiscreteDistribution::Train(const arma::mat& observations)
   for (size_t i = 0; i < dimensions; i++)
     probabilities[i].zeros();
 
-  // Iterate all the probabilities in each dimension
+  // Iterate all the probabilities in each dimension.
   for (size_t r = 0; r < observations.n_cols; ++r)
   {
     for (size_t i = 0; i < dimensions; ++i)

--- a/src/mlpack/core/dists/discrete_distribution.cpp
+++ b/src/mlpack/core/dists/discrete_distribution.cpp
@@ -69,7 +69,7 @@ void DiscreteDistribution::Train(const arma::mat& observations)
   for (size_t i = 0; i < dimensions; i++)
     probabilities[i].zeros();
 
-  // Iterate all the probabilities in each dimension.
+  // Iterate over all the probabilities in each dimension.
   for (size_t r = 0; r < observations.n_cols; ++r)
   {
     for (size_t i = 0; i < dimensions; ++i)

--- a/src/mlpack/core/dists/discrete_distribution.cpp
+++ b/src/mlpack/core/dists/discrete_distribution.cpp
@@ -58,8 +58,8 @@ void DiscreteDistribution::Train(const arma::mat& observations)
   // Make sure the observations have same dimension as the probabilities.
   if (observations.n_rows != probabilities.size())
   {
-    throw std::invalid_argument("observations must have same dimensionality as "
-        "the DiscreteDistribution object");
+    throw std::invalid_argument("observations must have same dimensionality as"
+        " the DiscreteDistribution object");
   }
 
   // Get the dimension size of the distribution.
@@ -113,8 +113,8 @@ void DiscreteDistribution::Train(const arma::mat& observations,
   // Make sure the observations have same dimension as the probabilities.
   if (observations.n_rows != probabilities.size())
   {
-    throw std::invalid_argument("observations must have same dimensionality as "
-        "the DiscreteDistribution object");
+    throw std::invalid_argument("observations must have same dimensionality as"
+        " the DiscreteDistribution object");
   }
 
   // Get the dimension size of the distribution.

--- a/src/mlpack/core/dists/discrete_distribution.hpp
+++ b/src/mlpack/core/dists/discrete_distribution.hpp
@@ -128,7 +128,7 @@ class DiscreteDistribution
   double Probability(const arma::vec& observation) const
   {
     double probability = 1.0;
-    // Ensure the observation has the same dimension with the probabilities
+    // Ensure the observation has the same dimension with the probabilities.
     if (observation.n_elem != probabilities.size())
     {
       Log::Fatal << "DiscreteDistribution::Probability(): observation has "
@@ -189,8 +189,8 @@ class DiscreteDistribution
    * in logProbabilities.
    *
    * @param x List of observations.
-   * @param logProbabilities probabilities Output probabilities for each 
-   *   input observation.
+   * @param logProbabilities Probabilities Output probabilities for each 
+   *     input observation.
    */
   void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const;
   /**
@@ -218,7 +218,7 @@ class DiscreteDistribution
    *
    * @param observations List of observations.
    * @param probabilities List of probabilities that each observation is
-   *    actually from this distribution.
+   *     actually from this distribution.
    */
   void Train(const arma::mat& observations,
              const arma::vec& probabilities);
@@ -246,7 +246,7 @@ class DiscreteDistribution
 
 /**
  * Calculates the Discrete log-probability function for each
- * data point (column) in the given matrix
+ * data point (column) in the given matrix.
  *
  * @param x List of observations.
  * @param logProbabilities Output log probabilities for each input observation.

--- a/src/mlpack/core/dists/discrete_distribution.hpp
+++ b/src/mlpack/core/dists/discrete_distribution.hpp
@@ -31,8 +31,8 @@ namespace distribution /** Probability distributions. */ {
  * observation is passed (i.e. observation > numObservations), a crash will
  * probably occur.
  *
- * This distribution only supports one-dimensional observations, so when passing
- * an arma::vec as an observation, it should only have one dimension
+ * This distribution only supports one-dimensional observations, so when
+ * passing an arma::vec as an observation, it should only have one dimension
  * (vec.n_rows == 1).  Any additional dimensions will simply be ignored.
  *
  * @note
@@ -47,7 +47,8 @@ class DiscreteDistribution
 {
  public:
   /**
-   * Default constructor, which creates a distribution that has no observations.
+   * Default constructor, which creates a distribution that has no
+   * observations.
    */
   DiscreteDistribution() :
       probabilities(std::vector<arma::vec>(1)){ /* Nothing to do. */ }
@@ -66,9 +67,9 @@ class DiscreteDistribution
   { /* Nothing to do. */ }
 
   /**
-   * Define the multidimensional discrete distribution as having numObservations possible
-   * observations.  The probability in each state will be set to (1 /
-   * numObservations of each dimension).
+   * Define the multidimensional discrete distribution as having
+   * numObservations possible observations.  The probability in each state will
+   * be set to (1 / numObservations of each dimension).
    *
    * @param numObservations Number of possible observations this distribution
    *    can have.
@@ -90,8 +91,8 @@ class DiscreteDistribution
   }
 
   /**
-   * Define the multidimensional discrete distribution as having the given probabilities for each
-   * observation.
+   * Define the multidimensional discrete distribution as having the given
+   * probabilities for each observation.
    *
    * @param probabilities Probabilities of each possible observation.
    */
@@ -131,8 +132,8 @@ class DiscreteDistribution
     if (observation.n_elem != probabilities.size())
     {
       Log::Fatal << "DiscreteDistribution::Probability(): observation has "
-          << "incorrect dimension " << observation.n_elem << " but should have "
-          << "dimension " << probabilities.size() << "!" << std::endl;
+          << "incorrect dimension " << observation.n_elem << " but should have"
+          << " dimension " << probabilities.size() << "!" << std::endl;
     }
 
     for (size_t dimension = 0; dimension < observation.n_elem; dimension++)
@@ -156,8 +157,8 @@ class DiscreteDistribution
   }
 
   /**
-   * Return the log probability of the given observation.  If the observation is
-   * greater than the number of possible observations, then a crash will
+   * Return the log probability of the given observation.  If the observation
+   * is greater than the number of possible observations, then a crash will
    * probably occur -- bounds checking is not performed.
    *
    * @param observation Observation to return the log probability of.
@@ -202,9 +203,9 @@ class DiscreteDistribution
   arma::vec Random() const;
 
   /**
-   * Estimate the probability distribution directly from the given observations.
-   * If any of the observations is greater than numObservations, a crash is
-   * likely to occur.
+   * Estimate the probability distribution directly from the given
+   * observations. If any of the observations is greater than numObservations,
+   * a crash is likely to occur.
    *
    * @param observations List of observations.
    */
@@ -248,7 +249,7 @@ class DiscreteDistribution
  * data point (column) in the given matrix
  *
  * @param x List of observations.
- * @param probabilities Output log probabilities for each input observation.
+ * @param logProbabilities Output log probabilities for each input observation.
  */
 inline void DiscreteDistribution::LogProbability(
     const arma::mat& x,

--- a/src/mlpack/core/dists/discrete_distribution.hpp
+++ b/src/mlpack/core/dists/discrete_distribution.hpp
@@ -189,8 +189,8 @@ class DiscreteDistribution
    * in logProbabilities.
    *
    * @param x List of observations.
-   * @param logProbabilities Probabilities Output probabilities for each 
-   *     input observation.
+   * @param logProbabilities Output log probabilities for each input
+   *     observation.
    */
   void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const;
   /**

--- a/src/mlpack/core/dists/gamma_distribution.cpp
+++ b/src/mlpack/core/dists/gamma_distribution.cpp
@@ -197,12 +197,12 @@ double GammaDistribution::Probability(double x, size_t dim) const
 
 // Returns the log probability of the provided observations.
 void GammaDistribution::LogProbability(const arma::mat& observations,
-                                       arma::vec& LogProbabilities) const
+                                       arma::vec& logProbabilities) const
 {
   size_t numObs = observations.n_cols;
 
   // Set all equal to 0 (addition neutral).
-  LogProbabilities.zeros(numObs);
+  logProbabilities.zeros(numObs);
 
   // Compute denominator only once for each dimension.
   arma::vec denominators(alpha.n_elem);
@@ -219,7 +219,7 @@ void GammaDistribution::LogProbability(const arma::mat& observations,
       double factor = std::exp(-observations(d, i) / beta(d));
       double numerator = std::pow(observations(d, i), alpha(d) - 1);
 
-      LogProbabilities(i) += std::log(numerator * factor / denominators(d));
+      logProbabilities(i) += std::log(numerator * factor / denominators(d));
     }
   }
 }

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -52,176 +52,178 @@ namespace distribution {
 class GammaDistribution
 {
  public:
-    /**
-     * Construct the Gamma distribution with the given number of dimensions
-     * (default 0); each parameter will be initialized to 0.
-     *
-     * @param dimensionality Number of dimensions.
-     */
-    GammaDistribution(const size_t dimensionality = 0);
+   /**
+    * Construct the Gamma distribution with the given number of dimensions
+    * (default 0); each parameter will be initialized to 0.
+    *
+    * @param dimensionality Number of dimensions.
+    */
+   GammaDistribution(const size_t dimensionality = 0);
 
-    /**
-     * Construct the Gamma distribution, training on the given parameters.
-     *
-     * @param data Data to train the distribution on.
-     * @param tol Convergence tolerance. This is *not* an absolute measure:
-     *    It will stop the approximation once the *change* in the value is
-     *    smaller than tol.
-     */
-    GammaDistribution(const arma::mat& data, const double tol = 1e-8);
+   /**
+    * Construct the Gamma distribution, training on the given parameters.
+    *
+    * @param data Data to train the distribution on.
+    * @param tol Convergence tolerance. This is *not* an absolute measure:
+    *    It will stop the approximation once the *change* in the value is
+    *    smaller than tol.
+    */
+   GammaDistribution(const arma::mat& data, const double tol = 1e-8);
 
-    /**
-     * Construct the Gamma distribution given two vectors alpha and beta.
-     *
-     * @param alpha The vector of alphas, one per dimension.
-     * @param beta The vector of betas, one per dimension.
-     */
-    GammaDistribution(const arma::vec& alpha, const arma::vec& beta);
+   /**
+    * Construct the Gamma distribution given two vectors alpha and beta.
+    *
+    * @param alpha The vector of alphas, one per dimension.
+    * @param beta The vector of betas, one per dimension.
+    */
+   GammaDistribution(const arma::vec& alpha, const arma::vec& beta);
 
-    /**
-     * Destructor.
-     */
-    ~GammaDistribution() {}
+   /**
+    * Destructor.
+    */
+   ~GammaDistribution() {}
 
-    /**
-     * This function trains (fits distribution parameters) to new data or the
-     * dataset the object owns.
-     *
-     * @param rdata Reference data to fit parameters to.
-     * @param tol Convergence tolerance. This is *not* an absolute measure:
-     *    It will stop the approximation once the *change* in the value is
-     *    smaller than tol.
-     */
-    void Train(const arma::mat& rdata, const double tol = 1e-8);
+   /**
+    * This function trains (fits distribution parameters) to new data or the
+    * dataset the object owns.
+    *
+    * @param rdata Reference data to fit parameters to.
+    * @param tol Convergence tolerance. This is *not* an absolute measure:
+    *    It will stop the approximation once the *change* in the value is
+    *    smaller than tol.
+    */
+   void Train(const arma::mat& rdata, const double tol = 1e-8);
 
-    /**
-     * Fits an alpha and beta parameter according to observation probabilities.
-     * This method is not yet implemented.
-     *
-     * @param observations The reference data, one observation per column
-     * @param probabilities The probability of each observation. One value per
-     *     column of the observations matrix.
-     * @param tol Convergence tolerance. This is *not* an absolute measure:
-     *    It will stop the approximation once the *change* in the value is
-     *    smaller than tol.
-     */
-    void Train(const arma::mat& observations,
-               const arma::vec& probabilities,
-               const double tol = 1e-8);
+   /**
+    * Fits an alpha and beta parameter according to observation probabilities.
+    * This method is not yet implemented.
+    *
+    * @param observations The reference data, one observation per column.
+    * @param probabilities The probability of each observation. One value per
+    *     column of the observations matrix.
+    * @param tol Convergence tolerance. This is *not* an absolute measure:
+    *    It will stop the approximation once the *change* in the value is
+    *    smaller than tol.
+    */
+   void Train(const arma::mat& observations,
+              const arma::vec& probabilities,
+              const double tol = 1e-8);
 
-    /**
-     * This function trains (fits distribution parameters) to a dataset with
-     * pre-computed statistics logMeanx, meanLogx, meanx for each dimension.
-     *
-     * @param logMeanxVec Is each dimension's logarithm of the mean
-     *     (log(mean(x))).
-     * @param meanLogxVec Is each dimension's mean of logarithms (mean(log(x))).
-     * @param meanxVec Is each dimension's mean (mean(x)).
-     * @param tol Convergence tolerance. This is *not* an absolute measure:
-     *    It will stop the approximation once the *change* in the value is
-     *    smaller than tol.
-     */
-    void Train(const arma::vec& logMeanxVec,
-               const arma::vec& meanLogxVec,
-               const arma::vec& meanxVec,
-               const double tol = 1e-8);
+   /**
+    * This function trains (fits distribution parameters) to a dataset with
+    * pre-computed statistics logMeanx, meanLogx, meanx for each dimension.
+    *
+    * @param logMeanxVec Is each dimension's logarithm of the mean
+    *     (log(mean(x))).
+    * @param meanLogxVec Is each dimension's mean of logarithms
+    *     (mean(log(x))).
+    * @param meanxVec Is each dimension's mean (mean(x)).
+    * @param tol Convergence tolerance. This is *not* an absolute measure:
+    *    It will stop the approximation once the *change* in the value is
+    *    smaller than tol.
+    */
+   void Train(const arma::vec& logMeanxVec,
+              const arma::vec& meanLogxVec,
+              const arma::vec& meanxVec,
+              const double tol = 1e-8);
 
 
-    /**
-     * This function returns the probability of a group of observations.
-     *
-     * The probability of the value x is
-     *
-     * \frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
-     * {-\frac{x}{\beta}}
-     *
-     * for one dimension. This implementation assumes each dimension is
-     * independent, so the product rule is used.
-     *
-     * @param observations Matrix of observations, one per column.
-     * @param probabilities column vector of probabilities, one per observation.
-     */
-    void Probability(const arma::mat& observations,
-                     arma::vec& Probabilities) const;
+   /**
+    * This function returns the probability of a group of observations.
+    *
+    * The probability of the value x is
+    *
+    * \frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+    * {-\frac{x}{\beta}}
+    *
+    * for one dimension. This implementation assumes each dimension is
+    * independent, so the product rule is used.
+    *
+    * @param observations Matrix of observations, one per column.
+    * @param probabilities column vector of probabilities, one per
+    *     observation.
+    */
+   void Probability(const arma::mat& observations,
+                    arma::vec& Probabilities) const;
 
-    /*
-     * This is a shortcut to the Probability(arma::mat&, arma::vec&) function
-     * for when we want to evaluate only the probability of one dimension of the
-     * gamma.
-     *
-     * @param x The 1-dimensional observation.
-     * @param dim The dimension for which to calculate the probability
-     */
-    double Probability(double x, size_t dim) const;
+   /*
+    * This is a shortcut to the Probability(arma::mat&, arma::vec&) function
+    * for when we want to evaluate only the probability of one dimension of
+    * the gamma.
+    *
+    * @param x The 1-dimensional observation.
+    * @param dim The dimension for which to calculate the probability.
+    */
+   double Probability(double x, size_t dim) const;
 
-    /**
-     * This function returns the logarithm of the probability of a group of
-     * observations.
-     *
-     * The logarithm of the probability of a value x is
-     *
-     * log(\frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
-     * {-\frac{x}{\beta}})
-     *
-     * for one dimension. This implementation assumes each dimension is
-     * independent, so the product rule is used.
-     *
-     * @param observations Matrix of observations, one per column.
-     * @param logProbabilities column vector of log probabilities, one per
-     *     observation.
-     */
-    void LogProbability(const arma::mat& observations,
-                        arma::vec& LogProbabilities) const;
+   /**
+    * This function returns the logarithm of the probability of a group of
+    * observations.
+    *
+    * The logarithm of the probability of a value x is
+    *
+    * log(\frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+    * {-\frac{x}{\beta}})
+    *
+    * for one dimension. This implementation assumes each dimension is
+    * independent, so the product rule is used.
+    *
+    * @param observations Matrix of observations, one per column.
+    * @param logProbabilities column vector of log probabilities, one per
+    *     observation.
+    */
+   void LogProbability(const arma::mat& observations,
+                       arma::vec& LogProbabilities) const;
 
-    /**
-     * This function returns the logarithm of the probability of a single
-     * observation. 
-     *
-     * @param x The 1-dimensional observation.
-     * @param dim The dimension for which to calculate the probability
-     */
-    double LogProbability(double x, size_t dim) const;
+   /**
+    * This function returns the logarithm of the probability of a single
+    * observation. 
+    *
+    * @param x The 1-dimensional observation.
+    * @param dim The dimension for which to calculate the probability.
+    */
+   double LogProbability(double x, size_t dim) const;
 
-    /**
-     * This function returns an observation of this distribution
-     */
-    arma::vec Random() const;
+   /**
+    * This function returns an observation of this distribution.
+    */
+   arma::vec Random() const;
 
-    // Access to Gamma distribution parameters.
+   // Access to Gamma distribution parameters.
 
-    //! Get the alpha parameter of the given dimension.
-    double Alpha(const size_t dim) const { return alpha[dim]; }
-    //! Modify the alpha parameter of the given dimension.
-    double& Alpha(const size_t dim) { return alpha[dim]; }
+   //! Get the alpha parameter of the given dimension.
+   double Alpha(const size_t dim) const { return alpha[dim]; }
+   //! Modify the alpha parameter of the given dimension.
+   double& Alpha(const size_t dim) { return alpha[dim]; }
 
-    //! Get the beta parameter of the given dimension.
-    double Beta(const size_t dim) const { return beta[dim]; }
-    //! Modify the beta parameter of the given dimension.
-    double& Beta(const size_t dim) { return beta[dim]; }
+   //! Get the beta parameter of the given dimension.
+   double Beta(const size_t dim) const { return beta[dim]; }
+   //! Modify the beta parameter of the given dimension.
+   double& Beta(const size_t dim) { return beta[dim]; }
 
-    //! Get the dimensionality of the distribution.
-    size_t Dimensionality() const { return alpha.n_elem; }
+   //! Get the dimensionality of the distribution.
+   size_t Dimensionality() const { return alpha.n_elem; }
 
  private:
-    //! Array of fitted alphas.
-    arma::vec alpha;
-    //! Array of fitted betas.
-    arma::vec beta;
+   //! Array of fitted alphas.
+   arma::vec alpha;
+   //! Array of fitted betas.
+   arma::vec beta;
 
-    /**
-     * This is a small function that returns true if the update of alpha is
-     * smaller than the tolerance ratio.
-     *
-     * @param aOld old value of parameter we want to estimate (alpha in our
-     *      case).
-     * @param aNew new value of parameter (the value after 1 iteration from
-     *      aOld).
-     * @param tol Convergence tolerance. Relative measure (see documentation of
-     *      GammaDistribution::Train).
-     */
-    inline bool Converged(const double aOld,
-                          const double aNew,
-                          const double tol);
+   /**
+    * This is a small function that returns true if the update of alpha is
+    * smaller than the tolerance ratio.
+    *
+    * @param aOld old value of parameter we want to estimate (alpha in our
+    *      case).
+    * @param aNew new value of parameter (the value after 1 iteration from
+    *      aOld).
+    * @param tol Convergence tolerance. Relative measure (see documentation of
+    *      GammaDistribution::Train).
+    */
+   inline bool Converged(const double aOld,
+                         const double aNew,
+                         const double tol);
 };
 
 } // namespace distribution

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -127,14 +127,14 @@ class GammaDistribution
              const arma::vec& meanxVec,
              const double tol = 1e-8);
 
-
   /**
    * This function returns the probability of a group of observations.
    *
    * The probability of the value x is
    *
-   * \frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
-   * {-\frac{x}{\beta}}
+   * \f[
+   * \frac{x^{(\alpha - 1)}}{\Gamma(\alpha) \beta^\alpha} e^{-\frac{x}{\beta}}
+   * \f]
    *
    * for one dimension. This implementation assumes each dimension is
    * independent, so the product rule is used.
@@ -162,8 +162,10 @@ class GammaDistribution
    *
    * The logarithm of the probability of a value x is
    *
-   * log(\frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+   * \f[
+   * \log(\frac{x^{(\alpha - 1)}}{\Gamma(\alpha) \beta^\alpha} e^
    * {-\frac{x}{\beta}})
+   * \f]
    *
    * for one dimension. This implementation assumes each dimension is
    * independent, so the product rule is used.
@@ -214,9 +216,9 @@ class GammaDistribution
    * This is a small function that returns true if the update of alpha is
    * smaller than the tolerance ratio.
    *
-   * @param aOld old value of parameter we want to estimate (alpha in our
+   * @param aOld Old value of parameter we want to estimate (alpha in our
    *     case).
-   * @param aNew new value of parameter (the value after 1 iteration from
+   * @param aNew New value of parameter (the value after 1 iteration from
    *     aOld).
    * @param tol Convergence tolerance. Relative measure (see documentation of
    *     GammaDistribution::Train).

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -140,7 +140,7 @@ class GammaDistribution
    * independent, so the product rule is used.
    *
    * @param observations Matrix of observations, one per column.
-   * @param probabilities column vector of probabilities, one per
+   * @param probabilities Column vector of probabilities, one per
    *     observation.
    */
   void Probability(const arma::mat& observations,
@@ -169,7 +169,7 @@ class GammaDistribution
    * independent, so the product rule is used.
    *
    * @param observations Matrix of observations, one per column.
-   * @param logProbabilities column vector of log probabilities, one per
+   * @param logProbabilities Column vector of log probabilities, one per
    *     observation.
    */
   void LogProbability(const arma::mat& observations,
@@ -215,11 +215,11 @@ class GammaDistribution
    * smaller than the tolerance ratio.
    *
    * @param aOld old value of parameter we want to estimate (alpha in our
-   *      case).
+   *     case).
    * @param aNew new value of parameter (the value after 1 iteration from
-   *      aOld).
+   *     aOld).
    * @param tol Convergence tolerance. Relative measure (see documentation of
-   *      GammaDistribution::Train).
+   *     GammaDistribution::Train).
    */
   inline bool Converged(const double aOld,
                         const double aNew,

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -52,178 +52,178 @@ namespace distribution {
 class GammaDistribution
 {
  public:
-   /**
-    * Construct the Gamma distribution with the given number of dimensions
-    * (default 0); each parameter will be initialized to 0.
-    *
-    * @param dimensionality Number of dimensions.
-    */
-   GammaDistribution(const size_t dimensionality = 0);
+  /**
+   * Construct the Gamma distribution with the given number of dimensions
+   * (default 0); each parameter will be initialized to 0.
+   *
+   * @param dimensionality Number of dimensions.
+   */
+  GammaDistribution(const size_t dimensionality = 0);
 
-   /**
-    * Construct the Gamma distribution, training on the given parameters.
-    *
-    * @param data Data to train the distribution on.
-    * @param tol Convergence tolerance. This is *not* an absolute measure:
-    *    It will stop the approximation once the *change* in the value is
-    *    smaller than tol.
-    */
-   GammaDistribution(const arma::mat& data, const double tol = 1e-8);
+  /**
+   * Construct the Gamma distribution, training on the given parameters.
+   *
+   * @param data Data to train the distribution on.
+   * @param tol Convergence tolerance. This is *not* an absolute measure:
+   *    It will stop the approximation once the *change* in the value is
+   *    smaller than tol.
+   */
+  GammaDistribution(const arma::mat& data, const double tol = 1e-8);
 
-   /**
-    * Construct the Gamma distribution given two vectors alpha and beta.
-    *
-    * @param alpha The vector of alphas, one per dimension.
-    * @param beta The vector of betas, one per dimension.
-    */
-   GammaDistribution(const arma::vec& alpha, const arma::vec& beta);
+  /**
+   * Construct the Gamma distribution given two vectors alpha and beta.
+   *
+   * @param alpha The vector of alphas, one per dimension.
+   * @param beta The vector of betas, one per dimension.
+   */
+  GammaDistribution(const arma::vec& alpha, const arma::vec& beta);
 
-   /**
-    * Destructor.
-    */
-   ~GammaDistribution() {}
+  /**
+   * Destructor.
+   */
+  ~GammaDistribution() {}
 
-   /**
-    * This function trains (fits distribution parameters) to new data or the
-    * dataset the object owns.
-    *
-    * @param rdata Reference data to fit parameters to.
-    * @param tol Convergence tolerance. This is *not* an absolute measure:
-    *    It will stop the approximation once the *change* in the value is
-    *    smaller than tol.
-    */
-   void Train(const arma::mat& rdata, const double tol = 1e-8);
+  /**
+   * This function trains (fits distribution parameters) to new data or the
+   * dataset the object owns.
+   *
+   * @param rdata Reference data to fit parameters to.
+   * @param tol Convergence tolerance. This is *not* an absolute measure:
+   *    It will stop the approximation once the *change* in the value is
+   *    smaller than tol.
+   */
+  void Train(const arma::mat& rdata, const double tol = 1e-8);
 
-   /**
-    * Fits an alpha and beta parameter according to observation probabilities.
-    * This method is not yet implemented.
-    *
-    * @param observations The reference data, one observation per column.
-    * @param probabilities The probability of each observation. One value per
-    *     column of the observations matrix.
-    * @param tol Convergence tolerance. This is *not* an absolute measure:
-    *    It will stop the approximation once the *change* in the value is
-    *    smaller than tol.
-    */
-   void Train(const arma::mat& observations,
-              const arma::vec& probabilities,
-              const double tol = 1e-8);
+  /**
+   * Fits an alpha and beta parameter according to observation probabilities.
+   * This method is not yet implemented.
+   *
+   * @param observations The reference data, one observation per column.
+   * @param probabilities The probability of each observation. One value per
+   *     column of the observations matrix.
+   * @param tol Convergence tolerance. This is *not* an absolute measure:
+   *    It will stop the approximation once the *change* in the value is
+   *    smaller than tol.
+   */
+  void Train(const arma::mat& observations,
+             const arma::vec& probabilities,
+             const double tol = 1e-8);
 
-   /**
-    * This function trains (fits distribution parameters) to a dataset with
-    * pre-computed statistics logMeanx, meanLogx, meanx for each dimension.
-    *
-    * @param logMeanxVec Is each dimension's logarithm of the mean
-    *     (log(mean(x))).
-    * @param meanLogxVec Is each dimension's mean of logarithms
-    *     (mean(log(x))).
-    * @param meanxVec Is each dimension's mean (mean(x)).
-    * @param tol Convergence tolerance. This is *not* an absolute measure:
-    *    It will stop the approximation once the *change* in the value is
-    *    smaller than tol.
-    */
-   void Train(const arma::vec& logMeanxVec,
-              const arma::vec& meanLogxVec,
-              const arma::vec& meanxVec,
-              const double tol = 1e-8);
+  /**
+   * This function trains (fits distribution parameters) to a dataset with
+   * pre-computed statistics logMeanx, meanLogx, meanx for each dimension.
+   *
+   * @param logMeanxVec Is each dimension's logarithm of the mean
+   *     (log(mean(x))).
+   * @param meanLogxVec Is each dimension's mean of logarithms
+   *     (mean(log(x))).
+   * @param meanxVec Is each dimension's mean (mean(x)).
+   * @param tol Convergence tolerance. This is *not* an absolute measure:
+   *    It will stop the approximation once the *change* in the value is
+   *    smaller than tol.
+   */
+  void Train(const arma::vec& logMeanxVec,
+             const arma::vec& meanLogxVec,
+             const arma::vec& meanxVec,
+             const double tol = 1e-8);
 
 
-   /**
-    * This function returns the probability of a group of observations.
-    *
-    * The probability of the value x is
-    *
-    * \frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
-    * {-\frac{x}{\beta}}
-    *
-    * for one dimension. This implementation assumes each dimension is
-    * independent, so the product rule is used.
-    *
-    * @param observations Matrix of observations, one per column.
-    * @param probabilities column vector of probabilities, one per
-    *     observation.
-    */
-   void Probability(const arma::mat& observations,
-                    arma::vec& probabilities) const;
+  /**
+   * This function returns the probability of a group of observations.
+   *
+   * The probability of the value x is
+   *
+   * \frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+   * {-\frac{x}{\beta}}
+   *
+   * for one dimension. This implementation assumes each dimension is
+   * independent, so the product rule is used.
+   *
+   * @param observations Matrix of observations, one per column.
+   * @param probabilities column vector of probabilities, one per
+   *     observation.
+   */
+  void Probability(const arma::mat& observations,
+                   arma::vec& probabilities) const;
 
-   /*
-    * This is a shortcut to the Probability(arma::mat&, arma::vec&) function
-    * for when we want to evaluate only the probability of one dimension of
-    * the gamma.
-    *
-    * @param x The 1-dimensional observation.
-    * @param dim The dimension for which to calculate the probability.
-    */
-   double Probability(double x, size_t dim) const;
+  /**
+   * This is a shortcut to the Probability(arma::mat&, arma::vec&) function
+   * for when we want to evaluate only the probability of one dimension of
+   * the gamma.
+   *
+   * @param x The 1-dimensional observation.
+   * @param dim The dimension for which to calculate the probability.
+   */
+  double Probability(double x, size_t dim) const;
 
-   /**
-    * This function returns the logarithm of the probability of a group of
-    * observations.
-    *
-    * The logarithm of the probability of a value x is
-    *
-    * log(\frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
-    * {-\frac{x}{\beta}})
-    *
-    * for one dimension. This implementation assumes each dimension is
-    * independent, so the product rule is used.
-    *
-    * @param observations Matrix of observations, one per column.
-    * @param logProbabilities column vector of log probabilities, one per
-    *     observation.
-    */
-   void LogProbability(const arma::mat& observations,
-                       arma::vec& logProbabilities) const;
+  /**
+   * This function returns the logarithm of the probability of a group of
+   * observations.
+   *
+   * The logarithm of the probability of a value x is
+   *
+   * log(\frac{x^(\alpha - 1)}{\Gamma(\alpha) * \beta^\alpha} * e ^
+   * {-\frac{x}{\beta}})
+   *
+   * for one dimension. This implementation assumes each dimension is
+   * independent, so the product rule is used.
+   *
+   * @param observations Matrix of observations, one per column.
+   * @param logProbabilities column vector of log probabilities, one per
+   *     observation.
+   */
+  void LogProbability(const arma::mat& observations,
+                      arma::vec& logProbabilities) const;
 
-   /**
-    * This function returns the logarithm of the probability of a single
-    * observation. 
-    *
-    * @param x The 1-dimensional observation.
-    * @param dim The dimension for which to calculate the probability.
-    */
-   double LogProbability(double x, size_t dim) const;
+  /**
+   * This function returns the logarithm of the probability of a single
+   * observation. 
+   *
+   * @param x The 1-dimensional observation.
+   * @param dim The dimension for which to calculate the probability.
+   */
+  double LogProbability(double x, size_t dim) const;
 
-   /**
-    * This function returns an observation of this distribution.
-    */
-   arma::vec Random() const;
+  /**
+   * This function returns an observation of this distribution.
+   */
+  arma::vec Random() const;
 
-   // Access to Gamma distribution parameters.
+  // Access to Gamma distribution parameters.
 
-   //! Get the alpha parameter of the given dimension.
-   double Alpha(const size_t dim) const { return alpha[dim]; }
-   //! Modify the alpha parameter of the given dimension.
-   double& Alpha(const size_t dim) { return alpha[dim]; }
+  //! Get the alpha parameter of the given dimension.
+  double Alpha(const size_t dim) const { return alpha[dim]; }
+  //! Modify the alpha parameter of the given dimension.
+  double& Alpha(const size_t dim) { return alpha[dim]; }
 
-   //! Get the beta parameter of the given dimension.
-   double Beta(const size_t dim) const { return beta[dim]; }
-   //! Modify the beta parameter of the given dimension.
-   double& Beta(const size_t dim) { return beta[dim]; }
+  //! Get the beta parameter of the given dimension.
+  double Beta(const size_t dim) const { return beta[dim]; }
+  //! Modify the beta parameter of the given dimension.
+  double& Beta(const size_t dim) { return beta[dim]; }
 
-   //! Get the dimensionality of the distribution.
-   size_t Dimensionality() const { return alpha.n_elem; }
+  //! Get the dimensionality of the distribution.
+  size_t Dimensionality() const { return alpha.n_elem; }
 
  private:
-   //! Array of fitted alphas.
-   arma::vec alpha;
-   //! Array of fitted betas.
-   arma::vec beta;
+  //! Array of fitted alphas.
+  arma::vec alpha;
+  //! Array of fitted betas.
+  arma::vec beta;
 
-   /**
-    * This is a small function that returns true if the update of alpha is
-    * smaller than the tolerance ratio.
-    *
-    * @param aOld old value of parameter we want to estimate (alpha in our
-    *      case).
-    * @param aNew new value of parameter (the value after 1 iteration from
-    *      aOld).
-    * @param tol Convergence tolerance. Relative measure (see documentation of
-    *      GammaDistribution::Train).
-    */
-   inline bool Converged(const double aOld,
-                         const double aNew,
-                         const double tol);
+  /**
+   * This is a small function that returns true if the update of alpha is
+   * smaller than the tolerance ratio.
+   *
+   * @param aOld old value of parameter we want to estimate (alpha in our
+   *      case).
+   * @param aNew new value of parameter (the value after 1 iteration from
+   *      aOld).
+   * @param tol Convergence tolerance. Relative measure (see documentation of
+   *      GammaDistribution::Train).
+   */
+  inline bool Converged(const double aOld,
+                        const double aNew,
+                        const double tol);
 };
 
 } // namespace distribution

--- a/src/mlpack/core/dists/gamma_distribution.hpp
+++ b/src/mlpack/core/dists/gamma_distribution.hpp
@@ -144,7 +144,7 @@ class GammaDistribution
     *     observation.
     */
    void Probability(const arma::mat& observations,
-                    arma::vec& Probabilities) const;
+                    arma::vec& probabilities) const;
 
    /*
     * This is a shortcut to the Probability(arma::mat&, arma::vec&) function
@@ -173,7 +173,7 @@ class GammaDistribution
     *     observation.
     */
    void LogProbability(const arma::mat& observations,
-                       arma::vec& LogProbabilities) const;
+                       arma::vec& logProbabilities) const;
 
    /**
     * This function returns the logarithm of the probability of a single

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -100,9 +100,9 @@ class GaussianDistribution
    * in logProbabilities.
    *
    * @param x List of observations.
-   * @param logProbabilities probabilities Output probabilities for each 
-   *   input observation.
-  */
+   * @param logProbabilities Output log probabilities for each input
+   *     observation.
+   */
   void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const;
 
   /**

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -121,8 +121,8 @@ class GaussianDistribution
   void Train(const arma::mat& observations);
 
   /**
-   * Estimate the Gaussian distribution from the given observations, taking into
-   * account the probability of each observation actually being from this
+   * Estimate the Gaussian distribution from the given observations, taking
+   * into account the probability of each observation actually being from this
    * distribution.
    */
   void Train(const arma::mat& observations,
@@ -167,18 +167,18 @@ class GaussianDistribution
  private:
   /**
    * This factors the covariance using arma::chol().  The function assumes that
-   * the given matrix is factorizable via the Cholesky decomposition.  If not, a
-   * std::runtime_error will be thrown.
+   * the given matrix is factorizable via the Cholesky decomposition.  If not,
+   * a std::runtime_error will be thrown.
    */
   void FactorCovariance();
 };
 
 /**
- * Calculates the multivariate Gaussian Log probability density function for each
- * data point (column) in the given matrix
+ * Calculates the multivariate Gaussian Log probability density function for
+ * each data point (column) in the given matrix.
  *
  * @param x List of observations.
- * @param probabilities Output log probabilities for each input observation.
+ * @param logProbabilities Output log probabilities for each input observation.
  */
 inline void GaussianDistribution::LogProbability(
     const arma::mat& x,

--- a/src/mlpack/core/dists/laplace_distribution.hpp
+++ b/src/mlpack/core/dists/laplace_distribution.hpp
@@ -24,8 +24,8 @@ namespace distribution {
  * \f]
  *
  * given scale parameter \f$\theta\f$ and mean \f$\mu\f$.  This implementation
- * assumes a diagonal covariance, but a rewrite to support arbitrary covariances
- * is possible.
+ * assumes a diagonal covariance, but a rewrite to support arbitrary
+ * covariances is possible.
  *
  * See the following paper for more information on the non-diagonal-covariance
  * Laplace distribution and estimation techniques:
@@ -42,9 +42,9 @@ namespace distribution {
  * }
  * @endcode
  *
- * Note that because of the diagonal covariance restriction, much of the algebra
- * in the paper above becomes simplified, and the PDF takes roughly the same
- * form as the univariate case.
+ * Note that because of the diagonal covariance restriction, much of the
+ * algebra in the paper above becomes simplified, and the PDF takes roughly
+ * the same form as the univariate case.
  */
 class LaplaceDistribution
 {
@@ -56,8 +56,8 @@ class LaplaceDistribution
   LaplaceDistribution() : scale(0) { }
 
   /**
-   * Construct the Laplace distribution with the given scale and dimensionality.
-   * The mean is initialized to zero.
+   * Construct the Laplace distribution with the given scale and
+   * dimensionality. The mean is initialized to zero.
    *
    * @param dimensionality Dimensionality of distribution.
    * @param scale Scale of distribution.
@@ -66,7 +66,8 @@ class LaplaceDistribution
       mean(arma::zeros<arma::vec>(dimensionality)), scale(scale) { }
 
   /**
-   * Construct the Laplace distribution with the given mean and scale parameter.
+   * Construct the Laplace distribution with the given mean and scale
+   * parameter.
    *
    * @param mean Mean of distribution.
    * @param scale Scale of distribution.

--- a/src/mlpack/core/dists/regression_distribution.cpp
+++ b/src/mlpack/core/dists/regression_distribution.cpp
@@ -2,7 +2,8 @@
  * @file regression_distribution.cpp
  * @author Michael Fox
  *
- * Implementation of conditional Gaussian distribution for HMM regression (HMMR)
+ * Implementation of conditional Gaussian distribution for HMM regression
+ * (HMMR).
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -16,7 +17,7 @@ using namespace mlpack;
 using namespace mlpack::distribution;
 
 /**
- * Estimate parameters using provided observation weights
+ * Estimate parameters using provided observation weights.
  *
  * @param observations List of observations.
  */
@@ -33,7 +34,7 @@ void RegressionDistribution::Train(const arma::mat& observations)
 /**
  * Estimate parameters using provided observation weights.
  *
- * @param weights probability that given observation is from distribution
+ * @param weights probability that given observation is from distribution.
  */
 void RegressionDistribution::Train(const arma::mat& observations,
                                    const arma::vec& weights)
@@ -55,7 +56,7 @@ void RegressionDistribution::Train(const arma::mat& observations,
 /**
  * Evaluate probability density function of given observation.
  *
- * @param observation point to evaluate probability at
+ * @param observation point to evaluate probability at.
  */
 double RegressionDistribution::Probability(const arma::vec& observation) const
 {

--- a/src/mlpack/core/dists/regression_distribution.cpp
+++ b/src/mlpack/core/dists/regression_distribution.cpp
@@ -34,7 +34,7 @@ void RegressionDistribution::Train(const arma::mat& observations)
 /**
  * Estimate parameters using provided observation weights.
  *
- * @param weights probability that given observation is from distribution.
+ * @param weights Probability that given observation is from distribution.
  */
 void RegressionDistribution::Train(const arma::mat& observations,
                                    const arma::vec& weights)
@@ -56,7 +56,7 @@ void RegressionDistribution::Train(const arma::mat& observations,
 /**
  * Evaluate probability density function of given observation.
  *
- * @param observation point to evaluate probability at.
+ * @param observation Point to evaluate probability at.
  */
 double RegressionDistribution::Probability(const arma::vec& observation) const
 {

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -102,7 +102,7 @@ class RegressionDistribution
    * Estimate parameters using provided observation weights.
    *
    * @param observations List of observations.
-   * @param weights probability that given observation is from distribution.
+   * @param weights Probability that given observation is from distribution.
    */
   mlpack_deprecated void Train(const arma::mat& observations,
                                const arma::vec& weights);
@@ -111,21 +111,21 @@ class RegressionDistribution
    * Estimate parameters using provided observation weights.
    *
    * @param observations List of observations.
-   * @param weights probability that given observation is from distribution.
+   * @param weights Probability that given observation is from distribution.
    */
   void Train(const arma::mat& observations, const arma::rowvec& weights);
 
   /**
   * Evaluate probability density function of given observation.
   *
-  * @param observation point to evaluate probability at.
+  * @param observation Point to evaluate probability at.
   */
   double Probability(const arma::vec& observation) const;
 
   /**
   * Evaluate log probability density function of given observation.
   *
-  * @param observation point to evaluate log probability at.
+  * @param observation Point to evaluate log probability at.
   */
   double LogProbability(const arma::vec& observation) const
   { return log(Probability(observation)); }
@@ -133,8 +133,8 @@ class RegressionDistribution
   /**
    * Calculate y_i for each data point in points.
    *
-   * @param points the data points to calculate with.
-   * @param predictions y, will contain calculated values on completion.
+   * @param points The data points to calculate with.
+   * @param predictions Y, will contain calculated values on completion.
    */
   mlpack_deprecated void Predict(const arma::mat& points,
                                  arma::vec& predictions) const;
@@ -142,8 +142,8 @@ class RegressionDistribution
   /**
    * Calculate y_i for each data point in points.
    *
-   * @param points the data points to calculate with.
-   * @param predictions y, will contain calculated values on completion.
+   * @param points The data points to calculate with.
+   * @param predictions Y, will contain calculated values on completion.
    */
   void Predict(const arma::mat& points, arma::rowvec& predictions) const;
 

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -2,7 +2,8 @@
  * @file regression_distribution.hpp
  * @author Michael Fox
  *
- * Implementation of conditional Gaussian distribution for HMM regression (HMMR)
+ * Implementation of conditional Gaussian distribution for HMM regression
+ * (HMMR).
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -98,35 +99,36 @@ class RegressionDistribution
   void Train(const arma::mat& observations);
 
   /**
-   * Estimate parameters using provided observation weights
+   * Estimate parameters using provided observation weights.
    *
-   * @param weights probability that given observation is from distribution
+   * @param observations List of observations.
+   * @param weights probability that given observation is from distribution.
    */
   mlpack_deprecated void Train(const arma::mat& observations,
                                const arma::vec& weights);
 
   /**
-   * Estimate parameters using provided observation weights
+   * Estimate parameters using provided observation weights.
    *
-   * @param weights probability that given observation is from distribution
+   * @param observations List of observations.
+   * @param weights probability that given observation is from distribution.
    */
   void Train(const arma::mat& observations, const arma::rowvec& weights);
 
   /**
-  * Evaluate probability density function of given observation
+  * Evaluate probability density function of given observation.
   *
-  * @param observation point to evaluate probability at
+  * @param observation point to evaluate probability at.
   */
   double Probability(const arma::vec& observation) const;
 
   /**
-  * Evaluate log probability density function of given observation
+  * Evaluate log probability density function of given observation.
   *
-  * @param observation point to evaluate log probability at
+  * @param observation point to evaluate log probability at.
   */
-  double LogProbability(const arma::vec& observation) const {
-    return log(Probability(observation));
-  }
+  double LogProbability(const arma::vec& observation) const
+  { return log(Probability(observation)); }
 
   /**
    * Calculate y_i for each data point in points.
@@ -148,7 +150,7 @@ class RegressionDistribution
   //! Return the parameters (the b vector).
   const arma::vec& Parameters() const { return rf.Parameters(); }
 
-  //! Return the dimensionality
+  //! Return the dimensionality.
   size_t Dimensionality() const { return rf.Parameters().n_elem; }
 };
 

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -116,17 +116,17 @@ class RegressionDistribution
   void Train(const arma::mat& observations, const arma::rowvec& weights);
 
   /**
-  * Evaluate probability density function of given observation.
-  *
-  * @param observation Point to evaluate probability at.
-  */
+   * Evaluate probability density function of given observation.
+   *
+   * @param observation Point to evaluate probability at.
+   */
   double Probability(const arma::vec& observation) const;
 
   /**
-  * Evaluate log probability density function of given observation.
-  *
-  * @param observation Point to evaluate log probability at.
-  */
+   * Evaluate log probability density function of given observation.
+   *
+   * @param observation Point to evaluate log probability at.
+   */
   double LogProbability(const arma::vec& observation) const
   { return log(Probability(observation)); }
 

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -128,7 +128,9 @@ class RegressionDistribution
    * @param observation Point to evaluate log probability at.
    */
   double LogProbability(const arma::vec& observation) const
-  { return log(Probability(observation)); }
+  {
+    return log(Probability(observation));
+  }
 
   /**
    * Calculate y_i for each data point in points.

--- a/src/mlpack/methods/gmm/em_fit.hpp
+++ b/src/mlpack/methods/gmm/em_fit.hpp
@@ -56,9 +56,8 @@ class EMFit
    *
    * @param maxIterations Maximum number of iterations for EM.
    * @param tolerance Log-likelihood tolerance required for convergence.
-   * @param forcePositive Check for positive-definiteness of each covariance
-   *     matrix at each iteration.
    * @param clusterer Object which will perform the initial clustering.
+   * @param constraint Constraint policy of covariance.
    */
   EMFit(const size_t maxIterations = 300,
         const double tolerance = 1e-10,

--- a/src/mlpack/methods/gmm/gmm.hpp
+++ b/src/mlpack/methods/gmm/gmm.hpp
@@ -190,7 +190,7 @@ class GMM
    * @param component Index of the component of the GMM to be considered.
    */
   double LogProbability(const arma::vec& observation,
-                     const size_t component) const;
+                        const size_t component) const;
   /**
    * Return a randomly generated observation according to the probability
    * distribution defined by this object.

--- a/src/mlpack/methods/gmm/gmm.hpp
+++ b/src/mlpack/methods/gmm/gmm.hpp
@@ -140,14 +140,14 @@ class GMM
   /**
    * Return a const reference to a component distribution.
    *
-   * @param i index of component.
+   * @param i Index of component.
    */
   const distribution::GaussianDistribution& Component(size_t i) const {
       return dists[i]; }
   /**
    * Return a reference to a component distribution.
    *
-   * @param i index of component.
+   * @param i Index of component.
    */
   distribution::GaussianDistribution& Component(size_t i) { return dists[i]; }
 


### PR DESCRIPTION
I noticed some functions don't synchronize parameter's name with `@param` in documents of `src/mlpack/core/dists` and `src/mlpack/methods/gmm/`. Also, I edited some files to comply with the style guidelines.