### PR TITLE
Add more Error metrics

### DIFF
--- a/src/mlpack/core/cv/metrics/CMakeLists.txt
+++ b/src/mlpack/core/cv/metrics/CMakeLists.txt
@@ -7,12 +7,16 @@ set(SOURCES
   f1.hpp
   f1_impl.hpp
   facilities.hpp
+  mae.hpp
+  mae_impl.hpp
   mse.hpp
   mse_impl.hpp
   precision.hpp
   precision_impl.hpp
   recall.hpp
   recall_impl.hpp
+  rmse.hpp
+  rmse_impl.hpp
 )
 
 # Add directory name to sources.

--- a/src/mlpack/core/cv/metrics/facilities.hpp
+++ b/src/mlpack/core/cv/metrics/facilities.hpp
@@ -40,6 +40,21 @@ void AssertSizes(const DataType& data,
   }
 }
 
+template<typename DataType, typename ResponsesType>
+void AssertColumnSizes(const DataType& data,
+                       const ResponsesType& responses,
+                       const std::string& callerDescription)
+{
+  if (data.n_cols != responses.n_cols)
+  {
+    std::ostringstream oss;
+    oss << callerDescription <<": number of points (" << data.n_cols << ") "
+        << "does not match number of responses (" << responses.n_cols << ")!"
+        << std::endl;
+    throw std::invalid_argument(oss.str());
+  }
+}
+
 } // namespace cv
 } // namespace mlpack
 

--- a/src/mlpack/core/cv/metrics/facilities.hpp
+++ b/src/mlpack/core/cv/metrics/facilities.hpp
@@ -1,6 +1,7 @@
 /**
  * @file facilities.hpp
  * @author Kirill Mishchenko
+ * @author Gaurav Sharma
  *
  * Functionality that is used more than in one metric.
  *

--- a/src/mlpack/core/cv/metrics/mae.hpp
+++ b/src/mlpack/core/cv/metrics/mae.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file mae.hpp
+ * @author Gaurav Sharma
+ *
+ * The mean absolute error (MAE).
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_MAE_HPP
+#define MLPACK_CORE_CV_METRICS_MAE_HPP
+
+#include <mlpack/core.hpp>
+
+namespace mlpack {
+namespace cv {
+
+/**
+ * The MeanAbsoluteError is a metric of performance for regression algorithms
+ * that is equal to the mean absolute error between predicted values and ground
+ * truth (correct) values for given test items.
+ */
+class MAE
+{
+ public:
+  /**
+   * Run prediction and calculate the mean absolute error.
+   *
+   * @param model A regression model.
+   * @param data Column-major data containing test items.
+   * @param responses Ground truth (correct) target values for the test items,
+   *     should be either a row vector or a column-major matrix.
+   */
+  template<typename MLAlgorithm, typename DataType, typename ResponsesType>
+  static double Evaluate(MLAlgorithm& model,
+                         const DataType& data,
+                         const ResponsesType& responses);
+
+  /**
+   * Information for hyper-parameter tuning code. It indicates that we want
+   * to minimize the measurement.
+   */
+  static const bool NeedsMinimization = true;
+};
+
+} // namespace cv
+} // namespace mlpack
+
+// Include implementation.
+#include "mae_impl.hpp"
+
+#endif

--- a/src/mlpack/core/cv/metrics/mae_impl.hpp
+++ b/src/mlpack/core/cv/metrics/mae_impl.hpp
@@ -1,0 +1,37 @@
+/**
+ * @file mae_impl.hpp
+ * @author Gaurav Sharma
+ *
+ * The implementation of the class MAE.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_MAE_IMPL_HPP
+#define MLPACK_CORE_CV_METRICS_MAE_IMPL_HPP
+
+#include <mlpack/core/cv/metrics/facilities.hpp>
+
+namespace mlpack {
+namespace cv {
+
+template<typename MLAlgorithm, typename DataType, typename ResponsesType>
+double MAE::Evaluate(MLAlgorithm& model,
+                     const DataType& data,
+                     const ResponsesType& responses)
+{
+  AssertColumnSizes(data, responses, "MAE::Evaluate()");
+
+  ResponsesType predictedResponses;
+  model.Predict(data, predictedResponses);
+  double sum = arma::accu(arma::abs(responses - predictedResponses));
+
+  return sum / responses.n_elem;
+}
+
+} // namespace cv
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/core/cv/metrics/mse.hpp
+++ b/src/mlpack/core/cv/metrics/mse.hpp
@@ -36,7 +36,8 @@ class MSE
   template<typename MLAlgorithm, typename DataType, typename ResponsesType>
   static double Evaluate(MLAlgorithm& model,
                          const DataType& data,
-                         const ResponsesType& responses);
+                         const ResponsesType& responses,
+						              const std::string& callerDescription = "MSE::Evaluate()");
 
   /**
    * Information for hyper-parameter tuning code. It indicates that we want

--- a/src/mlpack/core/cv/metrics/mse_impl.hpp
+++ b/src/mlpack/core/cv/metrics/mse_impl.hpp
@@ -12,23 +12,19 @@
 #ifndef MLPACK_CORE_CV_METRICS_MSE_IMPL_HPP
 #define MLPACK_CORE_CV_METRICS_MSE_IMPL_HPP
 
+#include <mlpack/core/cv/metrics/facilities.hpp>
+
 namespace mlpack {
 namespace cv {
 
 template<typename MLAlgorithm, typename DataType, typename ResponsesType>
 double MSE::Evaluate(MLAlgorithm& model,
                      const DataType& data,
-                     const ResponsesType& responses)
+                     const ResponsesType& responses,
+					 const std::string& callerDescription)
 {
-  if (data.n_cols != responses.n_cols)
-  {
-    std::ostringstream oss;
-    oss << "MSE::Evaluate(): number of points (" << data.n_cols << ") "
-        << "does not match number of responses (" << responses.n_cols << ")!"
-        << std::endl;
-    throw std::invalid_argument(oss.str());
-  }
-
+  AssertColumnSizes(data, responses, "MSE::Evaluate()");
+  
   ResponsesType predictedResponses;
   model.Predict(data, predictedResponses);
   double sum = arma::accu(arma::square(responses - predictedResponses));

--- a/src/mlpack/core/cv/metrics/rmse.hpp
+++ b/src/mlpack/core/cv/metrics/rmse.hpp
@@ -1,0 +1,55 @@
+/**
+ * @file rmse.hpp
+ * @author Gaurav Sharma
+ *
+ * The root mean squared error (RMSE).
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_RMSE_HPP
+#define MLPACK_CORE_CV_METRICS_RMSE_HPP
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/cv/metrics/mse.hpp>
+
+namespace mlpack {
+namespace cv {
+
+/**
+ * The RootMeanSquaredError is a metric of performance for regression algorithms
+ * that is equal to the root mean squared error between predicted values and
+ * ground truth (correct) values for given test items.
+ */
+class RMSE
+{
+ public:
+  /**
+   * Run prediction and calculate the root mean squared error.
+   *
+   * @param model A regression model.
+   * @param data Column-major data containing test items.
+   * @param responses Ground truth (correct) target values for the test items,
+   *     should be either a row vector or a column-major matrix.
+   */
+  template<typename MLAlgorithm, typename DataType, typename ResponsesType>
+  static double Evaluate(MLAlgorithm& model,
+                         const DataType& data,
+                         const ResponsesType& responses);
+
+  /**
+   * Information for hyper-parameter tuning code. It indicates that we want
+   * to minimize the measurement.
+   */
+  static const bool NeedsMinimization = true;
+};
+
+} // namespace cv
+} // namespace mlpack
+
+// Include implementation.
+#include "rmse_impl.hpp"
+
+#endif

--- a/src/mlpack/core/cv/metrics/rmse_impl.hpp
+++ b/src/mlpack/core/cv/metrics/rmse_impl.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file rmse_impl.hpp
+ * @author Gaurav Sharma
+ *
+ * The implementation of the class RMSE.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_RMSE_IMPL_HPP
+#define MLPACK_CORE_CV_METRICS_RMSE_IMPL_HPP
+
+namespace mlpack {
+namespace cv {
+
+template<typename MLAlgorithm, typename DataType, typename ResponsesType>
+double RMSE::Evaluate(MLAlgorithm& model,
+                     const DataType& data,
+                     const ResponsesType& responses)
+{
+  return sqrt(MSE::Evaluate(model, data, responses, "ERROR::Evaluate_RMSE()"));
+}
+
+} // namespace cv
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -15,6 +15,8 @@
 #include <mlpack/core/cv/metrics/accuracy.hpp>
 #include <mlpack/core/cv/metrics/f1.hpp>
 #include <mlpack/core/cv/metrics/mse.hpp>
+#include <mlpack/core/cv/metrics/mae.hpp>
+#include <mlpack/core/cv/metrics/rmse.hpp>
 #include <mlpack/core/cv/metrics/precision.hpp>
 #include <mlpack/core/cv/metrics/recall.hpp>
 #include <mlpack/core/cv/simple_cv.hpp>
@@ -142,6 +144,48 @@ BOOST_AUTO_TEST_CASE(MSETest)
   double expectedMSE = (0 * 0 + 1 * 1 + 2 * 2) / 3.0;
 
   BOOST_REQUIRE_CLOSE(MSE::Evaluate(lr, data, responses), expectedMSE, 1e-5);
+}
+
+/**
+ * Test the mean absolute error.
+ */
+BOOST_AUTO_TEST_CASE(MAETest)
+{
+  // Making two points that define the linear function f(x) = x - 1
+  arma::mat trainingData("0 1");
+  arma::rowvec trainingResponses("-1 0");
+
+  LinearRegression lr(trainingData, trainingResponses);
+
+  // Making three responses that differ from the correct ones by 0, 1, and 2
+  // respectively
+  arma::mat data("2 3 4");
+  arma::rowvec responses("1 3 5");
+
+  double expectedMAE = (0 + 1 + 2) / 3.0;
+
+  BOOST_REQUIRE_CLOSE(MAE::Evaluate(lr, data, responses), expectedMAE, 1e-5);
+}
+
+/**
+ * Test the root mean squared error.
+ */
+BOOST_AUTO_TEST_CASE(RMSETest)
+{
+  // Making two points that define the linear function f(x) = x - 1
+  arma::mat trainingData("0 1");
+  arma::rowvec trainingResponses("-1 0");
+
+  LinearRegression lr(trainingData, trainingResponses);
+
+  // Making three responses that differ from the correct ones by 0, 1, and 2
+  // respectively
+  arma::mat data("2 3 4");
+  arma::rowvec responses("1 3 5");
+
+  double expectedRMSE = sqrt((0 * 0 + 1 * 1 + 2 * 2) / 3.0);
+
+  BOOST_REQUIRE_CLOSE(RMSE::Evaluate(lr, data, responses), expectedRMSE, 1e-5);
 }
 
 /**


### PR DESCRIPTION
In this PR I added mean absolute error(MAE) and root mean squared error(RMSE), these two errors are very frequently used by machine learning practitioner while dealing with model's accuracy and errors, so having support for these two very common metrics will be very useful and handy for mlpack users.

I also added a function AssetColumnSizes() in facilities.hpp as this function is used by many metric classes. 

I replace code with function call to AssertColumnSizes() in mse_impl.hpp.

I also added tests for both metrics.  