### PR TITLE
Fix very occasional LSH test failures

### DIFF
--- a/src/mlpack/tests/lsh_test.cpp
+++ b/src/mlpack/tests/lsh_test.cpp
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE(DeterministicNoMerge)
 BOOST_AUTO_TEST_CASE(MultiprobeTest)
 {
   // Test parameters.
-  const double epsilonIncrease = 0.05;
+  const double epsilonIncrease = 0.01;
   const size_t repetitions = 5; // Train five objects.
 
   const size_t probeTrials = 5;
@@ -506,6 +506,11 @@ BOOST_AUTO_TEST_CASE(MultiprobeTest)
   arma::mat qdata;
   data::Load(trainSet, rdata, true);
   data::Load(testSet, qdata, true);
+
+  // Add a slight amount of noise to the dataset, so that we don't end up with
+  // points that have the same distance (hopefully).
+  rdata += 0.0001 * arma::randn<arma::mat>(rdata.n_rows, rdata.n_cols);
+  qdata += 0.0001 * arma::randn<arma::mat>(qdata.n_rows, qdata.n_cols);
 
   // Run classic knn on reference set.
   KNN knn(rdata);


### PR DESCRIPTION
I was surprised to find, when digging, that the LSH `MultiprobeTest` failure is actually caused by points having the exact same distance from each other (and the random projections being *just right* to cause the failure).  So, we can work around this by randomly adding some noise to the iris dataset.  I ran about 6000 trials and had no failures; I expect that this test will not fail anymore.

This fix is part of #1993.