### PR TITLE
Fix `KNNMainTest/KNNAllTreeTypesTest` 

### DIFF
--- a/src/mlpack/tests/main_tests/knn_test.cpp
+++ b/src/mlpack/tests/main_tests/knn_test.cpp
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(KNNAllTreeTypesTest)
   queryData.randu(3, 90); // 90 points in 3 dimensions.
 
   // Keep some k <= number of reference points same over all.
-  SetInputParam("k", (int) 10);
+  SetInputParam("k", (int) 15);
 
   arma::Mat<size_t> neighborsCompare;
   arma::mat distancesCompare;


### PR DESCRIPTION
In `KNNMainTest/KNNAllTreeTypesTest`, I found out that the tree type, `r-plus`, failed with the seed `1567791088`, so I increased `k` from 10 to 15 to make this test robust.
During about 4,000 iterations with random seeds, any error didn't happen.