### PR TITLE
Random forest test stability fixes

### DIFF
--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffMinLeafSizeTest)
     BOOST_FAIL("Cannot load labels for vc2_labels.txt");
 
   bool success = false;
-  for (size_t trial = 0; trial < 3; ++trial)
+  for (size_t trial = 0; trial < 5; ++trial)
   {
     // Input training data.
     SetInputParam("training", inputData);

--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -354,8 +354,8 @@ BOOST_AUTO_TEST_CASE(RandomForestDiffNumTreeTest)
     // Train for num_trees 10.
 
     // Input training data.
-    SetInputParam("training", std::move(inputData));
-    SetInputParam("labels", std::move(labels));
+    SetInputParam("training", inputData);
+    SetInputParam("labels", labels);
     SetInputParam("num_trees", (int) 10);
     SetInputParam("minimum_leaf_size", (int) 1);
 


### PR DESCRIPTION
Just some quick fixes that I put together based on looking at the recent Jenkins nightly build failures.  I found a logical error in one test and increased the number of trials for another.