### PR TITLE
OpenMP support for some methods

### DIFF
--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -54,6 +54,8 @@ void Split(const arma::Mat<T>& input,
            arma::Row<U>& testLabel,
            const double testRatio)
 {
+  Timer::Start("splitting_data");
+
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
   const size_t trainSize = input.n_cols - testSize;
   trainData.set_size(input.n_rows, trainSize);
@@ -64,18 +66,20 @@ void Split(const arma::Mat<T>& input,
   const arma::Col<size_t> order =
       arma::shuffle(arma::linspace<arma::Col<size_t>>(0, input.n_cols - 1,
                                                       input.n_cols));
-
-  for (size_t i = 0; i != trainSize; ++i)
+  #pragma omp parallel for
+  for (omp_size_t i = 0; i < trainSize; ++i)
   {
     trainData.col(i) = input.col(order[i]);
     trainLabel(i) = inputLabel(order[i]);
   }
-
-  for (size_t i = 0; i != testSize; ++i)
+  #pragma omp parallel for
+  for (omp_size_t i = 0; i < testSize; ++i)
   {
     testData.col(i) = input.col(order[i + trainSize]);
     testLabel(i) = inputLabel(order[i + trainSize]);
   }
+
+  Timer::Stop("splitting_data");
 }
 
 /**
@@ -105,6 +109,8 @@ void Split(const arma::Mat<T>& input,
            arma::Mat<T>& testData,
            const double testRatio)
 {
+  Timer::Start("splitting_data");
+
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
   const size_t trainSize = input.n_cols - testSize;
   trainData.set_size(input.n_rows, trainSize);
@@ -113,15 +119,18 @@ void Split(const arma::Mat<T>& input,
   const arma::Col<size_t> order =
       arma::shuffle(arma::linspace<arma::Col<size_t>>(0, input.n_cols -1,
                                                       input.n_cols));
-
-  for (size_t i = 0; i != trainSize; ++i)
+  #pragma omp parallel for
+  for (omp_size_t i = 0; i < trainSize; ++i)
   {
     trainData.col(i) = input.col(order[i]);
   }
-  for (size_t i = 0; i != testSize; ++i)
+  #pragma omp parallel for
+  for (omp_size_t i = 0; i < testSize; ++i)
   {
     testData.col(i) = input.col(order[i + trainSize]);
   }
+
+  Timer::Stop("splitting_data");
 }
 
 /**

--- a/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
@@ -108,7 +108,8 @@ double DecisionStump<MatType>::Train(const MatType& data,
   const double rootEntropy = CalculateEntropy<UseWeights>(labels, weights);
 
   double gain, bestGain = 0.0;
-  for (size_t i = 0; i < data.n_rows; i++)
+  #pragma omp parallel for private(entropy, gain)
+  for (omp_size_t i = 0; i < data.n_rows; i++)
   {
     // Go through each dimension of the data.
     if (IsDistinct(data.row(i)))
@@ -123,6 +124,7 @@ double DecisionStump<MatType>::Train(const MatType& data,
 
       // We are maximizing gain, which is what is returned from
       // SetupSplitDimension().
+      #pragma omp critical
       if (gain < bestGain)
       {
         bestDim = i;
@@ -322,6 +324,7 @@ void DecisionStump<MatType>::TrainOnDim(const VecType& dimension,
   arma::Row<size_t> sortedLabels(dimension.n_elem);
   sortedLabels.fill(0);
 
+  #pragma omp parallel for
   for (i = 0; i < dimension.n_elem; i++)
     sortedLabels(i) = labels(sortedSplitIndexDim(i));
 

--- a/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
+++ b/src/mlpack/methods/decision_stump/decision_stump_impl.hpp
@@ -150,7 +150,8 @@ void DecisionStump<MatType>::Classify(const MatType& test,
                                       arma::Row<size_t>& predictedLabels)
 {
   predictedLabels.set_size(test.n_cols);
-  for (size_t i = 0; i < test.n_cols; i++)
+  #pragma omp parallel for
+  for (omp_size_t i = 0; i < test.n_cols; i++)
   {
     // Determine which bin the test point falls into.
     // Assume first that it falls into the first bin, then proceed through the


### PR DESCRIPTION
Added omp pragmas to some code sections which gave some significant speedups

The folllowing are the speedups:
- 1.6x for `Split(...)` in `core/data/split_data.hpp` excluding data load/save times*
- Over 1.4x for `Train(...)`  in decision_stump
- 2x for `Classify(...)` in decision_stump
- Over 2.5x overall speed up for the Radical module

Verified and tested with `OMP_NUM_THREADS=4` using [covertype.data.csv](http://www.mlpack.org/datasets/covertype.data.csv.gz) (contains over 500000 instances) and a randomly generated 100x60 matrix (for Radical) on the following machine: 
```
Model name:          Intel(R) Core(TM) i3-4030U CPU @ 1.90GHz
CPU(s):              4
Thread(s) per core:  2
Core(s) per socket:  2
Socket(s):           1
```

\* The data load/save times are very large compared to split time