### PR TITLE
Documentation fixups

### DIFF
--- a/src/mlpack/core/cv/metrics/average_strategy.hpp
+++ b/src/mlpack/core/cv/metrics/average_strategy.hpp
@@ -21,14 +21,6 @@ namespace cv {
  *
  * The "Binary" strategy means binary classification is going to be used, and
  * there is no need to average.
- *
- * The "Micro" strategy is used for multiclass classification, in this strategy
- * TP(True Positive), TN(True Negative) and FN(False Negative) all are counted
- * globally for calculating metrics.
- *
- * The "Macro" strategy is also used for multiclass classification, in this
- * metric is calculated for each label separately and then an unweighted
- * average is taken.
  */
 enum AverageStrategy
 {

--- a/src/mlpack/core/cv/metrics/average_strategy.hpp
+++ b/src/mlpack/core/cv/metrics/average_strategy.hpp
@@ -22,12 +22,13 @@ namespace cv {
  * The "Binary" strategy means binary classification is going to be used, and
  * there is no need to average.
  *
- * The "Micro" strategy is used for multiclass classification considering
- * TP(True Positive), TN(True Negative) and FN(False Negative) all at once
- * for evaluating both precision and recall.
+ * The "Micro" strategy is used for multiclass classification, in this strategy
+ * TP(True Positive), TN(True Negative) and FN(False Negative) all are counted
+ * globally for calculating metrics.
  *
- * The "Macro" strategy is also used for multiclass classification but by
- * taking the average of individually calculated precision and recall.
+ * The "Macro" strategy is also used for multiclass classification, in this
+ * metric is calculated for each label separately and then an unweighted
+ * average is taken.
  */
 enum AverageStrategy
 {

--- a/src/mlpack/core/cv/metrics/average_strategy.hpp
+++ b/src/mlpack/core/cv/metrics/average_strategy.hpp
@@ -21,6 +21,13 @@ namespace cv {
  *
  * The "Binary" strategy means binary classification is going to be used, and
  * there is no need to average.
+ *
+ * The "Micro" strategy is used for multiclass classification considering
+ * TP(True Positive), TN(True Negative) and FN(False Negative) all at once
+ * for evaluating both precision and recall.
+ *
+ * The "Macro" strategy is also used for multiclass classification but by
+ * taking the average of individually calculated precision and recall.
  */
 enum AverageStrategy
 {

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -68,7 +68,7 @@ class Imputer
   //! Get the strategy
   const StrategyType& Strategy() const { return strategy; }
 
-  //! Modify the given given strategy (be careful!)
+  //! Modify the given strategy (be careful!)
   StrategyType& Strategy() { return strategy; }
 
   //! Get the mapper

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -65,16 +65,16 @@ class Imputer
     strategy.Impute(input, mappedValue, dimension, columnMajor);
   }
 
-  //! Get the strategy
+  //! Get the strategy.
   const StrategyType& Strategy() const { return strategy; }
 
-  //! Modify the given strategy
+  //! Modify the given strategy.
   StrategyType& Strategy() { return strategy; }
 
-  //! Get the mapper
+  //! Get the mapper.
   const MapperType& Mapper() const { return mapper; }
 
-  //! Modify the given mapper
+  //! Modify the given mapper.
   MapperType& Mapper() { return mapper; }
 
  private:

--- a/src/mlpack/core/data/imputer.hpp
+++ b/src/mlpack/core/data/imputer.hpp
@@ -68,13 +68,13 @@ class Imputer
   //! Get the strategy
   const StrategyType& Strategy() const { return strategy; }
 
-  //! Modify the given strategy (be careful!)
+  //! Modify the given strategy
   StrategyType& Strategy() { return strategy; }
 
   //! Get the mapper
   const MapperType& Mapper() const { return mapper; }
 
-  //! Modify the given mapper (be careful!)
+  //! Modify the given mapper
   MapperType& Mapper() { return mapper; }
 
  private:

--- a/src/mlpack/core/data/map_policies/increment_policy.hpp
+++ b/src/mlpack/core/data/map_policies/increment_policy.hpp
@@ -22,7 +22,7 @@ namespace data {
 /**
  * IncrementPolicy is used as a helper class for DatasetMapper. It tells how the
  * strings should be mapped. Purpose of this policy is to map all dimension if
- * one if the variables in a dimension turns out to be a categorical variable.
+ * one of the variables in a dimension turns out to be a categorical variable.
  * IncrementPolicy maps strings to incrementing unsigned integers (size_t).
  * The first input to be mapped will be mapped to 0, the next to 1 and so on.
  *

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -86,8 +86,8 @@ class LinearRegression
    *
    * @param predictors X, the matrix of data points to train the model on.
    * @param responses y, the responses to the data points.
-   * @param intercept Whether or not to fit an intercept term.
    * @param weights Observation weights (for boosting).
+   * @param intercept Whether or not to fit an intercept term.
    * @return The least squares error after training.
    */
   double Train(const arma::mat& predictors,

--- a/src/mlpack/tests/imputation_test.cpp
+++ b/src/mlpack/tests/imputation_test.cpp
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(MeanImputationTest)
 }
 
 /**
- * Make sure MeanImputation method replaces data 0 to median value of each
+ * Make sure MedianImputation method replaces data 0 to median value of each
  * dimensions.
  */
 BOOST_AUTO_TEST_CASE(MedianImputationTest)


### PR DESCRIPTION
This PR corrects the following documentation ->

1. Corrects incorrect documentation in imputation_test.cpp.
2. Removes extra given from line 71 in imputer.hpp.
3. Corrects the miss-leading comment at line 25 in increment_policy.hpp.
4. Swap comments at line 89 and 90 in linear_regression.hpp to match the exact sequence of function   
    parameters for more readability and to avoid any confusion at first look.