### PR TITLE
Mode imputation class

### DIFF
--- a/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
@@ -83,7 +83,7 @@ class ModeImputation
     // elemsWithFreq contains the elements of elemsToKeep
     // with their respective frequency
     std::vector<PairType> elemsWithFreq;
-    // modeCountPair is a PairType that contains the mode 
+    // modeCountPair is a PairType that contains the mode
     // and it's count(number of occurences)
     PairType modeCountPair;
 
@@ -115,7 +115,7 @@ class ModeImputation
 
      if (flag)
      {
-      // if the current element of elemsToKeep 
+      // if the current element of elemsToKeep
       // is not present in elemsWithFreq then add it
       elemsWithFreq.emplace_back(elemsToKeep[i], 1);
 

--- a/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
@@ -82,7 +82,7 @@ class ModeImputation
     // calculate mode
     // elemsWithFreq contains the elements of elemsToKeep with their respective frequency
     std::vector<PairType> elemsWithFreq; 
-    // modeCountPair is a PairType that contains the mode and it's count(no of occurences)
+    // modeCountPair is a PairType that contains the mode and it's count(number of occurences)
     PairType modeCountPair;
 
     for (size_t i = 0; i < elemsToKeep.size(); ++i)

--- a/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
@@ -1,0 +1,144 @@
+/**
+ * @file mode_imputation.hpp
+ * @author Gaurav Sharma
+ *
+ * Definition and Implementation of the ModeImputation class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MODE_IMPUTATION_HPP
+#define MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MODE_IMPUTATION_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace data {
+/**
+ * A simple mode imputation class
+ * @tparam T Type of armadillo matrix
+ */
+template <typename T>
+class ModeImputation
+{
+ public:
+  /**
+   * Impute function searches through the input looking for mappedValue and
+   * replaces it with the mode of the given dimension. The result is overwritten
+   * to the input matrix.
+   *
+   * @param input Matrix that contains mappedValue.
+   * @param mappedValue Value that the user wants to get rid of.
+   * @param dimension Index of the dimension of the mappedValue.
+   * @param columnMajor State of whether the input matrix is columnMajor or not.
+   */
+  void Impute(arma::Mat<T>& input,
+              const T& mappedValue,
+              const size_t dimension,
+              const bool columnMajor = true)
+  {
+    double sum = 0;
+    size_t elems = 0; // excluding nan or missing target
+
+    using PairType = std::pair<size_t, size_t>;
+    // dimensions and indexes are saved as pairs inside this vector.
+    std::vector<PairType> targets;
+    // good elements are kept inside this vector.
+    std::vector<double> elemsToKeep;
+
+    if (columnMajor)
+    {
+      for (size_t i = 0; i < input.n_cols; ++i)
+      {
+        if (input(dimension, i) == mappedValue ||
+            std::isnan(input(dimension, i)))
+        {
+          targets.emplace_back(dimension, i);
+        }
+        else
+        {
+          elemsToKeep.push_back(input(dimension,i));
+        }
+      }
+    }
+    else
+    {
+      for (size_t i = 0; i < input.n_rows; ++i)
+      {
+        if (input(i, dimension) == mappedValue ||
+            std::isnan(input(i, dimension)))
+        {
+          targets.emplace_back(i, dimension);
+        }
+        else
+        {
+         elemsToKeep.push_back(input(i,dimension));
+        }
+      }
+    }
+
+    // calculate mode
+    // elemsWithFreq contains the elements of elemsToKeep with their respective frequency
+    std::vector<PairType> elemsWithFreq; 
+    // modeCountPair is a PairType that contains the mode and it's count(no of occurences)
+    PairType modeCountPair;
+
+    for (size_t i = 0; i < elemsToKeep.size(); ++i)
+    {
+     bool flag = true;
+
+     for (PairType &elems : elemsWithFreq)
+     {
+      if (elemsToKeep[i] == elems.first)
+      {
+       elems.second += 1;     // increase the frequency by 1
+
+       if (elems.second > modeCountPair.second)
+       {
+        modeCountPair.first = elems.first;
+        modeCountPair.second = elems.second;
+       }
+       else if (elems.second == modeCountPair.second)
+       {
+        // if two element have the same frequency then take their avg as mode
+        modeCountPair.first = (elems.first + modeCountPair.first) / 2;
+       }
+
+       flag = false;
+       break;
+      }
+     }
+
+     if (flag)
+     {
+      // if the current element of elemsToKeep is not present in elemsWithFreq then add it
+      elemsWithFreq.emplace_back(elemsToKeep[i], 1);
+
+      if (modeCountPair.second == 1)
+      {
+       modeCountPair.first = (modeCountPair.first + elemsToKeep[i]) / 2;
+      }
+
+      if (i == 0)
+      {
+       modeCountPair.first = elemsToKeep[i];
+       modeCountPair.second = 1;
+      }
+     }
+    }
+
+    // Now replace the calculated mode to the missing variables
+    // It only needs to loop through targets vector, not the whole matrix.
+    for (const PairType &target : targets)
+    {
+     input(target.first, target.second) = modeCountPair.first;
+    }
+  }
+}; // class ModeImputation
+
+} // namespace data
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
@@ -59,7 +59,7 @@ class ModeImputation
         }
         else
         {
-          elemsToKeep.push_back(input(dimension,i));
+          elemsToKeep.push_back(input(dimension, i));
         }
       }
     }
@@ -74,15 +74,17 @@ class ModeImputation
         }
         else
         {
-         elemsToKeep.push_back(input(i,dimension));
+         elemsToKeep.push_back(input(i, dimension));
         }
       }
     }
 
     // calculate mode
-    // elemsWithFreq contains the elements of elemsToKeep with their respective frequency
-    std::vector<PairType> elemsWithFreq; 
-    // modeCountPair is a PairType that contains the mode and it's count(number of occurences)
+    // elemsWithFreq contains the elements of elemsToKeep
+    // with their respective frequency
+    std::vector<PairType> elemsWithFreq;
+    // modeCountPair is a PairType that contains the mode 
+    // and it's count(number of occurences)
     PairType modeCountPair;
 
     for (size_t i = 0; i < elemsToKeep.size(); ++i)
@@ -113,7 +115,8 @@ class ModeImputation
 
      if (flag)
      {
-      // if the current element of elemsToKeep is not present in elemsWithFreq then add it
+      // if the current element of elemsToKeep 
+      // is not present in elemsWithFreq then add it
       elemsWithFreq.emplace_back(elemsToKeep[i], 1);
 
       if (modeCountPair.second == 1)

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -68,7 +68,7 @@ class Imputer
   //! Get the strategy
   const StrategyType& Strategy() const { return strategy; }
 
-  //! Modify the given given strategy (be careful!)
+  //! Modify the given strategy (be careful!)
   StrategyType& Strategy() { return strategy; }
 
   //! Get the mapper

--- a/src/mlpack/core/data/map_policies/increment_policy.hpp
+++ b/src/mlpack/core/data/map_policies/increment_policy.hpp
@@ -22,7 +22,7 @@ namespace data {
 /**
  * IncrementPolicy is used as a helper class for DatasetMapper. It tells how the
  * strings should be mapped. Purpose of this policy is to map all dimension if
- * one if the variables in a dimension turns out to be a categorical variable.
+ * one of the variables in a dimension turns out to be a categorical variable.
  * IncrementPolicy maps strings to incrementing unsigned integers (size_t).
  * The first input to be mapped will be mapped to 0, the next to 1 and so on.
  *

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -86,8 +86,8 @@ class LinearRegression
    *
    * @param predictors X, the matrix of data points to train the model on.
    * @param responses y, the responses to the data points.
-   * @param intercept Whether or not to fit an intercept term.
    * @param weights Observation weights (for boosting).
+   * @param intercept Whether or not to fit an intercept term.
    * @return The least squares error after training.
    */
   double Train(const arma::mat& predictors,


### PR DESCRIPTION
I created a mode_imputation.hpp containing ModeImputation class. Impute function searches through the input looking for mappedValue and replaces it with the mode of the given dimension. The result is overwritten to the input matrix. The purpose of this class is to impute mode for empty values just like we did for other imputation methods like mean and median.

Actually I am not sure that whether armadillo has any inbuilt function for mode because I can't find it in their website so I coded it by my own but if their is indeed a inbuilt function then it will be replaced simply by replacing mode with median in,

 const double median = arma::median(arma::vec(elemsToKeep));

Apart from that this PR also consists of  correction of miss leading documentation in increment_policy.hpp.