### PR TITLE
Fix occasional `DecisionTreeMainTest` bugs

### DIFF
--- a/src/mlpack/tests/data/braziltourism.arff
+++ b/src/mlpack/tests/data/braziltourism.arff
@@ -33,7 +33,6 @@
 @attribute 'Active' {0,1,2,3,4,5,6}
 @attribute 'Passive' {0,1,2,3,4}
 @attribute 'Logged_income' REAL
-@attribute 'Trips' {0,1,2,3,4,5}
 
 @data
 41,0,2187.5,186.9,0,0,3,7.690514618

--- a/src/mlpack/tests/data/braziltourism_test.arff
+++ b/src/mlpack/tests/data/braziltourism_test.arff
@@ -33,7 +33,6 @@
 @attribute 'Active' {0,1,2,3,4,5,6}
 @attribute 'Passive' {0,1,2,3,4}
 @attribute 'Logged_income' REAL
-@attribute 'Trips' {0,1,2,3,4,5,7}
 
 @data
 19,1,2351.485149,170.4,0,0,0,7.762802386


### PR DESCRIPTION
I was trying to debug some occasional `DecisionTreeMainTest` bugs that I've seen in the past.  I found a few in `main_tests/decision_tree_test.cpp`, and now this test runs without any valgrind issues.

I also found that when `braziltourism.arff` was added, the labels were stripped and placed in a different file---but the `@attribute` for those labels wasn't removed.  That meant that mlpack was loading an extra column of garbage every time, which could (depending on a lot of things) occasionally cause issues.