### PR TITLE
Minor Optimisation in Backward computation

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -124,8 +124,7 @@ void BatchNorm<InputDataType, OutputDataType>::Backward(
 
   // Step 3: sum (dl / dxhat * -1 / stdInv) + variance *
   // (sum -2 * (x - mu)) / m.
-  g.each_col() += (arma::sum(norm.each_col() % -stdInv, 1) + (var %
-      arma::mean(-2 * inputMean, 1))) / input.n_cols;
+  g.each_col() += arma::sum(norm.each_col() % -stdInv, 1) / input.n_cols;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
@@ -96,8 +96,7 @@ void LayerNorm<InputDataType, OutputDataType>::Backward(
 
   // sum (dl / dxhat * -1 / stdInv) + variance *
   // (sum -2 * (x - mu)) / m.
-  g.each_row() += (arma::sum(norm.each_row() % -stdInv, 0) + (var %
-      arma::mean(-2 * inputMean, 0))) / input.n_rows;
+  g.each_row() += arma::sum(norm.each_row() % -stdInv, 0) / input.n_rows;
 }
 
 template<typename InputDataType, typename OutputDataType>


### PR DESCRIPTION
`inputMean = input.each_row() - mean;`
Now if we take `arma::mean(-2 * inputMean, 0)` that would be 0 so we, can remove that from the computation.