### PR TITLE
Rectified imports in Python documentation

### DIFF
--- a/src/mlpack/bindings/markdown/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/markdown/print_doc_functions_impl.hpp
@@ -453,7 +453,7 @@ inline std::string ProgramCall(const std::string& programName)
   else if (BindingInfo::Language() == "python")
   {
     s += "python\n";
-    std::string import = PrintImport(GetBindingName(programName));
+    std::string import = PrintImport(programName);
     if (import.size() > 0)
       s += ">>> " + import + "\n";
     s += python::ProgramCall(programName);


### PR DESCRIPTION
This PR rectifies generation markdown [python documentation(mlpack-3.0.4)](http://www.mlpack.org/doc/mlpack-3.0.4/python_documentation.html).
Eg. Converted from 
```python
>>> from mlpack import softmax_regression()
```
to
```python
>>> from mlpack import softmax_regression
```