### PR TITLE
Cosine distance metric

### DIFF
--- a/src/mlpack/core/metrics/CMakeLists.txt
+++ b/src/mlpack/core/metrics/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SOURCES
   lmetric_impl.hpp
   mahalanobis_distance.hpp
   mahalanobis_distance_impl.hpp
+  cosine_similarity.hpp
+  cosine_similarity_impl.hpp
 )
 
 # add directory name to sources

--- a/src/mlpack/core/metrics/cosine_similarity.hpp
+++ b/src/mlpack/core/metrics/cosine_similarity.hpp
@@ -1,0 +1,47 @@
+/***
+ * @file cosine_similarity.hpp
+ * @author jeffin Sam
+ *
+ * The Cosine similarity metric.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_METRICS_COSINE_SIMILARITY_HPP
+#define MLPACK_CORE_METRICS_COSINE_SIMILARITY_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace metric {
+
+/**
+ * Class for Cosine Similarity
+ */
+class CosineSimilarity
+{
+ public:
+  /**
+   * Empty constructor for CosineSimilarity Class
+   */
+  CosineSimilarity() { }
+
+  /**
+   * Evaluate the Cosine Similarity
+   *
+   * @param a First vector.
+   * @param b Second vector.
+   * vector could be arma::rowvec or arma::colvec
+   */
+  template<typename VecType>
+  double Evaluate(const VecType& a, const VecType& b);
+};
+
+} // namespace metric
+} // namespace mlpack
+
+#include "cosine_similarity_impl.hpp"
+
+#endif

--- a/src/mlpack/core/metrics/cosine_similarity.hpp
+++ b/src/mlpack/core/metrics/cosine_similarity.hpp
@@ -19,6 +19,18 @@ namespace metric {
 
 /**
  * Class for Cosine Similarity
+ *
+ * For more information, see the following.
+ *
+ * @code
+ * @inproceedings{ICIDEAL 2013,
+ *   title  = {Distance Weighted Cosine Similarity Measure for Text
+ *             Classification},
+ *   author = {Baoli Li, Liping Han},
+ *   year   = {2013}
+ * }
+ * @endcode 
+ *
  */
 class CosineSimilarity
 {

--- a/src/mlpack/core/metrics/cosine_similarity_impl.hpp
+++ b/src/mlpack/core/metrics/cosine_similarity_impl.hpp
@@ -9,8 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_CORE_METRICS_MAHALANOBIS_DISTANCE_IMPL_HPP
-#define MLPACK_CORE_METRICS_MAHALANOBIS_DISTANCE_IMPL_HPP
+#ifndef MLPACK_CORE_METRICS_COSINE_SIMILARITY_IMPL_HPP
+#define MLPACK_CORE_METRICS_COSINE_SIMILARITY_IMPL_HPP
 
 #include "cosine_similarity.hpp"
 

--- a/src/mlpack/core/metrics/cosine_similarity_impl.hpp
+++ b/src/mlpack/core/metrics/cosine_similarity_impl.hpp
@@ -1,0 +1,29 @@
+/***
+ * @file cosine_similarity_impl.hpp
+ * @author jeffin Sam
+ *
+ * The Cosine similarity metric.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_METRICS_MAHALANOBIS_DISTANCE_IMPL_HPP
+#define MLPACK_CORE_METRICS_MAHALANOBIS_DISTANCE_IMPL_HPP
+
+#include "cosine_similarity.hpp"
+
+namespace mlpack {
+namespace metric {
+
+template<typename VecType>
+double CosineSimilarity::Evaluate(const VecType& a, const VecType& b)
+{
+  return arma::accu(arma::normalise(a) % arma::normalise(b));
+}
+
+} // namespace metric
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/metric_test.cpp
+++ b/src/mlpack/tests/metric_test.cpp
@@ -10,6 +10,7 @@
  */
 #include <mlpack/core.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
+#include <mlpack/core/metrics/cosine_similarity.hpp>
 #include <boost/test/unit_test.hpp>
 #include "test_tools.hpp"
 
@@ -85,6 +86,29 @@ BOOST_AUTO_TEST_CASE(LINFMetricTest)
 
   BOOST_REQUIRE_CLOSE((double) arma::as_scalar(arma::max(arma::abs(a2 - b2))),
                       lMetric.Evaluate(a2, b2), 1e-5);
+}
+
+BOOST_AUTO_TEST_CASE(CosineSimilarityMetricTest)
+{
+  arma::rowvec a1(5);
+  a1.randn();
+
+  arma::rowvec b1(5);
+  b1.randn();
+
+  arma::colvec a2(5);
+  a2 << 1 << 2 << 1 << 0 << 5;
+
+  arma::colvec b2(5);
+  b2 << 1 << 2 << 1 << 0 << 5;
+
+  CosineSimilarity CosineMetric;
+
+  BOOST_REQUIRE_CLOSE((double) arma::accu(arma::normalise(a1) %
+                      arma::normalise(b1)), CosineMetric.Evaluate(a1, b1), 1e-5);
+
+  BOOST_REQUIRE_CLOSE((double) arma::accu(arma::normalise(a2) %
+                      arma::normalise(b2)), CosineMetric.Evaluate(a2, b2), 1e-5);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/metric_test.cpp
+++ b/src/mlpack/tests/metric_test.cpp
@@ -105,10 +105,10 @@ BOOST_AUTO_TEST_CASE(CosineSimilarityMetricTest)
   CosineSimilarity CosineMetric;
 
   BOOST_REQUIRE_CLOSE((double) arma::accu(arma::normalise(a1) %
-                      arma::normalise(b1)), CosineMetric.Evaluate(a1, b1), 1e-5);
+                  arma::normalise(b1)), CosineMetric.Evaluate(a1, b1), 1e-5);
 
   BOOST_REQUIRE_CLOSE((double) arma::accu(arma::normalise(a2) %
-                      arma::normalise(b2)), CosineMetric.Evaluate(a2, b2), 1e-5);
+                  arma::normalise(b2)), CosineMetric.Evaluate(a2, b2), 1e-5);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
I have implemented Cosine Similarity Metric, Cosine similarity is generally used as a metric for measuring distance when the magnitude of the vectors does not matter. 

Post Gsoc, Mlpack will have string utilities and thus Cosine similarity metric could be very useful since, it is used often to evaluate how 2 documents are related.

Optionally We might also want to apply cosine similarity for cases where some properties of the instances make so that the weights might be larger without meaning anything different. Sensor values that were captured in various lengths (in time) between instances could be such an example.

You could find relevance of cosine similarity in this [article](https://cmry.github.io/notes/euclidean-v-cosine), Under Cosine in Action - we could find an implementation of it.