### PR TITLE
Copy data for sample Windows installer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -145,7 +145,7 @@ build_script:
       C:\projects\mlpack\dist\win-installer\staging -recurse
   - ps: >
       cp C:\projects\mlpack\src\mlpack\tests\data\german.csv
-      C:\projects\mlpack\dist\win-installer\staging\sample-ml-app\sample-ml-app\data\
+      C:\projects\mlpack\dist\win-installer\staging\examples\sample-ml-app\sample-ml-app\data\
   
   # Checking current gitversion or mlpack version.
   - ps: >

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -143,6 +143,9 @@ build_script:
   - ps: >
       cp C:\projects\mlpack\doc\examples
       C:\projects\mlpack\dist\win-installer\staging -recurse
+  - ps: >
+      cp C:\projects\mlpack\src\mlpack\tests\data\german.csv
+      C:\projects\mlpack\dist\win-installer\staging\sample-ml-app\sample-ml-app\data\
   
   # Checking current gitversion or mlpack version.
   - ps: >


### PR DESCRIPTION
This is intended to handle #1942.  I think it will work, but I need to test using the generated AppVeyor artifact first.  The goal is just to have `german.csv` in the `sample-ml-app\data\` directory upon install.