### PR TITLE
Fix failing radical test.

### DIFF
--- a/src/mlpack/methods/radical/radical.cpp
+++ b/src/mlpack/methods/radical/radical.cpp
@@ -59,7 +59,7 @@ double Radical::Vasicek(vec& z) const
   uword range = z.n_elem - m;
   for (uword i = 0; i < range; i++)
   {
-    sum += log(z(i + m) - z(i));
+    sum += log(max(z(i + m) - z(i), DBL_MIN));
   }
 
   return sum;

--- a/src/mlpack/tests/main_tests/radical_test.cpp
+++ b/src/mlpack/tests/main_tests/radical_test.cpp
@@ -120,13 +120,11 @@ BOOST_AUTO_TEST_CASE(RadicalBoundsTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffNoiseStdDevTest)
 {
-  std::string inputStr = "0.497369 0.891621 0.565789;";
-  inputStr += "0.33821 0.494571 0.491079;";
-  inputStr += "0.424898 0.297599 0.475061;";
-  inputStr += "0.285009 0.152635 0.878107;";
-  inputStr += "0.321474 0.997979 0.42137";
-
-  arma::mat input(inputStr);
+  arma::mat input("0.497369 0.891621 0.565789;"
+                  "0.33821 0.494571 0.491079;"
+                  "0.424898 0.297599 0.475061;"
+                  "0.285009 0.152635 0.878107;"
+                  "0.321474 0.997979 0.42137");
 
   SetInputParam("input", input);
 
@@ -153,13 +151,11 @@ BOOST_AUTO_TEST_CASE(RadicalDiffNoiseStdDevTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffReplicatesTest)
 {
-  std::string inputStr = "0.497369 0.891621 0.565789;";
-  inputStr += "0.33821 0.494571 0.491079;";
-  inputStr += "0.424898 0.297599 0.475061;";
-  inputStr += "0.285009 0.152635 0.878107;";
-  inputStr += "0.321474 0.997979 0.42137";
-
-  arma::mat input(inputStr);
+  arma::mat input("0.497369 0.891621 0.565789;"
+                  "0.33821 0.494571 0.491079;"
+                  "0.424898 0.297599 0.475061;"
+                  "0.285009 0.152635 0.878107;"
+                  "0.321474 0.997979 0.42137");
 
   SetInputParam("input", input);
 
@@ -186,13 +182,11 @@ BOOST_AUTO_TEST_CASE(RadicalDiffReplicatesTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffAnglesTest)
 {
-  std::string inputStr = "0.497369 0.891621 0.565789;";
-  inputStr += "0.33821 0.494571 0.491079;";
-  inputStr += "0.424898 0.297599 0.475061;";
-  inputStr += "0.285009 0.152635 0.878107;";
-  inputStr += "0.321474 0.997979 0.42137";
-
-  arma::mat input(inputStr);
+  arma::mat input("0.497369 0.891621 0.565789;"
+                  "0.33821 0.494571 0.491079;"
+                  "0.424898 0.297599 0.475061;"
+                  "0.285009 0.152635 0.878107;"
+                  "0.321474 0.997979 0.42137");
 
   SetInputParam("input", input);
 
@@ -219,13 +213,11 @@ BOOST_AUTO_TEST_CASE(RadicalDiffAnglesTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffSweepsTest)
 {
-  std::string inputStr = "0.497369 0.891621 0.565789;";
-  inputStr += "0.33821 0.494571 0.491079;";
-  inputStr += "0.424898 0.297599 0.475061;";
-  inputStr += "0.285009 0.152635 0.878107;";
-  inputStr += "0.321474 0.997979 0.42137";
-
-  arma::mat input(inputStr);
+  arma::mat input("0.497369 0.891621 0.565789;"
+                  "0.33821 0.494571 0.491079;"
+                  "0.424898 0.297599 0.475061;"
+                  "0.285009 0.152635 0.878107;"
+                  "0.321474 0.997979 0.42137");
 
   SetInputParam("input", input);
 

--- a/src/mlpack/tests/main_tests/radical_test.cpp
+++ b/src/mlpack/tests/main_tests/radical_test.cpp
@@ -120,13 +120,13 @@ BOOST_AUTO_TEST_CASE(RadicalBoundsTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffNoiseStdDevTest)
 {
-  arma::mat input = {
-                      {0.497369, 0.891621, 0.565789},
-                      {0.33821, 0.494571, 0.491079},
-                      {0.424898, 0.297599, 0.475061},
-                      {0.285009, 0.152635, 0.878107},
-                      {0.321474, 0.997979, 0.42137}
-                    };
+  std::string inputStr = "0.497369 0.891621 0.565789;";
+  inputStr += "0.33821 0.494571 0.491079;";
+  inputStr += "0.424898 0.297599 0.475061;";
+  inputStr += "0.285009 0.152635 0.878107;";
+  inputStr += "0.321474 0.997979 0.42137";
+
+  arma::mat input(inputStr);
 
   SetInputParam("input", input);
 
@@ -153,13 +153,13 @@ BOOST_AUTO_TEST_CASE(RadicalDiffNoiseStdDevTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffReplicatesTest)
 {
-  arma::mat input = {
-                      {0.497369, 0.891621, 0.565789},
-                      {0.33821, 0.494571, 0.491079},
-                      {0.424898, 0.297599, 0.475061},
-                      {0.285009, 0.152635, 0.878107},
-                      {0.321474, 0.997979, 0.42137}
-                    };
+  std::string inputStr = "0.497369 0.891621 0.565789;";
+  inputStr += "0.33821 0.494571 0.491079;";
+  inputStr += "0.424898 0.297599 0.475061;";
+  inputStr += "0.285009 0.152635 0.878107;";
+  inputStr += "0.321474 0.997979 0.42137";
+
+  arma::mat input(inputStr);
 
   SetInputParam("input", input);
 
@@ -186,13 +186,13 @@ BOOST_AUTO_TEST_CASE(RadicalDiffReplicatesTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffAnglesTest)
 {
-  arma::mat input = {
-                      {0.497369, 0.891621, 0.565789},
-                      {0.33821, 0.494571, 0.491079},
-                      {0.424898, 0.297599, 0.475061},
-                      {0.285009, 0.152635, 0.878107},
-                      {0.321474, 0.997979, 0.42137}
-                    };
+  std::string inputStr = "0.497369 0.891621 0.565789;";
+  inputStr += "0.33821 0.494571 0.491079;";
+  inputStr += "0.424898 0.297599 0.475061;";
+  inputStr += "0.285009 0.152635 0.878107;";
+  inputStr += "0.321474 0.997979 0.42137";
+
+  arma::mat input(inputStr);
 
   SetInputParam("input", input);
 
@@ -219,13 +219,13 @@ BOOST_AUTO_TEST_CASE(RadicalDiffAnglesTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffSweepsTest)
 {
-  arma::mat input = {
-                      {0.497369, 0.891621, 0.565789},
-                      {0.33821, 0.494571, 0.491079},
-                      {0.424898, 0.297599, 0.475061},
-                      {0.285009, 0.152635, 0.878107},
-                      {0.321474, 0.997979, 0.42137}
-                    };
+  std::string inputStr = "0.497369 0.891621 0.565789;";
+  inputStr += "0.33821 0.494571 0.491079;";
+  inputStr += "0.424898 0.297599 0.475061;";
+  inputStr += "0.285009 0.152635 0.878107;";
+  inputStr += "0.321474 0.997979 0.42137";
+
+  arma::mat input(inputStr);
 
   SetInputParam("input", input);
 

--- a/src/mlpack/tests/main_tests/radical_test.cpp
+++ b/src/mlpack/tests/main_tests/radical_test.cpp
@@ -120,7 +120,13 @@ BOOST_AUTO_TEST_CASE(RadicalBoundsTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffNoiseStdDevTest)
 {
-  arma::mat input = arma::randu<arma::mat>(5, 3);
+  arma::mat input = {
+                      {0.497369, 0.891621, 0.565789},
+                      {0.33821, 0.494571, 0.491079},
+                      {0.424898, 0.297599, 0.475061},
+                      {0.285009, 0.152635, 0.878107},
+                      {0.321474, 0.997979, 0.42137}
+                    };
 
   SetInputParam("input", input);
 
@@ -147,7 +153,13 @@ BOOST_AUTO_TEST_CASE(RadicalDiffNoiseStdDevTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffReplicatesTest)
 {
-  arma::mat input = arma::randu<arma::mat>(5, 3);
+  arma::mat input = {
+                      {0.497369, 0.891621, 0.565789},
+                      {0.33821, 0.494571, 0.491079},
+                      {0.424898, 0.297599, 0.475061},
+                      {0.285009, 0.152635, 0.878107},
+                      {0.321474, 0.997979, 0.42137}
+                    };
 
   SetInputParam("input", input);
 
@@ -174,7 +186,13 @@ BOOST_AUTO_TEST_CASE(RadicalDiffReplicatesTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffAnglesTest)
 {
-  arma::mat input = arma::randu<arma::mat>(5, 3);
+  arma::mat input = {
+                      {0.497369, 0.891621, 0.565789},
+                      {0.33821, 0.494571, 0.491079},
+                      {0.424898, 0.297599, 0.475061},
+                      {0.285009, 0.152635, 0.878107},
+                      {0.321474, 0.997979, 0.42137}
+                    };
 
   SetInputParam("input", input);
 
@@ -201,7 +219,13 @@ BOOST_AUTO_TEST_CASE(RadicalDiffAnglesTest)
  */
 BOOST_AUTO_TEST_CASE(RadicalDiffSweepsTest)
 {
-  arma::mat input = arma::randu<arma::mat>(5, 3);
+  arma::mat input = {
+                      {0.497369, 0.891621, 0.565789},
+                      {0.33821, 0.494571, 0.491079},
+                      {0.424898, 0.297599, 0.475061},
+                      {0.285009, 0.152635, 0.878107},
+                      {0.321474, 0.997979, 0.42137}
+                    };
 
   SetInputParam("input", input);
 


### PR DESCRIPTION
Hi, 
This is a fix for failing `radical test` during the build. 
Following are the observations. 
1. `RadicalDiffNoiseStdDevTest`, `RadicalDiffReplicatesTest`, `RadicalDiffAnglesTest`, `RadicalDiffSweepsTest` fail occasionally. They failed `21` times in `10000` iterations. 
2.  After digging in it is being found `The covariance matrix` is not correctly remade after decomposing it during `whitening` of the `data matrix`.  
3. Earlier the output was exploding the values were coming in the range `1e7 to 1e14`. After modification the output is coming in `0 to 1` range. 
I am quite new to `ICA`. So, let me know if this is wrong.
