### PR TITLE
Travis Python fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       before_install:
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev python-pip cython python-numpy python-pandas
-        - sudo pip install --upgrade --ignore-installed setuptools
+        - sudo pip install --upgrade --ignore-installed setuptools cython
         - curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-6.500.5.tar.gz | tar xvz && cd armadillo*
         - cmake . && make && sudo make install && cd ..
         - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp
@@ -20,7 +20,7 @@ matrix:
       before_install:
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev python3-pip cython3 python3-numpy python3-pandas
-        - sudo pip3 install --upgrade --ignore-installed setuptools
+        - sudo pip3 install --upgrade --ignore-installed setuptools cython
         - curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-6.500.5.tar.gz | tar xvz && cd armadillo*
         - cmake . && make && sudo make install && cd ..
         - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       dist: xenial
-      env: CMAKE_OPTIONS="-DDEBUG=OFF -DPROFILE=OFF -DPYTHON=/usr/bin/python"
+      env: CMAKE_OPTIONS="-DDEBUG=OFF -DPROFILE=OFF -DPYTHON_EXECUTABLE=/usr/bin/python"
       before_install:
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev python-pip cython python-numpy python-pandas
@@ -16,7 +16,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: CMAKE_OPTIONS="-DDEBUG=OFF -DPROFILE=OFF -DPYTHON=/usr/bin/python3"
+      env: CMAKE_OPTIONS="-DDEBUG=OFF -DPROFILE=OFF -DPYTHON_EXECUTABLE=/usr/bin/python3"
       before_install:
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev python3-pip cython3 python3-numpy python3-pandas

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
       env: CMAKE_OPTIONS="-DDEBUG=OFF -DPROFILE=OFF -DPYTHON_EXECUTABLE=/usr/bin/python3"
       before_install:
         - sudo apt-get update
-        - sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev python3-pip cython3 python3-numpy python3-pandas
-        - sudo pip3 install --upgrade --ignore-installed setuptools cython
+        - sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev python3-pip cython3 python3-numpy
+        - sudo pip3 install --upgrade --ignore-installed setuptools cython pandas
         - curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-6.500.5.tar.gz | tar xvz && cd armadillo*
         - cmake . && make && sudo make install && cd ..
         - sudo cp .travis/config.hpp /usr/include/armadillo_bits/config.hpp


### PR DESCRIPTION
I noticed that Travis is not successfully building the Python bindings.  This should (hopefully) fix that.  It may take a few tries to get right, so I'll post another comment when I'm done with it.

@Yashwants19: in debugging locally, I found that some of the Python tests had some problems, so I had to update `matrix_utils.py` to fix these issues.  There were two main problems---using `y.flatten()` doesn't convert `dtype` if it's not the desired dtype (in fact it just reinterprets it, so `int(1)` does not become `float64(1)`), and also when we are not copying, using `y.flatten()` as a buffer causes problems because it goes out of scope and the memory is cleared when we leave `to_matrix()`, but it is still used by the program.  The changes here should fix that, but let me know if you see any problems. :+1: