### PR TITLE
Use correct Visual Studio version in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,10 +25,10 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       VSVER: Visual Studio 14 2015 Win64
-      VSVERNUM: 14.0
+      MSBUILD: C:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       VSVER: Visual Studio 15 2017 Win64
-      VSVERNUM: 15.0
+      MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe
 
 
 configuration: Release
@@ -77,8 +77,7 @@ build_script:
     -DBUILD_SHARED_LIBS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    "C:\Program Files (x86)\MSBuild\%VSVERNUM%\Bin\MSBuild.exe"
-    "C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
+    "%MSBUILD C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
     /m /verbosity:quiet /p:Configuration=Release;Platform=x64
   - cd C:\projects\mlpack && mkdir build && cd build
   - >
@@ -94,8 +93,7 @@ build_script:
     -DBUILD_PYTHON_BINDINGS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    "C:\Program Files (x86)\MSBuild\%VSVERNUM%\Bin\MSBuild.exe"
-    "C:\projects\mlpack\build\mlpack.sln"
+    "%MSBUILD% C:\projects\mlpack\build\mlpack.sln"
     /m /verbosity:minimal /nologo /p:BuildInParallel=true
     /p:Configuration=Release;Platform=x64
   

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ environment:
       MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       VSVER: Visual Studio 16 2019
-      MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin\MSBuild.exe
+      MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe
 
 
 configuration: Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,7 +77,7 @@ build_script:
     -DBUILD_SHARED_LIBS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    %MSBUILD% "C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
+    "%MSBUILD%" "C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
     /m /verbosity:quiet /p:Configuration=Release;Platform=x64
   - cd C:\projects\mlpack && mkdir build && cd build
   - >
@@ -93,7 +93,7 @@ build_script:
     -DBUILD_PYTHON_BINDINGS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    %MSBUILD% "C:\projects\mlpack\build\mlpack.sln"
+    "%MSBUILD%" "C:\projects\mlpack\build\mlpack.sln"
     /m /verbosity:minimal /nologo /p:BuildInParallel=true
     /p:Configuration=Release;Platform=x64
   

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,8 +25,10 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       VSVER: Visual Studio 14 2015 Win64
+      VSVERNUM: 14.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       VSVER: Visual Studio 15 2017 Win64
+      VSVERNUM: 15.0
 
 
 configuration: Release
@@ -68,19 +70,19 @@ build_script:
   - 7z x armadillo.tar.xz -so | 7z x -si -ttar > nul
   - cd armadillo-7.800.2 && mkdir build && cd build
   - >
-    cmake -G "Visual Studio 14 2015 Win64"
+    cmake -G "%VSVER%"
     -DBLAS_LIBRARY:FILEPATH=%BLAS_LIBRARY%
     -DLAPACK_LIBRARY:FILEPATH=%BLAS_LIBRARY%
     -DCMAKE_PREFIX:FILEPATH="%APPVEYOR_BUILD_FOLDER%/armadillo"
     -DBUILD_SHARED_LIBS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+    "C:\Program Files (x86)\MSBuild\%VSVERNUM%\Bin\MSBuild.exe"
     "C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
     /m /verbosity:quiet /p:Configuration=Release;Platform=x64
   - cd C:\projects\mlpack && mkdir build && cd build
   - >
-    cmake -G "Visual Studio 14 2015 Win64"
+    cmake -G "%VSVER%"
     -DBLAS_LIBRARY:FILEPATH=%BLAS_LIBRARY%
     -DLAPACK_LIBRARY:FILEPATH=%BLAS_LIBRARY%
     -DARMADILLO_INCLUDE_DIR="C:/projects/mlpack/armadillo-7.800.2/include"
@@ -92,7 +94,7 @@ build_script:
     -DBUILD_PYTHON_BINDINGS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+    "C:\Program Files (x86)\MSBuild\%VSVERNUM%\Bin\MSBuild.exe"
     "C:\projects\mlpack\build\mlpack.sln"
     /m /verbosity:minimal /nologo /p:BuildInParallel=true
     /p:Configuration=Release;Platform=x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ environment:
       VSVER: Visual Studio 15 2017 Win64
       MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      VSVER: Visual Studio 16 2019 Win64
+      VSVER: Visual Studio 16 2019
       MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin\MSBuild.exe
 
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ environment:
       MSBUILD: C:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       VSVER: Visual Studio 15 2017 Win64
-      MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe
+      MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
 
 
 configuration: Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,9 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       VSVER: Visual Studio 15 2017 Win64
       MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      VSVER: Visual Studio 16 2019 Win64
+      MSBUILD: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin\MSBuild.exe
 
 
 configuration: Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -77,7 +77,7 @@ build_script:
     -DBUILD_SHARED_LIBS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    "%MSBUILD C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
+    %MSBUILD% "C:\projects\mlpack\armadillo-7.800.2\build\armadillo.sln"
     /m /verbosity:quiet /p:Configuration=Release;Platform=x64
   - cd C:\projects\mlpack && mkdir build && cd build
   - >
@@ -93,7 +93,7 @@ build_script:
     -DBUILD_PYTHON_BINDINGS=OFF
     -DCMAKE_BUILD_TYPE=Release ..
   - >
-    "%MSBUILD% C:\projects\mlpack\build\mlpack.sln"
+    %MSBUILD% "C:\projects\mlpack\build\mlpack.sln"
     /m /verbosity:minimal /nologo /p:BuildInParallel=true
     /p:Configuration=Release;Platform=x64
   

--- a/src/mlpack/methods/linear_svm/linear_svm_function_impl.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_function_impl.hpp
@@ -285,7 +285,7 @@ void LinearSVMFunction<MatType>::Gradient(
   }
   else
   {
-    gradient.set_size(size(parameters));
+    gradient.set_size(arma::size(parameters));
     gradient.submat(0, 0, parameters.n_rows - 2, parameters.n_cols - 1) =
         dataset * difference.t();
     gradient.row(parameters.n_rows - 1) =
@@ -342,7 +342,7 @@ void LinearSVMFunction<MatType>::Gradient(
   }
   else
   {
-    gradient.set_size(size(parameters));
+    gradient.set_size(arma::size(parameters));
     gradient.submat(0, 0, parameters.n_rows - 2, parameters.n_cols - 1) =
         dataset.cols(firstId, lastId) * difference.t();
     gradient.row(parameters.n_rows - 1) =


### PR DESCRIPTION
@gmanlan pointed out in #1863 that the AppVeyor build configuration doesn't actually use Visual Studio 2017 like it's supposed to.  This is an attempt to fix that.  (And if it works, I'll also add Visual Studio 2019 to the build matrix.)