### PR TITLE
fix: avoid writing zero via sparse matrix iterator

### DIFF
--- a/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
@@ -88,6 +88,8 @@ class ZScoreNormalization
     }
 
     // Subtract mean from existing rating and divide it by stddev.
+    // TODO: consider using spmat::transform() instead of spmat iterators
+    // TODO: http://arma.sourceforge.net/docs.html#transform
     arma::sp_mat::iterator it = cleanedData.begin();
     arma::sp_mat::iterator it_end = cleanedData.end();
     for (; it != it_end; ++it)

--- a/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
@@ -92,11 +92,14 @@ class ZScoreNormalization
     arma::sp_mat::iterator it_end = cleanedData.end();
     for (; it != it_end; ++it)
     {
-      *it = (*it - mean) / stddev;
+      double tmp = (*it - mean) / stddev;
+      
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
-      if (*it == 0)
-        *it = std::numeric_limits<double>::min();
+      if (tmp == 0)
+        tmp = std::numeric_limits<double>::min();
+      
+      *it = tmp;
     }
   }
 


### PR DESCRIPTION
Writing a zero to a sparse matrix causes the element to be deleted. The zero is then immediately overwritten by a non-zero value.  When using iterators, this is horribly inefficient: memory re-allocation + copying.  It also has the potential to screw up the validity of the sparse matrix iterators.
