### PR TITLE
Fix intermittently failing Epanechnikov kernel KDE test

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,8 @@
   * Add support for probabilistic KDE (kernel density estimation) error bounds
     when using the Gaussian kernel (#1934).
 
+  * Fix negative distances for cover tree computation (#1979).
+
 ### mlpack 3.1.1
 ###### 2019-05-26
   * Fix random forest bug for numerical-only data (#1887).

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -911,8 +911,8 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
       other.Dataset().col(other.Point()));
 
   math::RangeType<ElemType> result;
-  result.Lo() = distance - furthestDescendantDistance -
-      other.FurthestDescendantDistance();
+  result.Lo() = std::max(distance - furthestDescendantDistance -
+      other.FurthestDescendantDistance(), 0.0);
   result.Hi() = distance + furthestDescendantDistance +
       other.FurthestDescendantDistance();
 
@@ -934,8 +934,8 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
                   const ElemType distance) const
 {
   math::RangeType<ElemType> result;
-  result.Lo() = distance - furthestDescendantDistance -
-      other.FurthestDescendantDistance();
+  result.Lo() = std::max(distance - furthestDescendantDistance -
+      other.FurthestDescendantDistance(), 0.0);
   result.Hi() = distance + furthestDescendantDistance +
       other.FurthestDescendantDistance();
 
@@ -956,8 +956,9 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
 {
   const ElemType distance = metric->Evaluate(dataset->col(point), other);
 
-  return math::RangeType<ElemType>(distance - furthestDescendantDistance,
-                     distance + furthestDescendantDistance);
+  return math::RangeType<ElemType>(
+      std::max(distance - furthestDescendantDistance, 0.0),
+      distance + furthestDescendantDistance);
 }
 
 //! Return the minimum and maximum distance to another point given that the
@@ -974,8 +975,9 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
     RangeDistance(const arma::vec& /* other */,
                   const ElemType distance) const
 {
-  return math::RangeType<ElemType>(distance - furthestDescendantDistance,
-                     distance + furthestDescendantDistance);
+  return math::RangeType<ElemType>(
+      std::max(distance - furthestDescendantDistance, 0.0),
+      distance + furthestDescendantDistance);
 }
 
 //! For a newly initialized node, create children using the near and far set.

--- a/src/mlpack/methods/kde/kde_rules_impl.hpp
+++ b/src/mlpack/methods/kde/kde_rules_impl.hpp
@@ -115,7 +115,8 @@ Score(const size_t queryIndex, TreeType& referenceNode)
     // Don't duplicate calculations.
     alreadyDidRefPoint0 = true;
     const double furthestDescDist = referenceNode.FurthestDescendantDistance();
-    minDistance = traversalInfo.LastBaseCase() - furthestDescDist;
+    minDistance = std::max(traversalInfo.LastBaseCase() - furthestDescDist,
+        0.0);
     maxDistance = traversalInfo.LastBaseCase() + furthestDescDist;
   }
   else
@@ -302,7 +303,7 @@ Score(TreeType& queryNode, TreeType& referenceNode)
     const double refFurtDescDist = referenceNode.FurthestDescendantDistance();
     const double queryFurtDescDist = queryNode.FurthestDescendantDistance();
     const double sumFurtDescDist = refFurtDescDist + queryFurtDescDist;
-    minDistance = traversalInfo.LastBaseCase() - sumFurtDescDist;
+    minDistance = std::max(traversalInfo.LastBaseCase() - sumFurtDescDist, 0.0);
     maxDistance = traversalInfo.LastBaseCase() + sumFurtDescDist;
   }
   else


### PR DESCRIPTION
Frequently, the test `KDETest/EpanechnikovCoverSingleKDETest` fails:

http://ci.mlpack.org/job/docker%20mlpack%20nightly%20build/armadillo_version=armadillo-6.500.5,boost_version=boost_1_49_0,buildmode=debug,compiler_version=gcc-7.2.0,label=docker/lastCompletedBuild/testReport/

```
[Exception] - difference{37.9501%} between bfEstimations[i]{0.6164662373649441} and treeEstimations[i]{0.99350104568814213} exceeds 8%
 == [File] - /home/jenkins/workspace/docker mlpack nightly build/armadillo_version/armadillo-6.500.5/boost_version/boost_1_49_0/buildmode/debug/compiler_version/gcc-7.2.0/label/docker/repo/src/mlpack/tests/kde_test.cpp
 == [Line] -233
```

I spent some time digging into this and this was kind of a funny bug to dig into.  I first determined that some of the prunes were invalid---it was estimated that the maximum kernel and minimum kernel for a query point and a reference node were both 0... but the actual kernel values were quite large!  So, this was confusing, until I noticed that the minimum distance between the query point and reference node was being computed as a negative value!

At this moment it all fell into place: this bug *only* occurs with a few types of kernels, most specifically *not* the Gaussian kernel, because if you give the Gaussian kernel a negative distance, it computes a very large value.  So it is only kernels that are symmetric about 0 that have this problem.  Further, the bug was only in the cover tree computation, so that narrows down the bug further.

Inside the cover tree, the minimum distance between a point and a node was being computed as

```
d(q, r) - furthestDescendantDistance
```

where `r` is the point at the center of the reference node.  However, we need to make sure this is not negative!  So the fix is quite easy.

We can thank me circa 2013 for this bug: https://github.com/mlpack/mlpack/commit/8a58c9fa98c3702625dea665be928539d1443500
:)

I also fixed this situation where it occurs a couple of times in the KDE rules, and everything seems to work well now.  I ran the test with the cover tree and Epanechnikov kernel in both single-tree and dual-tree mode 1000+ times and saw no failures, so I think the issue is resolved.

@robertohueso let me know what you think or if I overlooked anything. :)