### PR TITLE
Adding accessors for the network

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/q_learning.hpp
+++ b/src/mlpack/methods/reinforcement_learning/q_learning.hpp
@@ -105,6 +105,11 @@ class QLearning
   //! Get the indicator of training mode / test mode.
   const bool& Deterministic() const { return deterministic; }
 
+  //! Return the learning network.
+  const NetworkType& Network() const { return learningNetwork; }
+  //! Modify the learning network.
+  NetworkType& Network() { return learningNetwork; }
+
  private:
   /**
    * Select the best action based on given action value.


### PR DESCRIPTION
Adding accessors for the network, so users can retrieve the q-learned parameters
Function naming is consistent with AsyncLearning

This is related to #1861