### PR TITLE
Rectified Predict() in rnn_impl (#1846).

### DIFF
--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -164,9 +164,16 @@ void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Predict(
       Forward(std::move(arma::mat(predictors.slice(seqNum).colptr(begin),
           predictors.n_rows, effectiveBatchSize, false, true)));
 
-      results.slice(seqNum).submat(0, begin, results.n_rows - 1, begin +
-          effectiveBatchSize - 1) = boost::apply_visitor(outputParameterVisitor,
+      arma::mat out = boost::apply_visitor(outputParameterVisitor,
           network.back());
+
+      if (results.n_rows == 0)
+      {
+        results.set_size(out.n_rows, predictors.n_cols, rho);
+      }
+
+      results.slice(seqNum).submat(0, begin, results.n_rows - 1, begin +
+          effectiveBatchSize - 1) = out;
     }
   }
 }


### PR DESCRIPTION
```c++
  const size_t rho = 5;
  arma::cube questions = arma::ones(1,2,rho);
  arma::cube answers = arma::ones(1,2,rho);
  
  mlpack::ann::RNN<mlpack::ann::MeanSquaredError<> > model(rho);
  model.Add<mlpack::ann::Linear<> >(1, 10);
  model.Add<mlpack::ann::LSTM<> >(10,10);
  model.Add<mlpack::ann::Linear<> >(10, 1);
  
  model.Parameters().randu();
  model.Predict(questions, answers);
```
Running the above snippet produces :
```bash
error: Mat::submat(): indices out of bounds or incorrectly used
  terminate called after throwing an instance of 'std::logic_error'
    what():  Mat::submat(): indices out of bounds or incorrectly used
  Aborted (core dumped)
```
However, if the last line in the above snippet is replaced by:
```c++
model.Train(questions, answers);
model.Predict(questions, answers);
```
It works perfectly. 
Evalute method sets RNN::outputSize. When predict is called before Train() RNN::outputSize is 0. 
Thus Mat::submat() fails.This PR makes Predict and Evaluate method of class RNN consistent by adding a test and set for RNN::outputSize .
Closes #1846 . 