### PR TITLE
FastMKS segfault fix

### DIFF
--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -115,9 +115,13 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
   }
 
   // Use the furthest descendant distance to determine the scale of the root
-  // node.
-  if (furthestDescendantDistance == 0.0)
+  // node.  Note that if the root is a leaf, we can have scale INT_MIN, but if
+  // it *isn't* a leaf, we need to mark the scale as one higher than INT_MIN, so
+  // that the recursions don't fail.
+  if (furthestDescendantDistance == 0.0 && dataset.n_cols == 1)
     scale = INT_MIN;
+  else if (furthestDescendantDistance == 0.0)
+    scale = INT_MIN + 1;
   else
     scale = (int) ceil(log(furthestDescendantDistance) / log(base));
 
@@ -206,9 +210,13 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
   }
 
   // Use the furthest descendant distance to determine the scale of the root
-  // node.
-  if (furthestDescendantDistance == 0.0)
+  // node.  Note that if the root is a leaf, we can have scale INT_MIN, but if
+  // it *isn't* a leaf, we need to mark the scale as one higher than INT_MIN, so
+  // that the recursions don't fail.
+  if (furthestDescendantDistance == 0.0 && dataset.n_cols == 1)
     scale = INT_MIN;
+  else if (furthestDescendantDistance == 0.0)
+    scale = INT_MIN + 1;
   else
     scale = (int) ceil(log(furthestDescendantDistance) / log(base));
 
@@ -298,9 +306,13 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
   }
 
   // Use the furthest descendant distance to determine the scale of the root
-  // node.
-  if (furthestDescendantDistance == 0.0)
+  // node.  Note that if the root is a leaf, we can have scale INT_MIN, but if
+  // it *isn't* a leaf, we need to mark the scale as one higher than INT_MIN, so
+  // that the recursions don't fail.
+  if (furthestDescendantDistance == 0.0 && dataset->n_cols == 1)
     scale = INT_MIN;
+  else if (furthestDescendantDistance == 0.0)
+    scale = INT_MIN + 1;
   else
     scale = (int) ceil(log(furthestDescendantDistance) / log(base));
 
@@ -389,9 +401,13 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
   }
 
   // Use the furthest descendant distance to determine the scale of the root
-  // node.
-  if (furthestDescendantDistance == 0.0)
+  // node.  Note that if the root is a leaf, we can have scale INT_MIN, but if
+  // it *isn't* a leaf, we need to mark the scale as one higher than INT_MIN, so
+  // that the recursions don't fail.
+  if (furthestDescendantDistance == 0.0 && dataset->n_cols == 1)
     scale = INT_MIN;
+  else if (furthestDescendantDistance == 0.0)
+    scale = INT_MIN + 1;
   else
     scale = (int) ceil(log(furthestDescendantDistance) / log(base));
 

--- a/src/mlpack/methods/fastmks/fastmks_main.cpp
+++ b/src/mlpack/methods/fastmks/fastmks_main.cpp
@@ -121,6 +121,13 @@ static void mlpackMain()
       "gaussian", "triangular", "hyptan", "epanechnikov" }, true,
       "unknown kernel type");
 
+  // Make sure number of maximum kernels is greater than 0.
+  if (CLI::HasParam("k"))
+  {
+    RequireParamValue<int>("k", [](int x) { return x > 0; }, true,
+        "number of maximum kernels must be greater than 0");
+  }
+
   // Naive mode overrides single mode.
   ReportIgnoredParam({{ "naive", true }}, "single");
 

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -1972,8 +1972,10 @@ BOOST_AUTO_TEST_CASE(NonExistentFileARFFTest)
   arma::mat dataset;
   DatasetInfo info;
 
+  Log::Fatal.ignoreInput = true;
   BOOST_REQUIRE_THROW(data::LoadARFF("nonexistentfile.arff", dataset, info),
       std::runtime_error);
+  Log::Fatal.ignoreInput = false;
 }
 
 /**

--- a/src/mlpack/tests/main_tests/fastmks_test.cpp
+++ b/src/mlpack/tests/main_tests/fastmks_test.cpp
@@ -87,6 +87,21 @@ BOOST_AUTO_TEST_CASE(FastMKSInvalidKTest)
   Log::Fatal.ignoreInput = false;
 }
 
+/**
+ * Check that when k is specified, it must be greater than 0.
+ */
+BOOST_AUTO_TEST_CASE(FastMKSZeroKTest)
+{
+  arma::mat referenceData(3, 50, arma::fill::randu);
+
+  SetInputParam("reference", std::move(referenceData));
+  SetInputParam("k", (int) 0); // Invalid when reference is specified.
+
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+}
+
 /*
  * Check that we can't specify an invalid k when both reference
  * and query matrices are given.


### PR DESCRIPTION
I dug into #1767 and found that the issue is actually not the fact that the hyperbolic tangent kernel is only conditionally positive definite.  Instead, for the optdigits dataset, the issue is that the dot product between each point is sufficiently large that every kernel evaluation is identical---meaning that the distance between points is always 0.

This then means that the cover tree gets built in a weird way that is actually invalid.  So I fixed this bug in e584aea.

While I was in there, I also made the FastMKS binding check for a valid value of k, if it is passed, and added a test for it.  And I hid the `Log::Fatal` output from the one test that tries to load `nonexistentfile.arff`. :)