### PR TITLE
Support For TF- IDF Encoding 

### DIFF
--- a/src/mlpack/core/boost_backport/CMakeLists.txt
+++ b/src/mlpack/core/boost_backport/CMakeLists.txt
@@ -15,8 +15,11 @@ set(SOURCES
   unordered_collections_save_imp.hpp
   unordered_map.hpp
   vector.hpp
+  string_view.hpp
+  string_view_fwd.hpp
   collections_load_imp.hpp
   collections_save_imp.hpp
+  boost_backport_string_view.hpp
 )
 
 # add directory name to sources

--- a/src/mlpack/core/boost_backport/boost_backport_string_view.hpp
+++ b/src/mlpack/core/boost_backport/boost_backport_string_view.hpp
@@ -1,0 +1,43 @@
+/**
+ * @file boost_backport_string_view.hpp
+ * @author Jeffin Sam
+ *
+ * Centralized control of what boost files to include. We have backported the
+ * following boost functionality here:
+ *
+ *  * string_view support (added in boost 1.61.0)
+ *  * hash function support (added in boost 1.69.0)
+ *
+ * If the detected boost version is greater or equal to 1.61.0, we include the
+ * normal serialization functions (not the backported ones).  For all older
+ *  versions we include the backported headers.
+ */
+#ifndef MLPACK_CORE_BOOST_BACKPORT_STRING_VIEW_HPP
+#define MLPACK_CORE_BOOST_BACKPORT_STRING_VIEW_HPP
+
+#include <boost/version.hpp>
+#include <boost/functional/hash.hpp>
+
+#if BOOST_VERSION < 106100
+  // Backported unordered_map.
+  #include "mlpack/core/boost_backport/string_view.hpp"
+#else
+  // Boost's version.
+  #include <boost/utility/string_view.hpp>
+#endif
+
+#if BOOST_VERSION < 106900
+  namespace boost
+  {
+    template<>
+    struct hash<boost::string_view>
+    {
+      std::size_t operator()(boost::string_view str) const
+      {
+        return boost::hash_range(str.begin(), str.end());
+      }
+    };
+  }
+#endif
+
+#endif // MLPACK_CORE_BOOST_BACKPORT_STRING_VIEW_HPP

--- a/src/mlpack/core/boost_backport/string_view.hpp
+++ b/src/mlpack/core/boost_backport/string_view.hpp
@@ -1,0 +1,698 @@
+/*
+   Copyright (c) Marshall Clow 2012-2015.
+   Copyright (c) Beman Dawes 2015
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    For more information, see http://www.boost.org
+
+    Based on the StringRef implementation in LLVM (http://llvm.org) and
+    N3422 by Jeffrey Yasskin
+        http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html
+    Updated July 2015 to reflect the Library Fundamentals TS
+        http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4480.html
+*/
+
+#ifndef BOOST_STRING_VIEW_HPP
+#define BOOST_STRING_VIEW_HPP
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+#include <boost/version.hpp>
+#include <boost/throw_exception.hpp>
+
+#if BOOST_VERSION < 106100
+  // Backported unordered_map.
+  #include "mlpack/core/boost_backport/string_view_fwd.hpp"
+#else
+  // Boost's version.
+  #include <boost/utility/string_view_fwd.hpp>
+#endif
+
+#include <cstddef>
+#include <stdexcept>
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <cstring>
+#include <iosfwd>
+
+#if defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || (defined(BOOST_GCC) && ((BOOST_GCC+0) / 100) <= 406)
+// GCC 4.6 cannot handle a defaulted function with noexcept specifier
+#define BOOST_STRING_VIEW_NO_CXX11_DEFAULTED_NOEXCEPT_FUNCTIONS
+#endif
+
+namespace boost {
+
+    namespace detail {
+    //  A helper functor because sometimes we don't have lambdas
+        template <typename charT, typename traits>
+        class string_view_traits_eq {
+        public:
+            string_view_traits_eq ( charT ch ) : ch_(ch) {}
+            bool operator()( charT val ) const { return traits::eq (ch_, val); }
+            charT ch_;
+            };
+        }
+
+    template<typename charT, typename traits>  // traits defaulted in string_view_fwd.hpp
+    class basic_string_view {
+    public:
+      // types
+      typedef traits                                traits_type;
+      typedef charT                                 value_type;
+      typedef charT*                                pointer;
+      typedef const charT*                          const_pointer;
+      typedef charT&                                reference;
+      typedef const charT&                          const_reference;
+      typedef const_pointer                         const_iterator; // impl-defined
+      typedef const_iterator                        iterator;
+      typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+      typedef const_reverse_iterator                reverse_iterator;
+      typedef std::size_t                           size_type;
+      typedef std::ptrdiff_t                        difference_type;
+      static BOOST_CONSTEXPR_OR_CONST size_type     npos = size_type(-1);
+
+      // construct/copy
+      BOOST_CONSTEXPR basic_string_view() BOOST_NOEXCEPT
+        : ptr_(NULL), len_(0) {}
+
+      // by defaulting these functions, basic_string_ref becomes
+      //  trivially copy/move constructible.
+      BOOST_CONSTEXPR basic_string_view(const basic_string_view &rhs) BOOST_NOEXCEPT
+#ifndef BOOST_STRING_VIEW_NO_CXX11_DEFAULTED_NOEXCEPT_FUNCTIONS
+        = default;
+#else
+        : ptr_(rhs.ptr_), len_(rhs.len_) {}
+#endif
+
+      basic_string_view& operator=(const basic_string_view &rhs) BOOST_NOEXCEPT
+#ifndef BOOST_STRING_VIEW_NO_CXX11_DEFAULTED_NOEXCEPT_FUNCTIONS
+            = default;
+#else
+        {
+        ptr_ = rhs.ptr_;
+        len_ = rhs.len_;
+        return *this;
+        }
+#endif
+
+      template<typename Allocator>
+        basic_string_view(const std::basic_string<charT, traits, Allocator>& str) BOOST_NOEXCEPT
+          : ptr_(str.data()), len_(str.length()) {}
+
+// #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+//       // Constructing a string_view from a temporary string is a bad idea
+//       template<typename Allocator>
+//         basic_string_view(      std::basic_string<charT, traits, Allocator>&&)
+//           = delete;
+// #endif
+
+      BOOST_CONSTEXPR basic_string_view(const charT* str)
+        : ptr_(str), len_(traits::length(str)) {}
+
+      BOOST_CONSTEXPR basic_string_view(const charT* str, size_type len)
+        : ptr_(str), len_(len) {}
+
+        // iterators
+        BOOST_CONSTEXPR const_iterator   begin() const BOOST_NOEXCEPT { return ptr_; }
+        BOOST_CONSTEXPR const_iterator  cbegin() const BOOST_NOEXCEPT { return ptr_; }
+        BOOST_CONSTEXPR const_iterator     end() const BOOST_NOEXCEPT { return ptr_ + len_; }
+        BOOST_CONSTEXPR const_iterator    cend() const BOOST_NOEXCEPT { return ptr_ + len_; }
+                const_reverse_iterator  rbegin() const BOOST_NOEXCEPT { return const_reverse_iterator(end()); }
+                const_reverse_iterator crbegin() const BOOST_NOEXCEPT { return const_reverse_iterator(end()); }
+                const_reverse_iterator    rend() const BOOST_NOEXCEPT { return const_reverse_iterator(begin()); }
+                const_reverse_iterator   crend() const BOOST_NOEXCEPT { return const_reverse_iterator(begin()); }
+
+        // capacity
+        BOOST_CONSTEXPR size_type size()     const BOOST_NOEXCEPT { return len_; }
+        BOOST_CONSTEXPR size_type length()   const BOOST_NOEXCEPT { return len_; }
+        BOOST_CONSTEXPR size_type max_size() const BOOST_NOEXCEPT { return len_; }
+        BOOST_CONSTEXPR bool empty()         const BOOST_NOEXCEPT { return len_ == 0; }
+
+        // element access
+        BOOST_CONSTEXPR const_reference operator[](size_type pos) const BOOST_NOEXCEPT { return ptr_[pos]; }
+
+        BOOST_CONSTEXPR const_reference at(size_t pos) const {
+            return pos >= len_ ? BOOST_THROW_EXCEPTION(std::out_of_range("boost::string_view::at")), ptr_[0] : ptr_[pos];
+            }
+
+        BOOST_CONSTEXPR const_reference front() const                { return ptr_[0]; }
+        BOOST_CONSTEXPR const_reference back()  const                { return ptr_[len_-1]; }
+        BOOST_CONSTEXPR const_pointer data()    const BOOST_NOEXCEPT { return ptr_; }
+
+        // modifiers
+        void clear() BOOST_NOEXCEPT { len_ = 0; }          // Boost extension
+
+        BOOST_CXX14_CONSTEXPR void remove_prefix(size_type n) {
+            if ( n > len_ )
+                n = len_;
+            ptr_ += n;
+            len_ -= n;
+            }
+
+        BOOST_CXX14_CONSTEXPR void remove_suffix(size_type n) {
+            if ( n > len_ )
+                n = len_;
+            len_ -= n;
+            }
+
+        BOOST_CXX14_CONSTEXPR void swap(basic_string_view& s) BOOST_NOEXCEPT {
+            std::swap(ptr_, s.ptr_);
+            std::swap(len_, s.len_);
+            }
+
+        // basic_string_view string operations
+#ifndef BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
+        template<typename Allocator>
+        explicit operator std::basic_string<charT, traits, Allocator>() const {
+            return std::basic_string<charT, traits, Allocator>(begin(), end());
+            }
+#endif
+
+#ifndef BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS
+        template<typename Allocator = std::allocator<charT> >
+        std::basic_string<charT, traits, Allocator> to_string(const Allocator& a = Allocator()) const {
+            return std::basic_string<charT, traits, Allocator>(begin(), end(), a);
+            }
+#else
+        std::basic_string<charT, traits> to_string() const {
+            return std::basic_string<charT, traits>(begin(), end());
+            }
+
+        template<typename Allocator>
+        std::basic_string<charT, traits, Allocator> to_string(const Allocator& a) const {
+            return std::basic_string<charT, traits, Allocator>(begin(), end(), a);
+            }
+#endif
+
+        size_type copy(charT* s, size_type n, size_type pos=0) const {
+            if (pos > size())
+                BOOST_THROW_EXCEPTION(std::out_of_range("string_view::copy" ));
+            size_type rlen = (std::min)(n, len_ - pos);
+    		traits_type::copy(s, data() + pos, rlen);
+            return rlen;
+            }
+
+        BOOST_CXX14_CONSTEXPR basic_string_view substr(size_type pos, size_type n=npos) const {
+            if ( pos > size())
+                BOOST_THROW_EXCEPTION( std::out_of_range ( "string_view::substr" ) );
+            return basic_string_view(data() + pos, (std::min)(size() - pos, n));
+            }
+
+        BOOST_CXX14_CONSTEXPR int compare(basic_string_view x) const BOOST_NOEXCEPT {
+            const int cmp = traits::compare(ptr_, x.ptr_, (std::min)(len_, x.len_));
+            return cmp != 0 ? cmp : (len_ == x.len_ ? 0 : len_ < x.len_ ? -1 : 1);
+            }
+
+        BOOST_CXX14_CONSTEXPR int compare(size_type pos1, size_type n1, basic_string_view x)
+          const BOOST_NOEXCEPT {
+            return substr(pos1, n1).compare(x);
+            }
+
+        BOOST_CXX14_CONSTEXPR int compare(size_type pos1, size_type n1,
+          basic_string_view x, size_type pos2, size_type n2) const {
+            return substr(pos1, n1).compare(x.substr(pos2, n2));
+            }
+
+        BOOST_CXX14_CONSTEXPR int compare(const charT* x) const {
+            return compare(basic_string_view(x));
+            }
+
+        BOOST_CXX14_CONSTEXPR int compare(size_type pos1, size_type n1, const charT* x) const {
+            return substr(pos1, n1).compare(basic_string_view(x));
+            }
+
+        BOOST_CXX14_CONSTEXPR int compare(size_type pos1, size_type n1,
+          const charT* x, size_type n2) const {
+            return substr(pos1, n1).compare(basic_string_view(x, n2));
+            }
+
+        //  Searches
+        BOOST_CONSTEXPR bool starts_with(charT c) const BOOST_NOEXCEPT {              // Boost extension
+            return !empty() && traits::eq(c, front());
+            }
+
+        BOOST_CONSTEXPR bool starts_with(basic_string_view x) const BOOST_NOEXCEPT {  // Boost extension
+            return len_ >= x.len_ && traits::compare(ptr_, x.ptr_, x.len_) == 0;
+            }
+
+        BOOST_CONSTEXPR bool ends_with(charT c) const BOOST_NOEXCEPT {                // Boost extension
+            return !empty() && traits::eq(c, back());
+            }
+
+        BOOST_CONSTEXPR bool ends_with(basic_string_view x) const BOOST_NOEXCEPT {    // Boost extension
+            return len_ >= x.len_ &&
+               traits::compare(ptr_ + len_ - x.len_, x.ptr_, x.len_) == 0;
+            }
+
+        //  find
+        BOOST_CXX14_CONSTEXPR size_type find(basic_string_view s, size_type pos = 0) const BOOST_NOEXCEPT {
+            if (pos > size())
+              return npos;
+            if (s.empty())
+              return pos;
+            const_iterator iter = std::search(this->cbegin() + pos, this->cend(),
+                                               s.cbegin (), s.cend (), traits::eq);
+            return iter == this->cend () ? npos : std::distance(this->cbegin (), iter);
+            }
+        BOOST_CXX14_CONSTEXPR size_type find(charT c, size_type pos = 0) const BOOST_NOEXCEPT
+            { return find(basic_string_view(&c, 1), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find(const charT* s, size_type pos, size_type n) const BOOST_NOEXCEPT
+            { return find(basic_string_view(s, n), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find(const charT* s, size_type pos = 0) const BOOST_NOEXCEPT
+            { return find(basic_string_view(s), pos); }
+
+        //  rfind
+        BOOST_CXX14_CONSTEXPR size_type rfind(basic_string_view s, size_type pos = npos) const BOOST_NOEXCEPT {
+            if (len_ < s.len_)
+              return npos;
+            if (pos > len_ - s.len_)
+              pos = len_ - s.len_;
+            if (s.len_ == 0u)     // an empty string is always found
+              return pos;
+            for (const charT* cur = ptr_ + pos; ; --cur) {
+                if (traits::compare(cur, s.ptr_, s.len_) == 0)
+                  return cur - ptr_;
+                if (cur == ptr_)
+                  return npos;
+                };
+            }
+        BOOST_CXX14_CONSTEXPR size_type rfind(charT c, size_type pos = npos) const BOOST_NOEXCEPT
+            { return rfind(basic_string_view(&c, 1), pos); }
+        BOOST_CXX14_CONSTEXPR size_type rfind(const charT* s, size_type pos, size_type n) const BOOST_NOEXCEPT
+            { return rfind(basic_string_view(s, n), pos); }
+        BOOST_CXX14_CONSTEXPR size_type rfind(const charT* s, size_type pos = npos) const BOOST_NOEXCEPT
+            { return rfind(basic_string_view(s), pos); }
+
+        //  find_first_of
+        BOOST_CXX14_CONSTEXPR size_type find_first_of(basic_string_view s, size_type pos = 0) const BOOST_NOEXCEPT {
+            if (pos >= len_ || s.len_ == 0)
+              return npos;
+            const_iterator iter = std::find_first_of
+                (this->cbegin () + pos, this->cend (), s.cbegin (), s.cend (), traits::eq);
+            return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+            }
+        BOOST_CXX14_CONSTEXPR size_type find_first_of(charT c, size_type pos = 0) const BOOST_NOEXCEPT
+            { return find_first_of(basic_string_view(&c, 1), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_first_of(const charT* s, size_type pos, size_type n) const BOOST_NOEXCEPT
+            { return find_first_of(basic_string_view(s, n), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_first_of(const charT* s, size_type pos = 0) const BOOST_NOEXCEPT
+            { return find_first_of(basic_string_view(s), pos); }
+
+        //  find_last_of
+        BOOST_CXX14_CONSTEXPR size_type find_last_of(basic_string_view s, size_type pos = npos) const BOOST_NOEXCEPT {
+            if (s.len_ == 0u)
+              return npos;
+            if (pos >= len_)
+              pos = 0;
+            else
+              pos = len_ - (pos+1);
+            const_reverse_iterator iter = std::find_first_of
+                ( this->crbegin () + pos, this->crend (), s.cbegin (), s.cend (), traits::eq );
+            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter);
+            }
+        BOOST_CXX14_CONSTEXPR size_type find_last_of(charT c, size_type pos = npos) const BOOST_NOEXCEPT
+            { return find_last_of(basic_string_view(&c, 1), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_last_of(const charT* s, size_type pos, size_type n) const BOOST_NOEXCEPT
+            { return find_last_of(basic_string_view(s, n), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_last_of(const charT* s, size_type pos = npos) const BOOST_NOEXCEPT
+            { return find_last_of(basic_string_view(s), pos); }
+
+        //  find_first_not_of
+        BOOST_CXX14_CONSTEXPR size_type find_first_not_of(basic_string_view s, size_type pos = 0) const BOOST_NOEXCEPT {
+            if (pos >= len_)
+              return npos;
+            if (s.len_ == 0)
+              return pos;
+            const_iterator iter = find_not_of ( this->cbegin () + pos, this->cend (), s );
+            return iter == this->cend () ? npos : std::distance ( this->cbegin (), iter );
+            }
+        BOOST_CXX14_CONSTEXPR size_type find_first_not_of(charT c, size_type pos = 0) const BOOST_NOEXCEPT
+            { return find_first_not_of(basic_string_view(&c, 1), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_first_not_of(const charT* s, size_type pos, size_type n) const BOOST_NOEXCEPT
+            { return find_first_not_of(basic_string_view(s, n), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_first_not_of(const charT* s, size_type pos = 0) const BOOST_NOEXCEPT
+            { return find_first_not_of(basic_string_view(s), pos); }
+
+        //  find_last_not_of
+        BOOST_CXX14_CONSTEXPR size_type find_last_not_of(basic_string_view s, size_type pos = npos) const BOOST_NOEXCEPT {
+            if (pos >= len_)
+              pos = len_ - 1;
+            if (s.len_ == 0u)
+              return pos;
+            pos = len_ - (pos+1);
+            const_reverse_iterator iter = find_not_of ( this->crbegin () + pos, this->crend (), s );
+            return iter == this->crend () ? npos : reverse_distance ( this->crbegin (), iter );
+            }
+        BOOST_CXX14_CONSTEXPR size_type find_last_not_of(charT c, size_type pos = npos) const BOOST_NOEXCEPT
+            { return find_last_not_of(basic_string_view(&c, 1), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_last_not_of(const charT* s, size_type pos, size_type n) const BOOST_NOEXCEPT
+            { return find_last_not_of(basic_string_view(s, n), pos); }
+        BOOST_CXX14_CONSTEXPR size_type find_last_not_of(const charT* s, size_type pos = npos) const BOOST_NOEXCEPT
+            { return find_last_not_of(basic_string_view(s), pos); }
+
+    private:
+        template <typename r_iter>
+        size_type reverse_distance(r_iter first, r_iter last) const BOOST_NOEXCEPT {
+        // Portability note here: std::distance is not NOEXCEPT, but calling it with a string_view::reverse_iterator will not throw.
+            return len_ - 1 - std::distance ( first, last );
+            }
+
+        template <typename Iterator>
+        Iterator find_not_of(Iterator first, Iterator last, basic_string_view s) const BOOST_NOEXCEPT {
+            for (; first != last ; ++first)
+                if ( 0 == traits::find(s.ptr_, s.len_, *first))
+                    return first;
+            return last;
+            }
+
+        const charT *ptr_;
+        std::size_t len_;
+        };
+
+
+//  Comparison operators
+//  Equality
+    template<typename charT, typename traits>
+    inline bool operator==(basic_string_view<charT, traits> x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        if (x.size () != y.size ()) return false;
+        return x.compare(y) == 0;
+        }
+
+//  Inequality
+    template<typename charT, typename traits>
+    inline bool operator!=(basic_string_view<charT, traits> x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        if ( x.size () != y.size ()) return true;
+        return x.compare(y) != 0;
+        }
+
+//  Less than
+    template<typename charT, typename traits>
+    inline bool operator<(basic_string_view<charT, traits> x,
+                          basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return x.compare(y) < 0;
+        }
+
+//  Greater than
+    template<typename charT, typename traits>
+    inline bool operator>(basic_string_view<charT, traits> x,
+                          basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return x.compare(y) > 0;
+        }
+
+//  Less than or equal to
+    template<typename charT, typename traits>
+    inline bool operator<=(basic_string_view<charT, traits> x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return x.compare(y) <= 0;
+        }
+
+//  Greater than or equal to
+    template<typename charT, typename traits>
+    inline bool operator>=(basic_string_view<charT, traits> x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return x.compare(y) >= 0;
+        }
+
+// "sufficient additional overloads of comparison functions"
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator==(basic_string_view<charT, traits> x,
+                     const std::basic_string<charT, traits, Allocator> & y) BOOST_NOEXCEPT {
+        return x == basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator==(const std::basic_string<charT, traits, Allocator> & x,
+                                 basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) == y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator==(basic_string_view<charT, traits> x,
+                                              const charT * y) BOOST_NOEXCEPT {
+        return x == basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator==(const charT * x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) == y;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator!=(basic_string_view<charT, traits> x,
+                     const std::basic_string<charT, traits, Allocator> & y) BOOST_NOEXCEPT {
+        return x != basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator!=(const std::basic_string<charT, traits, Allocator> & x,
+                                 basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) != y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator!=(basic_string_view<charT, traits> x,
+                           const charT * y) BOOST_NOEXCEPT {
+        return x != basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator!=(const charT * x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) != y;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<(basic_string_view<charT, traits> x,
+                    const std::basic_string<charT, traits, Allocator> & y) BOOST_NOEXCEPT {
+        return x < basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<(const std::basic_string<charT, traits, Allocator> & x,
+                                basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) < y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<(basic_string_view<charT, traits> x,
+                          const charT * y) BOOST_NOEXCEPT {
+        return x < basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<(const charT * x,
+                          basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) < y;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>(basic_string_view<charT, traits> x,
+                    const std::basic_string<charT, traits, Allocator> & y) BOOST_NOEXCEPT {
+        return x > basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>(const std::basic_string<charT, traits, Allocator> & x,
+                                basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) > y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>(basic_string_view<charT, traits> x,
+                          const charT * y) BOOST_NOEXCEPT {
+        return x > basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>(const charT * x,
+                          basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) > y;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<=(basic_string_view<charT, traits> x,
+                     const std::basic_string<charT, traits, Allocator> & y) BOOST_NOEXCEPT {
+        return x <= basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator<=(const std::basic_string<charT, traits, Allocator> & x,
+                                 basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) <= y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<=(basic_string_view<charT, traits> x,
+                           const charT * y) BOOST_NOEXCEPT {
+        return x <= basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator<=(const charT * x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) <= y;
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>=(basic_string_view<charT, traits> x,
+                     const std::basic_string<charT, traits, Allocator> & y) BOOST_NOEXCEPT {
+        return x >= basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits, typename Allocator>
+    inline bool operator>=(const std::basic_string<charT, traits, Allocator> & x,
+                                 basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) >= y;
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>=(basic_string_view<charT, traits> x,
+                           const charT * y) BOOST_NOEXCEPT {
+        return x >= basic_string_view<charT, traits>(y);
+        }
+
+    template<typename charT, typename traits>
+    inline bool operator>=(const charT * x,
+                           basic_string_view<charT, traits> y) BOOST_NOEXCEPT {
+        return basic_string_view<charT, traits>(x) >= y;
+        }
+
+    namespace detail {
+
+        template<class charT, class traits>
+        inline void sv_insert_fill_chars(std::basic_ostream<charT, traits>& os, std::size_t n) {
+            enum { chunk_size = 8 };
+            charT fill_chars[chunk_size];
+            std::fill_n(fill_chars, static_cast< std::size_t >(chunk_size), os.fill());
+            for (; n >= chunk_size && os.good(); n -= chunk_size)
+                os.write(fill_chars, static_cast< std::size_t >(chunk_size));
+            if (n > 0 && os.good())
+                os.write(fill_chars, n);
+            }
+
+        template<class charT, class traits>
+        void sv_insert_aligned(std::basic_ostream<charT, traits>& os, const basic_string_view<charT,traits>& str) {
+            const std::size_t size = str.size();
+            const std::size_t alignment_size = static_cast< std::size_t >(os.width()) - size;
+            const bool align_left = (os.flags() & std::basic_ostream<charT, traits>::adjustfield) == std::basic_ostream<charT, traits>::left;
+            if (!align_left) {
+                detail::sv_insert_fill_chars(os, alignment_size);
+                if (os.good())
+                    os.write(str.data(), size);
+                }
+            else {
+                os.write(str.data(), size);
+                if (os.good())
+                    detail::sv_insert_fill_chars(os, alignment_size);
+                }
+            }
+
+        } // namespace detail
+
+    // Inserter
+    template<class charT, class traits>
+    inline std::basic_ostream<charT, traits>&
+    operator<<(std::basic_ostream<charT, traits>& os,
+      const basic_string_view<charT,traits>& str) {
+        if (os.good()) {
+            const std::size_t size = str.size();
+            const std::size_t w = static_cast< std::size_t >(os.width());
+            if (w <= size)
+                os.write(str.data(), size);
+            else
+                detail::sv_insert_aligned(os, str);
+            os.width(0);
+            }
+        return os;
+        }
+
+#if 0
+    // numeric conversions
+    //
+    //  These are short-term implementations.
+    //  In a production environment, I would rather avoid the copying.
+    //
+    inline int stoi (string_view str, size_t* idx=0, int base=10) {
+        return std::stoi ( std::string(str), idx, base );
+        }
+
+    inline long stol (string_view str, size_t* idx=0, int base=10) {
+        return std::stol ( std::string(str), idx, base );
+        }
+
+    inline unsigned long stoul (string_view str, size_t* idx=0, int base=10) {
+        return std::stoul ( std::string(str), idx, base );
+        }
+
+    inline long long stoll (string_view str, size_t* idx=0, int base=10) {
+        return std::stoll ( std::string(str), idx, base );
+        }
+
+    inline unsigned long long stoull (string_view str, size_t* idx=0, int base=10) {
+        return std::stoull ( std::string(str), idx, base );
+        }
+
+    inline float stof (string_view str, size_t* idx=0) {
+        return std::stof ( std::string(str), idx );
+        }
+
+    inline double stod (string_view str, size_t* idx=0) {
+        return std::stod ( std::string(str), idx );
+        }
+
+    inline long double stold (string_view str, size_t* idx=0)  {
+        return std::stold ( std::string(str), idx );
+        }
+
+    inline int  stoi (wstring_view str, size_t* idx=0, int base=10) {
+        return std::stoi ( std::wstring(str), idx, base );
+        }
+
+    inline long stol (wstring_view str, size_t* idx=0, int base=10) {
+        return std::stol ( std::wstring(str), idx, base );
+        }
+
+    inline unsigned long stoul (wstring_view str, size_t* idx=0, int base=10) {
+        return std::stoul ( std::wstring(str), idx, base );
+        }
+
+    inline long long stoll (wstring_view str, size_t* idx=0, int base=10) {
+        return std::stoll ( std::wstring(str), idx, base );
+        }
+
+    inline unsigned long long stoull (wstring_view str, size_t* idx=0, int base=10) {
+        return std::stoull ( std::wstring(str), idx, base );
+        }
+
+    inline float  stof (wstring_view str, size_t* idx=0) {
+        return std::stof ( std::wstring(str), idx );
+        }
+
+    inline double stod (wstring_view str, size_t* idx=0) {
+        return std::stod ( std::wstring(str), idx );
+        }
+
+    inline long double stold (wstring_view str, size_t* idx=0) {
+        return std::stold ( std::wstring(str), idx );
+        }
+#endif
+
+}
+
+#if 0
+namespace std {
+    // Hashing
+    template<> struct hash<boost::string_view>;
+    template<> struct hash<boost::u16string_view>;
+    template<> struct hash<boost::u32string_view>;
+    template<> struct hash<boost::wstring_view>;
+}
+#endif
+
+#endif

--- a/src/mlpack/core/boost_backport/string_view_fwd.hpp
+++ b/src/mlpack/core/boost_backport/string_view_fwd.hpp
@@ -1,0 +1,39 @@
+/*
+   Copyright (c) Marshall Clow 2012-2012.
+
+   Distributed under the Boost Software License, Version 1.0. (See accompanying
+   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    For more information, see http://www.boost.org
+
+    Based on the StringRef implementation in LLVM (http://llvm.org) and
+    N3422 by Jeffrey Yasskin
+        http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html
+    Updated July 2015 to reflect the Library Fundamentals TS
+        http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4480.html
+
+*/
+
+#ifndef BOOST_STRING_VIEW_FWD_HPP
+#define BOOST_STRING_VIEW_FWD_HPP
+
+#include <boost/config.hpp>
+#include <string>
+
+namespace boost {
+
+    template<typename charT, typename traits = std::char_traits<charT> > class basic_string_view;
+    typedef basic_string_view<char,     std::char_traits<char> >        string_view;
+    typedef basic_string_view<wchar_t,  std::char_traits<wchar_t> >    wstring_view;
+
+#ifndef BOOST_NO_CXX11_CHAR16_T
+    typedef basic_string_view<char16_t, std::char_traits<char16_t> > u16string_view;
+#endif
+
+#ifndef BOOST_NO_CXX11_CHAR32_T
+    typedef basic_string_view<char32_t, std::char_traits<char32_t> > u32string_view;
+#endif
+
+}
+
+#endif

--- a/src/mlpack/core/data/CMakeLists.txt
+++ b/src/mlpack/core/data/CMakeLists.txt
@@ -27,6 +27,8 @@ set(SOURCES
   confusion_matrix.hpp
   one_hot_encoding.hpp
   one_hot_encoding_impl.hpp
+  tokenizer/char_split.hpp
+  tokenizer/split_by_char.hpp
 )
 
 # add directory name to sources

--- a/src/mlpack/core/data/CMakeLists.txt
+++ b/src/mlpack/core/data/CMakeLists.txt
@@ -27,6 +27,8 @@ set(SOURCES
   confusion_matrix.hpp
   one_hot_encoding.hpp
   one_hot_encoding_impl.hpp
+  tfidf_encoding.hpp
+  tfidf_encoding_impl.hpp
   tokenizer/char_split.hpp
   tokenizer/split_by_char.hpp
 )

--- a/src/mlpack/core/data/tfidf_encoding.hpp
+++ b/src/mlpack/core/data/tfidf_encoding.hpp
@@ -1,0 +1,136 @@
+/**
+ * @file tfidf_encoding.hpp
+ * @author Jeffin Sam
+ *
+ * Definition of TfIdf encoding functions.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_DATA_TFIDF_ENCODING_HPP
+#define MLPACK_CORE_DATA_TFIDF_ENCODING_HPP
+
+#include <mlpack/prereqs.hpp>
+#include "mlpack/core/boost_backport/boost_backport_string_view.hpp"
+#include <utility>
+
+using MapType =   std::unordered_map<boost::string_view, size_t,
+    boost::hash<boost::string_view>>;
+
+namespace mlpack {
+namespace data {
+
+/**
+ * A simple TfIdf Enocding class.
+ *
+ * Term frequency–inverse document frequency (Tf-Idf), is a numerical statistic
+ * that is intended to reflect how important a word is to a document in a
+ * collection or corpus. The encoding here refers to substituting the TFIDF
+ * value for the respective word.
+ */
+class TfIdf
+{
+ public:
+  /**
+  * A function to create mapping from a given corpus.
+  * 
+  * @param input Corpus of text to encode.
+  * @param tokenizer A function that accepts a boost::string_view as
+  *                  an argument and returns a token.
+  * This can either be a function pointer or function object or a lamda
+  * function. Its return value should be a boost::string_view, a token.
+  *
+  * Definition of function should be of type
+  * boost::string_view fn(boost::string_view& str)
+  *
+  */
+  template<typename TokenizerType>
+  void CreateMap(std::string& input, TokenizerType tokenizer);
+  /**
+  * Default Constructor
+  */
+  TfIdf() {}
+  /**
+  * Copy Constructor.
+  */
+  TfIdf(const TfIdf& oldObject);
+  /*
+  * Move Constructor.
+  */
+  TfIdf(TfIdf&& oldObject) = default;
+  /*
+  * Move Assignment Operator.
+  */  
+  TfIdf& operator= (TfIdf&& oldObject) = default;
+  /*
+  * Assignment Operator.
+  */
+  TfIdf& operator= (const TfIdf& oldObject);
+  /**
+  * A function to reset the mapping that is clear all the encodings
+  */
+  void Reset();
+
+  /**
+  * A fucntion to encode given array of strings using a particular delimiter,
+  * providing custom rule for tokenization.
+  *
+  * For example 
+  * Vector is :
+  * [hello@wow, wow@hello@good] would be encoded using '@' as delimiter as 
+  * [0 0 0, 0 0 0.1] 
+  * User may also provide their custom tokenization rule.
+  *
+  * @param input Vector of strings.
+  * @param output Output Matrix to store encoded results (sp_mat or mat).
+  * @param tokenizer A function that accepts a boost::string_view as
+  *                  an argument and returns a token.
+  * This can either be a function pointer or function object or a lamda
+  * function. Its return value should be a boost::string_view, a token.
+  *
+  * Definition of function should be of type
+  * boost::string_view fn(boost::string_view& str)
+  *
+  */
+  template<typename MatType, typename TokenizerType>
+  void Encode(const std::vector<std::string>& input,
+              MatType& output, TokenizerType tokenizer);
+
+
+  //! Modify the originalStrings.
+  std::deque<std::string>& OriginalStrings() { return originalStrings; }
+
+  //! Return the originalStrings.
+  const std::deque<std::string>& OriginalStrings() const
+      { return originalStrings; }
+
+  //! Return the mappings
+  const MapType& Mappings() const { return mappings; }
+
+  //! Modify the mapappings.
+  MapType& Mappings() { return mappings; }
+
+  /**
+   * Serialize the class to the given archive.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */);
+ private:
+  //! A map which stores information about mapping.
+  MapType mappings;
+  //! A map which stores informaton about IDF.
+  std::unordered_map<boost::string_view, double,
+      boost::hash<boost::string_view>> idfdict;
+  //! A deque which holds the original string for map's string_view.
+  std::deque<std::string> originalStrings;
+}; // class TfIdf
+
+} // namespace data
+} // namespace mlpack
+
+// Include implementation.
+#include "tfidf_encoding_impl.hpp"
+
+#endif

--- a/src/mlpack/core/data/tfidf_encoding.hpp
+++ b/src/mlpack/core/data/tfidf_encoding.hpp
@@ -112,6 +112,10 @@ class TfIdf
   //! Modify the mapappings.
   MapType& Mappings() { return mappings; }
 
+  //! Return the Idf Values.
+  const std::unordered_map<boost::string_view, double,
+      boost::hash<boost::string_view>>& IdfValues() const { return idfdict; }
+
   /**
    * Serialize the class to the given archive.
    */
@@ -120,7 +124,7 @@ class TfIdf
  private:
   //! A map which stores information about mapping.
   MapType mappings;
-  //! A map which stores informaton about IDF.
+  //! A map which stores informaton about IDF values.
   std::unordered_map<boost::string_view, double,
       boost::hash<boost::string_view>> idfdict;
   //! A deque which holds the original string for map's string_view.

--- a/src/mlpack/core/data/tfidf_encoding.hpp
+++ b/src/mlpack/core/data/tfidf_encoding.hpp
@@ -16,7 +16,7 @@
 #include "mlpack/core/boost_backport/boost_backport_string_view.hpp"
 #include <utility>
 
-using MapType =   std::unordered_map<boost::string_view, size_t,
+using MapType = std::unordered_map<boost::string_view, size_t,
     boost::hash<boost::string_view>>;
 
 namespace mlpack {

--- a/src/mlpack/core/data/tfidf_encoding_impl.hpp
+++ b/src/mlpack/core/data/tfidf_encoding_impl.hpp
@@ -1,0 +1,170 @@
+/**
+ * @file tfidf_encoding_impl.hpp
+ * @author Jeffin Sam
+ *
+ * Implementation of TfIdf encoding functions.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_DATA_TFIDF_ENCODING_IMPL_HPP
+#define MLPACK_CORE_DATA_TFIDF_ENCODING_IMPL_HPP
+
+// In case it hasn't been included yet.
+#include "tfidf_encoding.hpp"
+
+namespace mlpack {
+namespace data {
+
+void TfIdf::Reset()
+{
+  mappings.clear();
+  originalStrings.clear();
+  idfdict.clear();
+}
+
+TfIdf::TfIdf(const TfIdf& oldObject) :
+    originalStrings(oldObject.originalStrings)
+{
+  std::deque<std::string>::iterator jt = originalStrings.begin();
+  for (auto it = oldObject.originalStrings.begin();
+      it != oldObject.originalStrings.end(); it++)
+  {
+    mappings[*jt] = oldObject.mappings.at(*it);
+    idfdict[*jt] = oldObject.idfdict.at(*it);
+    jt++;
+  }
+}
+
+TfIdf& TfIdf::operator= (const
+    TfIdf &oldObject)
+{
+  if (this != &oldObject)
+  {
+    mappings.clear();
+    originalStrings.clear();
+    idfdict.clear();
+    originalStrings = oldObject.originalStrings;
+    std::deque<std::string>::iterator jt = originalStrings.begin();
+    for (auto it = oldObject.originalStrings.begin(); it !=
+        oldObject.originalStrings.end(); it++)
+    {
+      mappings[*jt] = oldObject.mappings.at(*it);
+      idfdict[*jt] = oldObject.idfdict.at(*it);
+      jt++;
+    }
+  }
+  return *this;
+}
+
+template<typename TokenizerType>
+void TfIdf::CreateMap(std::string& input,
+    TokenizerType tokenizer)
+{
+  boost::string_view strView(input);
+  boost::string_view token;
+  token = tokenizer(strView);
+  std::size_t curLabel = mappings.size() + 1;
+  while (!token.empty())
+  {
+    if (mappings.find(token) == mappings.end())
+    {
+        originalStrings.push_back(std::string(token));
+        mappings[originalStrings.back()] = curLabel++;
+        idfdict[originalStrings.back()] = 0;
+    }
+    token = tokenizer(strView);
+  }
+}
+
+template<typename MatType, typename TokenizerType>
+void TfIdf::Encode(const std::vector<std::string>& input,
+                                MatType& output, TokenizerType tokenizer)
+{
+  boost::string_view strView;
+  boost::string_view token;
+  std::vector< std::vector<boost::string_view> > dataset;
+  size_t colSize = 0;
+  size_t curLabel = mappings.size();
+  for (size_t i = 0; i < input.size(); i++)
+  {
+    strView = input[i];
+    token = tokenizer(strView);
+    dataset.push_back(std::vector<boost::string_view>() );
+    while (!token.empty())
+    {
+      dataset[i].push_back(token);
+      if (mappings.find(token) == mappings.end())
+      {
+        originalStrings.push_back(std::string(token));
+        mappings[originalStrings.back()] = curLabel++;
+        idfdict[originalStrings.back()] = 0;
+      }
+      token = tokenizer(strView);
+    }
+    colSize = std::max(colSize, dataset[i].size());
+  }
+  output.zeros(dataset.size(), mappings.size());
+  for (size_t i = 0; i < dataset.size(); ++i)
+  {
+    for (size_t j = 0; j < dataset[i].size(); ++j)
+    {
+      output.at(i, mappings.at(dataset[i][j]))++;
+    }
+    for(size_t j = 0; j < mappings.size(); ++j)
+    {
+      if(output.at(i, j))
+        idfdict.at(originalStrings.at(j))++;
+    }
+    for (size_t j = 0; j < dataset[i].size(); ++j)
+    {
+      output.at(i, mappings.at(dataset[i][j])) = 
+          output.at(i, mappings.at(dataset[i][j])) / dataset[i].size();
+    }
+  }
+  for(auto it = idfdict.begin(); it != idfdict.end();it++)
+  {
+    it->second = std::log10(dataset.size()/it->second);
+  }
+  for (size_t i = 0; i < dataset.size(); ++i)
+  {
+    for (size_t j = 0; j < mappings.size(); ++j)
+    {
+      output.at(i, j) = output(i, j) * idfdict.at(originalStrings.at(j));
+    }
+  }
+}
+
+template<typename Archive>
+void TfIdf::serialize(Archive& ar, const unsigned int
+    /* version */)
+{
+  size_t count = originalStrings.size();
+  ar & BOOST_SERIALIZATION_NVP(count);
+  if (Archive::is_saving::value)
+  {
+    for (size_t i = 0; i < count; i++)
+    {
+      ar & BOOST_SERIALIZATION_NVP(originalStrings[i]);
+      ar & BOOST_SERIALIZATION_NVP(mappings.at(originalStrings[i]));
+      ar & BOOST_SERIALIZATION_NVP(idfdict.at(originalStrings[i]));
+    }
+  }
+  if (Archive::is_loading::value)
+  {
+    originalStrings.resize(count);
+    for (size_t i = 0; i < count; i++)
+    {
+      ar & BOOST_SERIALIZATION_NVP(originalStrings[i]);
+      ar & BOOST_SERIALIZATION_NVP(mappings[originalStrings[i]]);
+      ar & BOOST_SERIALIZATION_NVP(idfdict[originalStrings[i]]);
+    }
+  }
+}
+
+} // namespace data
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/core/data/tfidf_encoding_impl.hpp
+++ b/src/mlpack/core/data/tfidf_encoding_impl.hpp
@@ -113,9 +113,9 @@ void TfIdf::Encode(const std::vector<std::string>& input,
     {
       output.at(i, mappings.at(dataset[i][j]))++;
     }
-    for(size_t j = 0; j < mappings.size(); ++j)
+    for (size_t j = 0; j < mappings.size(); ++j)
     {
-      if(output.at(i, j))
+      if (output.at(i, j))
         idfdict.at(originalStrings.at(j))++;
     }
     for (size_t j = 0; j < dataset[i].size(); ++j)
@@ -124,9 +124,9 @@ void TfIdf::Encode(const std::vector<std::string>& input,
           output.at(i, mappings.at(dataset[i][j])) / dataset[i].size();
     }
   }
-  for(auto it = idfdict.begin(); it != idfdict.end();it++)
+  for (auto it = idfdict.begin(); it != idfdict.end();it++)
   {
-    it->second = std::log10(dataset.size()/it->second);
+    it->second = std::log10(dataset.size() / it->second);
   }
   for (size_t i = 0; i < dataset.size(); ++i)
   {

--- a/src/mlpack/core/data/tfidf_encoding_impl.hpp
+++ b/src/mlpack/core/data/tfidf_encoding_impl.hpp
@@ -120,11 +120,11 @@ void TfIdf::Encode(const std::vector<std::string>& input,
     }
     for (size_t j = 0; j < dataset[i].size(); ++j)
     {
-      output.at(i, mappings.at(dataset[i][j])) = 
+      output.at(i, mappings.at(dataset[i][j])) =
           output.at(i, mappings.at(dataset[i][j])) / dataset[i].size();
     }
   }
-  for (auto it = idfdict.begin(); it != idfdict.end();it++)
+  for (auto it = idfdict.begin(); it != idfdict.end(); it++)
   {
     it->second = std::log10(dataset.size() / it->second);
   }

--- a/src/mlpack/core/data/tokenizer/char_split.hpp
+++ b/src/mlpack/core/data/tokenizer/char_split.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file char_split.hpp
+ * @author Jeffin Sam
+ *
+ * Implementation of CharSplit class which tokenizes string into character.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_DATA_CHAR_SPLIT_HPP
+#define MLPACK_CORE_DATA_CHAR_SPLIT_HPP
+
+#include <mlpack/prereqs.hpp>
+#include "mlpack/core/boost_backport/boost_backport_string_view.hpp"
+
+namespace mlpack {
+namespace data {
+/**
+ * A simple CharSplit class.
+ *
+ * The class is used to split the documents into characters.The function
+ * returns a char token, and successive calls, would return many such tokens.
+ */
+class CharSplit
+{
+ public:
+  /**
+  * A function object which take boost::string_view as input and
+  * return a boost::string_view (token).
+  * @param str A string to retriev token from.
+  */
+  boost::string_view operator()(boost::string_view& str) const
+  {
+    if (str.empty())
+      return str;
+    boost::string_view retval = str.substr(0, 1);
+    str.remove_prefix(1);
+    return retval;
+  }
+}; // CharSplit class
+
+} // namespace data
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/core/data/tokenizer/split_by_char.hpp
+++ b/src/mlpack/core/data/tokenizer/split_by_char.hpp
@@ -1,0 +1,71 @@
+/**
+ * @file split_by_char.hpp
+ * @author Jeffin Sam
+ *
+ * Implementation of SplitByChar class which tokenizes string using a set of
+ * characters.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_DATA_SPLIT_BY_CHAR_HPP
+#define MLPACK_CORE_DATA_SPLIT_BY_CHAR_HPP
+
+#include <mlpack/prereqs.hpp>
+#include "mlpack/core/boost_backport/boost_backport_string_view.hpp"
+
+namespace mlpack {
+namespace data {
+/**
+ * A simple SplitByChar class.
+ *
+ * The class is used to split the documents using a set of characters, that
+ * is used as delimiter. The function returns a token, and successive calls,
+ * would return many such tokens.
+ */
+class SplitByChar
+{
+ public:
+  /**
+  * A constructor to set delimiter.
+  * @param Delimiter A set of characters which you want to use as delimiter.
+  */
+  SplitByChar(const std::string& delimiter)
+  {
+    this->delimiter = delimiter;
+  }
+  /**
+  * A function object which take boost::string_view as input and
+  * return a boost::string_view (token).
+  * @param str A string to retriev token from.
+  */
+  boost::string_view operator()(boost::string_view& str) const
+  {
+    boost::string_view retval;
+    boost::string_view delimiterView(delimiter);
+    while (retval.empty())
+    {
+      std::size_t pos = str.find_first_of(delimiterView);
+      if (pos == str.npos)
+      {
+        retval = str;
+        str.clear();
+        return retval;
+      }
+      retval = str.substr(0, pos);
+      str.remove_prefix(pos + 1);
+    }
+    return retval;
+  }
+
+ private:
+  // A set of characters by which the string is tokenized.
+  std::string delimiter;
+}; // SplitByChar
+
+} // namespace data
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ add_executable(mlpack_test
   termination_policy_test.cpp
   test_function_tools.hpp
   test_tools.hpp
+  tfidf_encoding_test.cpp
   timer_test.cpp
   tree_test.cpp
   tree_traits_test.cpp

--- a/src/mlpack/tests/tfidf_encoding_test.cpp
+++ b/src/mlpack/tests/tfidf_encoding_test.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file tfidf_encoding_test.cpp
+ * @author Jeffin Sam
+ *
+ * Tests for TFIDF Encoding Class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/core/data/tfidf_encoding.hpp>
+#include "mlpack/core/boost_backport/boost_backport_string_view.hpp"
+#include <mlpack/core/data/tokenizer/char_split.hpp>
+#include <mlpack/core/data/tokenizer/split_by_char.hpp>
+#include <boost/test/unit_test.hpp>
+#include "test_tools.hpp"
+
+using namespace mlpack;
+using namespace mlpack::data;
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(TfIdfEncodingTest);
+
+/**
+ * Test TfIdf encoding.
+ */
+BOOST_AUTO_TEST_CASE(TfidfEncodingTest)
+{
+  std::vector<string>arr(3);
+  arr[0] = "hello how are you";
+  arr[1] = "i am good";
+  arr[2] = "Good how are you";
+  arma::mat output;
+  data::TfIdf en;
+  en.Encode(arr, output, SplitByChar(" "));
+  arma::mat target = "0.1193 0.0440 0.0440 0.0440 0 0 0 0;"
+                     "0 0 0 0 0.1590 0.1590 0.1590 0;"
+                     "0 0.0440 0.0440 0.0440 0 0 0 0.1193;";
+  CheckMatrices(output, target, 1e-01);
+}
+
+/**
+* Testing the functionality of copy constructor.
+*/
+BOOST_AUTO_TEST_CASE(CopyConstructorCharTest)
+{
+  std::vector<string>arr(3);
+  arr[0] = "hello how are you";
+  arr[1] = "i am good";
+  arr[2] = "Good how are you";
+  arma::sp_mat output;
+  data::TfIdf en;
+  en.Encode(arr, output, SplitByChar(" "));
+  const std::unordered_map<boost::string_view, size_t,
+      boost::hash<boost::string_view>>& maps = en.Mappings();
+  const std::unordered_map<boost::string_view, double,
+      boost::hash<boost::string_view>>& idfmaps = en.IdfValues();
+
+  data::TfIdf en2 = en;
+  const std::unordered_map<boost::string_view, size_t,
+      boost::hash<boost::string_view>>& maps2 = en2.Mappings();
+  const std::unordered_map<boost::string_view, double,
+      boost::hash<boost::string_view>>& idfmaps2 = en2.IdfValues();
+
+  // Comparing both of them.
+  BOOST_REQUIRE_EQUAL(maps2 == maps, true);
+  BOOST_REQUIRE_EQUAL(idfmaps2 == idfmaps, true);
+}
+
+BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Term frequency–inverse document frequency (Tf-Idf), is a numerical statistic that is intended to reflect how important a word is to a document in a collection or corpus.