### PR TITLE
Added Regex for quoted strings in LoadCSV (#1754) (#1725).

### DIFF
--- a/src/mlpack/core/data/load_csv.cpp
+++ b/src/mlpack/core/data/load_csv.cpp
@@ -25,7 +25,7 @@ LoadCSV::LoadCSV(const std::string& file) :
   CheckOpen();
 
   // Set rules.
-  if (extension == "csv" || extension == "txt")
+  if (extension == "csv")
   {
     // Match quoted strings as: "string" or 'string'
     // Match all characters that are not ',', '\r', or '\n'.
@@ -34,6 +34,10 @@ LoadCSV::LoadCSV(const std::string& file) :
                          (qi::char_('"') >> *((qi::char_ - '"') |
                                  '"' >> qi::char_('"')) >> '"') |
                          *~qi::char_(",\r\n")];
+  }
+  else if(extension == "txt"){
+    // Match all characters that are not ',', '\r', or '\n'.
+    stringRule = qi::raw[*~qi::char_(" ,\r\n")]; 
   }
   else
   {
@@ -81,3 +85,4 @@ void LoadCSV::CheckOpen()
 
 } // namespace data
 } // namespace mlpack
+

--- a/src/mlpack/core/data/load_csv.cpp
+++ b/src/mlpack/core/data/load_csv.cpp
@@ -27,13 +27,23 @@ LoadCSV::LoadCSV(const std::string& file) :
   // Set rules.
   if (extension == "csv" || extension == "txt")
   {
+    // Match quoted strings as: "string" or 'string'
     // Match all characters that are not ',', '\r', or '\n'.
-    stringRule = qi::raw[*~qi::char_(" ,\r\n")];
+    stringRule = qi::raw[(qi::char_("'") >> *((qi::char_ - "'") |
+                                 "'" >> qi::char_("'")) >> "'") |
+                         (qi::char_('"') >> *((qi::char_ - '"') |
+                                 '"' >> qi::char_('"')) >> '"') |
+                         *~qi::char_(",\r\n")];
   }
   else
   {
+    // Match quoted strings as: "string" or 'string'
     // Match all characters that are not '\t', '\r', or '\n'.
-    stringRule = qi::raw[*~qi::char_(" \t\r\n")];
+    stringRule = qi::raw[(qi::char_("'") >> *((qi::char_ - "'") |
+                                 "'" >> qi::char_("'")) >> "'") |
+                         (qi::char_('"') >> *((qi::char_ - '"') |
+                                 '"' >> qi::char_('"')) >> '"') |
+                         *~qi::char_("\t\r\n")];
   }
 
   if (extension == "csv")


### PR DESCRIPTION

Added Regex for quoted strings so that LoadCSV along with mlpack::data::DatasetInfo cab load text from CSV files.
Resolves #1754 and also helps in issue #1725.

|    |                               |        | 
|----|-------------------------------|--------| 
| 1  | row 2                         | row 3  | 
| 2  | "row 2, with comma"           | row 3  | 
| 3  | row 2 with \"embedded quote\" | row 3  | 
| 4  |  row 2 with \n new line       | row 3  | 
| 5  |  row 2 with embedded \\       | row 3  | 
| 11 |                               | row 33 | 

```c
std::cout << "Data :" << std::endl;
for (size_t i = 0;i<dataset.n_cols;i++){
    std::cout<<dataset.at(0,i)<<"\t";
    for (size_t j = 1; j < info.Dimensionality(); ++j)
        std::cout<<info.UnmapString(dataset.at(j,i),j,0)<<"\t" ;
    std::cout<<std::endl;
}
```

For the csv file the above snippet initially produces:
```
Data :
1       row
2       "row
3       row
4       row
5       row
11
```
Now  produces:
```
Data :
1       row 2   row 3   
2       "row 2, with comma"     row 3   
3       row 2 with \"embedded quote\"   row 3   
4       row 2 with \n new line  row 3   
5       row 2 with embedded \\  row 3   
11              row 33  
```

Full code for the above snippet is [here](https://pastebin.com/xGnPQmDi).
