### PR TITLE
Fix Markdown binding issue

### DIFF
--- a/CMake/RunProgram.cmake
+++ b/CMake/RunProgram.cmake
@@ -5,4 +5,9 @@
 #
 #   PROGRAM: the program to run to.
 #   OUTPUT_FILE: the file to store the output in.
-execute_process(COMMAND ${PROGRAM} OUTPUT_FILE ${OUTPUT_FILE})
+execute_process(COMMAND ${PROGRAM} OUTPUT_FILE ${OUTPUT_FILE}
+    ERROR_VARIABLE err)
+
+if (err)
+  message(FATAL_ERROR "Fatal error running ${PROGRAM}: ${err}!")
+endif ()

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -36,11 +36,43 @@
 #include <mlpack/bindings/cli/cli_option.hpp>
 #include <mlpack/bindings/cli/print_doc_functions.hpp>
 
+/**
+ * PRINT_PARAM_STRING() returns a string that contains the correct
+ * language-specific representation of a parameter's name.
+ */
 #define PRINT_PARAM_STRING mlpack::bindings::cli::ParamString
+
+/**
+ * PRINT_PARAM_VALUE() returns a string that contains a correct
+ * language-specific representation of a parameter's value.
+ */
 #define PRINT_PARAM_VALUE mlpack::bindings::cli::PrintValue
+
+/**
+ * PRINT_CALL() returns a string that contains the full language-specific
+ * representation of a call to an mlpack binding.  The first argument should be
+ * the name of the binding, and all other arguments should be names of
+ * parameters followed by values (in the case where the preceding parameter is
+ * not a flag).
+ */
 #define PRINT_CALL mlpack::bindings::cli::ProgramCall
+
+/**
+ * PRINT_DATASET() returns a string that contains a correct language-specific
+ * representation of a dataset name.
+ */
 #define PRINT_DATASET mlpack::bindings::cli::PrintDataset
+
+/**
+ * PRINT_MODEL() returns a string that contains a correct language-specific
+ * representation of an mlpack model name.
+ */
 #define PRINT_MODEL mlpack::bindings::cli::PrintModel
+
+/**
+ * BINDING_IGNORE_CHECK() is an internally-used macro to determine whether or
+ * not a specific parameter check should be ignored.
+ */
 #define BINDING_IGNORE_CHECK mlpack::bindings::cli::IgnoreCheck
 
 namespace mlpack {
@@ -90,7 +122,20 @@ int main(int argc, char** argv)
 #define PRINT_PARAM_VALUE(A, B) std::string(" ")
 #define PRINT_DATASET(A) std::string(" ")
 #define PRINT_MODEL(A) std::string(" ")
+
+/**
+ * PRINT_CALL() returns a string that contains the full language-specific
+ * representation of a call to an mlpack binding.  The first argument should be
+ * the name of the binding, and all other arguments should be names of
+ * parameters followed by values (in the case where the preceding parameter is
+ * not a flag).
+ */
 #define PRINT_CALL(...) std::string(" ")
+
+/**
+ * BINDING_IGNORE_CHECK() is an internally-used macro to determine whether or
+ * not a specific parameter check should be ignored.
+ */
 #define BINDING_IGNORE_CHECK mlpack::bindings::tests::IgnoreCheck
 
 namespace mlpack {
@@ -119,11 +164,43 @@ using Option = mlpack::bindings::tests::TestOption<T>;
 #include <mlpack/bindings/python/py_option.hpp>
 #include <mlpack/bindings/python/print_doc_functions.hpp>
 
+/**
+ * PRINT_PARAM_STRING() returns a string that contains the correct
+ * language-specific representation of a parameter's name.
+ */
 #define PRINT_PARAM_STRING mlpack::bindings::python::ParamString
+
+/**
+ * PRINT_PARAM_VALUE() returns a string that contains a correct
+ * language-specific representation of a parameter's value.
+ */
 #define PRINT_PARAM_VALUE mlpack::bindings::python::PrintValue
+
+/**
+ * PRINT_DATASET() returns a string that contains a correct language-specific
+ * representation of a dataset name.
+ */
 #define PRINT_DATASET mlpack::bindings::python::PrintDataset
+
+/**
+ * PRINT_MODEL() returns a string that contains a correct language-specific
+ * representation of an mlpack model name.
+ */
 #define PRINT_MODEL mlpack::bindings::python::PrintModel
+
+/**
+ * PRINT_CALL() returns a string that contains the full language-specific
+ * representation of a call to an mlpack binding.  The first argument should be
+ * the name of the binding, and all other arguments should be names of
+ * parameters followed by values (in the case where the preceding parameter is
+ * not a flag).
+ */
 #define PRINT_CALL mlpack::bindings::python::ProgramCall
+
+/**
+ * BINDING_IGNORE_CHECK() is an internally-used macro to determine whether or
+ * not a specific parameter check should be ignored.
+ */
 #define BINDING_IGNORE_CHECK mlpack::bindings::python::IgnoreCheck
 
 namespace mlpack {
@@ -170,11 +247,43 @@ PARAM_FLAG("copy_all_inputs", "If specified, all input parameters will be deep"
 #include <mlpack/bindings/markdown/md_option.hpp>
 #include <mlpack/bindings/markdown/print_doc_functions.hpp>
 
+/**
+ * PRINT_PARAM_STRING() returns a string that contains the correct
+ * language-specific representation of a parameter's name.
+ */
 #define PRINT_PARAM_STRING mlpack::bindings::markdown::ParamString
+
+/**
+ * PRINT_PARAM_VALUE() returns a string that contains a correct
+ * language-specific representation of a parameter's value.
+ */
 #define PRINT_PARAM_VALUE mlpack::bindings::markdown::PrintValue
+
+/**
+ * PRINT_DATASET() returns a string that contains a correct language-specific
+ * representation of a dataset name.
+ */
 #define PRINT_DATASET mlpack::bindings::markdown::PrintDataset
+
+/**
+ * PRINT_MODEL() returns a string that contains a correct language-specific
+ * representation of an mlpack model name.
+ */
 #define PRINT_MODEL mlpack::bindings::markdown::PrintModel
+
+/**
+ * PRINT_CALL() returns a string that contains the full language-specific
+ * representation of a call to an mlpack binding.  The first argument should be
+ * the name of the binding, and all other arguments should be names of
+ * parameters followed by values (in the case where the preceding parameter is
+ * not a flag).
+ */
 #define PRINT_CALL mlpack::bindings::markdown::ProgramCall
+
+/**
+ * BINDING_IGNORE_CHECK() is an internally-used macro to determine whether or
+ * not a specific parameter check should be ignored.
+ */
 #define BINDING_IGNORE_CHECK mlpack::bindings::markdown::IgnoreCheck
 
 // This doesn't actually matter for this binding type.

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -77,7 +77,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * Define a flag parameter.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -100,7 +102,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * --ID=value.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  * @param DEF Default value of the parameter.
  *
@@ -131,7 +135,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * will be issued.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  *
  * @see mlpack::CLI, PROGRAM_INFO()
  *
@@ -153,7 +159,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * --ID=value.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  * @param DEF Default value of the parameter.
  *
@@ -183,7 +191,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * will be issued.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  *
  * @see mlpack::CLI, PROGRAM_INFO()
  *
@@ -206,7 +216,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * PROGRAM_INFO() macro), the parameter can be specified with just --ID=value.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  * @param DEF Default value of the parameter.
  *
@@ -236,7 +248,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -264,7 +278,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -290,7 +306,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -321,7 +339,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -348,7 +368,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -376,7 +398,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -409,7 +433,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -435,7 +461,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -462,7 +490,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -494,7 +524,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -521,7 +553,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -547,7 +581,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -573,7 +609,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -599,7 +637,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -626,7 +666,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -657,7 +699,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -688,7 +732,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -719,7 +765,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -750,7 +798,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * types.
  *
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @bug
@@ -771,7 +821,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * --ID=value1,value2,value3.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  * @param DEF Default value of the parameter.
  *
@@ -802,7 +854,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * will be issued.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  *
  * @see mlpack::CLI, PROGRAM_INFO()
  *
@@ -838,7 +892,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS One-character string representing the alias of the parameter.
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -881,7 +937,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  *
  * @param TYPE Type of the model to be loaded.
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter.
+ * @param DESC Description of the parameter.  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  */
 #define PARAM_MODEL_IN(TYPE, ID, DESC, ALIAS) \
@@ -913,7 +971,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  *
  * @param TYPE Type of the model to be loaded.
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter.
+ * @param DESC Description of the parameter.  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  */
 #define PARAM_MODEL_IN_REQ(TYPE, ID, DESC, ALIAS) \
@@ -936,7 +996,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  *
  * @param TYPE Type of the model to be saved.
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter.
+ * @param DESC Description of the parameter.  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  */
 #define PARAM_MODEL_OUT(TYPE, ID, DESC, ALIAS) \
@@ -948,7 +1010,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * The parameter must then be specified on the command line with --ID=value.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -970,7 +1034,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * The parameter must then be specified on the command line with --ID=value.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -992,7 +1058,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * The parameter must then be specified on the command line with --ID=value.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -1015,7 +1083,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * --ID=value1,value2,value3.
  *
  * @param ID Name of the parameter.
- * @param DESC Quick description of the parameter (1-2 sentences).
+ * @param DESC Quick description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS An alias for the parameter (one letter).
  *
  * @see mlpack::CLI, PROGRAM_INFO()
@@ -1052,7 +1122,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  *
  * @param T Type of the parameter.
  * @param ID Name of the parameter.
- * @param DESC Description of the parameter (1-2 sentences).
+ * @param DESC Description of the parameter (1-2 sentences).  Don't use
+ *      printing macros like PRINT_PARAM_STRING() or PRINT_DATASET() or others
+ *      here---it will cause problems.
  * @param ALIAS Alias for this parameter (one letter).
  * @param DEF Default value of the parameter.
  * @param REQ Whether or not parameter is required (boolean value).

--- a/src/mlpack/methods/kde/kde_main.cpp
+++ b/src/mlpack/methods/kde/kde_main.cpp
@@ -167,8 +167,7 @@ PARAM_INT_IN("initial_sample_size",
              KDEDefaultParams::initialSampleSize);
 PARAM_DOUBLE_IN("mc_entry_coef",
                 "Controls how much larger does the amount of node descendants "
-                "has to be compared to the " +
-                PRINT_PARAM_STRING("initial_sample_size") + " in order to be "
+                "has to be compared to the initial sample size in order to be "
                 "a candidate for Monte Carlo estimations.",
                 "C",
                 KDEDefaultParams::mcEntryCoef);


### PR DESCRIPTION
While skimming through various emails I noticed that the nightly job that builds the mlpack-git Markdown documentation was failing.  That means that https://mlpack.org/doc/mlpack-git/cli_documentation.html will 404 until we get this fix incorporated (I suppose that I could rebuild after hand-patching, but I'd prefer to just merge this and then the problem goes away on its own).

But, this Markdown binding generation failure didn't actually trigger any build failure or anything like this.  So I did some digging and came up with these changes:

1) Make any programs executed by CMake cause a fatal error if those programs themselves fail.

2) Remove use of `PRINT_PARAM_STRING()` macro inside of documentation for an individual program option.  The reason for this is that `PRINT_PARAM_STRING()` was only meant to be used as part of the long-form program documentation, which actually takes a `std::function()` not a string.  This interacts badly with the Markdown bindings, because any use of `PRINT_PARAM_STRING()` requires a language to be set, and it isn't at global construction time when the global object corresponding to an individual program option is constructed.

Admittedly, that restriction of `PRINT_PARAM_STRING()` isn't documented anywhere...

@robertohueso let me know what you think---I worked around the issue by just referring to the logical name of the option instead of the actual parameter name.  I guess I didn't realize it would be a problem during review. :)