### PR TITLE
Fix `DecisionTreeTest/PerfectTrainingSet`

### DIFF
--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE(PerfectTrainingSet)
 
     BOOST_REQUIRE_EQUAL(prediction, labels[i]);
     BOOST_REQUIRE_EQUAL(probabilities.n_elem, 2);
-    for (size_t j = 0; j < 3; ++j)
+    for (size_t j = 0; j < 2; ++j)
     {
       if (labels[i] == j)
         BOOST_REQUIRE_CLOSE(probabilities[j], 1.0, 1e-5);
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(PerfectTrainingSetWithWeight)
 
     BOOST_REQUIRE_EQUAL(prediction, labels[i]);
     BOOST_REQUIRE_EQUAL(probabilities.n_elem, 2);
-    for (size_t j = 0; j < 3; ++j)
+    for (size_t j = 0; j < 2; ++j)
     {
       if (labels[i] == j)
         BOOST_REQUIRE_CLOSE(probabilities[j], 1.0, 1e-5);


### PR DESCRIPTION
I spent a long time trying to reproduce this on my system but I found that it only happens on a specific version of LLVM when compiling without debug symbols.  This suggested that valgrind was needed, which definitely exposed what the bug was: an invalid index.

The only thing that's not clear is what I was thinking when I wrote that code! :)  89c5566596 was the offending commit.