### PR TITLE
Fix serialization of glimpse, maxPooling and meanPooling layers.

### DIFF
--- a/src/mlpack/methods/ann/layer/glimpse_impl.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse_impl.hpp
@@ -224,6 +224,9 @@ void Glimpse<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(depth);
   ar & BOOST_SERIALIZATION_NVP(scale);
   ar & BOOST_SERIALIZATION_NVP(inputWidth);
+  ar & BOOST_SERIALIZATION_NVP(inputHeight);
+  ar & BOOST_SERIALIZATION_NVP(outputWidth);
+  ar & BOOST_SERIALIZATION_NVP(outputHeight);
   ar & BOOST_SERIALIZATION_NVP(location);
 }
 

--- a/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
@@ -148,6 +148,7 @@ void MaxPooling<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(dW);
   ar & BOOST_SERIALIZATION_NVP(dH);
   ar & BOOST_SERIALIZATION_NVP(batchSize);
+  ar & BOOST_SERIALIZATION_NVP(floor);
   ar & BOOST_SERIALIZATION_NVP(inputWidth);
   ar & BOOST_SERIALIZATION_NVP(inputHeight);
   ar & BOOST_SERIALIZATION_NVP(outputWidth);

--- a/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
@@ -148,6 +148,10 @@ void MaxPooling<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(dW);
   ar & BOOST_SERIALIZATION_NVP(dH);
   ar & BOOST_SERIALIZATION_NVP(batchSize);
+  ar & BOOST_SERIALIZATION_NVP(inputWidth);
+  ar & BOOST_SERIALIZATION_NVP(inputHeight);
+  ar & BOOST_SERIALIZATION_NVP(outputWidth);
+  ar & BOOST_SERIALIZATION_NVP(outputHeight);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
@@ -122,6 +122,7 @@ void MeanPooling<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(dW);
   ar & BOOST_SERIALIZATION_NVP(dH);
   ar & BOOST_SERIALIZATION_NVP(batchSize);
+  ar & BOOST_SERIALIZATION_NVP(floor);
   ar & BOOST_SERIALIZATION_NVP(inputWidth);
   ar & BOOST_SERIALIZATION_NVP(inputHeight);
   ar & BOOST_SERIALIZATION_NVP(outputWidth);

--- a/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
@@ -122,6 +122,10 @@ void MeanPooling<InputDataType, OutputDataType>::serialize(
   ar & BOOST_SERIALIZATION_NVP(dW);
   ar & BOOST_SERIALIZATION_NVP(dH);
   ar & BOOST_SERIALIZATION_NVP(batchSize);
+  ar & BOOST_SERIALIZATION_NVP(inputWidth);
+  ar & BOOST_SERIALIZATION_NVP(inputHeight);
+  ar & BOOST_SERIALIZATION_NVP(outputWidth);
+  ar & BOOST_SERIALIZATION_NVP(outputHeight);
 }
 
 } // namespace ann


### PR DESCRIPTION
Hi @zoq, @ShikharJ,
While working on GAN serialization I have found an error in `mean pooling` layer. It was producing an `integer divide by zero` error after serialization at `line 60` in `mean_pooling_impl.hpp`. This is because the parameters  `inputWidth`, `inputHeight`, `outputWidth`, `outputHeight` were not serialize. 
I have also modified serialization of some other layers namely `max_pooling` and `glimpse`. Let me know your thoughts regarding the same. 