### PR TITLE
Add linear layer in model for numerical gradient tests

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -195,6 +195,9 @@ class BatchNorm
 
   //! Locally-stored normalized input.
   OutputDataType normalized;
+
+  //! Locally-stored 0 mean input.
+  OutputDataType inputMean;
 }; // class BatchNorm
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -196,7 +196,7 @@ class BatchNorm
   //! Locally-stored normalized input.
   OutputDataType normalized;
 
-  //! Locally-stored 0 mean input.
+  //! Locally-stored zero mean input.
   OutputDataType inputMean;
 }; // class BatchNorm
 

--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -22,11 +22,11 @@ namespace ann { /** Artificial Neural Network. */
 
 template<typename InputDataType, typename OutputDataType>
 BatchNorm<InputDataType, OutputDataType>::BatchNorm() :
+    size(0),
     eps(1e-8),
     loading(false),
     deterministic(false),
-    count(0),
-    size(0)
+    count(0)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -80,6 +80,7 @@ void BatchNorm<InputDataType, OutputDataType>::Forward(
 
     // Normalize the input.
     output = input.each_col() - mean;
+    inputMean = output;
     output.each_col() /= arma::sqrt(variance + eps);
 
     // Use Welford method to compute the sample variance and mean.
@@ -87,9 +88,9 @@ void BatchNorm<InputDataType, OutputDataType>::Forward(
     {
       count += 1;
 
-      OutputDataType delta = input.col(i) - runningMean;
-      runningMean = runningMean + delta / count;
-      runningVariance += delta % (input.col(i) - runningMean);
+      OutputDataType diff = input.col(i) - runningMean;
+      runningMean = runningMean + diff / count;
+      runningVariance += diff % (input.col(i) - runningMean);
     }
 
     // Reused in the backward and gradient step.
@@ -106,7 +107,6 @@ template<typename eT>
 void BatchNorm<InputDataType, OutputDataType>::Backward(
     const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
 {
-  const arma::mat inputMean = input.each_col() - mean;
   const arma::mat stdInv = 1.0 / arma::sqrt(variance + eps);
 
   // Step 1: dl / dxhat

--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -25,7 +25,8 @@ BatchNorm<InputDataType, OutputDataType>::BatchNorm() :
     eps(1e-8),
     loading(false),
     deterministic(false),
-    count(0)
+    count(0),
+    size(0)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/layer_norm.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm.hpp
@@ -185,7 +185,7 @@ class LayerNorm
   //! Locally-stored normalized input.
   OutputDataType normalized;
 
-  //! Locally-stored input with 0 mean.
+  //! Locally-stored zero mean input.
   OutputDataType inputMean;
 }; // class LayerNorm
 

--- a/src/mlpack/methods/ann/layer/layer_norm.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm.hpp
@@ -184,6 +184,9 @@ class LayerNorm
 
   //! Locally-stored normalized input.
   OutputDataType normalized;
+
+  //! Locally-stored input with 0 mean.
+  OutputDataType inputMean;
 }; // class LayerNorm
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
@@ -23,7 +23,8 @@ namespace ann { /** Artificial Neural Network. */
 template<typename InputDataType, typename OutputDataType>
 LayerNorm<InputDataType, OutputDataType>::LayerNorm() :
     eps(1e-8),
-    loading(false)
+    loading(false),
+    size(0)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
@@ -63,7 +63,7 @@ void LayerNorm<InputDataType, OutputDataType>::Forward(
 
   // Normalize the input.
   output = input.each_row() - mean;
-
+  inputMean = output;
   output.each_row() /= arma::sqrt(variance + eps);
 
   // Reused in the backward and gradient step.
@@ -79,7 +79,6 @@ template<typename eT>
 void LayerNorm<InputDataType, OutputDataType>::Backward(
     const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
 {
-  const arma::mat inputMean = input.each_row() - mean;
   const arma::mat stdInv = 1.0 / arma::sqrt(variance + eps);
 
   // dl / dxhat

--- a/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
@@ -22,9 +22,9 @@ namespace ann { /** Artificial Neural Network. */
 
 template<typename InputDataType, typename OutputDataType>
 LayerNorm<InputDataType, OutputDataType>::LayerNorm() :
+    size(0),
     eps(1e-8),
-    loading(false),
-    size(0)
+    loading(false)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -95,6 +95,7 @@ BOOST_AUTO_TEST_CASE(GradientAddLayerTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
+      model->Add<Linear<> >(10, 10);
       model->Add<Add<> >(10);
       model->Add<LogSoftMax<> >();
     }
@@ -400,6 +401,7 @@ BOOST_AUTO_TEST_CASE(GradientLinearLayerTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
+      model->Add<Linear<> >(10, 10);
       model->Add<Linear<> >(10, 2);
       model->Add<LogSoftMax<> >();
     }
@@ -483,6 +485,7 @@ BOOST_AUTO_TEST_CASE(GradientLinearNoBiasLayerTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
+      model->Add<Linear<> >(10, 10);
       model->Add<LinearNoBias<> >(10, 2);
       model->Add<LogSoftMax<> >();
     }
@@ -585,6 +588,7 @@ BOOST_AUTO_TEST_CASE(GradientFlexibleReLULayerTest)
 
       model->Predictors() = input;
       model->Responses() = target;
+      model->Add<Linear<> >(2, 2);
       model->Add<LinearNoBias<> >(2, 5);
       model->Add<FlexibleReLU<> >(0.05);
       model->Add<LogSoftMax<> >();
@@ -1307,6 +1311,7 @@ BOOST_AUTO_TEST_CASE(GradientConcatLayerTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
+      model->Add<Linear<> >(10, 10);
 
       concat = new Concat<>(true);
       concat->Add<Linear<> >(10, 2);
@@ -1578,6 +1583,7 @@ BOOST_AUTO_TEST_CASE(GradientBatchNormTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
+      model->Add<Linear<> >(10, 10);
       model->Add<BatchNorm<> >(10);
       model->Add<Linear<> >(10, 2);
       model->Add<LogSoftMax<> >();
@@ -1751,6 +1757,7 @@ BOOST_AUTO_TEST_CASE(GradientTransposedConvolutionLayerTest)
         model = new FFN<NegativeLogLikelihood<>, RandomInitialization>();
         model->Predictors() = input;
         model->Responses() = target;
+        model->Add<Linear<> >(36, 36);
         model->Add<TransposedConvolution<> >(1, 1, 3, 3, 2, 2, 1, 1, 6, 6);
         model->Add<LogSoftMax<> >();
       }
@@ -1868,6 +1875,7 @@ BOOST_AUTO_TEST_CASE(GradientAtrousConvolutionLayerTest)
       model = new FFN<NegativeLogLikelihood<>, RandomInitialization>();
       model->Predictors() = input;
       model->Responses() = target;
+      model->Add<Linear<> >(36, 36);
       model->Add<AtrousConvolution<> >(1, 1, 3, 3, 1, 1, 0, 0, 6, 6, 2, 2);
       model->Add<LogSoftMax<> >();
     }
@@ -1947,6 +1955,7 @@ BOOST_AUTO_TEST_CASE(GradientLayerNormTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
+      model->Add<Linear<> >(10, 10);
       model->Add<LayerNorm<> >(10);
       model->Add<Linear<> >(10, 2);
       model->Add<LogSoftMax<> >();
@@ -2355,7 +2364,7 @@ BOOST_AUTO_TEST_CASE(GradientSequentialLayerTest)
       model->Predictors() = input;
       model->Responses() = target;
       model->Add<IdentityLayer<> >();
-
+      model->Add<Linear<> >(10, 10);
       sequential = new Sequential<>();
       sequential->Add<Linear<> >(10, 10);
       sequential->Add<ReLULayer<> >();


### PR DESCRIPTION
I have added a linear layer for all numerical gradient tests behind the layer being tested.
This PR also include a fix in the implementation of `Backward` for BatchNorm layer. 

Closes https://github.com/mlpack/mlpack/issues/1923