### PR TITLE
[Ready] gcc-9 build fixes

### DIFF
--- a/src/mlpack/methods/det/dt_utils_impl.hpp
+++ b/src/mlpack/methods/det/dt_utils_impl.hpp
@@ -184,8 +184,7 @@ DTree<MatType, TagType>* Trainer(MatType& dataset,
   // intmax_t because size_t is not yet supported by their OpenMP
   // implementation. omp_size_t is the appropriate type according to the
   // platform.
-  #pragma omp parallel for default(none) \
-      shared(prunedSequence, regularizationConstants)
+  #pragma omp parallel for shared(prunedSequence, regularizationConstants)
   for (omp_size_t fold = 0; fold < (omp_size_t) folds; fold++)
   {
     // Break up data into train and test sets.


### PR DESCRIPTION
gcc 9.1.1 throws errors like
```
src/mlpack/methods/det/dt_utils_impl.hpp:189:3: error: ‘folds’ not specified in enclosing ‘parallel’
src/mlpack/methods/det/dt_utils_impl.hpp:192:33: error: ‘testSize’ not specified in enclosing ‘parallel’
src/mlpack/methods/det/dt_utils_impl.hpp:194:61: error: ‘cvData’ not specified in enclosing ‘parallel’
```

These variables are used inside `omp parallel for default(none)` clause and they are not marked as `shared`. Looks like the previous versions of gcc didn't throw any errors since the variables are declared as `const`.