### PR TITLE
Added max epsilon constraint in epsilon greedy policy

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
+++ b/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
@@ -51,7 +51,7 @@ class GreedyPolicy
       epsilon(initialEpsilon),
       minEpsilon(minEpsilon),
       maxEpsilon(maxEpsilon),
-      delta((initialEpsilon - (minEpsilon + maxEpsilon) / 2) / annealInterval)
+      delta((initialEpsilon - minEpsilon) / annealInterval)
   { /* Nothing to do here. */ }
 
   /**

--- a/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
+++ b/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
@@ -80,7 +80,7 @@ class GreedyPolicy
   void Anneal()
   {
     epsilon -= delta;
-    epsilon = (std::max(minEpsilon, epsilon) + std::min(maxEpsilon, epsilon))/2;
+    epsilon = std::max(minEpsilon, epsilon);
   }
 
   /**

--- a/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
+++ b/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
@@ -41,8 +41,6 @@ class GreedyPolicy
    * @param annealInterval The steps during which the probability to explore
    *        will anneal.
    * @param minEpsilon Epsilon will never be less than this value.
-   *
-   * @param maxEpsilon Epsilon will never be more than this value.
    */
   GreedyPolicy(const double initialEpsilon,
                const size_t annealInterval,
@@ -94,7 +92,7 @@ class GreedyPolicy
 
   //! Locally-stored lower bound for epsilon.
   double minEpsilon;
-
+ 
   //! Locally-stored upper bound for epsilon.
   double maxEpsilon;
 

--- a/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
+++ b/src/mlpack/methods/reinforcement_learning/policy/greedy_policy.hpp
@@ -41,13 +41,17 @@ class GreedyPolicy
    * @param annealInterval The steps during which the probability to explore
    *        will anneal.
    * @param minEpsilon Epsilon will never be less than this value.
+   *
+   * @param maxEpsilon Epsilon will never be more than this value.
    */
   GreedyPolicy(const double initialEpsilon,
                const size_t annealInterval,
-               const double minEpsilon) :
+               const double minEpsilon,
+               const double maxEpsilon) :
       epsilon(initialEpsilon),
       minEpsilon(minEpsilon),
-      delta((initialEpsilon - minEpsilon) / annealInterval)
+      maxEpsilon(maxEpsilon),
+      delta((initialEpsilon - (minEpsilon + maxEpsilon) / 2) / annealInterval)
   { /* Nothing to do here. */ }
 
   /**
@@ -76,7 +80,7 @@ class GreedyPolicy
   void Anneal()
   {
     epsilon -= delta;
-    epsilon = std::max(minEpsilon, epsilon);
+    epsilon = (std::max(minEpsilon, epsilon) + std::min(maxEpsilon, epsilon))/2;
   }
 
   /**
@@ -90,6 +94,9 @@ class GreedyPolicy
 
   //! Locally-stored lower bound for epsilon.
   double minEpsilon;
+
+  //! Locally-stored upper bound for epsilon.
+  double maxEpsilon;
 
   //! Locally-stored stride for epsilon to anneal.
   double delta;


### PR DESCRIPTION
Only having a min epsilon constraint was more like hard coding it to take some particular values. While adding a max constraint helps the algorithm to explore more while still limiting it by the value imposed by it. I think this would be particularly helpful in future works while exploring continuous action states. 