### PR TITLE
Added additional check to LoadARFF.

### DIFF
--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -30,7 +30,7 @@ void LoadARFF(const std::string& filename,
   std::ifstream ifs;
   ifs.open(filename, std::ios::in | std::ios::binary);
 
-  // if file is not open throw an error.
+  // if file is not open throw an error (file not found).
   if (!ifs.is_open())
   {
     std::stringstream error;

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -30,6 +30,14 @@ void LoadARFF(const std::string& filename,
   std::ifstream ifs;
   ifs.open(filename, std::ios::in | std::ios::binary);
 
+  // if file is not open throw an error.
+  if (!ifs.is_open())
+  {
+    std::stringstream error;
+    error << filename << " Not Found.";
+    throw std::runtime_error(error.str());
+  }
+
   std::string line;
   size_t dimensionality = 0;
   std::vector<bool> types;

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -31,7 +31,8 @@ void LoadARFF(const std::string& filename,
   ifs.open(filename, std::ios::in | std::ios::binary);
 
   // if file is not open throw an error (file not found).
-  if (!ifs.is_open()){
+  if (!ifs.is_open())
+  {
     Log::Fatal << "Cannot open file '" << filename << "'. " << std::endl;
   }
 

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -34,7 +34,7 @@ void LoadARFF(const std::string& filename,
   if (!ifs.is_open())
   {
     std::stringstream error;
-    error << filename << " Not Found.";
+    error << "File: " << filename << " could not be opened.";
     throw std::runtime_error(error.str());
   }
 

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -31,18 +31,15 @@ void LoadARFF(const std::string& filename,
   ifs.open(filename, std::ios::in | std::ios::binary);
 
   // if file is not open throw an error (file not found).
-  if (!ifs.is_open())
-  {
-    std::stringstream error;
-    error << "File: " << filename << " could not be opened.";
-    throw std::runtime_error(error.str());
+  if (!ifs.is_open()){
+    Log::Fatal << "Cannot open file '" << filename << "'. " << std::endl;
   }
 
   std::string line;
   size_t dimensionality = 0;
   std::vector<bool> types;
   size_t headerLines = 0;
-  while (!ifs.eof())
+  while (ifs.good())
   {
     // Read the next line, then strip whitespace from either side.
     std::getline(ifs, line, '\n');
@@ -136,7 +133,7 @@ void LoadARFF(const std::string& filename,
   // We need to find out how many lines of data are in the file.
   std::streampos pos = ifs.tellg();
   size_t row = 0;
-  while (!ifs.eof())
+  while (ifs.good())
   {
     std::getline(ifs, line, '\n');
     ++row;
@@ -153,7 +150,7 @@ void LoadARFF(const std::string& filename,
 
   // Now we are looking at the @data section.
   row = 0;
-  while (!ifs.eof())
+  while (ifs.good())
   {
     std::getline(ifs, line, '\n');
     boost::trim(line);

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -1804,6 +1804,18 @@ BOOST_AUTO_TEST_CASE(BadDatasetInfoARFFTest)
 }
 
 /**
+ * If file is not found, it should throw.
+ */
+BOOST_AUTO_TEST_CASE(NonExistentFileARFFTest)
+{
+  arma::mat dataset;
+  DatasetInfo info;
+
+  BOOST_REQUIRE_THROW(data::LoadARFF("nonexistentfile.arff", dataset, info),
+      std::runtime_error);
+}
+
+/**
  * A test to check whether the arff loader is case insensitive to declarations:
  * @relation, @attribute, @data.
  */


### PR DESCRIPTION
Resolves #1791.
Rectifies the reason for the failure of memory checks in #1756 for issue #1754. 

Added `is_open()` to make sure if file exists
```c++  
  // if file is not open throw an error (file not found).
  if (!ifs.is_open())
```
Also, added test for `NonExistentFileARFFTest` .