### PR TITLE
Fix link to 'getting involved'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ contribute to mlpack and join the community!  If you would like to make
 improvements to the library, add new features that are useful to you and others,
 or have found a bug that you know how to fix, please submit a pull request!
 
-If you would like to learn more about how to get started contributing, see
-[Getting Involved](http://www.mlpack.org/involved.html), and if you are
+If you would like to learn more about how to get started contributing, see the
+[Community](http://www.mlpack.org/community.html) page, and if you are
 interested in participating in Google Summer of Code, see
 [mlpack and Google Summer of Code](http://www.mlpack.org/gsoc.html).
 


### PR DESCRIPTION
This was pointed out by rajs123 in IRC; thanks rajs123!  I checked that there are no other references to `involved.html` in the repository.