### PR TITLE
Make models more accessible in Python (#1709)

### DIFF
--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -85,6 +85,7 @@ set(CYTHON_SOURCES
   mlpack/matrix_utils.py
   mlpack/serialization.hpp
   mlpack/serialization.pxd
+  mlpack/pythonize_model.py
 )
 
 set(TEST_SOURCES

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -91,6 +91,7 @@ set(CYTHON_SOURCES
 set(TEST_SOURCES
   tests/dataset_info_test.py
   tests/test_python_binding.py
+  tests/test_python_interpretation.py
 )
 
 # Set the include directories correctly.

--- a/src/mlpack/bindings/python/mlpack/pythonize_model.py
+++ b/src/mlpack/bindings/python/mlpack/pythonize_model.py
@@ -16,92 +16,92 @@ from collections import defaultdict
 from xml.etree import cElementTree as ET
 
 def etree_to_dict(t, attrib = False):
-    """
-    Convert ElementTree to python dict.
-    """
-    d = {t.tag: {} if t.attrib else None}
-    children = list(t)
-    if children:
-        dd = defaultdict(list)
-        for dc in map(etree_to_dict, children):
-            for k, v in dc.items():
-                dd[k].append(v)
-        d = {t.tag: {k:v[0] if len(v) == 1 else v for k, v in dd.items()}}
-    if t.attrib and attrib:
-        d[t.tag].update(('@' + k, v) for k, v in t.attrib.items())
-    if t.text:
-        text = t.text.strip()
-        if children or t.attrib:
-            if text:
-              d[t.tag]['#text'] = text
-        else:
-            d[t.tag] = text
-    return d
+  """
+  Convert ElementTree to python dict.
+  """
+  d = {t.tag: {} if t.attrib else None}
+  children = list(t)
+  if children:
+    dd = defaultdict(list)
+    for dc in map(etree_to_dict, children):
+      for k, v in dc.items():
+        dd[k].append(v)
+    d = {t.tag: {k:v[0] if len(v) == 1 else v for k, v in dd.items()}}
+  if t.attrib and attrib:
+    d[t.tag].update(('@' + k, v) for k, v in t.attrib.items())
+  if t.text:
+    text = t.text.strip()
+    if children or t.attrib:
+      if text:
+        d[t.tag]['#text'] = text
+    else:
+      d[t.tag] = text
+  return d
 
 # Vector state mapping.
 vec_state = {0: "matrix", 1: "column vector", 2: "row vector"}
 
 def recursive_transform(json):
-    """
-    Recursiely traverse and convert array to numpy
-    std::pair<> to python tuple().
-    """
-    # Check if the parameter is dict.
-    if type(json).__name__ == 'dict':
-        keys = list(json.keys())
+  """
+  Recursiely traverse and convert array to numpy
+  std::pair<> to python tuple().
+  """
+  # Check if the parameter is dict.
+  if type(json).__name__ == 'dict':
+    keys = list(json.keys())
 
-        # Check if serialized object was a std::pair<>, std::unordered_map.
-        if any(key in keys for key in ['first', 'second']):
-            pair = (recursive_transform(json['first']), recursive_transform(json['second']))
-            for key in ['first', 'second']:
-                del json[key]
-            return pair
+    # Check if serialized object was a std::pair<>, std::unordered_map.
+    if any(key in keys for key in ['first', 'second']):
+      pair = (recursive_transform(json['first']), recursive_transform(json['second']))
+      for key in ['first', 'second']:
+        del json[key]
+      return pair
 
-        # Check if the field containns Armadillo serialization numbers.
-        if any(key in keys for key in ['n_cols', 'n_rows', 'n_elem']):
-            if 'item' in keys:
-                json['item'] = np.array(map(float, json['item']))
-            try:
-                json['vec_state'] = vec_state[int(json['vec_state'])]
-            except Exception as e:
-                print(e, 'Vec state :%d, not known'%(int(json['vec_state'])))
+    # Check if the field containns Armadillo serialization numbers.
+    if any(key in keys for key in ['n_cols', 'n_rows', 'n_elem']):
+      if 'item' in keys:
+        json['item'] = np.array(map(float, json['item']))
+      try:
+        json['vec_state'] = vec_state[int(json['vec_state'])]
+      except Exception as e:
+        print(e, 'Vec state :%d, not known'%(int(json['vec_state'])))
 
-        # Recursively call on the keys.
-        for key in keys:
-            json[key] = recursive_transform(json[key])
+    # Recursively call on the keys.
+    for key in keys:
+      json[key] = recursive_transform(json[key])
 
-    # Check if the parameter is list.
-    elif type(json).__name__ == 'list':
-        item_list = []
-        for x in json:
-            item_list.append(recursive_transform(x))
-        return item_list
+  # Check if the parameter is list.
+  elif type(json).__name__ == 'list':
+    item_list = []
+    for x in json:
+      item_list.append(recursive_transform(x))
+    return item_list
 
-    # The paramter is an item/value.
-    else:
-        try:
-            # Convert to float if some numeric data is found.
-            json = float(json)
-        except Exception as e:
-            pass
-    return json
+  # The paramter is an item/value.
+  else:
+    try:
+      # Convert to float if some numeric data is found.
+      json = float(json)
+    except Exception as e:
+      pass
+  return json
 
 def transform(model):
-    """
-    Extract serialized information for model.
-    """
-    try:
-        if type(model).__name__ != 'str':
-            # Get the boost serializaled xml.
-            model = model.__getparams__()
-    except Exception as e:
-        raise e
+  """
+  Extract serialized information for model.
+  """
+  try:
+    if type(model).__name__ != 'str':
+      # Get the boost serializaled xml.
+      model = model.__getparams__()
+  except Exception as e:
+    raise e
 
-    # Get the xml tree.
-    tree = ET.XML(model)
+  # Get the xml tree.
+  tree = ET.XML(model)
 
-    # Convert the XML tree to python dict.
-    model_dict = etree_to_dict(tree)
-    model_dict = model_dict[model_dict.keys()[0]]
-    model_dict = model_dict[model_dict.keys()[0]]
-    return recursive_transform(model_dict)
+  # Convert the XML tree to python dict.
+  model_dict = etree_to_dict(tree)
+  model_dict = model_dict[model_dict.keys()[0]]
+  model_dict = model_dict[model_dict.keys()[0]]
+  return recursive_transform(model_dict)

--- a/src/mlpack/bindings/python/mlpack/pythonize_model.py
+++ b/src/mlpack/bindings/python/mlpack/pythonize_model.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Utilities for model parameters extraction.
+#
+# @file pythonize_model.py
+# @author Mehul Kumar Nirala
+#
+# mlpack is free software; you may redistribute it and/or modify it under the
+# terms of the 3-clause BSD license.  You should have received a copy of the
+# 3-clause BSD license along with mlpack.  If not, see
+# http://www.opensource.org/licenses/BSD-3-Clause for more information.
+
+
+import numpy as np
+from collections import defaultdict
+from xml.etree import cElementTree as ET
+
+def etree_to_dict(t, attrib = False):
+    d = {t.tag: {} if t.attrib else None}
+    children = list(t)
+    if children:
+        dd = defaultdict(list)
+        for dc in map(etree_to_dict, children):
+            for k, v in dc.items():
+                dd[k].append(v)
+        d = {t.tag: {k:v[0] if len(v) == 1 else v for k, v in dd.items()}}
+    if t.attrib and attrib:
+        d[t.tag].update(('@' + k, v) for k, v in t.attrib.items())
+    if t.text:
+        text = t.text.strip()
+        if children or t.attrib:
+            if text:
+              d[t.tag]['#text'] = text
+        else:
+            d[t.tag] = text
+    return d
+
+def xml_to_dict(s):
+    tree = ET.XML(s)
+    d = etree_to_dict(tree)
+    d = d[d.keys()[0]]
+    d = d[d.keys()[0]]
+    return d
+
+def transform(model):
+    result = {}
+    try:
+        if type(model).__name__ != 'str':
+            model = model.__getparams__()
+    except Exception as e:
+        raise e
+    
+    model_dict = xml_to_dict(model)
+
+    # network parameters
+    try:
+        result["parameters"] = model_dict["parameters"]["item"]
+    except Exception as e:
+        try:
+            result["parameters"] = model_dict["parameters"]
+        except Exception as e:
+            raise e
+    result['parameters'] = np.array(map(float,result['parameters']))
+
+    # looking for other parameters
+    for param in model_dict:
+        # remove attributes and 'parameters'
+        if ('parameters' == param):
+            continue
+        result[param] = model_dict[param]
+
+    return result

--- a/src/mlpack/bindings/python/mlpack/pythonize_model.py
+++ b/src/mlpack/bindings/python/mlpack/pythonize_model.py
@@ -102,6 +102,6 @@ def transform(model):
 
   # Convert the XML tree to python dict.
   model_dict = etree_to_dict(tree)
-  model_dict = model_dict[model_dict.keys()[0]]
-  model_dict = model_dict[model_dict.keys()[0]]
+  model_dict = model_dict[list(model_dict.keys())[0]]
+  model_dict = model_dict[list(model_dict.keys())[0]]
   return recursive_transform(model_dict)

--- a/src/mlpack/bindings/python/mlpack/pythonize_model.py
+++ b/src/mlpack/bindings/python/mlpack/pythonize_model.py
@@ -16,6 +16,9 @@ from collections import defaultdict
 from xml.etree import cElementTree as ET
 
 def etree_to_dict(t, attrib = False):
+    """
+    Convert ElementTree to python dict.
+    """
     d = {t.tag: {} if t.attrib else None}
     children = list(t)
     if children:
@@ -35,38 +38,70 @@ def etree_to_dict(t, attrib = False):
             d[t.tag] = text
     return d
 
-def xml_to_dict(s):
-    tree = ET.XML(s)
-    d = etree_to_dict(tree)
-    d = d[d.keys()[0]]
-    d = d[d.keys()[0]]
-    return d
+# Vector state mapping.
+vec_state = {0: "matrix", 1: "column vector", 2: "row vector"}
+
+def recursive_transform(json):
+    """
+    Recursiely traverse and convert array to numpy
+    std::pair<> to python tuple().
+    """
+    # Check if the parameter is dict.
+    if type(json).__name__ == 'dict':
+        keys = list(json.keys())
+
+        # Check if serialized object was a std::pair<>, std::unordered_map.
+        if any(key in keys for key in ['first', 'second']):
+            pair = (recursive_transform(json['first']), recursive_transform(json['second']))
+            for key in ['first', 'second']:
+                del json[key]
+            return pair
+
+        # Check if the field containns Armadillo serialization numbers.
+        if any(key in keys for key in ['n_cols', 'n_rows', 'n_elem']):
+            if 'item' in keys:
+                json['item'] = np.array(map(float, json['item']))
+            try:
+                json['vec_state'] = vec_state[int(json['vec_state'])]
+            except Exception as e:
+                print(e, 'Vec state :%d, not known'%(int(json['vec_state'])))
+
+        # Recursively call on the keys.
+        for key in keys:
+            json[key] = recursive_transform(json[key])
+
+    # Check if the parameter is list.
+    elif type(json).__name__ == 'list':
+        item_list = []
+        for x in json:
+            item_list.append(recursive_transform(x))
+        return item_list
+
+    # The paramter is an item/value.
+    else:
+        try:
+            # Convert to float if some numeric data is found.
+            json = float(json)
+        except Exception as e:
+            pass
+    return json
 
 def transform(model):
-    result = {}
+    """
+    Extract serialized information for model.
+    """
     try:
         if type(model).__name__ != 'str':
+            # Get the boost serializaled xml.
             model = model.__getparams__()
     except Exception as e:
         raise e
-    
-    model_dict = xml_to_dict(model)
 
-    # network parameters
-    try:
-        result["parameters"] = model_dict["parameters"]["item"]
-    except Exception as e:
-        try:
-            result["parameters"] = model_dict["parameters"]
-        except Exception as e:
-            raise e
-    result['parameters'] = np.array(map(float,result['parameters']))
+    # Get the xml tree.
+    tree = ET.XML(model)
 
-    # looking for other parameters
-    for param in model_dict:
-        # remove attributes and 'parameters'
-        if ('parameters' == param):
-            continue
-        result[param] = model_dict[param]
-
-    return result
+    # Convert the XML tree to python dict.
+    model_dict = etree_to_dict(tree)
+    model_dict = model_dict[model_dict.keys()[0]]
+    model_dict = model_dict[model_dict.keys()[0]]
+    return recursive_transform(model_dict)

--- a/src/mlpack/bindings/python/mlpack/serialization.hpp
+++ b/src/mlpack/bindings/python/mlpack/serialization.hpp
@@ -31,7 +31,7 @@ std::string SerializeOut(T* t, const std::string& name)
 }
 
 template<typename T>
-std::string SerializeParamsOut(T* t, const std::string& name)
+std::string SerializeToXML(T* t, const std::string& name)
 {
   std::ostringstream oss;
   {

--- a/src/mlpack/bindings/python/mlpack/serialization.hpp
+++ b/src/mlpack/bindings/python/mlpack/serialization.hpp
@@ -31,6 +31,17 @@ std::string SerializeOut(T* t, const std::string& name)
 }
 
 template<typename T>
+std::string SerializeParamsOut(T* t, const std::string& name)
+{
+  std::ostringstream oss;
+  {
+    boost::archive::xml_oarchive oa(oss);
+    oa << BOOST_SERIALIZATION_NVP(t);
+  }
+  return oss.str();
+}
+
+template<typename T>
 void SerializeIn(T* t, const std::string& str, const std::string& name)
 {
   std::istringstream iss(str);

--- a/src/mlpack/bindings/python/mlpack/serialization.pxd
+++ b/src/mlpack/bindings/python/mlpack/serialization.pxd
@@ -11,5 +11,5 @@ from libcpp.string cimport string
 
 cdef extern from "serialization.hpp" namespace "mlpack::bindings::python" nogil:
   string SerializeOut[T](T* t, string name) nogil
-  string SerializeParamsOut[T](T* t, string name) nogil
+  string SerializeToXML[T](T* t, string name) nogil
   void SerializeIn[T](T* t, string str, string name) nogil

--- a/src/mlpack/bindings/python/mlpack/serialization.pxd
+++ b/src/mlpack/bindings/python/mlpack/serialization.pxd
@@ -11,4 +11,5 @@ from libcpp.string cimport string
 
 cdef extern from "serialization.hpp" namespace "mlpack::bindings::python" nogil:
   string SerializeOut[T](T* t, string name) nogil
+  string SerializeParamsOut[T](T* t, string name) nogil
   void SerializeIn[T](T* t, string str, string name) nogil

--- a/src/mlpack/bindings/python/print_class_defn.hpp
+++ b/src/mlpack/bindings/python/print_class_defn.hpp
@@ -98,6 +98,10 @@ void PrintClassDefn(
   std::cout << "    return (self.__class__, (), self.__getstate__())"
       << std::endl;
   std::cout << std::endl;
+  std::cout << "  def __getparams__(self):" << std::endl;
+  std::cout << "    return SerializeParamsOut(self.modelptr, \"" << printedType
+      << "\")" << std::endl;
+  std::cout << std::endl;
 }
 
 /**

--- a/src/mlpack/bindings/python/print_class_defn.hpp
+++ b/src/mlpack/bindings/python/print_class_defn.hpp
@@ -99,7 +99,7 @@ void PrintClassDefn(
       << std::endl;
   std::cout << std::endl;
   std::cout << "  def __getparams__(self):" << std::endl;
-  std::cout << "    return SerializeParamsOut(self.modelptr, \"" << printedType
+  std::cout << "    return SerializeToXML(self.modelptr, \"" << printedType
       << "\")" << std::endl;
   std::cout << std::endl;
 }

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -82,7 +82,7 @@ void PrintPYX(const ProgramDoc& programInfo,
       << "ResetTimers, EnableTimers" << endl;
   cout << "from matrix_utils import to_matrix, to_matrix_with_info" << endl;
   cout << "from serialization cimport SerializeIn, SerializeOut, "
-      << "SerializeParamsOut" << endl;
+      << "SerializeToXML" << endl;
   cout << endl;
   cout << "import numpy as np" << endl;
   cout << "cimport numpy as np" << endl;

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -81,7 +81,8 @@ void PrintPYX(const ProgramDoc& programInfo,
   cout << "from cli cimport EnableVerbose, DisableVerbose, DisableBacktrace, "
       << "ResetTimers, EnableTimers" << endl;
   cout << "from matrix_utils import to_matrix, to_matrix_with_info" << endl;
-  cout << "from serialization cimport SerializeIn, SerializeOut, SerializeParamsOut" << endl;
+  cout << "from serialization cimport SerializeIn, SerializeOut, "
+      << "SerializeParamsOut" << endl;
   cout << endl;
   cout << "import numpy as np" << endl;
   cout << "cimport numpy as np" << endl;

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -81,7 +81,7 @@ void PrintPYX(const ProgramDoc& programInfo,
   cout << "from cli cimport EnableVerbose, DisableVerbose, DisableBacktrace, "
       << "ResetTimers, EnableTimers" << endl;
   cout << "from matrix_utils import to_matrix, to_matrix_with_info" << endl;
-  cout << "from serialization cimport SerializeIn, SerializeOut" << endl;
+  cout << "from serialization cimport SerializeIn, SerializeOut, SerializeParamsOut" << endl;
   cout << endl;
   cout << "import numpy as np" << endl;
   cout << "cimport numpy as np" << endl;

--- a/src/mlpack/bindings/python/tests/CMakeLists.txt
+++ b/src/mlpack/bindings/python/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 # Add the Python binding test.
 add_python_binding(test_python_binding)
+add_python_binding(test_python_interpretation)

--- a/src/mlpack/bindings/python/tests/CMakeLists.txt
+++ b/src/mlpack/bindings/python/tests/CMakeLists.txt
@@ -1,3 +1,2 @@
 # Add the Python binding test.
 add_python_binding(test_python_binding)
-add_python_binding(test_python_interpretation)

--- a/src/mlpack/bindings/python/tests/test_python_interpretation.py
+++ b/src/mlpack/bindings/python/tests/test_python_interpretation.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+@file test_python_model.py
+@author Mehul Kumar Nirala
+
+Test that python interpretation of mlpack models works successfully.
+
+mlpack is free software; you may redistribute it and/or modify it under the
+terms of the 3-clause BSD license.  You should have received a copy of the
+3-clause BSD license along with mlpack.  If not, see
+http://www.opensource.org/licenses/BSD-3-Clause for more information.
+"""
+import unittest
+import pandas as pd
+import numpy as np
+from mlpack import logistic_regression, perceptron
+from mlpack import pythonize_model
+
+# Fake test data
+x = np.random.rand(10,10)
+y = [1,0,1,0,1,0,1,0,0,0]
+
+class TestPythonInterpretation(unittest.TestCase):
+  """
+  This class tests the basic functionality of the Python interpretation model.
+  """
+
+  def testRunForLogisticPerceptron(self):
+    """
+    Test the output parameters for Perceptron.
+    """
+    output = perceptron(labels=y, training=x)
+    python_interpretation = pythonize_model.transform(output['output_model'])
+
+    weights = python_interpretation['p']['weights']
+    biases = python_interpretation['p']['biases']
+
+    self.assertEqual(len(weights['item']), 20)
+    self.assertEqual(len(biases['item']), 2)
+    self.assertEqual(weights['vec_state'], 'matrix')
+    self.assertEqual(weights['n_elem'], 2.0 * 10.0)
+    self.assertEqual(weights['n_cols'], 2.0)
+    self.assertEqual(weights['n_rows'], 10.0)
+    self.assertEqual(biases['vec_state'], 'column vector')
+    self.assertEqual(biases['n_elem'], 1.0 * 2.0)
+    self.assertEqual(biases['n_cols'], 1.0)
+    self.assertEqual(biases['n_rows'], 2.0)
+
+  def testRunForLogisticRegression(self):
+    """
+    Test the output parameters for Lgistic Regression.
+    """
+    output = logistic_regression(labels=y, training=x)
+    python_interpretation = pythonize_model.transform(output['output_model'])
+    weights = python_interpretation['parameters']['item']
+    self.assertEqual(len(weights), 11)
+    self.assertEqual(python_interpretation['parameters']['n_cols'], 11.0)
+    self.assertEqual(python_interpretation['parameters']['n_rows'], 1.0)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/src/mlpack/bindings/python/tests/test_python_interpretation.py
+++ b/src/mlpack/bindings/python/tests/test_python_interpretation.py
@@ -35,8 +35,8 @@ class TestPythonInterpretation(unittest.TestCase):
     weights = python_interpretation['p']['weights']
     biases = python_interpretation['p']['biases']
 
-    self.assertEqual(len(weights['item']), 20)
-    self.assertEqual(len(biases['item']), 2)
+    self.assertEqual(weights['item'].shape[0], 20)
+    self.assertEqual(biases['item'].shape[0], 2)
     self.assertEqual(weights['vec_state'], 'matrix')
     self.assertEqual(weights['n_elem'], 2.0 * 10.0)
     self.assertEqual(weights['n_cols'], 2.0)
@@ -53,7 +53,7 @@ class TestPythonInterpretation(unittest.TestCase):
     output = logistic_regression(labels=y, training=x)
     python_interpretation = pythonize_model.transform(output['output_model'])
     weights = python_interpretation['parameters']['item']
-    self.assertEqual(len(weights), 11)
+    self.assertEqual(weights.shape[0], 11)
     self.assertEqual(python_interpretation['parameters']['n_cols'], 11.0)
     self.assertEqual(python_interpretation['parameters']['n_rows'], 1.0)
 


### PR DESCRIPTION
 Make models more accessible in Python #1709  . Added SerializeParamOut with boost xml_archive. 
This PR removes xml2json dependency in #1734 . I will close #1734 .

```python
>>> import numpy as np
>>> from mlpack import pythonize_model 
>>> from mlpack import logistic_regression

>>> x = np.random.rand(10,10)
>>> y = [1,0,1,0,1,0,1,0,0,0]

>>> output = logistic_regression(training=x,labels=y)
>>> pythonize_model.transform(output['output_model'])

{'parameters': array([  7.14841847,  72.40319186, -22.58314159,  40.70852354,
       -27.78725555, -75.40210697,  29.39998803,  14.44999113,
       -60.09246953,  18.63193182, -17.18063739]), 'lambda': 0}
```