### PR TITLE
Python spacing fix

### DIFF
--- a/doc/guide/python_quickstart.hpp
+++ b/doc/guide/python_quickstart.hpp
@@ -99,7 +99,8 @@ output = mlpack.random_forest(input_model=random_forest,
 
 # Now print the accuracy.  The 'probabilities' output could also be used
 # to generate an ROC curve.
-correct = np.sum(output['predictions'] == test_labels)
+correct = np.sum(
+    output['predictions'] == np.reshape(test_labels, (test_labels.shape[0],)))
 print(str(correct) + ' correct out of ' + str(len(test_labels)) + ' (' +
     str(100 * float(correct) / float(len(test_labels))) + '%).')
 @endcode

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -323,44 +323,43 @@ void PrintInputProcessing(
   {
     if (T::is_row || T::is_col)
     {
-      std::cout << prefix << "  " << d.name << "_tuple = to_matrix("
-          << d.name << ", dtype=" << GetNumpyType<typename T::elem_type>()
+      std::cout << prefix << d.name << "_tuple = to_matrix(" << d.name
+          << ", dtype=" << GetNumpyType<typename T::elem_type>()
           << ", copy=CLI.HasParam('copy_all_inputs'))" << std::endl;
-      std::cout << prefix << "  if len(" << d.name << "_tuple[0].shape) > 1:"
+      std::cout << prefix << "if len(" << d.name << "_tuple[0].shape) > 1:"
           << std::endl;
-      std::cout << prefix << "    if " << d.name << "_tuple[0]"
-          << ".shape[0] == 1 or " << d.name << "_tuple[0].shape[1] == 1:"
-          << std::endl;
-      std::cout << prefix << "      " << d.name << "_tuple[0].shape = ("
+      std::cout << prefix << "  if " << d.name << "_tuple[0].shape[0] == 1 or "
+          << d.name << "_tuple[0].shape[1] == 1:" << std::endl;
+      std::cout << prefix << "    " << d.name << "_tuple[0].shape = ("
           << d.name << "_tuple[0].size,)" << std::endl;
-      std::cout << prefix << "  " << d.name << "_mat = arma_numpy.numpy_to_"
+      std::cout << prefix << d.name << "_mat = arma_numpy.numpy_to_"
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << d.name
           << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
-      std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
+      std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
           << "](<const string> '" << d.name << "', dereference("
           << d.name << "_mat))"<< std::endl;
-      std::cout << prefix << "  CLI.SetPassed(<const string> '" << d.name
-          << "')" << std::endl;
-      std::cout << prefix << "  del " << d.name << "_mat" << std::endl;
+      std::cout << prefix << "CLI.SetPassed(<const string> '" << d.name << "')"
+          << std::endl;
+      std::cout << prefix << "del " << d.name << "_mat" << std::endl;
     }
     else
     {
-      std::cout << prefix << "  " << d.name << "_tuple = to_matrix("
-          << d.name << ", dtype=" << GetNumpyType<typename T::elem_type>()
+      std::cout << prefix << d.name << "_tuple = to_matrix(" << d.name
+          << ", dtype=" << GetNumpyType<typename T::elem_type>()
           << ", copy=CLI.HasParam('copy_all_inputs'))" << std::endl;
-      std::cout << prefix << "  if len(" << d.name << "_tuple[0].shape) > 2:"
+      std::cout << prefix << "if len(" << d.name << "_tuple[0].shape) > 2:"
           << std::endl;
-      std::cout << prefix << "    " << d.name << "_tuple[0].shape = (" << d.name
+      std::cout << prefix << "  " << d.name << "_tuple[0].shape = (" << d.name
           << "_tuple[0].shape[0], 1)" << std::endl;
-      std::cout << prefix << "  " << d.name << "_mat = arma_numpy.numpy_to_"
+      std::cout << prefix << d.name << "_mat = arma_numpy.numpy_to_"
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << d.name
           << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
-      std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
-          << "](<const string> '" << d.name << "', dereference("
-          << d.name << "_mat))"<< std::endl;
-      std::cout << prefix << "  CLI.SetPassed(<const string> '" << d.name
-          << "')" << std::endl;
-      std::cout << prefix << "  del " << d.name << "_mat" << std::endl;
+      std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
+          << "](<const string> '" << d.name << "', dereference(" << d.name
+          << "_mat))" << std::endl;
+      std::cout << prefix << "CLI.SetPassed(<const string> '" << d.name << "')"
+          << std::endl;
+      std::cout << prefix << "del " << d.name << "_mat" << std::endl;
     }
   }
   std::cout << std::endl;

--- a/src/mlpack/bindings/python/tests/test_python_binding.py
+++ b/src/mlpack/bindings/python/tests/test_python_binding.py
@@ -29,6 +29,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  flag1=True)
 
     self.assertEqual(output['string_out'], 'hello2')
@@ -41,7 +43,9 @@ class TestPythonBinding(unittest.TestCase):
     """
     output = test_python_binding(string_in='hello',
                                  int_in=12,
-                                 double_in=4.0)
+                                 double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0])
 
     self.assertNotEqual(output['string_out'], 'hello2')
     self.assertNotEqual(output['int_out'], 13)
@@ -54,6 +58,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='goodbye',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  flag1=True)
 
     self.assertNotEqual(output['string_out'], 'hello2')
@@ -65,6 +71,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=15,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  flag1=True)
 
     self.assertNotEqual(output['int_out'], 13)
@@ -76,6 +84,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=2.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  flag1=True)
 
     self.assertNotEqual(output['double_out'], 5.0)
@@ -87,6 +97,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  flag1=True,
                                  flag2=True)
 
@@ -105,6 +117,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=z)
 
     self.assertEqual(output['matrix_out'].shape[0], 100)
@@ -127,6 +141,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=x,
                                  copy_all_inputs=True)
 
@@ -152,6 +168,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=z)
 
     self.assertEqual(output['matrix_out'].shape[0], 100)
@@ -174,6 +192,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=x,
                                  copy_all_inputs=True)
 
@@ -197,6 +217,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  smatrix_in=z)
 
     self.assertEqual(output['smatrix_out'].shape[0], 100)
@@ -215,6 +237,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  smatrix_in=x,
                                  copy_all_inputs=True)
 
@@ -234,6 +258,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  s_umatrix_in=z)
 
     self.assertEqual(output['s_umatrix_out'].shape[0], 100)
@@ -252,6 +278,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  s_umatrix_in=x,
                                  copy_all_inputs=True)
 
@@ -271,6 +299,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  col_in=z)
 
     self.assertEqual(output['col_out'].shape[0], 100)
@@ -288,6 +318,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  col_in=x,
                                  copy_all_inputs=True)
 
@@ -308,6 +340,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=z)
 
     self.assertEqual(output['matrix_out'].shape[0], 100)
@@ -330,6 +364,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=x,
                                  copy_all_inputs=True)
 
@@ -354,6 +390,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=x)
 
     self.assertEqual(output['matrix_out'].shape[0], 3)
@@ -383,6 +421,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_in=x,
                                  copy_all_inputs=True)
 
@@ -414,6 +454,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  umatrix_in=z)
 
     self.assertEqual(output['umatrix_out'].shape[0], 100)
@@ -435,6 +477,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  umatrix_in=x,
                                  copy_all_inputs=True)
 
@@ -459,6 +503,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  umatrix_in=x)
 
     self.assertEqual(output['umatrix_out'].shape[0], 3)
@@ -488,6 +534,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  umatrix_in=x,
                                  copy_all_inputs=True)
 
@@ -519,6 +567,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  col_in=z)
 
     self.assertEqual(output['col_out'].shape[0], 100)
@@ -536,6 +586,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  col_in=x,
                                  copy_all_inputs=True)
 
@@ -555,6 +607,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  ucol_in=z)
 
     self.assertEqual(output['ucol_out'].shape[0], 100)
@@ -571,6 +625,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  ucol_in=x,
                                  copy_all_inputs=True)
 
@@ -589,6 +645,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  row_in=z)
 
     self.assertEqual(output['row_out'].shape[0], 100)
@@ -606,6 +664,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  row_in=x,
                                  copy_all_inputs=True)
 
@@ -625,6 +685,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  urow_in=z)
 
     self.assertEqual(output['urow_out'].shape[0], 100)
@@ -642,6 +704,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  urow_in=x,
                                  copy_all_inputs=True)
 
@@ -661,6 +725,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_and_info_in=z)
 
     self.assertEqual(output['matrix_and_info_out'].shape[0], 100)
@@ -679,6 +745,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_and_info_in=x,
                                  copy_all_inputs=True)
 
@@ -701,6 +769,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_and_info_in=z)
 
     self.assertEqual(output['matrix_and_info_out'].shape[0], 10)
@@ -726,6 +796,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_and_info_in=x,
                                  copy_all_inputs=True)
 
@@ -751,6 +823,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  vector_in=x)
 
     self.assertEqual(output['vector_out'], [1, 2, 3, 4])
@@ -765,6 +839,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  str_vector_in=x)
 
     self.assertEqual(output['str_vector_out'],
@@ -778,11 +854,15 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  build_model=True)
 
     output2 = test_python_binding(string_in='hello',
                                   int_in=12,
                                   double_in=4.0,
+                                  mat_req_in=[[1.0]],
+                                  col_req_in=[1.0],
                                   model_in=output['model_out'])
 
     self.assertEqual(output2['model_bw_out'], 20.0)
@@ -797,6 +877,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  smatrix_in=z)
 
     self.assertEqual(output['smatrix_out'].shape[0], 100)
@@ -815,6 +897,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  smatrix_in=x,
                                  copy_all_inputs=True)
 
@@ -834,6 +918,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  s_umatrix_in=z)
 
     self.assertEqual(output['s_umatrix_out'].shape[0], 100)
@@ -851,6 +937,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  s_umatrix_in=x,
                                  copy_all_inputs=True)
 
@@ -870,6 +958,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  col_in=z)
 
     self.assertEqual(output['col_out'].shape[0], 100)
@@ -887,6 +977,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  col_in=x,
                                  copy_all_inputs=True)
 
@@ -906,6 +998,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  ucol_in=z)
 
     self.assertEqual(output['ucol_out'].shape[0], 100)
@@ -922,6 +1016,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  ucol_in=x,
                                  copy_all_inputs=True)
 
@@ -940,6 +1036,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  row_in=x)
 
     self.assertEqual(output['row_out'].shape[0], 100)
@@ -957,6 +1055,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  row_in=x,
                                  copy_all_inputs=True)
 
@@ -976,6 +1076,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  urow_in=z)
 
     self.assertEqual(output['urow_out'].shape[0], 100)
@@ -993,6 +1095,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  urow_in=x,
                                  copy_all_inputs=True)
 
@@ -1012,6 +1116,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_and_info_in=z[0])
 
     self.assertEqual(output['matrix_and_info_out'].shape[0], 10)
@@ -1028,6 +1134,8 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  matrix_and_info_in=x[0],
                                  copy_all_inputs=True)
 
@@ -1045,24 +1153,32 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in=10,
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True))
 
     self.assertRaises(TypeError,
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=10.0,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True))
 
     self.assertRaises(TypeError,
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in='bad',
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True))
 
     self.assertRaises(TypeError,
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    flag2=10))
 
@@ -1070,6 +1186,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    matrix_in= 10.0))
 
@@ -1077,6 +1195,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    matrix_in= 1))
 
@@ -1084,6 +1204,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    matrix_and_info_in = 10.0))
 
@@ -1091,6 +1213,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    copy_all_inputs = 10.0))
 
@@ -1098,6 +1222,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    col_in = 10))
 
@@ -1105,6 +1231,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    row_in = 10.0))
 
@@ -1112,6 +1240,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    str_vector_in = 'bad'))
 
@@ -1119,6 +1249,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    urow_in = 10.0))
 
@@ -1126,6 +1258,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    ucol_in = 10.0))
 
@@ -1133,6 +1267,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    umatrix_in = 10.0))
 
@@ -1140,6 +1276,8 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    verbose = 10))
 
@@ -1147,8 +1285,26 @@ class TestPythonBinding(unittest.TestCase):
                       lambda : test_python_binding(string_in='hello',
                                                    int_in=12,
                                                    double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=[1.0],
                                                    flag1=True,
                                                    vector_in = 10.0))
+
+    self.assertRaises(TypeError,
+                      lambda : test_python_binding(string_in='hello',
+                                                   int_in=12,
+                                                   double_in=4.0,
+                                                   mat_req_in=False,
+                                                   col_req_in=[1.0],
+                                                   flag1=True))
+
+    self.assertRaises(TypeError,
+                      lambda : test_python_binding(string_in='hello',
+                                                   int_in=12,
+                                                   double_in=4.0,
+                                                   mat_req_in=[[1.0]],
+                                                   col_req_in=False,
+                                                   flag1=True))
 
   def testModelForceCopy(self):
     """
@@ -1158,17 +1314,23 @@ class TestPythonBinding(unittest.TestCase):
     output = test_python_binding(string_in='hello',
                                  int_in=12,
                                  double_in=4.0,
+                                 mat_req_in=[[1.0]],
+                                 col_req_in=[1.0],
                                  build_model=True)
 
     output2 = test_python_binding(string_in='hello',
                                   int_in=12,
                                   double_in=4.0,
+                                  mat_req_in=[[1.0]],
+                                  col_req_in=[1.0],
                                   model_in=output['model_out'],
                                   copy_all_inputs=True)
 
     output3 = test_python_binding(string_in='hello',
                                   int_in=12,
                                   double_in=4.0,
+                                  mat_req_in=[[1.0]],
+                                  col_req_in=[1.0],
                                   model_in=output['model_out'])
 
     self.assertEqual(output2['model_bw_out'], 20.0)

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -27,6 +27,10 @@ PROGRAM_INFO("Python binding test",
 PARAM_STRING_IN_REQ("string_in", "Input string, must be 'hello'.", "s");
 PARAM_INT_IN_REQ("int_in", "Input int, must be 12.", "i");
 PARAM_DOUBLE_IN_REQ("double_in", "Input double, must be 4.0.", "d");
+PARAM_MATRIX_IN_REQ("mat_req_in", "Input matrix, must be 1x1 and contain '1'.",
+    "");
+PARAM_COL_IN_REQ("col_req_in", "Input column, must have '1' as the only "
+    "element.", "");
 PARAM_FLAG("flag1", "Input flag, must be specified.", "f");
 PARAM_FLAG("flag2", "Input flag, must not be specified.", "F");
 PARAM_MATRIX_IN("matrix_in", "Input matrix.", "m");
@@ -84,6 +88,20 @@ static void mlpackMain()
 
     if (d == 4.0)
       CLI::GetParam<double>("double_out") = 5.0;
+  }
+
+  const arma::mat& matReqIn = CLI::GetParam<arma::mat>("mat_req_in");
+  const arma::vec& colReqIn = CLI::GetParam<arma::vec>("col_req_in");
+  if (matReqIn.n_rows != 1 || matReqIn.n_cols != 1 || matReqIn(0, 0) != 1.0)
+  {
+    throw std::invalid_argument("mat_req_in must be 1x1 and contain only "
+        "'1.0'!");
+  }
+
+  if (colReqIn.n_elem != 1 || colReqIn(0) != 1.0)
+  {
+    throw std::invalid_argument("col_req_in must have '1.0' as its only "
+        "single element!");
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -536,6 +536,32 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
     PARAM_COL(ID, DESC, ALIAS, false, true, true)
 
 /**
+ * Define a required vector input parameter (type arma::vec).  From the command
+ * line, the user can specify the file that holds the vector, using the name of
+ * the vector parameter with "_file" appended (and the same alias).  So for
+ * instance, if the name of the vector parameter was "vec", the user could
+ * specify that the "vec" vector was held in vec.csv by giving the parameter:
+ *
+ * @code
+ * --vec_file vector.csv
+ * @endcode
+ *
+ * @param ID Name of the parameter.
+ * @param DESC Description of the parameter (1-2 sentences).
+ * @param ALIAS An alias for the parameter (one letter).
+ *
+ * @bug
+ * The __COUNTER__ variable is used in most cases to guarantee a unique global
+ * identifier for options declared using the PARAM_*() macros. However, not all
+ * compilers have this support--most notably, gcc < 4.3. In that case, the
+ * __LINE__ macro is used as an attempt to get a unique global identifier, but
+ * collisions are still possible, and they produce bizarre error messages.  See
+ * https://github.com/mlpack/mlpack/issues/100 for more information.
+ */
+#define PARAM_COL_IN_REQ(ID, DESC, ALIAS) \
+    PARAM_COL(ID, DESC, ALIAS, true, true, true)
+
+/**
  * Define a row vector input parameter (type arma::rowvec).  From the command
  * line, the user can specify the file that holds the vector, using the name of
  * the vector parameter with "_file" appended (and the same alias).  So for


### PR DESCRIPTION
This is a fix for #1772.

Essentially, what I found is that there was extra spacing for required matrix arguments in the generated `.pyx` files:

```
  if isinstance(copy_all_inputs, bool):
    if copy_all_inputs:
      SetParam[cbool](<const string> 'copy_all_inputs', copy_all_inputs)
      CLI.SetPassed(<const string> 'copy_all_inputs')
  else:
    raise TypeError("'copy_all_inputs' must have type 'bool'!")

  # Detect if the parameter was passed; set if so.
    input_tuple = to_matrix(input, dtype=np.double, copy=CLI.HasParam('copy_all_inputs'))
    if len(input_tuple[0].shape) > 2:
      input_tuple[0].shape = (input_tuple[0].shape[0], 1)
    input_mat = arma_numpy.numpy_to_mat_d(input_tuple[0], input_tuple[1])
    SetParam[arma.Mat[double]](<const string> 'input', dereference(input_mat))
    CLI.SetPassed(<const string> 'input')
    del input_mat
```

I fixed this and added tests to ensure that required matrices and vectors are handled correctly.  Also there was a little error in the quickstart code that produced some amusing output when doing the accuracy computation:

```
341557698 correct out of 30000 (1138525.66%).
```

I don't think our random forest is *that* good. :)