### PR TITLE
more fixes to avoid writing zero via sparse matrix iterator

### DIFF
--- a/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
@@ -109,11 +109,14 @@ class ItemMeanNormalization
     it = cleanedData.begin();
     for (; it != cleanedData.end(); ++it)
     {
-      *it = *it - itemMean(it.row());
+      double tmp = *it - itemMean(it.row());
+
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
-      if (*it == 0)
-        *it = std::numeric_limits<double>::min();
+      if (tmp == 0)
+        tmp = std::numeric_limits<double>::min();
+
+      *it = tmp;
     }
   }
 

--- a/src/mlpack/methods/cf/normalization/overall_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/overall_mean_normalization.hpp
@@ -76,11 +76,14 @@ class OverallMeanNormalization
       arma::sp_mat::iterator it_end = cleanedData.end();
       for (; it != it_end; ++it)
       {
-        *it = *it - mean;
+        double tmp = *it - mean;
+
         // The algorithm omits rating of zero. If normalized rating equals zero,
         // it is set to the smallest positive double value.
-        if (*it == 0)
-          *it = std::numeric_limits<double>::min();
+        if (tmp == 0)
+          tmp = std::numeric_limits<double>::min();
+
+        *it = tmp;
       }
     }
     else

--- a/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
@@ -109,11 +109,14 @@ class UserMeanNormalization
     it = cleanedData.begin();
     for (; it != cleanedData.end(); ++it)
     {
-      *it = *it - userMean(it.col());
+      double tmp = *it - userMean(it.col());
+
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
-      if (*it == 0)
-        *it = std::numeric_limits<double>::min();
+      if (tmp == 0)
+        tmp = std::numeric_limits<double>::min();
+
+      *it = tmp;
     }
   }
 


### PR DESCRIPTION
More fixes in the same vein as #1989

Writing a zero to a sparse matrix causes the element to be deleted. The zero is then immediately overwritten by a non-zero value. When using iterators, this is horribly inefficient: memory re-allocation + copying. It also has the potential to screw up the validity of the sparse matrix iterators.
