### PR TITLE
Added support for concat along an axis.

### DIFF
--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -61,7 +61,7 @@ class Concat
    * @param model Expose all network modules.
    * @param run Call the Forward/Backward method before the output is merged.
    */
-  Concat(arma::Row<size_t> inputSize,
+  Concat(arma::Row<size_t>& inputSize,
          const size_t axis,
          const bool model = false,
          const bool run = true);

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -62,7 +62,7 @@ class Concat
    * @param run Call the Forward/Backward method before the output is merged.
    */
   Concat(arma::Row<size_t> inputSize,
-         const int axis,
+         const size_t axis,
          const bool model = false,
          const bool run = true);
 
@@ -211,7 +211,10 @@ class Concat
   arma::Row<size_t> inputSize;
 
   //! Parameter which indicates the axis of concatenation.
-  int axis;
+  size_t axis;
+
+  //! Parameter which indicates whether to use the axis of concatenation.
+  bool useAxis;
 
   //! Parameter to store channels
   size_t channels;

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -61,7 +61,7 @@ class Concat
    * @param model Expose all network modules.
    * @param run Call the Forward/Backward method before the output is merged.
    */
-  Concat(std::vector<int> inputSize,
+  Concat(arma::Row<arma::sword> inputSize,
          const int axis = -1,
          const bool model = false,
          const bool run = true);
@@ -208,7 +208,7 @@ class Concat
 
  private:
   //! Parameter which indicates the input size of modules.
-  std::vector<int> inputSize;
+  arma::Row<arma::sword> inputSize;
 
   //! Parameter which indicates the axis of concatenation.
   int axis;

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -213,11 +213,8 @@ class Concat
   //! Parameter which indicates the axis of concatenation.
   int axis;
 
-  //! Parameter to store oldColSize
-  size_t oldColSize;
-
-  //! Parameter to store newColSize
-  size_t newColSize;
+  //! Parameter to store channels
+  size_t channels;
 
   //! Parameter which indicates if the modules should be exposed.
   bool model;

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -61,8 +61,8 @@ class Concat
    * @param model Expose all network modules.
    * @param run Call the Forward/Backward method before the output is merged.
    */
-  Concat(arma::Row<arma::sword> inputSize,
-         const int axis = -1,
+  Concat(arma::Row<size_t> inputSize,
+         const int axis,
          const bool model = false,
          const bool run = true);
 
@@ -208,7 +208,7 @@ class Concat
 
  private:
   //! Parameter which indicates the input size of modules.
-  arma::Row<arma::sword> inputSize;
+  arma::Row<size_t> inputSize;
 
   //! Parameter which indicates the axis of concatenation.
   int axis;

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -54,6 +54,19 @@ class Concat
          const bool run = true);
 
   /**
+   * Create the Concat object using the specified parameters.
+   *
+   * @param inputSize A vector denoting input size of each layer added.
+   * @param axis Concat axis.
+   * @param model Expose all network modules.
+   * @param run Call the Forward/Backward method before the output is merged.
+   */
+  Concat(std::vector<int> inputSize,
+         const int axis = -1,
+         const bool model = false,
+         const bool run = true);
+
+  /**
    * Destroy the layers held by the model.
    */
   ~Concat();
@@ -194,6 +207,18 @@ class Concat
   void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
+  //! Parameter which indicates the input size of modules.
+  std::vector<int> inputSize;
+
+  //! Parameter which indicates the axis of concatenation.
+  int axis;
+
+  //! Parameter to store oldColSize
+  size_t oldColSize;
+
+  //! Parameter to store newColSize
+  size_t newColSize;
+
   //! Parameter which indicates if the modules should be exposed.
   bool model;
 

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -207,7 +207,6 @@ class Concat
   void serialize(Archive& /* ar */, const unsigned int /* version */);
 
  private:
-
   //! Parameter which indicates the input size of modules.
   std::vector<int> inputSize;
 

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -216,7 +216,7 @@ class Concat
   //! Parameter which indicates whether to use the axis of concatenation.
   bool useAxis;
 
-  //! Parameter to store channels
+  //! Parameter to store channels.
   size_t channels;
 
   //! Parameter which indicates if the modules should be exposed.

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -206,6 +206,8 @@ class Concat
   template<typename Archive>
   void serialize(Archive& /* ar */, const unsigned int /* version */);
 
+ private:
+
   //! Parameter which indicates the input size of modules.
   std::vector<int> inputSize;
 
@@ -218,7 +220,6 @@ class Concat
   //! Parameter to store newColSize
   size_t newColSize;
 
- private:
   //! Parameter which indicates if the modules should be exposed.
   bool model;
 

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -206,7 +206,6 @@ class Concat
   template<typename Archive>
   void serialize(Archive& /* ar */, const unsigned int /* version */);
 
- private:
   //! Parameter which indicates the input size of modules.
   std::vector<int> inputSize;
 
@@ -219,6 +218,7 @@ class Concat
   //! Parameter to store newColSize
   size_t newColSize;
 
+ private:
   //! Parameter which indicates if the modules should be exposed.
   bool model;
 

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -20,7 +20,7 @@
 #include "../visitor/gradient_visitor.hpp"
 
 namespace mlpack {
-namespace ann /** Artificial Neural Network. */ {  
+namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
@@ -160,7 +160,7 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
       size_t rows = boost::apply_visitor(
           outputParameterVisitor, network[i]).n_rows;
 
-      // Extract from gy the parameters for the i-th network. 
+      // Extract from gy the parameters for the i-th network.
       delta = gy.rows(rowCount / channels, (rowCount + rows) / channels - 1);
       delta.reshape(delta.n_rows * channels, delta.n_cols / channels);
 
@@ -238,7 +238,7 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
       size_t rows = boost::apply_visitor(
           outputParameterVisitor, network[i]).n_rows;
 
-      // Extract from error the parameters for the i-th network. 
+      // Extract from error the parameters for the i-th network.
       arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) /
           channels - 1);
       err.reshape(err.n_rows * channels, err.n_cols / channels);

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -45,7 +45,7 @@ Concat<InputDataType,
        OutputDataType,
        CustomLayers...
       >::Concat(
-      arma::Row<size_t> inputSize,
+      arma::Row<size_t>& inputSize,
       const size_t axis,
       const bool model,
       const bool run) :
@@ -53,8 +53,7 @@ Concat<InputDataType,
       axis(axis),
       useAxis(true),
       model(model),
-      run(run),
-      channels(1)
+      run(run)
 {
   parameters.set_size(0, 0);
 

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -24,12 +24,18 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
-Concat<InputDataType, OutputDataType, CustomLayers...>::Concat(
-    const bool model, const bool run) : model(model), run(run)
+Concat<InputDataType,
+       OutputDataType,
+       CustomLayers...
+      >::Concat(
+      const bool model,
+      const bool run) :
+      axis(-1),
+      model(model),
+      run(run),
+      channels(1)
 {
   parameters.set_size(0, 0);
-  axis = -1;
-  channels = 1;
 }
 
 template<typename InputDataType, typename OutputDataType,
@@ -45,10 +51,10 @@ Concat<InputDataType,
       inputSize(inputSize),
       axis(axis),
       model(model),
-      run(run)
+      run(run),
+      channels(1)
 {
   parameters.set_size(0, 0);
-  channels = 1;
 }
 
 template<typename InputDataType, typename OutputDataType,

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -60,7 +60,7 @@ Concat<InputDataType,
     }
     if (unknown > 1)
     {
-      throw std::runtime_error("More than one dimension unknown.");
+      throw std::logic_error("More than one dimension unknown.");
     }
   }
 }
@@ -114,12 +114,12 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
     }
     else
     {
-      throw std::runtime_error("Input Dimensions not specified.");
+      throw std::logic_error("Input Dimensions not specified.");
     }
   }
   if (newColSize <= 0)
   {
-      throw std::runtime_error("Col Size is zero.");
+      throw std::logic_error("Col Size is zero.");
   }
   rowSize = output.n_rows * output.n_cols / newColSize;
   output.reshape(rowSize, newColSize);

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -119,14 +119,15 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
   }
   if (newColSize <= 0)
   {
-      throw std::runtime_error("Output not found;");
+      throw std::runtime_error("Col Size is zero.");
   }
   rowSize = output.n_rows * output.n_cols / newColSize;
   output.reshape(rowSize, newColSize);
 
   for (size_t i = 1; i < network.size(); ++i)
   {
-    arma::Mat<eT> out = boost::apply_visitor(outputParameterVisitor, network[i]);
+    arma::Mat<eT> out = boost::apply_visitor(outputParameterVisitor,
+        network[i]);
 
     rowSize = out.n_rows * out.n_cols / newColSize;
     out.reshape(rowSize, newColSize);
@@ -191,13 +192,15 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
 
   for (size_t i = 0; i < index; ++i)
   {
-    rowCount += boost::apply_visitor(outputParameterVisitor, network[i]).n_rows;
+    rowCount += boost::apply_visitor(
+        outputParameterVisitor, network[i]).n_rows;
   }
   rows = boost::apply_visitor(outputParameterVisitor, network[index]).n_rows;
 
   gy.reshape(gy.n_rows / channels, gy.n_cols * channels);
 
-  arma::Mat<eT> delta = gy.rows(rowCount / channels, (rowCount + rows) / channels - 1);
+  arma::Mat<eT> delta = gy.rows(rowCount / channels, (rowCount + rows) /
+      channels - 1);
   delta.reshape(delta.n_rows * channels, delta.n_cols / channels);
 
   boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
@@ -228,7 +231,8 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
       size_t rows = boost::apply_visitor(
           outputParameterVisitor, network[i]).n_rows;
 
-      arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) / channels - 1);
+      arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) /
+          channels - 1);
       err.reshape(err.n_rows * channels, err.n_cols / channels);
 
       boost::apply_visitor(GradientVisitor(std::move(input),
@@ -253,13 +257,15 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
 
   for (size_t i = 0; i < index; ++i)
   {
-    rowCount += boost::apply_visitor(outputParameterVisitor, network[i]).n_rows;
+    rowCount += boost::apply_visitor(outputParameterVisitor,
+        network[i]).n_rows;
   }
   size_t rows = boost::apply_visitor(
       outputParameterVisitor, network[index]).n_rows;
 
   error.reshape(error.n_rows / channels, error.n_cols * channels);
-  arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) / channels - 1);
+  arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) /
+      channels - 1);
   err.reshape(err.n_rows * channels, err.n_cols / channels);
 
   boost::apply_visitor(GradientVisitor(std::move(input),

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -38,7 +38,7 @@ Concat<InputDataType,
        OutputDataType,
        CustomLayers...
       >::Concat(
-      std::vector<int> inputSize,
+      arma::Row<arma::sword> inputSize,
       const int axis,
       const bool model,
       const bool run) :
@@ -51,7 +51,7 @@ Concat<InputDataType,
   int unknown = 0;
   if (axis < 0)
   {
-    for (int i = 0; i < inputSize.size(); ++i)
+    for (int i = 0; i < inputSize.n_elem; ++i)
     {
       if (inputSize[i] < 0)
       {
@@ -103,13 +103,13 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
   {
     // Axis is specified without input dimension.
     // Throw an error.
-    if (inputSize.size() > 0)
+    if (inputSize.n_elem > 0)
     {
       // Calculate rowSize, newColSize based on the axis
       // of concatenation. Finally concat along cols and
       // reshape to original format i.e. (input, batch_size).
-      int i = std::min(axis + 1, (int) inputSize.size());
-      for (; i < inputSize.size(); ++i)
+      int i = std::min(axis + 1, (int) inputSize.n_elem);
+      for (; i < inputSize.n_elem; ++i)
       {
         newColSize *= inputSize[i];
       }

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -30,7 +30,8 @@ Concat<InputDataType,
       >::Concat(
       const bool model,
       const bool run) :
-      axis(-1),
+      axis(0),
+      useAxis(false),
       model(model),
       run(run),
       channels(1)
@@ -45,11 +46,12 @@ Concat<InputDataType,
        CustomLayers...
       >::Concat(
       arma::Row<size_t> inputSize,
-      const int axis,
+      const size_t axis,
       const bool model,
       const bool run) :
       inputSize(inputSize),
       axis(axis),
+      useAxis(true),
       model(model),
       run(run),
       channels(1)
@@ -88,8 +90,8 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
 
   newColSize = oldColSize = output.n_cols;
 
-  // Axis is not specified.
-  if (axis >= 0)
+  // Axis is specified and useAxis is true.
+  if (useAxis)
   {
     // Axis is specified without input dimension.
     // Throw an error.
@@ -98,7 +100,7 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
       // Calculate rowSize, newColSize based on the axis
       // of concatenation. Finally concat along cols and
       // reshape to original format i.e. (input, batch_size).
-      size_t i = std::min(axis + 1, (int)inputSize.n_elem);
+      size_t i = std::min(axis + 1, (size_t)inputSize.n_elem);
       for (; i < inputSize.n_elem; ++i)
       {
         newColSize *= inputSize[i];

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -38,7 +38,7 @@ Concat<InputDataType,
        OutputDataType,
        CustomLayers...
       >::Concat(
-      arma::Row<arma::sword> inputSize,
+      arma::Row<size_t> inputSize,
       const int axis,
       const bool model,
       const bool run) :
@@ -48,23 +48,7 @@ Concat<InputDataType,
       run(run)
 {
   parameters.set_size(0, 0);
-  int unknown = 0;
-  if (axis < 0)
-  {
-    for (int i = 0; i < inputSize.n_elem; ++i)
-    {
-      if (inputSize[i] < 0)
-      {
-        Concat::axis = i;
-        unknown++;
-      }
-    }
-    if (unknown > 1)
-    {
-      throw std::logic_error("More than one dimension unknown.");
-    }
-  }
-  Concat::channels = 1;
+  channels = 1;
 }
 
 template<typename InputDataType, typename OutputDataType,
@@ -93,7 +77,7 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
   }
 
   // Parameter to store dimensions(rowSize).
-  int rowSize, oldColSize, newColSize;
+  size_t rowSize, oldColSize, newColSize;
   output = boost::apply_visitor(outputParameterVisitor, network.front());
 
   newColSize = oldColSize = output.n_cols;
@@ -108,7 +92,7 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
       // Calculate rowSize, newColSize based on the axis
       // of concatenation. Finally concat along cols and
       // reshape to original format i.e. (input, batch_size).
-      int i = std::min(axis + 1, (int) inputSize.n_elem);
+      size_t i = std::min(axis + 1, (int)inputSize.n_elem);
       for (; i < inputSize.n_elem; ++i)
       {
         newColSize *= inputSize[i];
@@ -116,12 +100,12 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
     }
     else
     {
-      throw std::logic_error("Input Dimensions not specified.");
+      throw std::logic_error("Input dimensions not specified.");
     }
   }
   if (newColSize <= 0)
   {
-      throw std::logic_error("Col Size is zero.");
+      throw std::logic_error("Col size is zero.");
   }
 
   channels = newColSize / oldColSize;

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -57,6 +57,40 @@ Concat<InputDataType,
       channels(1)
 {
   parameters.set_size(0, 0);
+
+  // Parameters to help calculate the number of channels.
+  size_t  oldColSize = 1, newColSize = 1;
+  // Axis is specified and useAxis is true.
+  if (useAxis)
+  {
+    // Axis is specified without input dimension.
+    // Throw an error.
+    if (inputSize.n_elem > 0)
+    {
+      // Calculate rowSize, newColSize based on the axis
+      // of concatenation. Finally concat along cols and
+      // reshape to original format i.e. (input, batch_size).
+      size_t i = std::min(axis + 1, (size_t)inputSize.n_elem);
+      for (; i < inputSize.n_elem; ++i)
+      {
+        newColSize *= inputSize[i];
+      }
+    }
+    else
+    {
+      throw std::logic_error("Input dimensions not specified.");
+    }
+  }
+  else
+  {
+    channels = 1;
+  }
+  if (newColSize <= 0)
+  {
+      throw std::logic_error("Col size is zero.");
+  }
+  channels = newColSize / oldColSize;
+  inputSize.clear();
 }
 
 template<typename InputDataType, typename OutputDataType,
@@ -84,57 +118,23 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
     }
   }
 
-  // Parameter to store dimensions(rowSize).
-  size_t rowSize, oldColSize, newColSize;
   output = boost::apply_visitor(outputParameterVisitor, network.front());
 
-  newColSize = oldColSize = output.n_cols;
-
-  // Axis is specified and useAxis is true.
-  if (useAxis)
-  {
-    // Axis is specified without input dimension.
-    // Throw an error.
-    if (inputSize.n_elem > 0)
-    {
-      // Calculate rowSize, newColSize based on the axis
-      // of concatenation. Finally concat along cols and
-      // reshape to original format i.e. (input, batch_size).
-      size_t i = std::min(axis + 1, (size_t)inputSize.n_elem);
-      for (; i < inputSize.n_elem; ++i)
-      {
-        newColSize *= inputSize[i];
-      }
-    }
-    else
-    {
-      throw std::logic_error("Input dimensions not specified.");
-    }
-  }
-  if (newColSize <= 0)
-  {
-      throw std::logic_error("Col size is zero.");
-  }
-
-  channels = newColSize / oldColSize;
-  // Compute the rowSize after which join_cols() is called.
-  rowSize = output.n_rows * output.n_cols / newColSize;
-  output.reshape(rowSize, newColSize);
+  // Reshape output to incorporate the channels.
+  output.reshape(output.n_rows / channels, output.n_cols * channels);
 
   for (size_t i = 1; i < network.size(); ++i)
   {
     arma::Mat<eT> out = boost::apply_visitor(outputParameterVisitor,
         network[i]);
 
-    rowSize = out.n_rows * out.n_cols / newColSize;
-    out.reshape(rowSize, newColSize);
+    out.reshape(out.n_rows / channels, out.n_cols * channels);
 
     // Vertically concatentate output from each layer.
     output = arma::join_cols(output, out);
   }
-
-  rowSize = output.n_rows * output.n_cols / oldColSize;
-  output.reshape(rowSize, oldColSize);
+  // Reshape output to its original shape.
+  output.reshape(output.n_rows * channels, output.n_cols / channels);
 }
 
 template<typename InputDataType, typename OutputDataType,
@@ -222,8 +222,6 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
   if (run)
   {
     size_t rowCount = 0;
-
-
     // Reshape error to extract the i-th layer error.
     error.reshape(error.n_rows / channels, error.n_cols * channels);
     for (size_t i = 0; i < network.size(); ++i)
@@ -256,7 +254,6 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
     const size_t index)
 {
   size_t rowCount = 0;
-
   for (size_t i = 0; i < index; ++i)
   {
     rowCount += boost::apply_visitor(outputParameterVisitor,

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1104,7 +1104,8 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
     }
 
     // Compute output of Concat<> layer.
-    Concat<> module({outputWidth, outputHeight, outputChannel}, axis);
+    arma::Row<size_t> inputSize{outputWidth, outputHeight, outputChannel};
+    Concat<> module(inputSize, axis);
     module.Add(moduleA);
     module.Add(moduleB);
     module.Forward(std::move(input), std::move(output));

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1040,10 +1040,10 @@ BOOST_AUTO_TEST_CASE(SimpleConcatLayerTest)
 BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
 {
   arma::mat output, input, outputA, outputB;
-  int inputWidth = 4, inputHeight = 4, inputChannel = 2;
-  int outputWidth, outputHeight, outputChannel = 2;
-  int kW = 3, kH = 3;
-  int batch = 1;
+  size_t inputWidth = 4, inputHeight = 4, inputChannel = 2;
+  size_t outputWidth, outputHeight, outputChannel = 2;
+  size_t kW = 3, kH = 3;
+  size_t batch = 1;
 
   // Using Convolution<> layer as inout to Concat<> layer.
   // Compute the output shape of convolution layer.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1035,11 +1035,11 @@ BOOST_AUTO_TEST_CASE(SimpleConcatLayerTest)
 }
 
 /**
- * Test to check Concat<> along different axis.
+ * Test to check Concat layer along different axes.
  */
 BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
 {
-  arma::mat output, input, outputA, outputB;
+  arma::mat output, input, error, outputA, outputB;
   size_t inputWidth = 4, inputHeight = 4, inputChannel = 2;
   size_t outputWidth, outputHeight, outputChannel = 2;
   size_t kW = 3, kH = 3;
@@ -1068,6 +1068,8 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
 
   arma::cube A(outputA.memptr(), outputWidth, outputHeight, outputChannel);
   arma::cube B(outputB.memptr(), outputWidth, outputHeight, outputChannel);
+
+  error = arma::ones(outputWidth * outputHeight * outputChannel * 2, 1);
 
   for (size_t axis = 0; axis < 3; ++axis)
   {

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1034,6 +1034,9 @@ BOOST_AUTO_TEST_CASE(SimpleConcatLayerTest)
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 }
 
+/**
+ * Test to check Concat<> along different axis.
+ */
 BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
 {
   arma::mat output, input, outputA, outputB;
@@ -1042,6 +1045,8 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
   int kW = 3, kH = 3;
   int batch = 1;
 
+  // Using Convolution<> layer as inout to Concat<> layer.
+  // Compute the output shape of convolution layer.
   outputWidth  = (inputWidth - kW) + 1;
   outputHeight = (inputHeight - kH) + 1;
 
@@ -1057,6 +1062,7 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
   moduleB.Reset();
   moduleB.Parameters().randu();
 
+  // Compute output of each layer.
   moduleA.Forward(std::move(input), std::move(outputA));
   moduleB.Forward(std::move(input), std::move(outputB));
 
@@ -1095,12 +1101,14 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
       z = 2;
     }
 
+    // Compute output of Concat<> layer.
     Concat<> module({outputWidth, outputHeight, outputChannel}, axis);
     module.Add(moduleA);
     module.Add(moduleB);
     module.Forward(std::move(input), std::move(output));
     arma::cube concatOut(output.memptr(), x * outputWidth, y * outputHeight, z * outputChannel);
 
+    // Verify if the output reshaped to cubes are similar. 
     CheckMatrices(concatOut, calculatedOut, 1e-12);
   }
 }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1052,7 +1052,7 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
 
   input = arma::ones(inputWidth * inputHeight * inputChannel, batch);
 
-  Convolution<> moduleA(inputChannel, outputChannel, kW, kH,1, 1, 0, 0,
+  Convolution<> moduleA(inputChannel, outputChannel, kW, kH, 1, 1, 0, 0,
       inputWidth, inputHeight);
   Convolution<> moduleB(inputChannel, outputChannel, kW, kH, 1, 1, 0, 0,
       inputWidth, inputHeight);
@@ -1106,9 +1106,10 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
     module.Add(moduleA);
     module.Add(moduleB);
     module.Forward(std::move(input), std::move(output));
-    arma::cube concatOut(output.memptr(), x * outputWidth, y * outputHeight, z * outputChannel);
+    arma::cube concatOut(output.memptr(), x * outputWidth,
+        y * outputHeight, z * outputChannel);
 
-    // Verify if the output reshaped to cubes are similar. 
+    // Verify if the output reshaped to cubes are similar.
     CheckMatrices(concatOut, calculatedOut, 1e-12);
   }
 }


### PR DESCRIPTION
I have added an axis parameter for `Concat<>` layer to help achieve concatenation along a specific axis. It would help in models which need concat along an arbitrary axis.

Besides, the axis it also needs `inputShape` from the previous layer.