### PR TITLE
Fix O'Reilly GAN Test

### DIFF
--- a/src/mlpack/tests/dcgan_test.cpp
+++ b/src/mlpack/tests/dcgan_test.cpp
@@ -12,7 +12,7 @@
 #include <mlpack/core.hpp>
 
 #include <mlpack/methods/ann/init_rules/gaussian_init.hpp>
-#include <mlpack/methods/ann/loss_functions/cross_entropy_error.hpp>
+#include <mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp>
 #include <mlpack/methods/ann/gan/gan.hpp>
 #include <mlpack/methods/ann/ffn.hpp>
 #include <mlpack/methods/ann/layer/layer.hpp>
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(DCGANMNISTTest)
   Log::Info << trainData.n_rows << "--------" << trainData.n_cols << std::endl;
 
   // Create the Discriminator network
-  FFN<CrossEntropyError<> > discriminator;
+  FFN<SigmoidCrossEntropyError<> > discriminator;
   discriminator.Add<Convolution<> >(1, dNumKernels, 4, 4, 2, 2, 1, 1, 28, 28);
   discriminator.Add<LeakyReLU<> >(0.2);
   discriminator.Add<Convolution<> >(dNumKernels, 2 * dNumKernels, 4, 4, 2, 2,
@@ -90,10 +90,9 @@ BOOST_AUTO_TEST_CASE(DCGANMNISTTest)
   discriminator.Add<LeakyReLU<> >(0.2);
   discriminator.Add<Convolution<> >(8 * dNumKernels, 1, 4, 4, 1, 1,
       1, 1, 2, 2);
-  discriminator.Add<SigmoidLayer<> >();
 
   // Create the Generator network
-  FFN<CrossEntropyError<> > generator;
+  FFN<SigmoidCrossEntropyError<> > generator;
   generator.Add<TransposedConvolution<> >(noiseDim, 8 * dNumKernels, 2, 2,
       1, 1, 1, 1, 1, 1);
   generator.Add<BatchNorm<> >(1024);
@@ -120,7 +119,7 @@ BOOST_AUTO_TEST_CASE(DCGANMNISTTest)
       tolerance, shuffle);
   std::function<double()> noiseFunction = [] () {
       return math::RandNormal(0, 1);};
-  GAN<FFN<CrossEntropyError<> >, GaussianInitialization,
+  GAN<FFN<SigmoidCrossEntropyError<> >, GaussianInitialization,
       std::function<double()>, DCGAN> dcgan(trainData, generator, discriminator,
       gaussian, noiseFunction, noiseDim, batchSize, generatorUpdateStep,
       discriminatorPreTrain, multiplier);
@@ -205,7 +204,7 @@ BOOST_AUTO_TEST_CASE(DCGANCelebATest)
   Log::Info << trainData.n_rows << "--------" << trainData.n_cols << std::endl;
 
   // Create the Discriminator network
-  FFN<CrossEntropyError<> > discriminator;
+  FFN<SigmoidCrossEntropyError<> > discriminator;
   discriminator.Add<Convolution<> >(3, dNumKernels, 4, 4, 2, 2, 1, 1, 64, 64);
   discriminator.Add<LeakyReLU<> >(0.2);
   discriminator.Add<Convolution<> >(dNumKernels, 2 * dNumKernels, 4, 4, 2, 2,
@@ -219,10 +218,9 @@ BOOST_AUTO_TEST_CASE(DCGANCelebATest)
   discriminator.Add<LeakyReLU<> >(0.2);
   discriminator.Add<Convolution<> >(8 * dNumKernels, 1, 4, 4, 1, 1,
       0, 0, 4, 4);
-  discriminator.Add<SigmoidLayer<> >();
 
   // Create the Generator network
-  FFN<CrossEntropyError<> > generator;
+  FFN<SigmoidCrossEntropyError<> > generator;
   generator.Add<TransposedConvolution<> >(noiseDim, 8 * dNumKernels, 4, 4,
       1, 1, 2, 2, 1, 1);
   generator.Add<BatchNorm<> >(4096);
@@ -249,7 +247,7 @@ BOOST_AUTO_TEST_CASE(DCGANCelebATest)
       tolerance, shuffle);
   std::function<double()> noiseFunction = [] () {
       return math::RandNormal(0, 1);};
-  GAN<FFN<CrossEntropyError<> >, GaussianInitialization,
+  GAN<FFN<SigmoidCrossEntropyError<> >, GaussianInitialization,
       std::function<double()>, DCGAN> dcgan(trainData, generator, discriminator,
       gaussian, noiseFunction, noiseDim, batchSize, generatorUpdateStep,
       discriminatorPreTrain, multiplier);

--- a/src/mlpack/tests/gan_test.cpp
+++ b/src/mlpack/tests/gan_test.cpp
@@ -13,7 +13,6 @@
 #include <mlpack/core.hpp>
 
 #include <mlpack/methods/ann/init_rules/gaussian_init.hpp>
-#include <mlpack/methods/ann/loss_functions/cross_entropy_error.hpp>
 #include <mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp>
 #include <mlpack/methods/ann/gan/gan.hpp>
 #include <mlpack/methods/ann/layer/layer.hpp>

--- a/src/mlpack/tests/gan_test.cpp
+++ b/src/mlpack/tests/gan_test.cpp
@@ -14,6 +14,7 @@
 
 #include <mlpack/methods/ann/init_rules/gaussian_init.hpp>
 #include <mlpack/methods/ann/loss_functions/cross_entropy_error.hpp>
+#include <mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp>
 #include <mlpack/methods/ann/gan/gan.hpp>
 #include <mlpack/methods/ann/layer/layer.hpp>
 #include <mlpack/methods/softmax_regression/softmax_regression.hpp>
@@ -173,8 +174,8 @@ BOOST_AUTO_TEST_CASE(GANMNISTTest)
             << trainData.n_cols << ")" << std::endl;
   Log::Info << trainData.n_rows << "--------" << trainData.n_cols << std::endl;
 
-  // Create the Discriminator network.
-  FFN<CrossEntropyError<> > discriminator;
+  // Create the Discriminator network
+  FFN<SigmoidCrossEntropyError<> > discriminator;
   discriminator.Add<Convolution<> >(1, dNumKernels, 5, 5, 1, 1, 2, 2, 28, 28);
   discriminator.Add<ReLULayer<> >();
   discriminator.Add<MeanPooling<> >(2, 2, 2, 2);
@@ -186,8 +187,8 @@ BOOST_AUTO_TEST_CASE(GANMNISTTest)
   discriminator.Add<ReLULayer<> >();
   discriminator.Add<Linear<> >(1024, 1);
 
-  // Create the Generator network.
-  FFN<CrossEntropyError<> > generator;
+  // Create the Generator network
+  FFN<SigmoidCrossEntropyError<> > generator;
   generator.Add<Linear<> >(noiseDim, 3136);
   generator.Add<BatchNorm<> >(3136);
   generator.Add<ReLULayer<> >();
@@ -201,7 +202,7 @@ BOOST_AUTO_TEST_CASE(GANMNISTTest)
   generator.Add<ReLULayer<> >();
   generator.Add<BilinearInterpolation<> >(28, 28, 56, 56, noiseDim / 4);
   generator.Add<Convolution<> >(noiseDim / 4, 1, 3, 3, 2, 2, 1, 1, 56, 56);
-  generator.Add<TanHLayer<> >();
+  generator.Add<SigmoidLayer<> >();
 
   // Create GAN
   GaussianInitialization gaussian(0, 1);
@@ -209,13 +210,14 @@ BOOST_AUTO_TEST_CASE(GANMNISTTest)
       tolerance, shuffle);
   std::function<double()> noiseFunction = [] () {
       return math::RandNormal(0, 1);};
-  GAN<FFN<CrossEntropyError<> >, GaussianInitialization,
+  GAN<FFN<SigmoidCrossEntropyError<> >, GaussianInitialization,
       std::function<double()> > gan(trainData, generator, discriminator,
       gaussian, noiseFunction, noiseDim, batchSize, generatorUpdateStep,
       discriminatorPreTrain, multiplier);
 
   Log::Info << "Training..." << std::endl;
-  gan.Train(optimizer);
+  double objVal = gan.Train(optimizer);
+  BOOST_REQUIRE_EQUAL(std::isfinite(objVal), true);
 
   // Generate samples.
   Log::Info << "Sampling..." << std::endl;

--- a/src/mlpack/tests/gan_test.cpp
+++ b/src/mlpack/tests/gan_test.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(GANTest)
   trainData = arma::sort(trainData);
 
   // Create the Discriminator network
-  FFN<CrossEntropyError<> > discriminator;
+  FFN<SigmoidCrossEntropyError<> > discriminator;
   discriminator.Add<Linear<> > (
       generatorOutputSize, discriminatorHiddenLayerSize * 2);
   discriminator.Add<ReLULayer<> >();
@@ -67,9 +67,9 @@ BOOST_AUTO_TEST_CASE(GANTest)
   discriminator.Add<ReLULayer<> >();
   discriminator.Add<Linear<> > (
       discriminatorHiddenLayerSize * 2, discriminatorOutputSize);
-  discriminator.Add<SigmoidLayer<> >();
+
   // Create the Generator network
-  FFN<CrossEntropyError<> > generator;
+  FFN<SigmoidCrossEntropyError<> > generator;
   generator.Add<Linear<> >(noiseDim, generatorHiddenLayerSize);
   generator.Add<SoftPlusLayer<> >();
   generator.Add<Linear<> >(generatorHiddenLayerSize, generatorOutputSize);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(GANTest)
   GaussianInitialization gaussian(0, 0.1);
   std::function<double ()> noiseFunction = [](){ return math::Random(-8, 8) +
       math::RandNormal(0, 1) * 0.01;};
-  GAN<FFN<CrossEntropyError<> >,
+  GAN<FFN<SigmoidCrossEntropyError<> >,
       GaussianInitialization,
       std::function<double()> >
   gan(trainData, generator, discriminator, gaussian, noiseFunction,
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(GANMNISTTest)
   generator.Add<ReLULayer<> >();
   generator.Add<BilinearInterpolation<> >(28, 28, 56, 56, noiseDim / 4);
   generator.Add<Convolution<> >(noiseDim / 4, 1, 3, 3, 2, 2, 1, 1, 56, 56);
-  generator.Add<SigmoidLayer<> >();
+  generator.Add<TanHLayer<> >();
 
   // Create GAN
   GaussianInitialization gaussian(0, 1);


### PR DESCRIPTION
I went over the O'Reilly test and they use `sigmoid_cross_entropy_with_logits` because the output of the discriminator is unscaled (there is no `softmax` or `sigmoid` layer at the end). Therefore, I have switched to using `SigmoidCrossEntropyError`, which gives a finite value for the loss function and solves the `nan` encountered here https://github.com/mlpack/mlpack/pull/1724
Earlier `CrossEntropyError` would produce `nan` while taking log of negative unscaled output from discriminator.
@ShikharJ @walragatver let me know what you think.