### PR TITLE
Install ensmallen headers when downloaded during build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,14 +336,17 @@ if (NOT ENSMALLEN_FOUND)
             "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include")
         message(STATUS
             "Successfully downloaded ensmallen into ${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/")
+
+        # Now we have to also ensure these header files get installed.
+        install(DIRECTORY ${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits)
+        install(FILES ${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
       else ()
         message(FATAL_ERROR "Problem unpacking ensmallen!  Expected only one directory ensmallen-x.y.z/; found ${ENS_DIRECTORIES}. Try removing the directory ${CMAKE_BINARY_DIR}/deps and reconfiguring.")
       endif ()
     else ()
       list(GET ENS_DOWNLOAD_STATUS_LIST 1 ENS_DOWNLOAD_ERROR)
       message(FATAL_ERROR
-          "Could not download ensmallen! Error code ${ENS_DOWNLOAD_STATUS}:
-${ENS_DOWNLOAD_ERROR}!  Error log: ${ENS_DOWBLOAD_LOG}")
+          "Could not download ensmallen! Error code ${ENS_DOWNLOAD_STATUS}: ${ENS_DOWNLOAD_ERROR}!  Error log: ${ENS_DOWNLOAD_LOG}")
     endif ()
   else ()
     # Release versions will have ensmallen packaged with the release so we can

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,8 +7,10 @@
   * Concatenated ReLU layer (#1843).
 
   * Accelerate NormalizeLabels function using hashing instead of linear search
-    (see `src/mlpack/core/data/normalize_labels_impl.hpp`)(#1780).
-  
+    (see `src/mlpack/core/data/normalize_labels_impl.hpp`) (#1780).
+
+  * Install ensmallen headers when it is downloaded during build (#1900).
+
 ### mlpack 3.1.0
 ###### 2019-04-25
   * Add DiagonalGaussianDistribution and DiagonalGMM classes to speed up the


### PR DESCRIPTION
While reading #1866 I realized that if CMake downloads ensmallen for the build, if the user installs mlpack it *only* installs the mlpack headers, meaning they can't ever build anything against mlpack unless they go and also install ensmallen.

This PR fixes that by having CMake install ensmallen, but only when it is downloaded during the build process because it is not available on the system.