### PR TITLE
Valid and Same padding option in convolution layers.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Add `valid` and `same` padding option in `Convolution` and `Transposed
+    Convolution` layer (#1988).
+
   * Add Model() to the FFN class to access individual layers (#2043).
 
   * Update documentation for pip and conda installation packages (#2044).
@@ -673,4 +676,3 @@
   * Initial release.  See any resolved tickets numbered less than #196 or
     execute this query:
     http://www.mlpack.org/trac/query?status=closed&milestone=mlpack+1.0.0
-

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
-  * Add `valid` and `same` padding option in `Convolution` and `Transposed
+  * Add `valid` and `same` padding option in `Convolution` and `Atrous
     Convolution` layer (#1988).
 
   * Add Model() to the FFN class to access individual layers (#2043).

--- a/src/mlpack/methods/ann/layer/atrous_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution.hpp
@@ -71,6 +71,7 @@ class AtrousConvolution
    * @param inputHeight The height of the input data.
    * @param dilationW The space between the cells of filters in x direction.
    * @param dilationH The space between the cells of filters in y direction.
+   * @param paddingType The type of padding (Valid or Same). Defaults to None.
    */
   AtrousConvolution(const size_t inSize,
                     const size_t outSize,
@@ -83,7 +84,45 @@ class AtrousConvolution
                     const size_t inputWidth = 0,
                     const size_t inputHeight = 0,
                     const size_t dilationW = 1,
-                    const size_t dilationH = 1);
+                    const size_t dilationH = 1,
+                    const std::string paddingType = "None");
+
+  /**
+   * Create the AtrousConvolution object using the specified number of
+   * input maps, output maps, filter size, stride, dilation and
+   * padding parameter.
+   *
+   * @param inSize The number of input maps.
+   * @param outSize The number of output maps.
+   * @param kW Width of the filter/kernel.
+   * @param kH Height of the filter/kernel.
+   * @param dW Stride of filter application in the x direction.
+   * @param dH Stride of filter application in the y direction.
+   * @param padW A two-value tuple indicating padding widths of the input.
+   *             First value is padding at left side. Second value is padding on
+   *             right side.
+   * @param padH A two-value tuple indicating padding heights of the input.
+   *             First value is padding at top. Second value is padding on
+   *             bottom.
+   * @param inputWidth The widht of the input data.
+   * @param inputHeight The height of the input data.
+   * @param dilationW The space between the cells of filters in x direction.
+   * @param dilationH The space between the cells of filters in y direction.
+   * @param paddingType The type of padding (Valid or Same). Defaults to None.
+   */
+  AtrousConvolution(const size_t inSize,
+                    const size_t outSize,
+                    const size_t kW,
+                    const size_t kH,
+                    const size_t dW,
+                    const size_t dH,
+                    const std::tuple<size_t, size_t> padW,
+                    const std::tuple<size_t, size_t> padH,
+                    const size_t inputWidth = 0,
+                    const size_t inputHeight = 0,
+                    const size_t dilationW = 1,
+                    const size_t dilationH = 1,
+                    const std::string paddingType = "None");
 
   /*
    * Set the weight and bias term.
@@ -182,18 +221,25 @@ class AtrousConvolution
    * @param size The size of the input (row or column).
    * @param k The size of the filter (width or height).
    * @param s The stride size (x or y direction).
-   * @param p The size of the padding (width or height).
+   * @param pSideOne The size of the padding (width or height) on one side.
+   * @param pSideTwo The size of the padding (width or height) on another side.
    * @param d The dilation size.
    * @return The convolution output size.
    */
   size_t ConvOutSize(const size_t size,
-                      const size_t k,
-                      const size_t s,
-                      const size_t p,
-                      const size_t d)
+                     const size_t k,
+                     const size_t s,
+                     const size_t pSideOne,
+                     const size_t pSideTwo,
+                     const size_t d)
   {
-    return std::floor(size + p * 2 - d * (k - 1) - 1) / s + 1;
+    return std::floor(size + pSideOne + pSideTwo - d * (k - 1) - 1) / s + 1;
   }
+
+  /*
+   * Function to assign padding such that output size is same as input size.
+   */
+  void InitializeSamePadding();
 
   /*
    * Rotates a 3rd-order tensor counterclockwise by 180 degrees.
@@ -245,11 +291,17 @@ class AtrousConvolution
   //! Locally-stored stride of the filter in y-direction.
   size_t dH;
 
-  //! Locally-stored padding width.
-  size_t padW;
+  //! Locally-stored left-side padding width.
+  size_t padWLeft;
 
-  //! Locally-stored padding height.
-  size_t padH;
+  //! Locally-stored right-side padding width.
+  size_t padWRight;
+
+  //! Locally-stored bottom padding height.
+  size_t padHBottom;
+
+  //! Locally-stored top padding height.
+  size_t padHTop;
 
   //! Locally-stored weight object.
   OutputDataType weights;

--- a/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
@@ -62,15 +62,18 @@ AtrousConvolution<
     const size_t inputWidth,
     const size_t inputHeight,
     const size_t dilationW,
-    const size_t dilationH) :
+    const size_t dilationH,
+    const std::string paddingType) :
     inSize(inSize),
     outSize(outSize),
     kW(kW),
     kH(kH),
     dW(dW),
     dH(dH),
-    padW(padW),
-    padH(padH),
+    padWLeft(padW),
+    padWRight(padW),
+    padHBottom(padH),
+    padHTop(padH),
     inputWidth(inputWidth),
     inputHeight(inputHeight),
     outputWidth(0),
@@ -79,7 +82,91 @@ AtrousConvolution<
     dilationH(dilationH)
 {
   weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
-  padding = new Padding<>(padW, padW, padH, padH);
+
+  // Transform paddingType to lowercase.
+  std::string paddingTypeLow = paddingType;
+  std::transform(paddingType.begin(), paddingType.end(), paddingTypeLow.begin(),
+      [](unsigned char c){ return std::tolower(c); });
+
+  if (paddingTypeLow == "valid")
+  {
+    padWLeft = 0;
+    padWRight = 0;
+    padHTop = 0;
+    padHBottom = 0;
+  }
+  else if (paddingTypeLow == "same")
+  {
+    InitializeSamePadding();
+  }
+
+  padding = new Padding<>(padWLeft, padWRight, padHTop, padHBottom);
+}
+
+template<
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+AtrousConvolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>::AtrousConvolution(
+    const size_t inSize,
+    const size_t outSize,
+    const size_t kW,
+    const size_t kH,
+    const size_t dW,
+    const size_t dH,
+    const std::tuple<size_t, size_t> padW,
+    const std::tuple<size_t, size_t> padH,
+    const size_t inputWidth,
+    const size_t inputHeight,
+    const size_t dilationW,
+    const size_t dilationH,
+    const std::string paddingType) :
+    inSize(inSize),
+    outSize(outSize),
+    kW(kW),
+    kH(kH),
+    dW(dW),
+    dH(dH),
+    padWLeft(std::get<0>(padW)),
+    padWRight(std::get<1>(padW)),
+    padHBottom(std::get<1>(padH)),
+    padHTop(std::get<0>(padH)),
+    inputWidth(inputWidth),
+    inputHeight(inputHeight),
+    outputWidth(0),
+    outputHeight(0),
+    dilationW(dilationW),
+    dilationH(dilationH)
+{
+  weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
+
+  // Transform paddingType to lowercase.
+  std::string paddingTypeLow = paddingType;
+  std::transform(paddingType.begin(), paddingType.end(), paddingTypeLow.begin(),
+      [](unsigned char c){ return std::tolower(c); });
+
+  if (paddingTypeLow == "valid")
+  {
+    padWLeft = 0;
+    padWRight = 0;
+    padHTop = 0;
+    padHBottom = 0;
+  }
+  else if (paddingTypeLow == "same")
+  {
+    InitializeSamePadding();
+  }
+
+  padding = new Padding<>(padWLeft, padWRight, padHTop, padHBottom);
 }
 
 template<
@@ -123,10 +210,10 @@ void AtrousConvolution<
   inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
-  if (padW != 0 || padH != 0)
+  if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
   {
-    inputPaddedTemp.set_size(inputTemp.n_rows + padW * 2,
-        inputTemp.n_cols + padH * 2, inputTemp.n_slices);
+    inputPaddedTemp.set_size(inputTemp.n_rows + padWLeft + padWRight,
+        inputTemp.n_cols + padHTop + padHBottom, inputTemp.n_slices);
 
     for (size_t i = 0; i < inputTemp.n_slices; ++i)
     {
@@ -135,8 +222,10 @@ void AtrousConvolution<
     }
   }
 
-  size_t wConv = ConvOutSize(inputWidth, kW, dW, padW, dilationW);
-  size_t hConv = ConvOutSize(inputHeight, kH, dH, padH, dilationH);
+  size_t wConv = ConvOutSize(inputWidth, kW, dW, padWLeft, padWRight,
+      dilationW);
+  size_t hConv = ConvOutSize(inputHeight, kH, dH, padHTop, padHBottom,
+      dilationH);
 
   output.set_size(wConv * hConv * outSize, batchSize);
   outputTemp = arma::Cube<eT>(output.memptr(), wConv, hConv,
@@ -156,7 +245,7 @@ void AtrousConvolution<
     {
       arma::Mat<eT> convOutput;
 
-      if (padW != 0 || padH != 0)
+      if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
       {
         ForwardConvolutionRule::Convolution(inputPaddedTemp.slice(inMap +
             batchCount * inSize), weight.slice(outMapIdx), convOutput, dW, dH,
@@ -221,11 +310,10 @@ void AtrousConvolution<
       BackwardConvolutionRule::Convolution(mappedError.slice(outMap),
           rotatedFilter, output, dW, dH, dilationW, dilationH);
 
-      if (padW != 0 || padH != 0)
+      if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
       {
-        gTemp.slice(inMap + batchCount * inSize) += output.submat(padW, padH,
-            padW + gTemp.n_rows - 1,
-            padH + gTemp.n_cols - 1);
+        gTemp.slice(inMap + batchCount * inSize) += output.submat(padWLeft,
+            padHTop, padWLeft + gTemp.n_rows - 1, padHTop + gTemp.n_cols - 1);
       }
       else
       {
@@ -274,7 +362,7 @@ void AtrousConvolution<
     for (size_t inMap = 0; inMap < inSize; inMap++, outMapIdx++)
     {
       arma::Mat<eT> inputSlice;
-      if (padW != 0 || padH != 0)
+      if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
       {
         inputSlice = inputPaddedTemp.slice(inMap + batchCount * inSize);
       }
@@ -348,8 +436,10 @@ void AtrousConvolution<
   ar & BOOST_SERIALIZATION_NVP(kH);
   ar & BOOST_SERIALIZATION_NVP(dW);
   ar & BOOST_SERIALIZATION_NVP(dH);
-  ar & BOOST_SERIALIZATION_NVP(padW);
-  ar & BOOST_SERIALIZATION_NVP(padH);
+  ar & BOOST_SERIALIZATION_NVP(padWLeft);
+  ar & BOOST_SERIALIZATION_NVP(padWRight);
+  ar & BOOST_SERIALIZATION_NVP(padHBottom);
+  ar & BOOST_SERIALIZATION_NVP(padHTop);
   ar & BOOST_SERIALIZATION_NVP(inputWidth);
   ar & BOOST_SERIALIZATION_NVP(inputHeight);
   ar & BOOST_SERIALIZATION_NVP(outputWidth);
@@ -362,6 +452,35 @@ void AtrousConvolution<
 
   if (Archive::is_loading::value)
     weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
+}
+
+template<
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+void AtrousConvolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>::InitializeSamePadding()
+{
+  /*
+   * Using O = (W - F + 2P) / s + 1;
+   */
+  size_t totalVerticalPadding = (dW - 1) * inputWidth + kW - dW + (dilationW -
+      1) * (kW - 1);
+  size_t totalHorizontalPadding = (dH - 1) * inputHeight + kH - dH + (dilationH
+      - 1) * (kH - 1);
+
+  padWLeft = totalVerticalPadding / 2;
+  padWRight = totalVerticalPadding - totalVerticalPadding / 2;
+  padHTop = totalHorizontalPadding / 2;
+  padHBottom = totalHorizontalPadding - totalHorizontalPadding / 2;
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -64,6 +64,7 @@ class Convolution
    * @param padH Padding height of the input.
    * @param inputWidth The width of the input data.
    * @param inputHeight The height of the input data.
+   * @param paddingType The type of padding (Valid or Same). Defaults to None.
    */
   Convolution(const size_t inSize,
               const size_t outSize,
@@ -74,7 +75,8 @@ class Convolution
               const size_t padW = 0,
               const size_t padH = 0,
               const size_t inputWidth = 0,
-              const size_t inputHeight = 0);
+              const size_t inputHeight = 0,
+              const std::string paddingType = "None");
 
   /*
    * Set the weight and bias term.
@@ -178,16 +180,23 @@ class Convolution
    * @param size The size of the input (row or column).
    * @param k The size of the filter (width or height).
    * @param s The stride size (x or y direction).
-   * @param p The size of the padding (width or height).
+   * @param pSideOne The size of the padding (width or height) on one side.
+   * @param pSideTwo The size of the padding (width or height) on another side.
    * @return The convolution output size.
    */
   size_t ConvOutSize(const size_t size,
                      const size_t k,
                      const size_t s,
-                     const size_t p)
+                     const size_t pSideOne,
+                     const size_t pSideTwo)
   {
-    return std::floor(size + p * 2 - k) / s + 1;
+    return std::floor(size + pSideOne + pSideTwo - k) / s + 1;
   }
+
+  /*
+   * Function to assign padding such that output size is same as input size.
+   */
+  void InitializeSamePadding();
 
   /*
    * Rotates a 3rd-order tensor counterclockwise by 180 degrees.
@@ -239,11 +248,17 @@ class Convolution
   //! Locally-stored stride of the filter in y-direction.
   size_t dH;
 
-  //! Locally-stored padding width.
-  size_t padW;
+  //! Locally-stored left-side padding width.
+  size_t padWLeft;
 
-  //! Locally-stored padding height.
-  size_t padH;
+  //! Locally-stored right-side padding width.
+  size_t padWRight;
+
+  //! Locally-stored bottom padding height.
+  size_t padHBottom;
+
+  //! Locally-stored top padding height.
+  size_t padHTop;
 
   //! Locally-stored weight object.
   OutputDataType weights;

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -78,6 +78,38 @@ class Convolution
               const size_t inputHeight = 0,
               const std::string paddingType = "None");
 
+  /**
+   * Create the Convolution object using the specified number of input maps,
+   * output maps, filter size, stride and padding parameter.
+   *
+   * @param inSize The number of input maps.
+   * @param outSize The number of output maps.
+   * @param kW Width of the filter/kernel.
+   * @param kH Height of the filter/kernel.
+   * @param dW Stride of filter application in the x direction.
+   * @param dH Stride of filter application in the y direction.
+   * @param padW A two-value tuple indicating padding widths of the input.
+   *             First value is padding at left side. Second value is padding on
+   *             right side.
+   * @param padH A two-value tuple indicating padding heights of the input.
+   *             First value is padding at top. Second value is padding on
+   *             bottom.
+   * @param inputWidth The width of the input data.
+   * @param inputHeight The height of the input data.
+   * @param paddingType The type of padding (Valid or Same). Defaults to None.
+   */
+  Convolution(const size_t inSize,
+              const size_t outSize,
+              const size_t kW,
+              const size_t kH,
+              const size_t dW,
+              const size_t dH,
+              const std::tuple<size_t, size_t> padW,
+              const std::tuple<size_t, size_t> padH,
+              const size_t inputWidth = 0,
+              const size_t inputHeight = 0,
+              const std::string paddingType = "None");
+
   /*
    * Set the weight and bias term.
    */

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -77,14 +77,20 @@ Convolution<
     outputHeight(0)
 {
   weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
-  if (paddingType == "Valid")
+
+  // Transform paddingType to lowercase.
+  std::string paddingTypeLow = paddingType;
+  std::transform(paddingType.begin(), paddingType.end(), paddingTypeLow.begin(),
+      [](unsigned char c){ return std::tolower(c); });
+
+  if (paddingTypeLow == "valid")
   {
     padWLeft = 0;
     padWRight = 0;
     padHTop = 0;
     padHBottom = 0;
   }
-  else if (paddingType == "Same")
+  else if (paddingTypeLow == "same")
   {
     InitializeSamePadding();
   }
@@ -133,14 +139,20 @@ Convolution<
     outputHeight(0)
 {
   weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
-  if (paddingType == "Valid")
+
+  // Transform paddingType to lowercase.
+  std::string paddingTypeLow = paddingType;
+  std::transform(paddingType.begin(), paddingType.end(), paddingTypeLow.begin(),
+      [](unsigned char c){ return std::tolower(c); });
+
+  if (paddingTypeLow == "valid")
   {
     padWLeft = 0;
     padWRight = 0;
     padHTop = 0;
     padHBottom = 0;
   }
-  else if (paddingType == "Same")
+  else if (paddingTypeLow == "same")
   {
     InitializeSamePadding();
   }
@@ -285,7 +297,7 @@ void Convolution<
       BackwardConvolutionRule::Convolution(mappedError.slice(outMap),
           rotatedFilter, output, dW, dH);
 
-      if (padWLeft != 0 || padHTop != 0)
+      if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
       {
         gTemp.slice(inMap + batchCount * inSize) += output.submat(padWLeft,
             padHTop, padWLeft + gTemp.n_rows - 1, padHTop + gTemp.n_cols - 1);

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -59,22 +59,37 @@ Convolution<
     const size_t padW,
     const size_t padH,
     const size_t inputWidth,
-    const size_t inputHeight) :
+    const size_t inputHeight,
+    const std::string paddingType) :
     inSize(inSize),
     outSize(outSize),
     kW(kW),
     kH(kH),
     dW(dW),
     dH(dH),
-    padW(padW),
-    padH(padH),
+    padWLeft(padW),
+    padWRight(padW),
+    padHBottom(padH),
+    padHTop(padH),
     inputWidth(inputWidth),
     inputHeight(inputHeight),
     outputWidth(0),
     outputHeight(0)
 {
   weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
-  padding = new Padding<>(padW, padW, padH, padH);
+  if (paddingType == "Valid")
+  {
+    padWLeft = 0;
+    padWRight = 0;
+    padHTop = 0;
+    padHBottom = 0;
+  }
+  else if (paddingType == "Same")
+  {
+    InitializeSamePadding();
+  }
+
+  padding = new Padding<>(padWLeft, padWRight, padHTop, padHBottom);
 }
 
 template<
@@ -118,10 +133,10 @@ void Convolution<
   inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
-  if (padW != 0 || padH != 0)
+  if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
   {
-    inputPaddedTemp.set_size(inputTemp.n_rows + padW * 2,
-        inputTemp.n_cols + padH * 2, inputTemp.n_slices);
+    inputPaddedTemp.set_size(inputTemp.n_rows + padWLeft + padWRight,
+        inputTemp.n_cols + padHTop + padHBottom, inputTemp.n_slices);
 
     for (size_t i = 0; i < inputTemp.n_slices; ++i)
     {
@@ -130,8 +145,8 @@ void Convolution<
     }
   }
 
-  size_t wConv = ConvOutSize(inputWidth, kW, dW, padW);
-  size_t hConv = ConvOutSize(inputHeight, kH, dH, padH);
+  size_t wConv = ConvOutSize(inputWidth, kW, dW, padWLeft, padWRight);
+  size_t hConv = ConvOutSize(inputHeight, kH, dH, padHTop, padHBottom);
 
   output.set_size(wConv * hConv * outSize, batchSize);
   outputTemp = arma::Cube<eT>(output.memptr(), wConv, hConv,
@@ -151,7 +166,7 @@ void Convolution<
     {
       arma::Mat<eT> convOutput;
 
-      if (padW != 0 || padH != 0)
+      if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
       {
         ForwardConvolutionRule::Convolution(inputPaddedTemp.slice(inMap +
             batchCount * inSize), weight.slice(outMapIdx), convOutput, dW, dH);
@@ -214,11 +229,10 @@ void Convolution<
       BackwardConvolutionRule::Convolution(mappedError.slice(outMap),
           rotatedFilter, output, dW, dH);
 
-      if (padW != 0 || padH != 0)
+      if (padWLeft != 0 || padHTop != 0)
       {
-        gTemp.slice(inMap + batchCount * inSize) += output.submat(padW, padH,
-            padW + gTemp.n_rows - 1,
-            padH + gTemp.n_cols - 1);
+        gTemp.slice(inMap + batchCount * inSize) += output.submat(padWLeft,
+            padHTop, padWLeft + gTemp.n_rows - 1, padHTop + gTemp.n_cols - 1);
       }
       else
       {
@@ -267,7 +281,7 @@ void Convolution<
     for (size_t inMap = 0; inMap < inSize; inMap++, outMapIdx++)
     {
       arma::Mat<eT> inputSlice;
-      if (padW != 0 || padH != 0)
+      if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
       {
         inputSlice = inputPaddedTemp.slice(inMap + batchCount * inSize);
       }
@@ -328,8 +342,10 @@ void Convolution<
   ar & BOOST_SERIALIZATION_NVP(kH);
   ar & BOOST_SERIALIZATION_NVP(dW);
   ar & BOOST_SERIALIZATION_NVP(dH);
-  ar & BOOST_SERIALIZATION_NVP(padW);
-  ar & BOOST_SERIALIZATION_NVP(padH);
+  ar & BOOST_SERIALIZATION_NVP(padWLeft);
+  ar & BOOST_SERIALIZATION_NVP(padWRight);
+  ar & BOOST_SERIALIZATION_NVP(padHBottom);
+  ar & BOOST_SERIALIZATION_NVP(padHTop);
   ar & BOOST_SERIALIZATION_NVP(inputWidth);
   ar & BOOST_SERIALIZATION_NVP(inputHeight);
   ar & BOOST_SERIALIZATION_NVP(outputWidth);
@@ -340,6 +356,33 @@ void Convolution<
 
   if (Archive::is_loading::value)
     weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
+}
+
+template<
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+void Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>::InitializeSamePadding()
+{
+  /*
+   * Using O = (W - F + 2P) / s + 1;
+   */
+  size_t totalVerticalPadding = (dW - 1) * inputWidth + kW - dW;
+  size_t totalHorizontalPadding = (dH - 1) * inputHeight + kH - dH;
+
+  padWLeft =totalVerticalPadding / 2;
+  padWRight = totalVerticalPadding - totalVerticalPadding / 2;
+  padHTop = totalHorizontalPadding / 2;
+  padHBottom = totalHorizontalPadding - totalHorizontalPadding / 2;
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -379,7 +379,7 @@ void Convolution<
   size_t totalVerticalPadding = (dW - 1) * inputWidth + kW - dW;
   size_t totalHorizontalPadding = (dH - 1) * inputHeight + kH - dH;
 
-  padWLeft =totalVerticalPadding / 2;
+  padWLeft = totalVerticalPadding / 2;
   padWRight = totalVerticalPadding - totalVerticalPadding / 2;
   padHTop = totalHorizontalPadding / 2;
   padHBottom = totalHorizontalPadding - totalHorizontalPadding / 2;

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -99,6 +99,62 @@ template<
     typename InputDataType,
     typename OutputDataType
 >
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>::Convolution(
+    const size_t inSize,
+    const size_t outSize,
+    const size_t kW,
+    const size_t kH,
+    const size_t dW,
+    const size_t dH,
+    const std::tuple<size_t, size_t> padW,
+    const std::tuple<size_t, size_t> padH,
+    const size_t inputWidth,
+    const size_t inputHeight,
+    const std::string paddingType) :
+    inSize(inSize),
+    outSize(outSize),
+    kW(kW),
+    kH(kH),
+    dW(dW),
+    dH(dH),
+    padWLeft(std::get<0>(padW)),
+    padWRight(std::get<1>(padW)),
+    padHBottom(std::get<1>(padH)),
+    padHTop(std::get<0>(padH)),
+    inputWidth(inputWidth),
+    inputHeight(inputHeight),
+    outputWidth(0),
+    outputHeight(0)
+{
+  weights.set_size((outSize * inSize * kW * kH) + outSize, 1);
+  if (paddingType == "Valid")
+  {
+    padWLeft = 0;
+    padWRight = 0;
+    padHTop = 0;
+    padHBottom = 0;
+  }
+  else if (paddingType == "Same")
+  {
+    InitializeSamePadding();
+  }
+
+  padding = new Padding<>(padWLeft, padWRight, padHTop, padHBottom);
+}
+
+template<
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
 void Convolution<
     ForwardConvolutionRule,
     BackwardConvolutionRule,

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -2027,8 +2027,9 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
   arma::mat output, input, delta;
 
   // Check valid padding option.
-  AtrousConvolution<> module1(1, 1, 3, 3, 1, 1, {1, 1}, {1, 1}, 7, 7, 2, 2,
-      "valid");
+  AtrousConvolution<> module1(1, 1, 3, 3, 1, 1,
+      std::tuple<size_t, size_t>(1, 1), std::tuple<size_t, size_t>(1, 1),7, 7,
+      2, 2, "valid");
 
   // Test the Forward function.
   input = arma::linspace<arma::colvec>(0, 48, 49);
@@ -2044,8 +2045,9 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
   module1.Backward(std::move(input), std::move(output), std::move(delta));
 
   // Check same padding option.
-  AtrousConvolution<> module2(1, 1, 3, 3, 1, 1, {0, 0}, {0, 0}, 7, 7, 2, 2,
-      "same");
+  AtrousConvolution<> module2(1, 1, 3, 3, 1, 1,
+      std::tuple<size_t, size_t>(0, 0), std::tuple<size_t, size_t>(0, 0), 7, 7,
+      2, 2, "same");
 
   // Test the forward function.
   input = arma::linspace<arma::colvec>(0, 48, 49);
@@ -2786,7 +2788,8 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
   arma::mat output, input, delta;
 
   // Check valid padding option.
-  Convolution<> module1(1, 1, 3, 3, 1, 1, {1, 1}, {1, 1}, 7, 7, "valid");
+  Convolution<> module1(1, 1, 3, 3, 1, 1, std::tuple<size_t, size_t>(1, 1),
+      std::tuple<size_t, size_t>(1, 1), 7, 7, "valid");
 
   // Test the Forward function.
   input = arma::linspace<arma::colvec>(0, 48, 49);
@@ -2802,7 +2805,8 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
   module1.Backward(std::move(input), std::move(output), std::move(delta));
 
   // Check same padding option.
-  Convolution<> module2(1, 1, 3, 3, 1, 1, {0, 0}, {0, 0}, 7, 7, "same");
+  Convolution<> module2(1, 1, 3, 3, 1, 1, std::tuple<size_t, size_t>(0, 0),
+      std::tuple<size_t, size_t>(0, 0), 7, 7, "same");
 
   // Test the forward function.
   input = arma::linspace<arma::colvec>(0, 48, 49);

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -2036,6 +2036,7 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
   module1.Reset();
   module1.Forward(std::move(input), std::move(output));
 
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 9);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
@@ -2052,6 +2053,7 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
   module2.Reset();
   module2.Forward(std::move(input), std::move(output));
 
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 49);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
@@ -2792,6 +2794,7 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
   module1.Reset();
   module1.Forward(std::move(input), std::move(output));
 
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 25);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
@@ -2807,6 +2810,7 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
   module2.Reset();
   module2.Forward(std::move(input), std::move(output));
 
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 49);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -2028,7 +2028,7 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
 
   // Check valid padding option.
   AtrousConvolution<> module1(1, 1, 3, 3, 1, 1,
-      std::tuple<size_t, size_t>(1, 1), std::tuple<size_t, size_t>(1, 1),7, 7,
+      std::tuple<size_t, size_t>(1, 1), std::tuple<size_t, size_t>(1, 1), 7, 7,
       2, 2, "valid");
 
   // Test the Forward function.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -2019,6 +2019,47 @@ BOOST_AUTO_TEST_CASE(GradientAtrousConvolutionLayerTest)
 }
 
 /**
+ * Test that the padding options are working correctly in Atrous Convolution
+ * layer.
+ */
+BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
+{
+  arma::mat output, input, delta;
+
+  // Check valid padding option.
+  AtrousConvolution<> module1(1, 1, 3, 3, 1, 1, {1, 1}, {1, 1}, 7, 7, 2, 2,
+      "valid");
+
+  // Test the Forward function.
+  input = arma::linspace<arma::colvec>(0, 48, 49);
+  module1.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
+  module1.Reset();
+  module1.Forward(std::move(input), std::move(output));
+
+  BOOST_REQUIRE_EQUAL(output.n_rows, 9);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // Test the Backward function.
+  module1.Backward(std::move(input), std::move(output), std::move(delta));
+
+  // Check same padding option.
+  AtrousConvolution<> module2(1, 1, 3, 3, 1, 1, {0, 0}, {0, 0}, 7, 7, 2, 2,
+      "same");
+
+  // Test the forward function.
+  input = arma::linspace<arma::colvec>(0, 48, 49);
+  module2.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
+  module2.Reset();
+  module2.Forward(std::move(input), std::move(output));
+
+  BOOST_REQUIRE_EQUAL(output.n_rows, 49);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // Test the backward function.
+  module2.Backward(std::move(input), std::move(output), std::move(delta));
+}
+
+/**
  * Tests the LayerNorm layer.
  */
 BOOST_AUTO_TEST_CASE(LayerNormTest)
@@ -2733,6 +2774,44 @@ BOOST_AUTO_TEST_CASE(LayerNormSerializationTest)
 {
   LayerNorm<> layer(10);
   ANNLayerSerializationTest(layer);
+}
+
+/**
+ * Test that the padding options are working correctly in Convolution layer.
+ */
+BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
+{
+  arma::mat output, input, delta;
+
+  // Check valid padding option.
+  Convolution<> module1(1, 1, 3, 3, 1, 1, {1, 1}, {1, 1}, 7, 7, "valid");
+
+  // Test the Forward function.
+  input = arma::linspace<arma::colvec>(0, 48, 49);
+  module1.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
+  module1.Reset();
+  module1.Forward(std::move(input), std::move(output));
+
+  BOOST_REQUIRE_EQUAL(output.n_rows, 25);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // Test the Backward function.
+  module1.Backward(std::move(input), std::move(output), std::move(delta));
+
+  // Check same padding option.
+  Convolution<> module2(1, 1, 3, 3, 1, 1, {0, 0}, {0, 0}, 7, 7, "same");
+
+  // Test the forward function.
+  input = arma::linspace<arma::colvec>(0, 48, 49);
+  module2.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
+  module2.Reset();
+  module2.Forward(std::move(input), std::move(output));
+
+  BOOST_REQUIRE_EQUAL(output.n_rows, 49);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // Test the backward function.
+  module2.Backward(std::move(input), std::move(output), std::move(delta));
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Hi,
I have modified `convolutional` layer. But I have a doubt. Should we take all four padding dimension's as an argument in `convolution.hpp`. Currently we only take two dimension as argument in `constructor`. I have kept it as it is for now. I think taking all four padding dimension's would be good but it may break backward compatibility. Let me know what you think.