### PR TITLE
Fix PyPI documentation error.

### DIFF
--- a/doc/guide/python_quickstart.hpp
+++ b/doc/guide/python_quickstart.hpp
@@ -17,7 +17,7 @@ Installing the mlpack bindings for Python is straightforward.  It's easy to use
 conda or pip to do this:
 
 @code{.sh}
-pip install mlpack/mlpack3
+pip install mlpack3
 @endcode
 
 @code{.sh}


### PR DESCRIPTION
While traveling I had a little downtime (everyone else in my group appears to have fallen asleep... but I am not tired since it's the middle of the day) so I decided to fix this quick issue. :)

The Python quickstart documentation is currently incorrect, as pointed out by #1795.  This quick patch fixes it.

I've manually updated the pages on the website to work around the issue.