### PR TITLE
Increase Linear SVM test tolerance slightly

### DIFF
--- a/src/mlpack/tests/linear_svm_test.cpp
+++ b/src/mlpack/tests/linear_svm_test.cpp
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(LinearSVMLBFGSTwoClasses)
 
   // Compare test accuracy to 1.
   const double testAcc = lsvm.ComputeAccuracy(data, labels);
-  BOOST_REQUIRE_CLOSE(testAcc, 1.0, 0.6);
+  BOOST_REQUIRE_CLOSE(testAcc, 1.0, 1.0);
 }
 
 /**


### PR DESCRIPTION
Sometimes we can get unlucky and L-BFGS won't optimize quite right.  I ran about 60k trials of the test and there were 5 failures, so I increased the tolerance so that none of those failures would have happened.