### PR TITLE
Fix random forest lack of randomness (#1887)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 ###### ????-??-??
   * Fix random forest bug for numerical-only data (#1887).
 
+  * Significant speedups for random forest (#1887).
+
+  * Random forest now has `minimum_gain_split` and `subspace_dim` parameters
+    (#1887).
+
+  * Decision tree parameter `print_training_error` deprecated in favor of
+    `print_training_accuracy`.
+
 ### mlpack 3.1.0
 ###### 2019-04-25
   * Add DiagonalGaussianDistribution and DiagonalGMM classes to speed up the

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
-### mlpack 3.1.0
+### mlpack 3.1.1
 ###### ????-??-??
+  * Fix random forest bug for numerical-only data (#1887).
 
 ### mlpack 3.1.0
 ###### 2019-04-25

--- a/src/mlpack/bindings/markdown/binding_info.hpp
+++ b/src/mlpack/bindings/markdown/binding_info.hpp
@@ -30,7 +30,6 @@ namespace markdown {
 class BindingInfo
 {
  public:
-
   //! Return a ProgramDoc object for a given bindingName.
   static util::ProgramDoc& GetProgramDoc(const std::string& bindingName);
 
@@ -42,7 +41,6 @@ class BindingInfo
   static std::string& Language();
 
  private:
-
   //! Private constructor, so that only one instance can be created.
   BindingInfo() { }
 

--- a/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
@@ -53,7 +53,7 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
   // If each child will have the minimum number of points in it, we can split.
   // Otherwise we can't.
   if (arma::min(counts) < minimumLeafSize)
-    return bestGain;
+    return DBL_MAX;
 
   // Calculate the gain of the split.  First we have to calculate the labels
   // that would be assigned to each child.
@@ -106,7 +106,7 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
   }
 
   // Otherwise there was no improvement.
-  return bestGain;
+  return DBL_MAX;
 }
 
 template<typename FitnessFunction>

--- a/src/mlpack/methods/decision_tree/all_dimension_select.hpp
+++ b/src/mlpack/methods/decision_tree/all_dimension_select.hpp
@@ -25,7 +25,7 @@ class AllDimensionSelect
   /**
    * Construct the AllDimensionSelect object for the given number of dimensions.
    */
-  AllDimensionSelect(const size_t dimensions) : i(0), dimensions(dimensions) { }
+  AllDimensionSelect() : i(0), dimensions(0) { }
 
   /**
    * Get the first dimension to select from.
@@ -46,11 +46,16 @@ class AllDimensionSelect
    */
   size_t Next() { return ++i; }
 
+  //! Get the number of dimensions.
+  size_t Dimensions() const { return dimensions; }
+  //! Modify the number of dimensions.
+  size_t& Dimensions() { return dimensions; }
+
  private:
   //! The current dimension we are looking at.
   size_t i;
   //! The number of dimensions to select from.
-  const size_t dimensions;
+  size_t dimensions;
 };
 
 } // namespace tree

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -30,7 +30,9 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
 {
   // First sanity check: if we don't have enough points, we can't split.
   if (data.n_elem < (minimumLeafSize * 2))
-    return bestGain;
+    return DBL_MAX;
+  if (bestGain == 0.0)
+    return DBL_MAX; // It can't be outperformed.
 
   // Next, sort the data.
   arma::uvec sortedIndices = arma::sort_index(data);
@@ -38,6 +40,11 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
   arma::rowvec sortedWeights;
   for (size_t i = 0; i < sortedLabels.n_elem; ++i)
     sortedLabels[i] = labels[sortedIndices[i]];
+
+  // Sanity check: if the first element is the same as the last, we can't split
+  // in this dimension.
+  if (data[sortedIndices[0]] == data[sortedIndices[sortedIndices.n_elem - 1]])
+    return DBL_MAX;
 
   // Only initialize if we are using weights.
   if (UseWeights)
@@ -50,10 +57,72 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
 
   // Loop through all possible split points, choosing the best one.  Also, force
   // a minimum leaf size of 1 (empty children don't make sense).
-  double bestFoundGain = bestGain;
+  double bestFoundGain = std::min(bestGain + minimumGainSplit, 0.0);
+  bool improved = false;
   const size_t minimum = std::max(minimumLeafSize, (size_t) 1);
-  for (size_t index = minimum; index < data.n_elem - (minimum - 1); ++index)
+
+  // We need to count the number of points for each class.
+  arma::Mat<size_t> classCounts;
+  arma::mat classWeightSums;
+  double totalWeight;
+  double totalLeftWeight = 0.0;
+  double totalRightWeight = 0.0;
+  if (UseWeights)
   {
+    classWeightSums.zeros(numClasses, 2);
+    totalWeight = arma::accu(sortedWeights);
+    bestFoundGain *= totalWeight;
+  }
+  else
+  {
+    classCounts.zeros(numClasses, 2);
+    bestFoundGain *= data.n_elem;
+  }
+
+  // Initialize the counts.
+  // These points have to be on the left.
+  for (size_t i = 0; i < minimum - 1; ++i)
+  {
+    if (UseWeights)
+    {
+      classWeightSums(sortedLabels[i], 0) += sortedWeights[i];
+      totalLeftWeight += sortedWeights[i];
+    }
+    else
+    {
+      ++classCounts(sortedLabels[i], 0);
+    }
+  }
+  // These points have to be on the right.
+  for (size_t i = minimum - 1; i < data.n_elem; ++i)
+  {
+    if (UseWeights)
+    {
+      classWeightSums(sortedLabels[i], 1) += sortedWeights[i];
+      totalRightWeight += sortedWeights[i];
+    }
+    else
+    {
+      ++classCounts(sortedLabels[i], 1);
+    }
+  }
+
+  for (size_t index = minimum; index < data.n_elem - minimum; ++index)
+  {
+    // Update class weight sums or counts.
+    if (UseWeights)
+    {
+      classWeightSums(sortedLabels[index - 1], 1) -= sortedWeights[index - 1];
+      classWeightSums(sortedLabels[index - 1], 0) += sortedWeights[index - 1];
+      totalLeftWeight += sortedWeights[index - 1];
+      totalRightWeight -= sortedWeights[index - 1];
+    }
+    else
+    {
+      --classCounts(sortedLabels[index - 1], 1);
+      ++classCounts(sortedLabels[index - 1], 0);
+    }
+
     // Make sure that the value has changed.
     if (data[sortedIndices[index]] == data[sortedIndices[index - 1]])
       continue;
@@ -61,36 +130,26 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     // Calculate the gain for the left and right child.  Only use weights if
     // needed.
     const double leftGain = UseWeights ?
-        FitnessFunction::template Evaluate<true>(sortedLabels.subvec(0,
-            index - 1), numClasses, sortedWeights.subvec(0, index - 1)) :
-        FitnessFunction::template Evaluate<false>(sortedLabels.subvec(0,
-            index - 1), numClasses, sortedWeights /* ignored */);
+        FitnessFunction::template EvaluatePtr<true>(classWeightSums.colptr(0),
+            numClasses, totalLeftWeight) :
+        FitnessFunction::template EvaluatePtr<false>(classCounts.colptr(0),
+            numClasses, index);
     const double rightGain = UseWeights ?
-        FitnessFunction::template Evaluate<true>(sortedLabels.subvec(index,
-            sortedLabels.n_elem - 1), numClasses, sortedWeights.subvec(index,
-            sortedLabels.n_elem - 1)) :
-        FitnessFunction::template Evaluate<false>(sortedLabels.subvec(index,
-            sortedLabels.n_elem - 1), numClasses, sortedWeights /* ignored */);
+        FitnessFunction::template EvaluatePtr<true>(classWeightSums.colptr(1),
+            numClasses, totalRightWeight) :
+        FitnessFunction::template EvaluatePtr<false>(classCounts.colptr(1),
+            numClasses, size_t(sortedLabels.n_elem - index));
 
     double gain;
     if (UseWeights)
     {
-      const double leftWeights = arma::accu(sortedWeights.subvec(0, index - 1));
-      const double rightWeights = arma::accu(sortedWeights.subvec(index,
-          sortedWeights.n_elem - 1));
-      const double fullWeight = leftWeights + rightWeights;
-
-      gain = (leftWeights / fullWeight) * leftGain +
-          (rightWeights / fullWeight) * rightGain;
+      gain = totalLeftWeight * leftGain + totalRightWeight * rightGain;
     }
     else
     {
-      // Calculate the fraction of points in the left and right children.
-      const double leftRatio = double(index) / double(sortedLabels.n_elem);
-      const double rightRatio = 1.0 - leftRatio;
-
       // Calculate the gain at this split point.
-      gain = leftRatio * leftGain + rightRatio * rightGain;
+      gain = double(index) * leftGain +
+          double(sortedLabels.n_elem - index) * rightGain;
     }
 
     // Corner case: is this the best possible split?
@@ -103,17 +162,29 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       // and index.
       classProbabilities[0] = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
+
       return gain;
     }
-    else if (gain > bestFoundGain + minimumGainSplit)
+    else if (gain > bestFoundGain)
     {
       // We still have a better split.
       bestFoundGain = gain;
       classProbabilities.set_size(1);
       classProbabilities[0] = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
+      improved = true;
     }
   }
+
+  // If we didn't improve, return the original gain exactly as we got it
+  // (without introducing floating point errors).
+  if (!improved)
+    return DBL_MAX;
+
+  if (UseWeights)
+    bestFoundGain /= totalWeight;
+  else
+    bestFoundGain /= sortedLabels.n_elem;
 
   return bestFoundGain;
 }

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -72,39 +72,35 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     classWeightSums.zeros(numClasses, 2);
     totalWeight = arma::accu(sortedWeights);
     bestFoundGain *= totalWeight;
+
+    // Initialize the counts.
+    // These points have to be on the left.
+    for (size_t i = 0; i < minimum - 1; ++i)
+    {
+      classWeightSums(sortedLabels[i], 0) += sortedWeights[i];
+      totalLeftWeight += sortedWeights[i];
+    }
+
+    // These points have to be on the right.
+    for (size_t i = minimum - 1; i < data.n_elem; ++i)
+    {
+      classWeightSums(sortedLabels[i], 1) += sortedWeights[i];
+      totalRightWeight += sortedWeights[i];
+    }
   }
   else
   {
     classCounts.zeros(numClasses, 2);
     bestFoundGain *= data.n_elem;
-  }
 
-  // Initialize the counts.
-  // These points have to be on the left.
-  for (size_t i = 0; i < minimum - 1; ++i)
-  {
-    if (UseWeights)
-    {
-      classWeightSums(sortedLabels[i], 0) += sortedWeights[i];
-      totalLeftWeight += sortedWeights[i];
-    }
-    else
-    {
+    // Initialize the counts.
+    // These points have to be on the left.
+    for (size_t i = 0; i < minimum - 1; ++i)
       ++classCounts(sortedLabels[i], 0);
-    }
-  }
-  // These points have to be on the right.
-  for (size_t i = minimum - 1; i < data.n_elem; ++i)
-  {
-    if (UseWeights)
-    {
-      classWeightSums(sortedLabels[i], 1) += sortedWeights[i];
-      totalRightWeight += sortedWeights[i];
-    }
-    else
-    {
+
+    // These points have to be on the right.
+    for (size_t i = minimum - 1; i < data.n_elem; ++i)
       ++classCounts(sortedLabels[i], 1);
-    }
   }
 
   for (size_t index = minimum; index < data.n_elem - minimum; ++index)

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -64,7 +64,7 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
   // We need to count the number of points for each class.
   arma::Mat<size_t> classCounts;
   arma::mat classWeightSums;
-  double totalWeight;
+  double totalWeight = 0.0;
   double totalLeftWeight = 0.0;
   double totalRightWeight = 0.0;
   if (UseWeights)

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -64,6 +64,7 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType, typename LabelsType>
   DecisionTree(MatType data,
@@ -71,7 +72,9 @@ class DecisionTree :
                LabelsType labels,
                const size_t numClasses,
                const size_t minimumLeafSize = 10,
-               const double minimumGainSplit = 1e-7);
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Construct the decision tree on the given data and labels, assuming that the
@@ -86,13 +89,16 @@ class DecisionTree :
    * @param numClasses Number of classes in the dataset.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType, typename LabelsType>
   DecisionTree(MatType data,
                LabelsType labels,
                const size_t numClasses,
                const size_t minimumLeafSize = 10,
-               const double minimumGainSplit = 1e-7);
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Construct the decision tree on the given data and labels with weights,
@@ -110,6 +116,7 @@ class DecisionTree :
    * @param weights The weight list of given label.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   DecisionTree(MatType data,
@@ -119,6 +126,8 @@ class DecisionTree :
                WeightsType weights,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType(),
                const std::enable_if_t<arma::is_arma_type<
                    typename std::remove_reference<WeightsType>::type>::value>*
                     = 0);
@@ -138,6 +147,7 @@ class DecisionTree :
    * @param weights The Weight list of given labels.
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
   DecisionTree(MatType data,
@@ -146,6 +156,8 @@ class DecisionTree :
                WeightsType weights,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType(),
                const std::enable_if_t<arma::is_arma_type<
                    typename std::remove_reference<WeightsType>::type>::value>*
                     = 0);
@@ -210,6 +222,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
@@ -218,7 +231,9 @@ class DecisionTree :
                LabelsType labels,
                const size_t numClasses,
                const size_t minimumLeafSize = 10,
-               const double minimumGainSplit = 1e-7);
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Train the decision tree on the given data, assuming that all dimensions are
@@ -234,6 +249,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
@@ -241,7 +257,9 @@ class DecisionTree :
                LabelsType labels,
                const size_t numClasses,
                const size_t minimumLeafSize = 10,
-               const double minimumGainSplit = 1e-7);
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Train the decision tree on the given weighted data.  This will overwrite
@@ -260,6 +278,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
@@ -270,6 +289,8 @@ class DecisionTree :
                WeightsType weights,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType(),
                const std::enable_if_t<arma::is_arma_type<typename
                    std::remove_reference<WeightsType>::type>::value>* = 0);
 
@@ -288,6 +309,7 @@ class DecisionTree :
    * @param weights Weights of all the labels
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
@@ -297,6 +319,8 @@ class DecisionTree :
                WeightsType weights,
                const size_t minimumLeafSize = 10,
                const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType(),
                const std::enable_if_t<arma::is_arma_type<typename
                    std::remove_reference<WeightsType>::type>::value>* = 0);
 
@@ -363,7 +387,7 @@ class DecisionTree :
   //! Modify the child of the given index (be careful!).
   DecisionTree& Child(const size_t i) { return *children[i]; }
 
-  //! Get the split dimension (only meaningful is this is a non-leaf in a
+  //! Get the split dimension (only meaningful if this is a non-leaf in a
   //! trained tree).
   size_t SplitDimension() const { return splitDimension; }
 
@@ -439,8 +463,9 @@ class DecisionTree :
                arma::Row<size_t>& labels,
                const size_t numClasses,
                arma::rowvec& weights,
-               const size_t minimumLeafSize = 10,
-               const double minimumGainSplit = 1e-7);
+               const size_t minimumLeafSize,
+               const double minimumGainSplit,
+               DimensionSelectionType& dimensionSelector);
 
   /**
    * Corresponding to the public Train() method, this method is designed for
@@ -464,8 +489,9 @@ class DecisionTree :
                arma::Row<size_t>& labels,
                const size_t numClasses,
                arma::rowvec& weights,
-               const size_t minimumLeafSize = 10,
-               const double minimumGainSplit = 1e-7);
+               const size_t minimumLeafSize,
+               const double minimumGainSplit,
+               DimensionSelectionType& dimensionSelector);
 };
 
 /**

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -363,6 +363,10 @@ class DecisionTree :
   //! Modify the child of the given index (be careful!).
   DecisionTree& Child(const size_t i) { return *children[i]; }
 
+  //! Get the split dimension (only meaningful is this is a non-leaf in a
+  //! trained tree).
+  size_t SplitDimension() const { return splitDimension; }
+
   /**
    * Given a point and that this node is not a leaf, calculate the index of the
    * child node this point would go towards.  This method is primarily used by

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -728,7 +728,9 @@ double DecisionTree<FitnessFunction,
       numClasses,
       UseWeights ? weights.subvec(begin, begin + count - 1) : weights);
   size_t bestDim = data.n_rows; // This means "no split".
-  for (size_t i = 0; i < data.n_rows; ++i)
+  DimensionSelectionType dimensions(data.n_rows);
+  for (size_t i = dimensions.Begin(); i != dimensions.End();
+       i = dimensions.Next())
   {
     const double dimGain = NumericSplitType<FitnessFunction>::template
         SplitIfBetter<UseWeights>(bestGain,

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -28,12 +28,14 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType data,
-                                        const data::DatasetInfo& datasetInfo,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+             NoRecursion>::DecisionTree(
+    MatType data,
+    const data::DatasetInfo& datasetInfo,
+    LabelsType labels,
+    const size_t numClasses,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -42,10 +44,13 @@ DecisionTree<FitnessFunction,
   TrueMatType tmpData(std::move(data));
   TrueLabelsType tmpLabels(std::move(labels));
 
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
+
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   Train<false>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
-      weights, minimumLeafSize, minimumGainSplit);
+      weights, minimumLeafSize, minimumGainSplit, dimensionSelector);
 }
 
 //! Construct and train.
@@ -61,11 +66,13 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType data,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+             NoRecursion>::DecisionTree(
+    MatType data,
+    LabelsType labels,
+    const size_t numClasses,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -73,11 +80,14 @@ DecisionTree<FitnessFunction,
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
   TrueLabelsType tmpLabels(std::move(labels));
+
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
 
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   Train<false>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, weights,
-      minimumLeafSize, minimumGainSplit);
+      minimumLeafSize, minimumGainSplit, dimensionSelector);
 }
 
 //! Construct and train with weights.
@@ -93,17 +103,19 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType data,
-                                        const data::DatasetInfo& datasetInfo,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        WeightsType weights,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit,
-                                        const std::enable_if_t<
-                                            arma::is_arma_type<
-                                            typename std::remove_reference<
-                                            WeightsType>::type>::value>*)
+             NoRecursion>::DecisionTree(
+    MatType data,
+    const data::DatasetInfo& datasetInfo,
+    LabelsType labels,
+    const size_t numClasses,
+    WeightsType weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector,
+    const std::enable_if_t<
+        arma::is_arma_type<
+        typename std::remove_reference<
+        WeightsType>::type>::value>*)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -113,10 +125,13 @@ DecisionTree<FitnessFunction,
   TrueMatType tmpData(std::move(data));
   TrueLabelsType tmpLabels(std::move(labels));
   TrueWeightsType tmpWeights(std::move(weights));
+
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
 
   // Pass off work to the weighted Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels, numClasses,
-      tmpWeights, minimumLeafSize, minimumGainSplit);
+      tmpWeights, minimumLeafSize, minimumGainSplit, dimensionSelector);
 }
 
 //! Construct and train with weights.
@@ -132,16 +147,18 @@ DecisionTree<FitnessFunction,
              CategoricalSplitType,
              DimensionSelectionType,
              ElemType,
-             NoRecursion>::DecisionTree(MatType data,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        WeightsType weights,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit,
-                                        const std::enable_if_t<
-                                            arma::is_arma_type<
-                                            typename std::remove_reference<
-                                            WeightsType>::type>::value>*)
+             NoRecursion>::DecisionTree(
+    MatType data,
+    LabelsType labels,
+    const size_t numClasses,
+    WeightsType weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector,
+    const std::enable_if_t<
+        arma::is_arma_type<
+        typename std::remove_reference<
+        WeightsType>::type>::value>*)
 {
   using TrueMatType = typename std::decay<MatType>::type;
   using TrueLabelsType = typename std::decay<LabelsType>::type;
@@ -152,9 +169,12 @@ DecisionTree<FitnessFunction,
   TrueLabelsType tmpLabels(std::move(labels));
   TrueWeightsType tmpWeights(std::move(weights));
 
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
+
   // Pass off work to the weighted Train() method.
   Train<true>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses, tmpWeights,
-      minimumLeafSize, minimumGainSplit);
+      minimumLeafSize, minimumGainSplit, dimensionSelector);
 }
 
 //! Construct, don't train.
@@ -345,12 +365,14 @@ double DecisionTree<FitnessFunction,
                     CategoricalSplitType,
                     DimensionSelectionType,
                     ElemType,
-                    NoRecursion>::Train(MatType data,
-                                        const data::DatasetInfo& datasetInfo,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+                    NoRecursion>::Train(
+    MatType data,
+    const data::DatasetInfo& datasetInfo,
+    LabelsType labels,
+    const size_t numClasses,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -369,10 +391,14 @@ double DecisionTree<FitnessFunction,
   TrueMatType tmpData(std::move(data));
   TrueLabelsType tmpLabels(std::move(labels));
 
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
+
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   return Train<false>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels,
-      numClasses, weights, minimumLeafSize, minimumGainSplit);
+      numClasses, weights, minimumLeafSize, minimumGainSplit,
+      dimensionSelector);
 }
 
 //! Train on the given data, assuming all dimensions are numeric.
@@ -388,11 +414,13 @@ double DecisionTree<FitnessFunction,
                     CategoricalSplitType,
                     DimensionSelectionType,
                     ElemType,
-                    NoRecursion>::Train(MatType data,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+                    NoRecursion>::Train(
+    MatType data,
+    LabelsType labels,
+    const size_t numClasses,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -410,11 +438,14 @@ double DecisionTree<FitnessFunction,
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
   TrueLabelsType tmpLabels(std::move(labels));
+
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
 
   // Pass off work to the Train() method.
   arma::rowvec weights; // Fake weights, not used.
   return Train<false>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses,
-      weights, minimumLeafSize, minimumGainSplit);
+      weights, minimumLeafSize, minimumGainSplit, dimensionSelector);
 }
 
 //! Train on the given weighted data.
@@ -430,17 +461,19 @@ double DecisionTree<FitnessFunction,
                     CategoricalSplitType,
                     DimensionSelectionType,
                     ElemType,
-                    NoRecursion>::Train(MatType data,
-                                        const data::DatasetInfo& datasetInfo,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        WeightsType weights,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit,
-                                        const std::enable_if_t<
-                                            arma::is_arma_type<
-                                            typename std::remove_reference<
-                                            WeightsType>::type>::value>*)
+                    NoRecursion>::Train(
+    MatType data,
+    const data::DatasetInfo& datasetInfo,
+    LabelsType labels,
+    const size_t numClasses,
+    WeightsType weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector,
+    const std::enable_if_t<
+        arma::is_arma_type<
+        typename std::remove_reference<
+        WeightsType>::type>::value>*)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -460,10 +493,14 @@ double DecisionTree<FitnessFunction,
   TrueMatType tmpData(std::move(data));
   TrueLabelsType tmpLabels(std::move(labels));
   TrueWeightsType tmpWeights(std::move(weights));
+
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
 
   // Pass off work to the Train() method.
   return Train<true>(tmpData, 0, tmpData.n_cols, datasetInfo, tmpLabels,
-      numClasses, tmpWeights, minimumLeafSize, minimumGainSplit);
+      numClasses, tmpWeights, minimumLeafSize, minimumGainSplit,
+      dimensionSelector);
 }
 
 //! Train on the given weighted data.
@@ -479,16 +516,18 @@ double DecisionTree<FitnessFunction,
                     CategoricalSplitType,
                     DimensionSelectionType,
                     ElemType,
-                    NoRecursion>::Train(MatType data,
-                                        LabelsType labels,
-                                        const size_t numClasses,
-                                        WeightsType weights,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit,
-                                        const std::enable_if_t<
-                                            arma::is_arma_type<
-                                            typename std::remove_reference<
-                                            WeightsType>::type>::value>*)
+                    NoRecursion>::Train(
+    MatType data,
+    LabelsType labels,
+    const size_t numClasses,
+    WeightsType weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType dimensionSelector,
+    const std::enable_if_t<
+        arma::is_arma_type<
+        typename std::remove_reference<
+        WeightsType>::type>::value>*)
 {
   // Sanity check on data.
   if (data.n_cols != labels.n_elem)
@@ -509,9 +548,12 @@ double DecisionTree<FitnessFunction,
   TrueLabelsType tmpLabels(std::move(labels));
   TrueWeightsType tmpWeights(std::move(weights));
 
+  // Set the correct dimensionality for the dimension selector.
+  dimensionSelector.Dimensions() = tmpData.n_rows;
+
   // Pass off work to the Train() method.
   return Train<true>(tmpData, 0, tmpData.n_cols, tmpLabels, numClasses,
-      tmpWeights, minimumLeafSize, minimumGainSplit);
+      tmpWeights, minimumLeafSize, minimumGainSplit, dimensionSelector);
 }
 
 //! Train on the given data.
@@ -527,15 +569,17 @@ double DecisionTree<FitnessFunction,
                     CategoricalSplitType,
                     DimensionSelectionType,
                     ElemType,
-                    NoRecursion>::Train(MatType& data,
-                                        const size_t begin,
-                                        const size_t count,
-                                        const data::DatasetInfo& datasetInfo,
-                                        arma::Row<size_t>& labels,
-                                        const size_t numClasses,
-                                        arma::rowvec& weights,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+                    NoRecursion>::Train(
+    MatType& data,
+    const size_t begin,
+    const size_t count,
+    const data::DatasetInfo& datasetInfo,
+    arma::Row<size_t>& labels,
+    const size_t numClasses,
+    arma::rowvec& weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType& dimensionSelector)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -552,9 +596,8 @@ double DecisionTree<FitnessFunction,
       numClasses,
       UseWeights ? weights.subvec(begin, begin + count - 1) : weights);
   size_t bestDim = datasetInfo.Dimensionality(); // This means "no split".
-  DimensionSelectionType dimensions(datasetInfo.Dimensionality());
-  for (size_t i = dimensions.Begin(); i != dimensions.End();
-       i = dimensions.Next())
+  for (size_t i = dimensionSelector.Begin(); i != dimensionSelector.End();
+       i = dimensionSelector.Next())
   {
     double dimGain = -DBL_MAX;
     if (datasetInfo.Type(i) == data::Datatype::categorical)
@@ -583,12 +626,14 @@ double DecisionTree<FitnessFunction,
           *this);
     }
 
+    // If the splitter reported that it did not split, move to the next
+    // dimension.
+    if (dimGain == DBL_MAX)
+      continue;
+
     // Was there an improvement?  If so mark that it's the new best dimension.
-    if (dimGain > bestGain)
-    {
-      bestDim = i;
-      bestGain = dimGain;
-    }
+    bestDim = i;
+    bestGain = dimGain;
 
     // If the gain is the best possible, no need to keep looking.
     if (bestGain >= 0.0)
@@ -660,14 +705,15 @@ double DecisionTree<FitnessFunction,
       {
         child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, datasetInfo, labels, numClasses,
-            weights, currentCol - currentChildBegin, minimumGainSplit);
+            weights, currentCol - currentChildBegin, minimumGainSplit,
+            dimensionSelector);
       }
       else
       {
         // During recursion entropy of child node may change.
         double childGain = child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, datasetInfo, labels, numClasses,
-            weights, minimumLeafSize, minimumGainSplit);
+            weights, minimumLeafSize, minimumGainSplit, dimensionSelector);
         bestGain += double(childCounts[i]) / double(count) * (-childGain);
       }
       children.push_back(child);
@@ -701,14 +747,16 @@ double DecisionTree<FitnessFunction,
                     CategoricalSplitType,
                     DimensionSelectionType,
                     ElemType,
-                    NoRecursion>::Train(MatType& data,
-                                        const size_t begin,
-                                        const size_t count,
-                                        arma::Row<size_t>& labels,
-                                        const size_t numClasses,
-                                        arma::rowvec& weights,
-                                        const size_t minimumLeafSize,
-                                        const double minimumGainSplit)
+                    NoRecursion>::Train(
+    MatType& data,
+    const size_t begin,
+    const size_t count,
+    arma::Row<size_t>& labels,
+    const size_t numClasses,
+    arma::rowvec& weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    DimensionSelectionType& dimensionSelector)
 {
   // Clear children if needed.
   for (size_t i = 0; i < children.size(); ++i)
@@ -728,9 +776,8 @@ double DecisionTree<FitnessFunction,
       numClasses,
       UseWeights ? weights.subvec(begin, begin + count - 1) : weights);
   size_t bestDim = data.n_rows; // This means "no split".
-  DimensionSelectionType dimensions(data.n_rows);
-  for (size_t i = dimensions.Begin(); i != dimensions.End();
-       i = dimensions.Next())
+  for (size_t i = dimensionSelector.Begin(); i != dimensionSelector.End();
+       i = dimensionSelector.Next())
   {
     const double dimGain = NumericSplitType<FitnessFunction>::template
         SplitIfBetter<UseWeights>(bestGain,
@@ -745,11 +792,13 @@ double DecisionTree<FitnessFunction,
                                   classProbabilities,
                                   *this);
 
-    if (dimGain > bestGain)
-    {
-      bestDim = i;
-      bestGain = dimGain;
-    }
+    // If the splitter did not report that it improved, then move to the next
+    // dimension.
+    if (dimGain == DBL_MAX)
+      continue;
+
+    bestDim = i;
+    bestGain = dimGain;
 
     // If the gain is the best possible, no need to keep looking.
     if (bestGain >= 0.0)
@@ -808,14 +857,15 @@ double DecisionTree<FitnessFunction,
       {
         child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, labels, numClasses, weights,
-            currentCol - currentChildBegin, minimumGainSplit);
+            currentCol - currentChildBegin, minimumGainSplit,
+            dimensionSelector);
       }
       else
       {
         // During recursion entropy of child node may change.
         double childGain = child->Train<UseWeights>(data, currentChildBegin,
             currentCol - currentChildBegin, labels, numClasses, weights,
-            minimumLeafSize, minimumGainSplit);
+            minimumLeafSize, minimumGainSplit, dimensionSelector);
         bestGain += double(childCounts[i]) / double(count) * (-childGain);
       }
       children.push_back(child);

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -596,7 +596,8 @@ double DecisionTree<FitnessFunction,
       numClasses,
       UseWeights ? weights.subvec(begin, begin + count - 1) : weights);
   size_t bestDim = datasetInfo.Dimensionality(); // This means "no split".
-  for (size_t i = dimensionSelector.Begin(); i != dimensionSelector.End();
+  const size_t end = dimensionSelector.End();
+  for (size_t i = dimensionSelector.Begin(); i != end;
        i = dimensionSelector.Next())
   {
     double dimGain = -DBL_MAX;

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -28,6 +28,24 @@ class GiniGain
 {
  public:
   /**
+   * Evaluate the Gini impurity given a vector of class weight counts.
+   */
+  template<bool UseWeights, typename CountType>
+  static double EvaluatePtr(const CountType* counts,
+                            const size_t countLength,
+                            const CountType totalCount)
+  {
+    if (totalCount == 0)
+      return 0.0;
+
+    CountType impurity = 0.0;
+    for (size_t i = 0; i < countLength; ++i)
+      impurity += counts[i] * (totalCount - counts[i]);
+
+    return -((double) impurity / ((double) std::pow(totalCount, 2)));
+  }
+
+  /**
    * Evaluate the Gini impurity on the given set of labels.  RowType should be
    * an Armadillo vector that holds size_t objects.
    *

--- a/src/mlpack/methods/decision_tree/information_gain.hpp
+++ b/src/mlpack/methods/decision_tree/information_gain.hpp
@@ -26,6 +26,26 @@ class InformationGain
 {
  public:
   /**
+   * Evaluate the Gini impurity given a vector of class weight counts.
+   */
+  template<bool UseWeights, typename CountType>
+  static double EvaluatePtr(const CountType* counts,
+                            const size_t countLength,
+                            const CountType totalCount)
+  {
+    double gain = 0.0;
+
+    for (size_t i = 0; i < countLength; ++i)
+    {
+      const double f = ((double) counts[i] / (double) totalCount);
+      if (f > 0.0)
+        gain += f * std::log2(f);
+    }
+
+    return gain;
+  }
+
+  /**
    * Given a set of labels, calculate the information gain of those labels.
    * Note that it is possible that due to floating-point representation issues,
    * it is possible that the gain returned can be very slightly greater than 0!

--- a/src/mlpack/methods/decision_tree/multiple_random_dimension_select.hpp
+++ b/src/mlpack/methods/decision_tree/multiple_random_dimension_select.hpp
@@ -22,16 +22,30 @@ namespace tree {
  *
  * @tparam NumDimensions Number of random dimensions to select.
  */
-template<size_t NumDimensions = 3>
 class MultipleRandomDimensionSelect
 {
  public:
   /**
    * Instantiate the MultipleRandomDimensionSelect object.
    */
-  MultipleRandomDimensionSelect(const size_t dimensions)
+  MultipleRandomDimensionSelect(const size_t numDimensions = 0) :
+        numDimensions(numDimensions),
+        dimensions(0)
+  { }
+
+  /**
+   * Get the first random value.
+   */
+  size_t Begin()
   {
-    for (size_t i = 0; i < NumDimensions; ++i)
+    // Reset if possible.
+    if (numDimensions == 0 || numDimensions > dimensions)
+      numDimensions = (size_t) std::sqrt(dimensions);
+
+    values.set_size(numDimensions + 1);
+
+    // Try setting new values.
+    for (size_t i = 0; i < numDimensions; ++i)
     {
       // Generate random different numbers.
       bool unique = false;
@@ -55,14 +69,8 @@ class MultipleRandomDimensionSelect
       values[i] = value;
     }
 
-    values[NumDimensions] = std::numeric_limits<size_t>::max();
-  }
+    values[numDimensions] = std::numeric_limits<size_t>::max();
 
-  /**
-   * Get the first random value.
-   */
-  size_t Begin()
-  {
     i = 0;
     return values[0];
   }
@@ -80,11 +88,20 @@ class MultipleRandomDimensionSelect
     return values[++i];
   }
 
+  //! Get the number of dimensions.
+  size_t Dimensions() const { return dimensions; }
+  //! Set the number of dimensions.
+  size_t& Dimensions() { return dimensions; }
+
  private:
+  //! The number of dimensions.
+  size_t numDimensions;
   //! The values we select from.
-  size_t values[NumDimensions + 1];
+  arma::Col<size_t> values;
   //! The current value we are looking at.
   size_t i;
+  //! Number of dimensions.
+  size_t dimensions;
 };
 
 } // namespace tree

--- a/src/mlpack/methods/decision_tree/multiple_random_dimension_select.hpp
+++ b/src/mlpack/methods/decision_tree/multiple_random_dimension_select.hpp
@@ -30,6 +30,7 @@ class MultipleRandomDimensionSelect
    */
   MultipleRandomDimensionSelect(const size_t numDimensions = 0) :
         numDimensions(numDimensions),
+        i(0),
         dimensions(0)
   { }
 

--- a/src/mlpack/methods/decision_tree/multiple_random_dimension_select.hpp
+++ b/src/mlpack/methods/decision_tree/multiple_random_dimension_select.hpp
@@ -17,16 +17,16 @@ namespace tree {
 
 /**
  * This dimension selection policy allows the selection from a few random
- * dimensions.  The number of random dimensions to use is specified by the
- * NumDimensions template parameter.
- *
- * @tparam NumDimensions Number of random dimensions to select.
+ * dimensions.  The number of random dimensions to use is specified in the
+ * constructor.
  */
 class MultipleRandomDimensionSelect
 {
  public:
   /**
    * Instantiate the MultipleRandomDimensionSelect object.
+   *
+   * @param numDimensions Number of random dimensions to try for each split.
    */
   MultipleRandomDimensionSelect(const size_t numDimensions = 0) :
         numDimensions(numDimensions),

--- a/src/mlpack/methods/decision_tree/random_dimension_select.hpp
+++ b/src/mlpack/methods/decision_tree/random_dimension_select.hpp
@@ -25,7 +25,7 @@ class RandomDimensionSelect
    * Construct the RandomDimensionSelect object with the given number of
    * dimensions.
    */
-  RandomDimensionSelect(const size_t dimensions) : dimensions(dimensions) { }
+  RandomDimensionSelect() : dimensions(0) { }
 
   /**
    * Get the first dimension to select from.
@@ -43,9 +43,14 @@ class RandomDimensionSelect
    */
   size_t Next() const { return dimensions; }
 
+  //! Get the number of dimensions.
+  size_t Dimensions() const { return dimensions; }
+  //! Set the number of dimensions.
+  size_t& Dimensions() { return dimensions; }
+
  private:
   //! The number of dimensions to select from.
-  const size_t dimensions;
+  size_t dimensions;
 };
 
 } // namespace tree

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -20,7 +20,7 @@ namespace mlpack {
 namespace tree {
 
 template<typename FitnessFunction = GiniGain,
-         typename DimensionSelectionType = MultipleRandomDimensionSelect<>,
+         typename DimensionSelectionType = MultipleRandomDimensionSelect,
          template<typename> class NumericSplitType = BestBinaryNumericSplit,
          template<typename> class CategoricalSplitType = AllCategoricalSplit,
          typename ElemType = double>
@@ -39,26 +39,35 @@ class RandomForest
 
   /**
    * Create a random forest, training on the given labeled training data with
-   * the given number of trees.  The minimumLeafSize parameter is given to each
-   * individual decision tree during tree building.
+   * the given number of trees.  The minimumLeafSize and minimumGainSplit
+   * parameters are given to each individual decision tree during tree building.
+   * Optionally, you may specify a DimensionSelectionType to set parameters for
+   * the strategy used to choose dimensions.
    *
    * @param dataset Dataset to train on.
    * @param labels Labels for dataset.
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType>
   RandomForest(const MatType& dataset,
                const arma::Row<size_t>& labels,
                const size_t numClasses,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Create a random forest, training on the given labeled training data with
    * the given dataset info and the given number of trees.  The minimumLeafSize
-   * parameter is given to each individual decision tree during tree building.
+   * and minimumGainSplit parameters are given to each individual decision tree
+   * during tree building.  Optionally, you may specify a DimensionSelectionType
+   * to set parameters for the strategy used to choose dimensions.
    * This constructor can be used to train on categorical data.
    *
    * @param dataset Dataset to train on.
@@ -67,14 +76,19 @@ class RandomForest
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType>
   RandomForest(const MatType& dataset,
                const data::DatasetInfo& datasetInfo,
                const arma::Row<size_t>& labels,
                const size_t numClasses,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Create a random forest, training on the given weighted labeled training
@@ -93,14 +107,19 @@ class RandomForest
                const arma::Row<size_t>& labels,
                const size_t numClasses,
                const arma::rowvec& weights,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Create a random forest, training on the given weighted labeled training
    * data with the given dataset info and the given number of trees.  The
-   * minimumLeafSize parameter is given to each individual decision tree during
-   * tree building.  This can be used for categorical weighted training.
+   * minimumLeafSize and minimumGainSplit parameters are given to each
+   * individual decision tree during tree building.  Optionally, you may specify
+   * a DimensionSelectionType to set parameters for the strategy used to choose
+   * dimensions.  This can be used for categorical weighted training.
    *
    * @param dataset Dataset to train on.
    * @param datasetInfo Dimension info for the dataset.
@@ -109,6 +128,8 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    */
   template<typename MatType>
   RandomForest(const MatType& dataset,
@@ -116,32 +137,45 @@ class RandomForest
                const arma::Row<size_t>& labels,
                const size_t numClasses,
                const arma::rowvec& weights,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Train the random forest on the given labeled training data with the given
-   * number of trees.  The minimumLeafSize parameter is given to each individual
-   * decision tree during tree building.
+   * number of trees.  The minimumLeafSize and minimumGainSplit parameters are
+   * given to each individual decision tree during tree building.  Optionally,
+   * you may specify a DimensionSelectionType to set parameters for the strategy
+   * used to choose dimensions.
    *
    * @param data Dataset to train on.
    * @param labels Labels for dataset.
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
                const size_t numClasses,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Train the random forest on the given labeled training data with the given
    * dataset info and the given number of trees.  The minimumLeafSize parameter
-   * is given to each individual decision tree during tree building.  This
+   * is given to each individual decision tree during tree building.
+   * Optionally, you may specify a DimensionSelectionType to set parameters for
+   * the strategy used to choose dimensions.
+   * This
    * overload can be used to train on categorical data.
    *
    * @param data Dataset to train on.
@@ -150,6 +184,8 @@ class RandomForest
    * @param numClasses Number of classes in dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
@@ -157,13 +193,18 @@ class RandomForest
                const data::DatasetInfo& datasetInfo,
                const arma::Row<size_t>& labels,
                const size_t numClasses,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Train the random forest on the given weighted labeled training data with
-   * the given number of trees.  The minimumLeafSize parameter is given to each
-   * individual decision tree during tree building.
+   * the given number of trees.  The minimumLeafSize and minimumGainSplit
+   * parameters are given to each individual decision tree during tree building.
+   * Optionally, you may specify a DimensionSelectionType to set parameters for
+   * the strategy used to choose dimensions.
    *
    * @param data Dataset to train on.
    * @param labels Labels for dataset.
@@ -171,6 +212,8 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
@@ -178,14 +221,19 @@ class RandomForest
                const arma::Row<size_t>& labels,
                const size_t numClasses,
                const arma::rowvec& weights,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Train the random forest on the given weighted labeled training data with
    * the given dataset info and the given number of trees.  The minimumLeafSize
-   * parameter is given to each individual decision tree during tree building.
-   * This overload can be used for categorical weighted training.
+   * and minimumGainSplit parameters are given to each individual decision tree
+   * during tree building.  Optionally, you may specify a DimensionSelectionType
+   * to set parameters for the strategy used to choose dimensions.  This
+   * overload can be used for categorical weighted training.
    *
    * @param data Dataset to train on.
    * @param datasetInfo Dimension info for the dataset.
@@ -194,6 +242,8 @@ class RandomForest
    * @param weights Weights (importances) of each point in the dataset.
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each tree's leaf nodes.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @return The average entropy of all the decision trees trained under forest.
    */
   template<typename MatType>
@@ -202,8 +252,11 @@ class RandomForest
                const arma::Row<size_t>& labels,
                const size_t numClasses,
                const arma::rowvec& weights,
-               const size_t numTrees = 50,
-               const size_t minimumLeafSize = 20);
+               const size_t numTrees = 20,
+               const size_t minimumLeafSize = 1,
+               const double minimumGainSplit = 1e-7,
+               DimensionSelectionType dimensionSelector =
+                   DimensionSelectionType());
 
   /**
    * Predict the class of the given point.  If the random forest has not been
@@ -280,6 +333,8 @@ class RandomForest
    * @param weights Weights for each point in the dataset (may be ignored).
    * @param numTrees Number of trees in the forest.
    * @param minimumLeafSize Minimum number of points in each leaf node.
+   * @param minimumGainSplit Minimum gain for splitting a decision tree node.
+   * @param dimensionSelector Instantiated dimension selection policy.
    * @tparam UseWeights Whether or not to use the weights parameter.
    * @tparam UseDatasetInfo Whether or not to use the datasetInfo parameter.
    * @tparam MatType The type of data matrix (i.e. arma::mat).
@@ -292,7 +347,9 @@ class RandomForest
                const size_t numClasses,
                const arma::rowvec& weights,
                const size_t numTrees,
-               const size_t minimumLeafSize);
+               const size_t minimumLeafSize,
+               const double minimumGainSplit,
+               DimensionSelectionType& dimensionSelector);
 
   //! The trees in the forest.
   std::vector<DecisionTreeType> trees;

--- a/src/mlpack/methods/random_forest/random_forest_impl.hpp
+++ b/src/mlpack/methods/random_forest/random_forest_impl.hpp
@@ -447,25 +447,26 @@ double RandomForest<
     {
       if (UseDatasetInfo)
       {
-        avgGain += trees[i].Train(dataset, datasetInfo, labels, numClasses,
-            weights, minimumLeafSize);
+        avgGain += trees[i].Train(bootstrapDataset, datasetInfo,
+            bootstrapLabels, numClasses, bootstrapWeights, minimumLeafSize);
       }
       else
       {
-        avgGain += trees[i].Train(dataset, labels, numClasses, weights,
-            minimumLeafSize);
+        avgGain += trees[i].Train(bootstrapDataset, bootstrapLabels, numClasses,
+            bootstrapWeights, minimumLeafSize);
       }
     }
     else
     {
       if (UseDatasetInfo)
       {
-        avgGain += trees[i].Train(dataset, datasetInfo, labels, numClasses,
-            minimumLeafSize);
+        avgGain += trees[i].Train(bootstrapDataset, datasetInfo,
+            bootstrapLabels, numClasses, minimumLeafSize);
       }
       else
       {
-        avgGain += trees[i].Train(dataset, labels, numClasses, minimumLeafSize);
+        avgGain += trees[i].Train(bootstrapDataset, bootstrapLabels, numClasses,
+            minimumLeafSize);
       }
     }
   }

--- a/src/mlpack/methods/random_forest/random_forest_impl.hpp
+++ b/src/mlpack/methods/random_forest/random_forest_impl.hpp
@@ -308,18 +308,14 @@ void RandomForest<
     arma::vec treeProbs;
     size_t treePrediction; // Ignored.
     trees[i].Classify(point, treePrediction, treeProbs);
-//    std::cout << treeProbs.t();
 
     probabilities += treeProbs;
   }
-//  std::cout << "total probs:\n";
-//  std::cout << probabilities.t();
 
   // Find maximum element after renormalizing probabilities.
   probabilities /= trees.size();
   arma::uword maxIndex = 0;
   probabilities.max(maxIndex);
-//  std::cout << "max index " << maxIndex << "\n";
 
   // Set prediction.
   prediction = (size_t) maxIndex;
@@ -356,7 +352,6 @@ void RandomForest<
   #pragma omp parallel for
   for (omp_size_t i = 0; i < data.n_cols; ++i)
   {
-//    std::cout << "point " << i << "\n";
     predictions[i] = Classify(data.col(i));
   }
 }

--- a/src/mlpack/methods/random_forest/random_forest_main.cpp
+++ b/src/mlpack/methods/random_forest/random_forest_main.cpp
@@ -106,6 +106,8 @@ PARAM_MATRIX_OUT("probabilities", "Predicted class probabilities for each "
 PARAM_UROW_OUT("predictions", "Predicted classes for each point in the test "
     "set.", "p");
 
+PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
+
 /**
  * This is the class that we will serialize.  It is a pretty simple wrapper
  * around DecisionTree<>.  In order to support categoricals, it will need to
@@ -135,6 +137,12 @@ PARAM_MODEL_OUT(RandomForestModel, "output_model", "Model to save trained "
 
 static void mlpackMain()
 {
+  // Initialize random seed if needed.
+  if (CLI::GetParam<int>("seed") != 0)
+    math::RandomSeed((size_t) CLI::GetParam<int>("seed"));
+  else
+    math::RandomSeed((size_t) std::time(NULL));
+
   // Check for incompatible input parameters.
   RequireOnlyOnePassed({ "training", "input_model" }, true);
 

--- a/src/mlpack/methods/random_forest/random_forest_main.cpp
+++ b/src/mlpack/methods/random_forest/random_forest_main.cpp
@@ -161,7 +161,7 @@ static void mlpackMain()
   ReportIgnoredParam({{ "test", false }}, "test_labels");
 
   RequireAtLeastOnePassed({ "test", "output_model", "print_training_accuracy" },
-      "the trained forest model will not be used or saved");
+      false, "the trained forest model will not be used or saved");
 
   if (CLI::HasParam("training"))
   {

--- a/src/mlpack/methods/random_forest/random_forest_main.cpp
+++ b/src/mlpack/methods/random_forest/random_forest_main.cpp
@@ -48,11 +48,11 @@ PROGRAM_INFO("Random forests",
     "into each leaf for it to be split.  The " +
     PRINT_PARAM_STRING("num_trees") +
     " controls the number of trees in the random forest.  The " +
-    PRINT_PARAM_STRING("minimum_gain_split") + " parameter control the minimum "
-    "required gain for a decision tree node to split.  Larger values will force"
-    " higher-confidence splits.  The " + PRINT_PARAM_STRING("subspace_dim") +
-    " parameter is used to control the number of random dimensions chosen for "
-    "an individual node's split.  If " +
+    PRINT_PARAM_STRING("minimum_gain_split") + " parameter controls the minimum"
+    " required gain for a decision tree node to split.  Larger values will "
+    "force higher-confidence splits.  The " +
+    PRINT_PARAM_STRING("subspace_dim") + " parameter is used to control the "
+    "number of random dimensions chosen for an individual node's split.  If " +
     PRINT_PARAM_STRING("print_training_accuracy") + " is specified, the "
     "calculated accuracy on the training set will be printed."
     "\n\n"

--- a/src/mlpack/methods/random_forest/random_forest_main.cpp
+++ b/src/mlpack/methods/random_forest/random_forest_main.cpp
@@ -47,7 +47,12 @@ PROGRAM_INFO("Random forests",
     " parameter specifies the minimum number of training points that must fall "
     "into each leaf for it to be split.  The " +
     PRINT_PARAM_STRING("num_trees") +
-    " controls the number of trees in the random forest. If " +
+    " controls the number of trees in the random forest.  The " +
+    PRINT_PARAM_STRING("minimum_gain_split") + " parameter control the minimum "
+    "required gain for a decision tree node to split.  Larger values will force"
+    " higher-confidence splits.  The " + PRINT_PARAM_STRING("subspace_dim") +
+    " parameter is used to control the number of random dimensions chosen for "
+    "an individual node's split.  If " +
     PRINT_PARAM_STRING("print_training_accuracy") + " is specified, the "
     "calculated accuracy on the training set will be printed."
     "\n\n"
@@ -99,12 +104,18 @@ PARAM_FLAG("print_training_accuracy", "If set, then the accuracy of the model "
 
 PARAM_INT_IN("num_trees", "Number of trees in the random forest.", "N", 10);
 PARAM_INT_IN("minimum_leaf_size", "Minimum number of points in each leaf "
-    "node.", "n", 20);
+    "node.", "n", 1);
 
 PARAM_MATRIX_OUT("probabilities", "Predicted class probabilities for each "
     "point in the test set.", "P");
 PARAM_UROW_OUT("predictions", "Predicted classes for each point in the test "
     "set.", "p");
+
+PARAM_DOUBLE_IN("minimum_gain_split", "Minimum gain needed to make a split "
+    "when building a tree.", "g", 0);
+PARAM_INT_IN("subspace_dim", "Dimensionality of random subspace to use for "
+    "each split.  '0' will autoselect the square root of data dimensionality.",
+    "d", 0);
 
 PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
 
@@ -147,13 +158,6 @@ static void mlpackMain()
   RequireOnlyOnePassed({ "training", "input_model" }, true);
 
   ReportIgnoredParam({{ "training", false }}, "print_training_accuracy");
-
-  if (CLI::HasParam("test"))
-  {
-    RequireAtLeastOnePassed({ "probabilities", "predictions" }, "no test output"
-        " will be saved");
-  }
-
   ReportIgnoredParam({{ "test", false }}, "test_labels");
 
   RequireAtLeastOnePassed({ "test", "output_model", "print_training_accuracy" },
@@ -173,6 +177,11 @@ static void mlpackMain()
 
   RequireParamValue<int>("minimum_leaf_size", [](int x) { return x > 0; }, true,
       "minimum leaf size must be greater than 0");
+  RequireParamValue<int>("subspace_dim", [](int x) { return x >= 0; }, true,
+      "subspace dimensionality must be nonnegative");
+  RequireParamValue<double>("minimum_gain_split",
+      [](double x) { return x >= 0.0; }, true,
+      "minimum gain for splitting must be nonnegative");
 
   ReportIgnoredParam({{ "training", false }}, "num_trees");
   ReportIgnoredParam({{ "training", false }}, "minimum_leaf_size");
@@ -180,15 +189,27 @@ static void mlpackMain()
   RandomForestModel* rfModel;
   if (CLI::HasParam("training"))
   {
+    Timer::Start("rf_training");
     rfModel = new RandomForestModel();
 
     // Train the model on the given input data.
     arma::mat data = std::move(CLI::GetParam<arma::mat>("training"));
     arma::Row<size_t> labels =
         std::move(CLI::GetParam<arma::Row<size_t>>("labels"));
+
+    // Make sure the subspace dimensionality is valid.
+    RequireParamValue<int>("subspace_dim",
+        [data](int x) { return (size_t) x <= data.n_rows; }, true, "subspace "
+        "dimensionality must not be greater than data dimensionality");
+
     const size_t numTrees = (size_t) CLI::GetParam<int>("num_trees");
     const size_t minimumLeafSize =
         (size_t) CLI::GetParam<int>("minimum_leaf_size");
+    const double minimumGainSplit = CLI::GetParam<double>("minimum_gain_split");
+    const size_t randomDims = (CLI::GetParam<int>("subspace_dim") == 0) ?
+        (size_t) std::sqrt(data.n_rows) :
+        (size_t) CLI::GetParam<int>("subspace_dim");
+    MultipleRandomDimensionSelect mrds(randomDims);
 
     Log::Info << "Training random forest with " << numTrees << " trees..."
         << endl;
@@ -196,11 +217,14 @@ static void mlpackMain()
     const size_t numClasses = arma::max(labels) + 1;
 
     // Train the model.
-    rfModel->rf.Train(data, labels, numClasses, numTrees, minimumLeafSize);
+    rfModel->rf.Train(data, labels, numClasses, numTrees, minimumLeafSize,
+        minimumGainSplit, mrds);
+    Timer::Stop("rf_training");
 
     // Did we want training accuracy?
     if (CLI::HasParam("print_training_accuracy"))
     {
+      Timer::Start("rf_prediction");
       arma::Row<size_t> predictions;
       rfModel->rf.Classify(data, predictions);
 
@@ -209,6 +233,7 @@ static void mlpackMain()
       Log::Info << correct << " of " << labels.n_elem << " correct on training"
           << " set (" << (double(correct) / double(labels.n_elem) * 100) << ")."
           << endl;
+      Timer::Stop("rf_prediction");
     }
   }
   else
@@ -220,6 +245,7 @@ static void mlpackMain()
   if (CLI::HasParam("test"))
   {
     arma::mat testData = std::move(CLI::GetParam<arma::mat>("test"));
+    Timer::Start("rf_prediction");
 
     // Get predictions and probabilities.
     arma::Row<size_t> predictions;
@@ -237,6 +263,7 @@ static void mlpackMain()
       Log::Info << correct << " of " << testLabels.n_elem << " correct on test"
           << " set (" << (double(correct) / double(testLabels.n_elem) * 100)
           << ")." << endl;
+      Timer::Stop("rf_prediction");
     }
 
     // Save the outputs.

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(BestBinaryNumericSplitSimpleSplitTest)
   // Make sure that a split was made.
   BOOST_REQUIRE_GT(gain, bestGain);
 
-  // Make sure weight works and make no different with no weighted one
+  // Make sure weight works and is not different than the unweighted one.
   BOOST_REQUIRE_EQUAL(gain, weightedGain);
 
   // The split is perfect, so we should be able to accomplish a gain of 0.
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(BestBinaryNumericSplitMinSamplesTest)
       labels, 2, weights, 8, 1e-7, classProbabilities, aux);
 
   // Make sure that no split was made.
-  BOOST_REQUIRE_EQUAL(gain, bestGain);
+  BOOST_REQUIRE_EQUAL(gain, DBL_MAX);
   BOOST_REQUIRE_EQUAL(gain, weightedGain);
   BOOST_REQUIRE_EQUAL(classProbabilities.n_elem, 0);
 }
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(BestBinaryNumericSplitNoGainTest)
       bestGain, values, labels, 2, weights, 10, 1e-7, classProbabilities, aux);
 
   // Make sure there was no split.
-  BOOST_REQUIRE_EQUAL(gain, bestGain);
+  BOOST_REQUIRE_EQUAL(gain, DBL_MAX);
   BOOST_REQUIRE_EQUAL(classProbabilities.n_elem, 0);
 }
 
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(AllCategoricalSplitMinSamplesTest)
       aux);
 
   // Make sure it's not split.
-  BOOST_REQUIRE_EQUAL(gain, bestGain);
+  BOOST_REQUIRE_EQUAL(gain, DBL_MAX);
   BOOST_REQUIRE_EQUAL(classProbabilities.n_elem, 0);
 }
 
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(AllCategoricalSplitNoGainTest)
       labels, 3, weights, 10, 1e-7, classProbabilities, aux);
 
   // Make sure that there was no split.
-  BOOST_REQUIRE_EQUAL(gain, bestGain);
+  BOOST_REQUIRE_EQUAL(gain, DBL_MAX);
   BOOST_REQUIRE_EQUAL(gain, weightedGain);
   BOOST_REQUIRE_EQUAL(classProbabilities.n_elem, 0);
 }
@@ -471,14 +471,21 @@ BOOST_AUTO_TEST_CASE(AllCategoricalSplitNoGainTest)
  */
 BOOST_AUTO_TEST_CASE(BasicConstructionTest)
 {
-  arma::mat dataset(10, 1000, arma::fill::randu);
-  arma::Row<size_t> labels(1000);
-
-  for (size_t i = 0; i < 1000; ++i)
-    labels[i] = i % 3; // 3 classes.
+  arma::mat dataset(10, 100, arma::fill::randu);
+  arma::Row<size_t> labels(100);
+  for (size_t i = 0; i < 50; ++i)
+  {
+    dataset(3, i) = 0.0;
+    labels[i] = 0;
+  }
+  for (size_t i = 50; i < 100; ++i)
+  {
+    dataset(3, i) = 1.0;
+    labels[i] = 1;
+  }
 
   // Use default parameters.
-  DecisionTree<> d(dataset, labels, 3, 50);
+  DecisionTree<> d(dataset, labels, 2, 10);
 
   // Now require that we have some children.
   BOOST_REQUIRE_GT(d.NumChildren(), 0);
@@ -489,17 +496,24 @@ BOOST_AUTO_TEST_CASE(BasicConstructionTest)
  */
 BOOST_AUTO_TEST_CASE(BasicConstructionTestWithWeight)
 {
-  arma::mat dataset(10, 1000, arma::fill::randu);
-  arma::Row<size_t> labels(1000);
+  arma::mat dataset(10, 100, arma::fill::randu);
+  arma::Row<size_t> labels(100);
+  for (size_t i = 0; i < 50; ++i)
+  {
+    dataset(3, i) = 0.0;
+    labels[i] = 0;
+  }
+  for (size_t i = 50; i < 100; ++i)
+  {
+    dataset(3, i) = 1.0;
+    labels[i] = 1;
+  }
   arma::rowvec weights(labels.n_elem);
   weights.ones();
 
-  for (size_t i = 0; i < 1000; ++i)
-    labels[i] = i % 3; // 3 classes.
-
   // Use default parameters.
-  DecisionTree<> wd(dataset, labels, 3, weights, 50);
-  DecisionTree<> d(dataset, labels, 3, 50);
+  DecisionTree<> wd(dataset, labels, 2, weights, 10);
+  DecisionTree<> d(dataset, labels, 2, 10);
 
   // Now require that we have some children.
   BOOST_REQUIRE_GT(wd.NumChildren(), 0);
@@ -512,25 +526,30 @@ BOOST_AUTO_TEST_CASE(BasicConstructionTestWithWeight)
  */
 BOOST_AUTO_TEST_CASE(PerfectTrainingSet)
 {
-  // Completely random dataset with no structure.
-  arma::mat dataset(10, 1000, arma::fill::randu);
-  arma::Row<size_t> labels(1000);
-  for (size_t i = 0; i < 1000; ++i)
-    labels[i] = i % 3; // 3 classes.
-  arma::rowvec weights(labels.n_elem);
-  weights.ones();
+  arma::mat dataset(10, 100, arma::fill::randu);
+  arma::Row<size_t> labels(100);
+  for (size_t i = 0; i < 50; ++i)
+  {
+    dataset(3, i) = 0.0;
+    labels[i] = 0;
+  }
+  for (size_t i = 50; i < 100; ++i)
+  {
+    dataset(3, i) = 1.0;
+    labels[i] = 1;
+  }
 
-  DecisionTree<> d(dataset, labels, 3, 1); // Minimum leaf size of 1.
+  DecisionTree<> d(dataset, labels, 2, 1, 0.0); // Minimum leaf size of 1.
 
   // Make sure that we can get perfect accuracy on the training set.
-  for (size_t i = 0; i < 1000; ++i)
+  for (size_t i = 0; i < 100; ++i)
   {
     size_t prediction;
     arma::vec probabilities;
     d.Classify(dataset.col(i), prediction, probabilities);
 
     BOOST_REQUIRE_EQUAL(prediction, labels[i]);
-    BOOST_REQUIRE_EQUAL(probabilities.n_elem, 3);
+    BOOST_REQUIRE_EQUAL(probabilities.n_elem, 2);
     for (size_t j = 0; j < 3; ++j)
     {
       if (labels[i] == j)
@@ -547,24 +566,33 @@ BOOST_AUTO_TEST_CASE(PerfectTrainingSet)
 BOOST_AUTO_TEST_CASE(PerfectTrainingSetWithWeight)
 {
   // Completely random dataset with no structure.
-  arma::mat dataset(10, 1000, arma::fill::randu);
-  arma::Row<size_t> labels(1000);
-  for (size_t i = 0; i < 1000; ++i)
-    labels[i] = i % 3; // 3 classes.
+  arma::mat dataset(10, 100, arma::fill::randu);
+  arma::Row<size_t> labels(100);
+  for (size_t i = 0; i < 50; ++i)
+  {
+    dataset(3, i) = 0.0;
+    labels[i] = 0;
+  }
+  for (size_t i = 50; i < 100; ++i)
+  {
+    dataset(3, i) = 1.0;
+    labels[i] = 1;
+  }
   arma::rowvec weights(labels.n_elem);
   weights.ones();
 
-  DecisionTree<> d(dataset, labels, 3, weights, 1); // Minimum leaf size of 1.
+  // Minimum leaf size of 1.
+  DecisionTree<> d(dataset, labels, 2, weights, 1, 0.0);
 
   // This part of code is dupliacte with no weighted one.
-  for (size_t i = 0; i < 1000; ++i)
+  for (size_t i = 0; i < 100; ++i)
   {
     size_t prediction;
     arma::vec probabilities;
     d.Classify(dataset.col(i), prediction, probabilities);
 
     BOOST_REQUIRE_EQUAL(prediction, labels[i]);
-    BOOST_REQUIRE_EQUAL(probabilities.n_elem, 3);
+    BOOST_REQUIRE_EQUAL(probabilities.n_elem, 2);
     for (size_t j = 0; j < 3; ++j)
     {
       if (labels[i] == j)
@@ -981,7 +1009,8 @@ BOOST_AUTO_TEST_CASE(CategoricalInformationGainWeightedBuildTest)
  */
 BOOST_AUTO_TEST_CASE(RandomDimensionSelectTest)
 {
-  RandomDimensionSelect r(10);
+  RandomDimensionSelect r;
+  r.Dimensions() = 10;
 
   BOOST_REQUIRE_LT(r.Begin(), 10);
   BOOST_REQUIRE_EQUAL(r.Next(), r.End());
@@ -995,7 +1024,11 @@ BOOST_AUTO_TEST_CASE(RandomDimensionSelectTest)
 BOOST_AUTO_TEST_CASE(RandomDimensionSelectRandomTest)
 {
   // We'll check that 4 values are not all the same.
-  RandomDimensionSelect r1(100000), r2(100000), r3(100000), r4(100000);
+  RandomDimensionSelect r1, r2, r3, r4;
+  r1.Dimensions() = 100000;
+  r2.Dimensions() = 100000;
+  r3.Dimensions() = 100000;
+  r4.Dimensions() = 100000;
 
   BOOST_REQUIRE((r1.Begin() != r2.Begin()) ||
                 (r1.Begin() != r3.Begin()) ||
@@ -1008,7 +1041,8 @@ BOOST_AUTO_TEST_CASE(RandomDimensionSelectRandomTest)
  */
 BOOST_AUTO_TEST_CASE(MultipleRandomDimensionSelectTest)
 {
-  MultipleRandomDimensionSelect<5> r(10);
+  MultipleRandomDimensionSelect r(5);
+  r.Dimensions() = 10;
 
   // Make sure we get five elements.
   BOOST_REQUIRE_LT(r.Begin(), 10);
@@ -1024,7 +1058,8 @@ BOOST_AUTO_TEST_CASE(MultipleRandomDimensionSelectTest)
  */
 BOOST_AUTO_TEST_CASE(MultipleRandomDimensionAllSelectTest)
 {
-  MultipleRandomDimensionSelect<3> r(3);
+  MultipleRandomDimensionSelect r(3);
+  r.Dimensions() = 3;
 
   bool found[3];
   found[0] = found[1] = found[2] = false;

--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(RandomForestTrainingVerTest)
 }
 
 /**
- * Ensure that training accuracy goes up as minimum_leaf_size decreases.
+ * Ensure that training accuracy changes as minimum_leaf_size decreases.
  */
 BOOST_AUTO_TEST_CASE(RandomForestDiffMinLeafSizeTest)
 {
@@ -228,58 +228,66 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffMinLeafSizeTest)
   if (!data::Load("vc2_labels.txt", labels))
     BOOST_FAIL("Cannot load labels for vc2_labels.txt");
 
-  // Input training data.
-  SetInputParam("training", inputData);
-  SetInputParam("labels", labels);
-  SetInputParam("minimum_leaf_size", (int) 20);
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    // Input training data.
+    SetInputParam("training", inputData);
+    SetInputParam("labels", labels);
+    SetInputParam("minimum_leaf_size", (int) 20);
 
-  mlpackMain();
+    mlpackMain();
 
-  // Calculate training accuracy.
-  arma::Row<size_t> predictions;
-  CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(inputData,
-       predictions);
+    // Calculate training accuracy.
+    arma::Row<size_t> predictions;
+    CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(inputData,
+        predictions);
 
-  size_t correct = arma::accu(predictions == labels);
-  double accuracy20 = (double(correct) / double(labels.n_elem) * 100);
+    size_t correct = arma::accu(predictions == labels);
+    double accuracy20 = (double(correct) / double(labels.n_elem) * 100);
 
-  bindings::tests::CleanMemory();
+    bindings::tests::CleanMemory();
 
-  // Train for minimum leaf size 10.
+    // Train for minimum leaf size 10.
 
-  // Input training data.
-  SetInputParam("training", inputData);
-  SetInputParam("labels", labels);
-  SetInputParam("minimum_leaf_size", (int) 10);
+    // Input training data.
+    SetInputParam("training", inputData);
+    SetInputParam("labels", labels);
+    SetInputParam("minimum_leaf_size", (int) 10);
 
-  mlpackMain();
+    mlpackMain();
 
-  // Calculate training accuracy.
-  CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(inputData,
-       predictions);
+    // Calculate training accuracy.
+    CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(inputData,
+         predictions);
 
-  correct = arma::accu(predictions == labels);
-  double accuracy10 = (double(correct) / double(labels.n_elem) * 100);
+    correct = arma::accu(predictions == labels);
+    double accuracy10 = (double(correct) / double(labels.n_elem) * 100);
 
-  bindings::tests::CleanMemory();
+    bindings::tests::CleanMemory();
 
-  // Train for minimum leaf size 1.
+    // Train for minimum leaf size 1.
 
-  // Input training data.
-  SetInputParam("training", inputData);
-  SetInputParam("labels", labels);
-  SetInputParam("minimum_leaf_size", (int) 1);
+    // Input training data.
+    SetInputParam("training", inputData);
+    SetInputParam("labels", labels);
+    SetInputParam("minimum_leaf_size", (int) 1);
 
-  mlpackMain();
+    mlpackMain();
 
-  // Calculate training accuracy.
-  CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(inputData,
-       predictions);
+    // Calculate training accuracy.
+    CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(inputData,
+         predictions);
 
-  correct = arma::accu(predictions == labels);
-  double accuracy1 = (double(correct) / double(labels.n_elem) * 100);
+    correct = arma::accu(predictions == labels);
+    double accuracy1 = (double(correct) / double(labels.n_elem) * 100);
 
-  BOOST_REQUIRE(accuracy1 > accuracy10 && accuracy10 > accuracy20);
+    success = (accuracy1 != accuracy10 && accuracy10 != accuracy20);
+    if (success)
+      break;
+  }
+
+  BOOST_REQUIRE_EQUAL(success, true);
 }
 
 /**
@@ -305,57 +313,69 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffNumTreeTest)
   if (!data::Load("vc2_test_labels.txt", testLabels))
     BOOST_FAIL("Cannot load labels for vc2__test_labels.txt");
 
-  // Input training data.
-  SetInputParam("training", inputData);
-  SetInputParam("labels", labels);
-  SetInputParam("num_trees", (int) 1);
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    // Input training data.
+    SetInputParam("training", inputData);
+    SetInputParam("labels", labels);
+    SetInputParam("num_trees", (int) 1);
+    SetInputParam("minimum_leaf_size", (int) 1);
 
-  mlpackMain();
+    mlpackMain();
 
-  // Calculate training accuracy.
-  arma::Row<size_t> predictions;
-  CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(testData,
-       predictions);
-  bindings::tests::CleanMemory();
+    // Calculate training accuracy.
+    arma::Row<size_t> predictions;
+    CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(testData,
+         predictions);
+    bindings::tests::CleanMemory();
 
-  size_t correct = arma::accu(predictions == testLabels);
-  double accuracy1 = (double(correct) / double(testLabels.n_elem) * 100);
+    size_t correct = arma::accu(predictions == testLabels);
+    double accuracy1 = (double(correct) / double(testLabels.n_elem) * 100);
 
-  // Train for num_trees 5.
+    // Train for num_trees 5.
 
-  // Input training data.
-  SetInputParam("training", inputData);
-  SetInputParam("labels", labels);
-  SetInputParam("num_trees", (int) 5);
+    // Input training data.
+    SetInputParam("training", inputData);
+    SetInputParam("labels", labels);
+    SetInputParam("num_trees", (int) 5);
+    SetInputParam("minimum_leaf_size", (int) 1);
 
-  mlpackMain();
+    mlpackMain();
 
-  // Calculate training accuracy.
-  CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(testData,
-       predictions);
-  bindings::tests::CleanMemory();
+    // Calculate training accuracy.
+    CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(testData,
+         predictions);
+    bindings::tests::CleanMemory();
 
-  correct = arma::accu(predictions == testLabels);
-  double accuracy5 = (double(correct) / double(testLabels.n_elem) * 100);
+    correct = arma::accu(predictions == testLabels);
+    double accuracy5 = (double(correct) / double(testLabels.n_elem) * 100);
 
-  // Train for num_trees 10.
+    // Train for num_trees 10.
 
-  // Input training data.
-  SetInputParam("training", std::move(inputData));
-  SetInputParam("labels", std::move(labels));
-  SetInputParam("num_trees", (int) 10);
+    // Input training data.
+    SetInputParam("training", std::move(inputData));
+    SetInputParam("labels", std::move(labels));
+    SetInputParam("num_trees", (int) 10);
+    SetInputParam("minimum_leaf_size", (int) 1);
 
-  mlpackMain();
+    mlpackMain();
 
-  // Calculate training accuracy.
-  CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(testData,
-       predictions);
+    // Calculate training accuracy.
+    CLI::GetParam<RandomForestModel*>("output_model")->rf.Classify(testData,
+         predictions);
 
-  correct = arma::accu(predictions == testLabels);
-  double accuracy10 = (double(correct) / double(testLabels.n_elem) * 100);
+    correct = arma::accu(predictions == testLabels);
+    double accuracy10 = (double(correct) / double(testLabels.n_elem) * 100);
 
-  BOOST_REQUIRE_NE(accuracy10, accuracy5);
-  BOOST_REQUIRE_NE(accuracy5, accuracy1);
+    // It's possible this might not work just because of randomness.  The VC2
+    // dataset is not very large.
+    success = (accuracy10 != accuracy5 || accuracy5 != accuracy1);
+    if (success)
+      break;
+  }
+
+  BOOST_REQUIRE_EQUAL(success, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -354,8 +354,8 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffNumTreeTest)
   correct = arma::accu(predictions == testLabels);
   double accuracy10 = (double(correct) / double(testLabels.n_elem) * 100);
 
-  BOOST_REQUIRE_NE(accuracy10 != accuracy5);
-  BOOST_REQUIRE_NE(accuracy5 != accuracy1);
+  BOOST_REQUIRE_NE(accuracy10, accuracy5);
+  BOOST_REQUIRE_NE(accuracy5, accuracy1);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -283,7 +283,8 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffMinLeafSizeTest)
 }
 
 /**
- * Ensure that test accuracy goes up as num_trees increases.
+ * Ensure that test accuracy changes as num_trees increases (we aren't
+ * guaranteed that accuracy will go up).
  */
 BOOST_AUTO_TEST_CASE(RandomForestDiffNumTreeTest)
 {
@@ -353,7 +354,8 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffNumTreeTest)
   correct = arma::accu(predictions == testLabels);
   double accuracy10 = (double(correct) / double(testLabels.n_elem) * 100);
 
-  BOOST_REQUIRE(accuracy10 >= accuracy5 && accuracy5 >= accuracy1);
+  BOOST_REQUIRE_NE(accuracy10 != accuracy5);
+  BOOST_REQUIRE_NE(accuracy5 != accuracy1);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/random_forest_test.cpp
+++ b/src/mlpack/tests/random_forest_test.cpp
@@ -483,4 +483,32 @@ BOOST_AUTO_TEST_CASE(RandomForestCategoricalTrainReturnEntropy)
   BOOST_REQUIRE_EQUAL(std::isfinite(entropy), true);
 }
 
+/**
+ * Test that different trees get generated.
+  */
+BOOST_AUTO_TEST_CASE(DifferentTreesTest)
+{
+  arma::mat d(10, 100, arma::fill::randu);
+  arma::Row<size_t> l(100);
+  for (size_t i = 0; i < 50; ++i)
+    l(i) = 0;
+  for (size_t i = 50; i < 100; ++i)
+    l(i) = 1;
+
+  bool success = false;
+  size_t trial = 0;
+
+  while (!success && trial < 10)
+  {
+    RandomForest<GiniGain, RandomDimensionSelect> rf;
+    rf.Train(d, l, 2, 2, 5);
+
+    success = (rf.Tree(0).SplitDimension() != rf.Tree(1).SplitDimension());
+
+    ++trial;
+  }
+
+  BOOST_REQUIRE_EQUAL(success, true);
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/random_forest_test.cpp
+++ b/src/mlpack/tests/random_forest_test.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(WeightedNumericLearningTest)
     weights[i] = math::Random(0.0, 0.01); // Low weights for false points.
 
   // Train decision tree and random forest.
-  RandomForest<> rf(dataset, labels, 3, weights, 10, 1);
+  RandomForest<> rf(dataset, labels, 3, weights, 20, 1);
   DecisionTree<> dt(dataset, labels, 3, weights, 5);
 
   // Get performance statistics on test data.

--- a/src/mlpack/tests/random_forest_test.cpp
+++ b/src/mlpack/tests/random_forest_test.cpp
@@ -470,7 +470,9 @@ BOOST_AUTO_TEST_CASE(DifferentTreesTest)
   bool success = false;
   size_t trial = 0;
 
-  while (!success && trial < 10)
+  // It's possible we might get the same random dimensions selected, so let's do
+  // multiple trials.
+  while (!success && trial < 3)
   {
     RandomForest<GiniGain, RandomDimensionSelect> rf;
     rf.Train(d, l, 2, 2, 5);


### PR DESCRIPTION
I had a chance to look into it today and I actually found two bugs in the random forest:

 * The decision tree was not properly initializing the dimension selector in the case of numeric-only data.
 * The random forest was not giving bootstrapped data to the decision trees.

I added a test to check that dimensions are selected randomly, and adapted the other tests (since bootstrapped data no longer gives the same guarantees as we have when we train directly on the full dataset).