### PR TITLE
Increase Code Readability

### DIFF
--- a/src/mlpack/core/cv/metrics/f1_impl.hpp
+++ b/src/mlpack/core/cv/metrics/f1_impl.hpp
@@ -82,10 +82,10 @@ double F1<AS, PC>::Evaluate(MLAlgorithm& model,
   {
     size_t tp = arma::sum((labels == c) % (predictedLabels == c));
     size_t numberOfPositivePredictions = arma::sum(predictedLabels == c);
-    size_t numberOfClassInstances = arma::sum(labels == c);
+    size_t numberOfPositiveClassInstances = arma::sum(labels == c);
 
     double precision = double(tp) / numberOfPositivePredictions;
-    double recall = double(tp) / numberOfClassInstances;
+    double recall = double(tp) / numberOfPositiveClassInstances;
     f1s(c) = (precision + recall == 0.0) ? 0.0 :
         2.0 * precision * recall / (precision + recall);
   }

--- a/src/mlpack/core/cv/metrics/f1_impl.hpp
+++ b/src/mlpack/core/cv/metrics/f1_impl.hpp
@@ -81,11 +81,11 @@ double F1<AS, PC>::Evaluate(MLAlgorithm& model,
   for (size_t c = 0; c < numClasses; ++c)
   {
     size_t tp = arma::sum((labels == c) % (predictedLabels == c));
-    size_t numberOfPositivePredictions = arma::sum(predictedLabels == c);
-    size_t numberOfPositiveClassInstances = arma::sum(labels == c);
+    size_t positivePredictions = arma::sum(predictedLabels == c);
+    size_t positiveLabels = arma::sum(labels == c);
 
-    double precision = double(tp) / numberOfPositivePredictions;
-    double recall = double(tp) / numberOfPositiveClassInstances;
+    double precision = double(tp) / positivePredictions;
+    double recall = double(tp) / positiveLabels;
     f1s(c) = (precision + recall == 0.0) ? 0.0 :
         2.0 * precision * recall / (precision + recall);
   }

--- a/src/mlpack/core/cv/metrics/recall_impl.hpp
+++ b/src/mlpack/core/cv/metrics/recall_impl.hpp
@@ -75,8 +75,8 @@ double Recall<AS, PC>::Evaluate(MLAlgorithm& model,
   for (size_t c = 0; c < numClasses; ++c)
   {
     size_t tp = arma::sum((labels == c) % (predictedLabels == c));
-    size_t numberOfPositiveClassInstances = arma::sum(labels == c);
-    recalls(c) = double(tp) / numberOfPositiveClassInstances;
+    size_t positiveLabels = arma::sum(labels == c);
+    recalls(c) = double(tp) / positiveLabels;
   }
 
   return arma::mean(recalls);

--- a/src/mlpack/core/cv/metrics/recall_impl.hpp
+++ b/src/mlpack/core/cv/metrics/recall_impl.hpp
@@ -75,8 +75,8 @@ double Recall<AS, PC>::Evaluate(MLAlgorithm& model,
   for (size_t c = 0; c < numClasses; ++c)
   {
     size_t tp = arma::sum((labels == c) % (predictedLabels == c));
-    size_t numberOfClassInstances = arma::sum(labels == c);
-    recalls(c) = double(tp) / numberOfClassInstances;
+    size_t numberOfPositiveClassInstances = arma::sum(labels == c);
+    recalls(c) = double(tp) / numberOfPositiveClassInstances;
   }
 
   return arma::mean(recalls);

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -141,7 +141,7 @@ double LinearRegression::ComputeError(const arma::mat& predictors,
       Log::Fatal << "The test data must have the same number of columns as the "
           "training file." << std::endl;
     }
-    temp = responses - arma::trans(parameters) * predictors;
+    temp = responses - (arma::trans(parameters) * predictors);
   }
   const double cost = arma::dot(temp, temp) / nCols;
 

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -141,7 +141,7 @@ double LinearRegression::ComputeError(const arma::mat& predictors,
       Log::Fatal << "The test data must have the same number of columns as the "
           "training file." << std::endl;
     }
-    temp = responses - (arma::trans(parameters) * predictors);
+    temp = responses - arma::trans(parameters) * predictors;
   }
   const double cost = arma::dot(temp, temp) / nCols;
 


### PR DESCRIPTION
In this PR I did ->

1. In f1_impl.hpp variable numberOfClassInstances is shorten to positiveLabels at line
    85 and 88 because at line 85 condition (labels == c) holds true only for positive classes in the 
    respective cases in for loop whereas numberOfClassInstances signifies both positive and negative
    classes but in recall metric we deal with only positiveLabels. I also shorten numberOfPositivePredictions
    to positivePredictions only as the variable name is too big.

2. In recall_impl.hpp I did the same as in f1_impl.hpp.