### PR TITLE
DQN reward-clipping test adjustments.

### DIFF
--- a/src/mlpack/tests/q_learning_test.cpp
+++ b/src/mlpack/tests/q_learning_test.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(CartPoleWithDQN)
 
 //! Test DQN in Cart Pole task with Prioritized Replay.
 BOOST_AUTO_TEST_CASE(CartPoleWithDQNPrioritizedReplay)
-  {
+{
   // Set up the network.
   FFN<MeanSquaredError<>, GaussianInitialization> model(MeanSquaredError<>(),
       GaussianInitialization(0, 0.001));

--- a/src/mlpack/tests/reward_clipping_test.cpp
+++ b/src/mlpack/tests/reward_clipping_test.cpp
@@ -57,72 +57,81 @@ BOOST_AUTO_TEST_CASE(ClippedRewardTest)
 //! Test DQN in Acrobot task.
 BOOST_AUTO_TEST_CASE(RewardClippedAcrobotWithDQN)
 {
-    // Set up the network.
-  FFN<MeanSquaredError<>, GaussianInitialization> model(MeanSquaredError<>(),
-      GaussianInitialization(0, 0.001));
-  model.Add<Linear<>>(4, 64);
-  model.Add<ReLULayer<>>();
-  model.Add<Linear<>>(64, 32);
-  model.Add<ReLULayer<>>();
-  model.Add<Linear<>>(32, 3);
-
-  // Set up the policy and replay method.
-  GreedyPolicy<RewardClipping<Acrobot>> policy(1.0, 1000, 0.1, 0.99);
-  RandomReplay<RewardClipping<Acrobot>> replayMethod(20, 10000);
-
-  // Set up Acrobot task and reward clipping wrapper
-  Acrobot task;
-  RewardClipping<Acrobot> rewardClipping(task, -2.0, +2.0);
-
-  // Set up update rule
-  AdamUpdate update;
-
-  TrainingConfig config;
-  config.StepSize() = 0.01;
-  config.Discount() = 0.99;
-  config.TargetNetworkSyncInterval() = 100;
-  config.ExplorationSteps() = 100;
-  config.DoubleQLearning() = false;
-  config.StepLimit() = 400;
-
-  // Set up DQN agent.
-  QLearning<decltype(rewardClipping), decltype(model), AdamUpdate,
-            decltype(policy)>
-      agent(std::move(config), std::move(model), std::move(policy),
-      std::move(replayMethod), std::move(update), std::move(rewardClipping));
-
-  arma::running_stat<double> averageReturn;
-  size_t episodes = 0;
-  bool converged = true;
-  while (true)
+  // We will allow three trials, although it would be very uncommon for the test
+  // to use more than one.
+  bool converged = false;
+  for (size_t trial = 0; trial < 3; ++trial)
   {
-    double episodeReturn = agent.Episode();
-    averageReturn(episodeReturn);
-    episodes += 1;
+    // Set up the network.
+    FFN<MeanSquaredError<>, GaussianInitialization> model(MeanSquaredError<>(),
+        GaussianInitialization(0, 0.001));
+    model.Add<Linear<>>(4, 64);
+    model.Add<ReLULayer<>>();
+    model.Add<Linear<>>(64, 32);
+    model.Add<ReLULayer<>>();
+    model.Add<Linear<>>(32, 3);
 
-    if (episodes > 1000)
+    // Set up the policy and replay method.
+    GreedyPolicy<RewardClipping<Acrobot>> policy(1.0, 1000, 0.1, 0.99);
+    RandomReplay<RewardClipping<Acrobot>> replayMethod(20, 10000);
+
+    // Set up Acrobot task and reward clipping wrapper.
+    Acrobot task;
+    RewardClipping<Acrobot> rewardClipping(task, -2.0, +2.0);
+
+    // Set up update rule.
+    AdamUpdate update;
+
+    TrainingConfig config;
+    config.StepSize() = 0.01;
+    config.Discount() = 0.99;
+    config.TargetNetworkSyncInterval() = 100;
+    config.ExplorationSteps() = 100;
+    config.DoubleQLearning() = false;
+    config.StepLimit() = 400;
+
+    // Set up DQN agent.
+    QLearning<decltype(rewardClipping), decltype(model), AdamUpdate,
+              decltype(policy)>
+        agent(std::move(config), std::move(model), std::move(policy),
+        std::move(replayMethod), std::move(update), std::move(rewardClipping));
+
+    arma::running_stat<double> averageReturn;
+    size_t episodes = 0;
+    converged = true;
+    while (true)
     {
-      Log::Debug << "Acrobot with DQN failed." << std::endl;
-      converged = false;
-      break;
+      double episodeReturn = agent.Episode();
+      averageReturn(episodeReturn);
+      episodes += 1;
+
+      if (episodes > 1000)
+      {
+        Log::Debug << "Acrobot with DQN failed." << std::endl;
+        converged = false;
+        break;
+      }
+
+      /**
+       * I am using a thresold of -380 to check convegence.
+       */
+      Log::Debug << "Average return: " << averageReturn.mean()
+          << " Episode return: " << episodeReturn << std::endl;
+      if (averageReturn.mean() > -380.00)
+      {
+        agent.Deterministic() = true;
+        arma::running_stat<double> testReturn;
+        for (size_t i = 0; i < 20; ++i)
+          testReturn(agent.Episode());
+
+        Log::Debug << "Average return in deterministic test: "
+            << testReturn.mean() << std::endl;
+        break;
+      }
     }
 
-    /**
-     * I am using a thresold of -380 to check convegence.
-     */
-    Log::Debug << "Average return: " << averageReturn.mean()
-        << " Episode return: " << episodeReturn << std::endl;
-    if (averageReturn.mean() > -380.00)
-    {
-      agent.Deterministic() = true;
-      arma::running_stat<double> testReturn;
-      for (size_t i = 0; i < 20; ++i)
-        testReturn(agent.Episode());
-
-      Log::Debug << "Average return in deterministic test: "
-          << testReturn.mean() << std::endl;
+    if (converged)
       break;
-    }
   }
 
   BOOST_REQUIRE(converged);


### PR DESCRIPTION
The previous version failed once in 100 runs (due to the limited model size and test time), so to make this even more stable I just run the test multiple times.