### PR TITLE
Introduce Memory Sharing Between GAN and FFN

### DIFF
--- a/src/mlpack/methods/ann/gan/gan.hpp
+++ b/src/mlpack/methods/ann/gan/gan.hpp
@@ -308,7 +308,6 @@ class GAN
   //! Modify the matrix of data points (predictors).
   arma::mat& Predictors() { return predictors; }
 
-
   //! Serialize the model.
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */);

--- a/src/mlpack/methods/ann/gan/gan.hpp
+++ b/src/mlpack/methods/ann/gan/gan.hpp
@@ -210,7 +210,7 @@ class GAN
    * Gradient function for Standard GAN and DCGAN.
    * This function passes the gradient based on which network is being
    * trained, i.e., Generator or Discriminator.
-   * 
+   *
    * @param parameters present parameters of the network.
    * @param i Index of the predictors.
    * @param gradient Variable to store the present gradient.
@@ -228,7 +228,7 @@ class GAN
    * Gradient function for WGAN.
    * This function passes the gradient based on which network is being
    * trained, i.e., Generator or Discriminator.
-   * 
+   *
    * @param parameters present parameters of the network.
    * @param i Index of the predictors.
    * @param gradient Variable to store the present gradient.
@@ -245,7 +245,7 @@ class GAN
    * Gradient function for WGAN-GP.
    * This function passes the gradient based on which network is being
    * trained, i.e., Generator or Discriminator.
-   * 
+   *
    * @param parameters present parameters of the network.
    * @param i Index of the predictors.
    * @param gradient Variable to store the present gradient.
@@ -297,6 +297,17 @@ class GAN
 
   //! Return the number of separable functions (the number of predictor points).
   size_t NumFunctions() const { return numFunctions; }
+
+  //! Get the matrix of responses to the input data points.
+  const arma::mat& Responses() const { return responses; }
+  //! Modify the matrix of responses to the input data points.
+  arma::mat& Responses() { return responses; }
+
+  //! Get the matrix of data points (predictors).
+  const arma::mat& Predictors() const { return predictors; }
+  //! Modify the matrix of data points (predictors).
+  arma::mat& Predictors() { return predictors; }
+
 
   //! Serialize the model.
   template<typename Archive>

--- a/src/mlpack/methods/ann/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/gan_impl.hpp
@@ -65,18 +65,17 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::GAN(
 
   this->discriminator.deterministic = this->generator.deterministic = true;
 
-  responses.set_size(1, predictors.n_cols);
-  responses.ones();
+  this->predictors.set_size(predictors.n_rows, predictors.n_cols + batchSize);
+  this->predictors.cols(0, predictors.n_cols - 1) = predictors;
+  this->discriminator.predictors = arma::mat(this->predictors.memptr(),
+      this->predictors.n_rows, this->predictors.n_cols, false, false);
 
-  this->discriminator.predictors.set_size(predictors.n_rows,
-      predictors.n_cols + batchSize);
-  this->discriminator.predictors.cols(0, predictors.n_cols - 1) = predictors;
-  this->predictors = arma::mat(this->discriminator.predictors.memptr(),
-      predictors.n_rows, predictors.n_cols, false, false);
-  this->discriminator.responses.set_size(1, predictors.n_cols + batchSize);
-  this->discriminator.responses.ones();
-  this->discriminator.responses.cols(predictors.n_cols,
+  responses.set_size(1, predictors.n_cols + batchSize);
+  responses.ones();
+  responses.cols(predictors.n_cols,
       predictors.n_cols + batchSize - 1) = arma::zeros(1, batchSize);
+  this->discriminator.responses = arma::mat(this->responses.memptr(),
+      this->responses.n_rows, this->responses.n_cols, false, false);
 
   numFunctions = predictors.n_cols;
 
@@ -232,14 +231,14 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
   noise.imbue( [&]() { return noiseFunction();} );
   generator.Forward(std::move(noise));
 
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  discriminator.Forward(std::move(discriminator.predictors.cols(numFunctions,
+  discriminator.Forward(std::move(predictors.cols(numFunctions,
       numFunctions + batchSize - 1)));
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       arma::zeros(1, batchSize);
 
-  currentTarget = arma::mat(discriminator.responses.memptr() + numFunctions,
+  currentTarget = arma::mat(responses.memptr() + numFunctions,
       1, batchSize, false, false);
   res += discriminator.outputLayer.Forward(
       std::move(boost::apply_visitor(
@@ -299,9 +298,9 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
 
   noise.imbue( [&]() { return noiseFunction();} );
   generator.Forward(std::move(noise));
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       arma::zeros(1, batchSize);
 
   // Get the gradients of the Generator.
@@ -313,7 +312,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
   {
     // Minimize -log(D(G(noise))).
     // Pass the error from Discriminator to Generator.
-    discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+    responses.cols(numFunctions, numFunctions + batchSize - 1) =
         arma::ones(1, batchSize);
     discriminator.Gradient(discriminator.parameter, numFunctions,
         noiseGradientDiscriminator, batchSize);
@@ -372,8 +371,8 @@ void GAN<Model, InitializationRuleType, Noise, PolicyType>::Shuffle()
 {
   arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
       numFunctions - 1, numFunctions));
-  discriminator.predictors.cols(0, numFunctions- 1) =
-      predictors.cols(ordering);
+  arma::mat temp = predictors.cols(ordering);
+  predictors.cols(0, numFunctions - 1) = temp;
 }
 
 template<

--- a/src/mlpack/methods/ann/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/gan_impl.hpp
@@ -42,7 +42,6 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::GAN(
     const double multiplier,
     const double clippingParameter,
     const double lambda):
-    predictors(predictors),
     generator(std::move(generator)),
     discriminator(std::move(discriminator)),
     initializeRule(initializeRule),
@@ -72,7 +71,8 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::GAN(
   this->discriminator.predictors.set_size(predictors.n_rows,
       predictors.n_cols + batchSize);
   this->discriminator.predictors.cols(0, predictors.n_cols - 1) = predictors;
-
+  this->predictors = arma::mat(this->discriminator.predictors.memptr(),
+      predictors.n_rows, predictors.n_cols, false, false);
   this->discriminator.responses.set_size(1, predictors.n_cols + batchSize);
   this->discriminator.responses.ones();
   this->discriminator.responses.cols(predictors.n_cols,
@@ -372,8 +372,8 @@ void GAN<Model, InitializationRuleType, Noise, PolicyType>::Shuffle()
 {
   arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
       numFunctions - 1, numFunctions));
-  predictors = predictors.cols(ordering);
-  discriminator.predictors.cols(0, numFunctions-1) = predictors;
+  discriminator.predictors.cols(0, numFunctions- 1) =
+      predictors.cols(ordering);
 }
 
 template<

--- a/src/mlpack/methods/ann/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/gan_impl.hpp
@@ -371,8 +371,7 @@ void GAN<Model, InitializationRuleType, Noise, PolicyType>::Shuffle()
 {
   arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
       numFunctions - 1, numFunctions));
-  arma::mat temp = predictors.cols(ordering);
-  predictors.cols(0, numFunctions - 1) = temp;
+  predictors.cols(0, numFunctions - 1) = predictors.cols(ordering);
 }
 
 template<

--- a/src/mlpack/methods/ann/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/gan_impl.hpp
@@ -370,7 +370,10 @@ template<
 >
 void GAN<Model, InitializationRuleType, Noise, PolicyType>::Shuffle()
 {
-  math::ShuffleData(predictors, responses, predictors, responses);
+  arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
+      numFunctions - 1, numFunctions));
+  predictors = predictors.cols(ordering);
+  discriminator.predictors.cols(0, numFunctions-1) = predictors;
 }
 
 template<

--- a/src/mlpack/methods/ann/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/gan_impl.hpp
@@ -70,8 +70,7 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::GAN(
   this->discriminator.predictors = arma::mat(this->predictors.memptr(),
       this->predictors.n_rows, this->predictors.n_cols, false, false);
 
-  responses.set_size(1, predictors.n_cols + batchSize);
-  responses.ones();
+  responses.ones(1, predictors.n_cols + batchSize);
   responses.cols(predictors.n_cols,
       predictors.n_cols + batchSize - 1) = arma::zeros(1, batchSize);
   this->discriminator.responses = arma::mat(this->responses.memptr(),
@@ -369,7 +368,7 @@ template<
 >
 void GAN<Model, InitializationRuleType, Noise, PolicyType>::Shuffle()
 {
-  arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
+  const arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
       numFunctions - 1, numFunctions));
   predictors.cols(0, numFunctions - 1) = predictors.cols(ordering);
 }

--- a/src/mlpack/methods/ann/gan/wgan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/wgan_impl.hpp
@@ -51,14 +51,14 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
   noise.imbue( [&]() { return noiseFunction();} );
   generator.Forward(std::move(noise));
 
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  discriminator.Forward(std::move(discriminator.predictors.cols(numFunctions,
+  discriminator.Forward(std::move(predictors.cols(numFunctions,
       numFunctions + batchSize - 1)));
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       -arma::ones(1, batchSize);
 
-  currentTarget = arma::mat(discriminator.responses.memptr() + numFunctions,
+  currentTarget = arma::mat(responses.memptr() + numFunctions,
       1, batchSize, false, false);
   res += discriminator.outputLayer.Forward(
       std::move(boost::apply_visitor(
@@ -117,9 +117,9 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
 
   noise.imbue( [&]() { return noiseFunction();} );
   generator.Forward(std::move(noise));
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       -arma::ones(1, batchSize);
 
   // Get the gradients of the Generator.
@@ -133,7 +133,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
   {
     // Minimize -D(G(noise)).
     // Pass the error from Discriminator to Generator.
-    discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+    responses.cols(numFunctions, numFunctions + batchSize - 1) =
         arma::ones(1, batchSize);
     discriminator.Gradient(discriminator.parameter, numFunctions,
         noiseGradientDiscriminator, batchSize);

--- a/src/mlpack/methods/ann/gan/wgangp_impl.hpp
+++ b/src/mlpack/methods/ann/gan/wgangp_impl.hpp
@@ -54,14 +54,14 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
 
   arma::mat generatedData = boost::apply_visitor(outputParameterVisitor,
       generator.network.back());
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       generatedData;
-  discriminator.Forward(std::move(discriminator.predictors.cols(numFunctions,
+  discriminator.Forward(std::move(predictors.cols(numFunctions,
       numFunctions + batchSize - 1)));
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       -arma::ones(1, batchSize);
 
-  currentTarget = arma::mat(discriminator.responses.memptr() + numFunctions,
+  currentTarget = arma::mat(responses.memptr() + numFunctions,
       1, batchSize, false, false);
   res += discriminator.outputLayer.Forward(
       std::move(boost::apply_visitor(
@@ -70,9 +70,9 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
 
   // Gradient Penalty is calculated here.
   double epsilon = math::Random();
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       (epsilon * currentInput) + ((1.0 - epsilon) * generatedData);
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       -arma::ones(1, batchSize);
   discriminator.Gradient(discriminator.parameter, numFunctions,
       normGradientDiscriminator, batchSize);
@@ -139,15 +139,15 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
 
   // Gradient Penalty is calculated here.
   double epsilon = math::Random();
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       (epsilon * currentInput) + ((1.0 - epsilon) * generatedData);
-  discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+  responses.cols(numFunctions, numFunctions + batchSize - 1) =
       -arma::ones(1, batchSize);
   discriminator.Gradient(discriminator.parameter, numFunctions,
       normGradientDiscriminator, batchSize);
   res += lambda * std::pow(arma::norm(normGradientDiscriminator, 2) - 1, 2);
 
-  discriminator.predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       generatedData;
   res += discriminator.EvaluateWithGradient(discriminator.parameter,
       numFunctions, noiseGradientDiscriminator, batchSize);
@@ -157,7 +157,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
   {
     // Minimize -D(G(noise)).
     // Pass the error from Discriminator to Generator.
-    discriminator.responses.cols(numFunctions, numFunctions + batchSize - 1) =
+    responses.cols(numFunctions, numFunctions + batchSize - 1) =
         arma::ones(1, batchSize);
     discriminator.Gradient(discriminator.parameter, numFunctions,
         noiseGradientDiscriminator, batchSize);

--- a/src/mlpack/tests/gan_test.cpp
+++ b/src/mlpack/tests/gan_test.cpp
@@ -297,9 +297,12 @@ BOOST_AUTO_TEST_CASE(GANMemorySharingTest)
       noiseDim, batchSize, generatorUpdateStep, discriminatorPreTrain,
       multiplier);
 
+  CheckMatrices(gan.Predictors().head_cols(trainData.n_cols), trainData);
   CheckMatrices(gan.Predictors(), gan.Discriminator().Predictors());
   gan.Shuffle();
   CheckMatrices(gan.Predictors(), gan.Discriminator().Predictors());
+  CheckMatricesNotEqual(gan.Predictors().head_cols(trainData.n_cols),
+      trainData);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/gan_test.cpp
+++ b/src/mlpack/tests/gan_test.cpp
@@ -246,4 +246,60 @@ BOOST_AUTO_TEST_CASE(GANMNISTTest)
   Log::Info << "Output generated!" << std::endl;
 }
 
+/*
+ * Create GAN network and test for memory sharing
+ * between discriminator and gan predictors.
+ */
+BOOST_AUTO_TEST_CASE(GANMemorySharingTest)
+{
+  size_t generatorHiddenLayerSize = 8;
+  size_t discriminatorHiddenLayerSize = 8;
+  size_t generatorOutputSize = 1;
+  size_t discriminatorOutputSize = 1;
+  size_t discriminatorPreTrain = 0;
+  size_t batchSize = 8;
+  size_t noiseDim = 1;
+  size_t generatorUpdateStep = 1;
+  double multiplier = 1;
+
+  arma::mat trainData(1, 10000);
+  trainData.imbue( [&]() { return arma::as_scalar(RandNormal(4, 0.5));});
+  trainData = arma::sort(trainData);
+
+  // Create the Discriminator network
+  FFN<SigmoidCrossEntropyError<> > discriminator;
+  discriminator.Add<Linear<> > (
+      generatorOutputSize, discriminatorHiddenLayerSize * 2);
+  discriminator.Add<ReLULayer<> >();
+  discriminator.Add<Linear<> > (
+      discriminatorHiddenLayerSize * 2, discriminatorHiddenLayerSize * 2);
+  discriminator.Add<ReLULayer<> >();
+  discriminator.Add<Linear<> > (
+      discriminatorHiddenLayerSize * 2, discriminatorHiddenLayerSize * 2);
+  discriminator.Add<ReLULayer<> >();
+  discriminator.Add<Linear<> > (
+      discriminatorHiddenLayerSize * 2, discriminatorOutputSize);
+
+  // Create the Generator network
+  FFN<SigmoidCrossEntropyError<> > generator;
+  generator.Add<Linear<> >(noiseDim, generatorHiddenLayerSize);
+  generator.Add<SoftPlusLayer<> >();
+  generator.Add<Linear<> >(generatorHiddenLayerSize, generatorOutputSize);
+
+  // Create GAN
+  GaussianInitialization gaussian(0, 0.1);
+  std::function<double ()> noiseFunction = [](){ return math::Random(-8, 8) +
+      math::RandNormal(0, 1) * 0.01;};
+  GAN<FFN<SigmoidCrossEntropyError<> >,
+      GaussianInitialization,
+      std::function<double()> >
+  gan(trainData, generator, discriminator, gaussian, noiseFunction,
+      noiseDim, batchSize, generatorUpdateStep, discriminatorPreTrain,
+      multiplier);
+
+  CheckMatrices(gan.Predictors(), gan.Discriminator().Predictors());
+  gan.Shuffle();
+  CheckMatrices(gan.Predictors(), gan.Discriminator().Predictors());
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Previously during training the predictors were not being shuffled for the discriminator so, they were visited in the same order while `EvaluateWithGradient` was called on discriminator. 