### PR TITLE
Fix stray quotes during Python install.

### DIFF
--- a/src/mlpack/bindings/python/PythonInstall.cmake
+++ b/src/mlpack/bindings/python/PythonInstall.cmake
@@ -5,7 +5,7 @@
 if (DEFINED ENV{DESTDIR})
   execute_process(COMMAND ${PYTHON_EXECUTABLE}
       "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
-          --prefix=${CMAKE_INSTALL_PREFIX} --root="$ENV{DESTDIR}"
+          --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR}
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 else ()


### PR DESCRIPTION
This is @marcespie's patch from #1963.  Thanks Marc!