### PR TITLE
Refactor Windows Build Tutorial

### DIFF
--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -117,7 +117,7 @@ or a different VS version, update the cmake command accordingly.
 cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DARMADILLO_INCLUDE_DIR="C:/mlpack/armadillo/include" -DARMADILLO_LIBRARY:FILEPATH="C:/mlpack/armadillo/build/Debug/armadillo.lib" -DBOOST_INCLUDEDIR:PATH="C:/boost/" -DBOOST_LIBRARYDIR:PATH="C:/boost/lib64-msvc-14.1" -DDEBUG=OFF -DPROFILE=OFF ..
 @endcode
 
-@note cmake will attempt to automatically download the ENSMALLEN dependency. If for some reason cmake can't download the dependency, you will need to manually download ENSMALLEN from http://ensmallen.org/ and extract it to "C:\mlpack\mlpack\deps\". Then, specify the path to ENSMALLEN using the flag: -DENSMALLEN_INCLUDE_DIR=C:/mlpack/mlpack/deps/ensmallen/include
+@note cmake will attempt to automatically download the ensmallen dependency. If for some reason cmake can't download the dependency, you will need to manually download ensmallen from http://ensmallen.org/ and extract it to "C:\mlpack\mlpack\deps\". Then, specify the path to ensmallen using the flag: -DENSMALLEN_INCLUDE_DIR=C:/mlpack/mlpack/deps/ensmallen/include
 
 - Once CMake configuration has successfully finished, open "C:\mlpack\mlpack\build\mlpack.sln"
 - Build > Build Solution (this may be by default in Debug mode)

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -8,16 +8,10 @@
 
 @section build_windows_intro Introduction
 
-This document discusses how to build mlpack for Windows from source, so you can
-later create your own C++ applications.  There are a couple of other tutorials
-for Windows, but they may be out of date:
-
- * <a href="https://github.com/mlpack/mlpack/wiki/WindowsBuild">Github wiki Windows Build page</a><br/>
- * <a href="http://keon.io/mlpack-on-windows">Keon's tutorial for mlpack 2.0.3</a><br/>
- * <a href="https://overdosedblog.wordpress.com/2016/08/15/once_again/">Kirizaki's tutorial for mlpack 2</a><br/>
-
-Those guides could be used in addition to this tutorial. Furthermore, mlpack is
-now available for Windows installation through vcpkg:
+This tutorial will show you how to build mlpack for Windows from source, so you can
+later create your own C++ applications. Before you try building mlpack, you may
+want to install mlpack using vcpkg for Windows. If you don't want to install
+using vcpkg, skip this section and continue with the build tutorial.
 
 - Install Git (https://git-scm.com/downloads and execute setup)
 
@@ -25,7 +19,7 @@ now available for Windows installation through vcpkg:
 
 - Install vcpkg (https://github.com/Microsoft/vcpkg and execute setup)
 
-- To install only mlpack library:
+- To install the mlpack library only:
 
 @code
 PS> .\vcpkg install mlpack:x64-windows
@@ -41,12 +35,12 @@ an existing one). The library is immediately ready to be included
 (via preprocessor directives) and used in your project without additional
 configuration.
 
-@section build_windows_env Environment
+@section build_windows_env Build Environment
 
 This tutorial has been designed and tested using:
 - Windows 10
 - Visual Studio 2017 (toolset v141)
-- mlpack-3.0.4
+- mlpack
 - OpenBLAS.0.2.14.1
 - boost_1_66_0-msvc-14.1-64
 - armadillo-8.500.1
@@ -64,10 +58,10 @@ and make sure you can use it from the Command Prompt (may need to add to the PAT
 
 @section build_windows_instructions Windows build instructions
 
-- Unzip mlpack to "C:\mlpack\mlpack-3.0.4"
+- Unzip mlpack to "C:\mlpack\mlpack"
 - Open Visual Studio and select: File > New > Project from Existing Code
  - Type of project: Visual C++
- - Project location: "C:\mlpack\mlpack-3.0.4"
+ - Project location: "C:\mlpack\mlpack"
  - Project name: mlpack
  - Finish
 - We will use this Visual Studio project to get the OpenBLAS dependency in the next section
@@ -91,67 +85,81 @@ This tutorial follows the second approach for simplicity.
 
 @note Make sure you download the MSVC version that matches your Visual Studio
 
-- Install or unzip to "C:\boost\boost_1_66_0"
+- Install or unzip to "C:\boost\"
 
 <b> Armadillo Dependency </b>
 
 - Download "Armadillo" (armadillo-8.500.1.tar.xz) from <a href="http://arma.sourceforge.net/download.html">Sourceforge</a>
-- Unzip to "C:\mlpack\armadillo-8.500.1"
-- Create a "build" directory into "C:\mlpack\armadillo-8.500.1\"
-- Open the Command Prompt and navigate to "C:\mlpack\armadillo-8.500.1\build"
+- Unzip to "C:\mlpack\armadillo"
+- Create a "build" directory into "C:\mlpack\armadillo\"
+- Open the Command Prompt and navigate to "C:\mlpack\armadillo\build"
 - Run cmake: 
 
 @code
-cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DCMAKE_PREFIX:FILEPATH="C:/mlpack/armadillo" ..
+cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" ..
 @endcode
 
 @note If you are using different directory paths, a different configuration (e.g. Release)
 or a different VS version, update the cmake command accordingly.
 
-- Once it has successfully finished, open "C:\mlpack\armadillo-8.500.1\build\armadillo.sln"
+- Once it has successfully finished, open "C:\mlpack\armadillo\build\armadillo.sln"
 - Build > Build Solution
 - Once it has successfully finished, close Visual Studio
 
 @section build_windows_mlpack Building mlpack
 
-- Create a "build" directory into "C:\mlpack\mlpack-3.0.4\"
-- Use either the CMake GUI or the CMake command line to configure Armadillo.
+- Create a "build" directory into "C:\mlpack\mlpack\"
+- You can generate the project using either cmake via command line or GUI. If you prefer to use GUI, refer to the \ref build_windows_appendix "appendix"
+- To use the CMake command line prompt, open the Command Prompt and navigate to "C:\mlpack\mlpack\build"
+- Run cmake:
+
+@code
+cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DARMADILLO_INCLUDE_DIR="C:/mlpack/armadillo/include" -DARMADILLO_LIBRARY:FILEPATH="C:/mlpack/armadillo/build/Debug/armadillo.lib" -DBOOST_INCLUDEDIR:PATH="C:/boost/" -DBOOST_LIBRARYDIR:PATH="C:/boost/lib64-msvc-14.1" -DDEBUG=OFF -DPROFILE=OFF ..
+@endcode
+
+@note cmake will attempt to automatically download the ENSMALLEN dependency. If for some reason cmake can't download the dependency, you will need to manually download ENSMALLEN from http://ensmallen.org/ and extract it to "C:\mlpack\mlpack\deps\". Then, specify the path to ENSMALLEN using the flag: -DENSMALLEN_INCLUDE_DIR=C:/mlpack/mlpack/deps/ensmallen/include
+
+- Once CMake configuration has successfully finished, open "C:\mlpack\mlpack\build\mlpack.sln"
+- Build > Build Solution (this may be by default in Debug mode)
+- Once it has sucessfully finished, you will find the library files you need in: "C:\mlpack\mlpack\build\Debug" (or "C:\mlpack\mlpack\build\Release" if you changed to Release mode)
+
+You are ready to create your first application, take a look at the @ref sample_ml_app "Sample C++ ML App"
+
+@section build_windows_appendix Appendix
+
+If you prefer to use cmake GUI, follow these instructions:
+
   - To use the CMake GUI, open "CMake".
-    - For "Where is the source code:" set `C:\mlpack\mlpack-3.0.4\`
-    - For "Where to build the binaries:" set `C:\mlpack\mlpack-3.0.4\build`
+    - For "Where is the source code:" set `C:\mlpack\mlpack\`
+    - For "Where to build the binaries:" set `C:\mlpack\mlpack\build`
     - Click `Configure`
     - If there is an error and Armadillo is not found, try "Add Entry" with the
       following variables and reconfigure:
-      - Name: `ARMADILLO_INCLUDE_DIR`; type `PATH`; value `C:/mlpack/armadillo-8.500.1/include/`
-      - Name: `ARMADILLO_LIBRARY`; type `FILEPATH`; value `C:/mlpack/armadillo-8.500.1/build/Debug/armadillo.lib`
-      - Name: `BLAS_LIBRARY`; type `FILEPATH`; value `C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a`
-      - Name: `LAPACK_LIBRARY`; type `FILEPATH`; value `C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a`
+      - Name: `ARMADILLO_INCLUDE_DIR`; type `PATH`; value `C:/mlpack/armadillo/include/`
+      - Name: `ARMADILLO_LIBRARY`; type `FILEPATH`; value `C:/mlpack/armadillo/build/Debug/armadillo.lib`
+      - Name: `BLAS_LIBRARY`; type `FILEPATH`; value `C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a`
+      - Name: `LAPACK_LIBRARY`; type `FILEPATH`; value `C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a`
     - If there is an error and Boost is not found, try "Add Entry" with the
       following variables and reconfigure:
-      - Name: `BOOST_INCLUDEDIR`; type `PATH`; value `C:/boost/boost_1_66_0/`
-      - Name: `BOOST_LIBRARYDIR`; type `PATH`; value `C:/boost/boost_1_66_0/lib64-msvc-14.1`
+      - Name: `BOOST_INCLUDEDIR`; type `PATH`; value `C:/boost/`
+      - Name: `BOOST_LIBRARYDIR`; type `PATH`; value `C:/boost/lib64-msvc-14.1`
     - If Boost is still not found, try adding the following variables and
       reconfigure:
-      - Name: `Boost_INCLUDE_DIR`; type `PATH`; value `C:/boost/boost_1_66_0/`
-      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_program_options-vc141-mt-gd-x64-1_66.lib`
-      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
-      - Name: `Boost_SERIALIZATION_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_serialization-vc141-mt-gd-x64-1_66.lib`
-      - Name: `Boost_SERIALIZATION_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
-      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-gd-x64-1_66.lib`
-      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/boost_1_66_0/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-x64-1_66.lib`
+      - Name: `Boost_INCLUDE_DIR`; type `PATH`; value `C:/boost/`
+      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_program_options-vc141-mt-gd-x64-1_66.lib`
+      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
+      - Name: `Boost_SERIALIZATION_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_serialization-vc141-mt-gd-x64-1_66.lib`
+      - Name: `Boost_SERIALIZATION_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
+      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-gd-x64-1_66.lib`
+      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-x64-1_66.lib`
     - Once CMake has configured successfully, hit "Generate" to create the `.sln` file.
-  - To use the CMake command line prompt:
-    - Open the Command Prompt and navigate to "C:\mlpack\mlpack-3.0.4\build"
-    - Run cmake:
 
-@code
-cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack-3.0.4/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DARMADILLO_INCLUDE_DIR="C:/mlpack/armadillo-8.500.1/include" -DARMADILLO_LIBRARY:FILEPATH="C:/mlpack/armadillo-8.500.1/build/Debug/armadillo.lib" -DBOOST_INCLUDEDIR:PATH="C:/boost/boost_1_66_0/" -DBOOST_LIBRARYDIR:PATH="C:/boost/boost_1_66_0/lib64-msvc-14.1" -DDEBUG=OFF -DPROFILE=OFF ..
-@endcode
+@section build_windows_additional_information Additional Information
 
-- Once CMake configuration has successfully finished, open "C:\mlpack\mlpack-3.0.4\build\mlpack.sln"
-- Build > Build Solution (this may be by default in Debug mode)
-- Once it has sucessfully finished, you will find the library files you need in: "C:\mlpack\mlpack-3.0.4\build\Debug" (or "C:\mlpack\mlpack-3.0.4\build\Release" if you changed to Release mode)
+If you are facing issues during the build process of mlpack, you may take a look at other third-party tutorials for Windows, but they may be out of date:
 
-You are ready to create your first application, take a look at the @ref sample_ml_app "Sample C++ ML App"
+ * <a href="https://github.com/mlpack/mlpack/wiki/WindowsBuild">Github wiki Windows Build page</a><br/>
+ * <a href="http://keon.io/mlpack-on-windows">Keon's tutorial for mlpack 2.0.3</a><br/>
+ * <a href="https://overdosedblog.wordpress.com/2016/08/15/once_again/">Kirizaki's tutorial for mlpack 2</a><br/>
 
 */


### PR DESCRIPTION
Based on #1874, the following changes were made:

- Re-organized the tutorial structure so it's not that confusing: installation via vcpkg is introduced as an alternative to the build process with the option to skip it and continue with the build steps.
- Removed all the hardcoded versions of mlpack and dependencies from the paths, so we don't need to unnecessarily maintain the tutorial updated when new versions are released.
- Moved the alternative cmake GUI instructions to an appendix (so one main tutorial path can be followed).
- Added a NOTE about the ENSMALLEN dependency, that must be manually specified if cmake can't automatically download it
- Moved third party/old tutorials to a new section, so users can refer to them in case of issues