### PR TITLE
fix typo in negative_log_likelihood

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -40,7 +40,7 @@ class NegativeLogLikelihood
    */
   NegativeLogLikelihood();
 
-  /*
+  /**
    * Computes the Negative log likelihood.
    *
    * @param input Input data used for evaluating the specified function.
@@ -52,7 +52,7 @@ class NegativeLogLikelihood
 
   /**
    * Ordinary feed backward pass of a neural network. The negative log
-   * likelihood layer expectes that the input contains log-probabilities for
+   * likelihood layer expects that the input contains log-probabilities for
    * each class. The layer also expects a class index, in the range between 1
    * and the number of classes, as target when calling the Forward function.
    *


### PR DESCRIPTION
As mentioned, fix typo in negative_log_likelihood. 

The consistency of interface, I found that there are two interfaces in negative_log_likelihood.hpp
```c++
  //! Get the input parameter.
  InputDataType& InputParameter() const { return inputParameter; }
  //! Modify the input parameter.
  InputDataType& InputParameter() { return inputParameter; }
```
But in some other loss function, they have not. Shall we just keep it or remove?  Literally, it didn't affect the functionality.


