### PR TITLE
double-precision serialization is not lossless

### DIFF
--- a/src/mlpack/methods/cf/normalization/combined_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/combined_normalization.hpp
@@ -119,7 +119,7 @@ class CombinedNormalization
   void SequenceNormalize(MatType& data)
   {
     std::get<I>(normalizations).Normalize(data);
-    SequenceNormalize<I+1>(data);
+    SequenceNormalize<I + 1>(data);
   }
 
   //! End of tuple unpacking.
@@ -140,7 +140,7 @@ class CombinedNormalization
   {
     // The order of denormalization should be the reversed order
     // of normalization.
-    double realRating = SequenceDenormalize<I+1>(user, item, rating);
+    double realRating = SequenceDenormalize<I + 1>(user, item, rating);
     realRating =
         std::get<I>(normalizations).Denormalize(user, item, realRating);
     return realRating;
@@ -190,7 +190,7 @@ class CombinedNormalization
     tagName += std::to_string(I);
     ar & boost::serialization::make_nvp(
         tagName.c_str(), std::get<I>(normalizations));
-    SequenceSerialize<I+1, Archive>(ar, version);
+    SequenceSerialize<I + 1, Archive>(ar, version);
   }
 
   //! End of tuple unpacking.

--- a/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
@@ -76,7 +76,7 @@ class ItemMeanNormalization
       const size_t item = (size_t) datapoint(1);
       datapoint(2) -= itemMean(item);
       // The algorithm omits rating of zero. If normalized rating equals zero,
-      // it is set to the smallest positive double value.
+      // it is set to the smallest positive float value.
       if (datapoint(2) == 0)
         datapoint(2) = std::numeric_limits<float>::min();
     });

--- a/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
@@ -78,7 +78,7 @@ class ItemMeanNormalization
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
       if (datapoint(2) == 0)
-        datapoint(2) = std::numeric_limits<double>::min();
+        datapoint(2) = std::numeric_limits<float>::min();
     });
   }
 
@@ -114,7 +114,7 @@ class ItemMeanNormalization
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
       if (tmp == 0)
-        tmp = std::numeric_limits<double>::min();
+        tmp = std::numeric_limits<float>::min();
 
       *it = tmp;
     }

--- a/src/mlpack/methods/cf/normalization/overall_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/overall_mean_normalization.hpp
@@ -52,7 +52,7 @@ class OverallMeanNormalization
     mean = arma::mean(data.row(2));
     data.row(2) -= mean;
     // The algorithm omits rating of zero. If normalized rating equals zero,
-    // it is set to the smallest positive double value.
+    // it is set to the smallest positive float value.
     data.row(2).for_each([](double& x)
     {
       if (x == 0)
@@ -79,9 +79,9 @@ class OverallMeanNormalization
         double tmp = *it - mean;
 
         // The algorithm omits rating of zero. If normalized rating equals zero,
-        // it is set to the smallest positive double value.
+        // it is set to the smallest positive float value.
         if (tmp == 0)
-          tmp = std::numeric_limits<double>::min();
+          tmp = std::numeric_limits<float>::min();
 
         *it = tmp;
       }

--- a/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
@@ -112,7 +112,7 @@ class UserMeanNormalization
       double tmp = *it - userMean(it.col());
 
       // The algorithm omits rating of zero. If normalized rating equals zero,
-      // it is set to the smallest positive double value.
+      // it is set to the smallest positive float value.
       if (tmp == 0)
         tmp = std::numeric_limits<float>::min();
 

--- a/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
@@ -114,7 +114,7 @@ class UserMeanNormalization
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
       if (tmp == 0)
-        tmp = std::numeric_limits<double>::min();
+        tmp = std::numeric_limits<float>::min();
 
       *it = tmp;
     }

--- a/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
@@ -64,7 +64,7 @@ class ZScoreNormalization
     data.row(2).for_each([](double& x)
     {
       if (x == 0)
-        x = std::numeric_limits<double>::min();
+        x = std::numeric_limits<float>::min();
     });
   }
 
@@ -99,7 +99,7 @@ class ZScoreNormalization
       // The algorithm omits rating of zero. If normalized rating equals zero,
       // it is set to the smallest positive double value.
       if (tmp == 0)
-        tmp = std::numeric_limits<double>::min();
+        tmp = std::numeric_limits<float>::min();
 
       *it = tmp;
     }

--- a/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
@@ -60,7 +60,7 @@ class ZScoreNormalization
 
     data.row(2) = (data.row(2) - mean) / stddev;
     // The algorithm omits rating of zero. If normalized rating equals zero,
-    // it is set to the smallest positive double value.
+    // it is set to the smallest positive float value.
     data.row(2).for_each([](double& x)
     {
       if (x == 0)
@@ -97,7 +97,7 @@ class ZScoreNormalization
       double tmp = (*it - mean) / stddev;
 
       // The algorithm omits rating of zero. If normalized rating equals zero,
-      // it is set to the smallest positive double value.
+      // it is set to the smallest positive float value.
       if (tmp == 0)
         tmp = std::numeric_limits<float>::min();
 

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -702,7 +702,7 @@ BOOST_AUTO_TEST_CASE(RecommendationAccuracySVDCompleteTest)
 /**
  * Make sure recommendations that are generated are reasonably accurate
  * for SVD Incomplete Incremental method.
- */ 
+ */
 BOOST_AUTO_TEST_CASE(RecommendationAccuracySVDIncompleteTest)
 {
   RecommendationAccuracy<SVDIncompletePolicy>();
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE(RecommendationAccuracySVDIncompleteTest)
 /**
  * Make sure recommendations that are generated are reasonably accurate
  * for Bias SVD method.
- */ 
+ */
 BOOST_AUTO_TEST_CASE(RecommendationAccuracyBiasSVDTest)
 {
   RecommendationAccuracy<BiasSVDPolicy>();


### PR DESCRIPTION
 On macOS double-precision serialization is not lossless, using float is probably the easiest solution here.