### PR TITLE
Remove Inline Implimentation

### DIFF
--- a/src/mlpack/core/dists/discrete_distribution.hpp
+++ b/src/mlpack/core/dists/discrete_distribution.hpp
@@ -192,7 +192,13 @@ class DiscreteDistribution
    * @param logProbabilities Output log-probabilities for each input
    *   observation.
    */
-  void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const;
+  void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const
+  {
+    logProbabilities.set_size(x.n_cols);
+    for (size_t i = 0; i < x.n_cols; i++)
+      logProbabilities(i) = log(Probability(x.unsafe_col(i)));
+  }
+
   /**
    * Return a randomly generated observation (one-dimensional vector; one
    * observation) according to the probability distribution defined by this
@@ -243,22 +249,6 @@ class DiscreteDistribution
   //! probabilities for the observations in each dimension.
   std::vector<arma::vec> probabilities;
 };
-
-/**
- * Calculates the Discrete log-probability function for each
- * data point (column) in the given matrix.
- *
- * @param x List of observations.
- * @param logProbabilities Output log probabilities for each input observation.
- */
-inline void DiscreteDistribution::LogProbability(
-    const arma::mat& x,
-    arma::vec& logProbabilities) const
-{
-  logProbabilities.set_size(x.n_cols);
-  for (size_t i = 0; i < x.n_cols; i++)
-    logProbabilities(i) = log(Probability(x.unsafe_col(i)));
-}
 
 } // namespace distribution
 } // namespace mlpack

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -103,7 +103,24 @@ class GaussianDistribution
    * @param logProbabilities Output log probabilities for each input
    *     observation.
    */
-  void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const;
+  void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const
+  {
+    // Column i of 'diffs' is the difference between x.col(i) and the mean.
+    arma::mat diffs = x - (mean * arma::ones<arma::rowvec>(x.n_cols));
+
+    // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1 *
+    // diffs).  We just don't need any of the other elements.  We can calculate
+    // the right hand part of the equation (instead of the left side) so that
+    // later we are referencing columns, not rows -- that is faster.
+    const arma::mat rhs = -0.5 * invCov * diffs;
+    arma::vec logExponents(diffs.n_cols); // We will now fill this.
+    for (size_t i = 0; i < diffs.n_cols; i++)
+      logExponents(i) = accu(diffs.unsafe_col(i) % rhs.unsafe_col(i));
+
+    const size_t k = x.n_rows;
+
+    logProbabilities = -0.5 * k * log2pi - 0.5 * logDetCov + logExponents;
+  }
 
   /**
    * Return a randomly generated observation according to the probability
@@ -172,35 +189,6 @@ class GaussianDistribution
    */
   void FactorCovariance();
 };
-
-/**
- * Calculates the multivariate Gaussian Log probability density function for
- * each data point (column) in the given matrix.
- *
- * @param x List of observations.
- * @param logProbabilities Output log probabilities for each input observation.
- */
-inline void GaussianDistribution::LogProbability(
-    const arma::mat& x,
-    arma::vec& logProbabilities) const
-{
-  // Column i of 'diffs' is the difference between x.col(i) and the mean.
-  arma::mat diffs = x - (mean * arma::ones<arma::rowvec>(x.n_cols));
-
-  // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1 *
-  // diffs).  We just don't need any of the other elements.  We can calculate
-  // the right hand part of the equation (instead of the left side) so that
-  // later we are referencing columns, not rows -- that is faster.
-  const arma::mat rhs = -0.5 * invCov * diffs;
-  arma::vec logExponents(diffs.n_cols); // We will now fill this.
-  for (size_t i = 0; i < diffs.n_cols; i++)
-    logExponents(i) = accu(diffs.unsafe_col(i) % rhs.unsafe_col(i));
-
-  const size_t k = x.n_rows;
-
-  logProbabilities = -0.5 * k * log2pi - 0.5 * logDetCov + logExponents;
-}
-
 
 } // namespace distribution
 } // namespace mlpack

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -108,10 +108,10 @@ class GaussianDistribution
     // Column i of 'diffs' is the difference between x.col(i) and the mean.
     arma::mat diffs = x - (mean * arma::ones<arma::rowvec>(x.n_cols));
 
-    // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1 *
-    // diffs).  We just don't need any of the other elements.  We can calculate
-    // the right hand part of the equation (instead of the left side) so that
-    // later we are referencing columns, not rows -- that is faster.
+    // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1
+    // * diffs).  We just don't need any of the other elements.  We can
+    // calculate the right hand part of the equation (instead of the left side)
+    // so that later we are referencing columns, not rows -- that is faster.
     const arma::mat rhs = -0.5 * invCov * diffs;
     arma::vec logExponents(diffs.n_cols); // We will now fill this.
     for (size_t i = 0; i < diffs.n_cols; i++)

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -108,8 +108,8 @@ class GaussianDistribution
   void LogProbability(const arma::mat& x, arma::vec& logProbabilities) const
   {
     // Column i of 'diffs' is the difference between x.col(i) and the mean.
-    arma::mat diffs = x - (mean * arma::ones<arma::rowvec>(x.n_cols));
-
+    arma::mat diffs = x;
+    diffs.each_col() -= mean;
     // Now, we only want to calculate the diagonal elements of (diffs' * cov^-1
     // * diffs).  We just don't need any of the other elements.  We can
     // calculate the right hand part of the equation (instead of the left side)

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -119,9 +119,8 @@ class GaussianDistribution
     for (size_t i = 0; i < diffs.n_cols; i++)
       logExponents(i) = accu(diffs.unsafe_col(i) % rhs.unsafe_col(i));
 
-    const size_t k = x.n_rows;
-
-    logProbabilities = -0.5 * k * log2pi - 0.5 * logDetCov + logExponents;
+    logProbabilities = -0.5 * x.n_rows * log2pi - 0.5 * logDetCov +
+      logExponents;
   }
 
   /**


### PR DESCRIPTION
This PR removes inline implementation of LogProbability function for different distributions as discussed in https://github.com/mlpack/mlpack/pull/1749#discussion_r264014523.

Thanks 