### PR TITLE
Additional test fixes

### DIFF
--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(DiscreteHMMGenerateTest)
   hmm2.Train(sequences, states);
 
   // Check that training gives the same result.
-  BOOST_REQUIRE_LT(arma::norm(hmm.Transition() - hmm2.Transition()), 0.01);
+  BOOST_REQUIRE_LT(arma::norm(hmm.Transition() - hmm2.Transition()), 0.02);
 
   for (size_t row = 0; row < 6; row++)
   {
@@ -502,7 +502,7 @@ BOOST_AUTO_TEST_CASE(DiscreteHMMGenerateTest)
     for (size_t col = 0; col < 4; col++)
     {
       BOOST_REQUIRE_SMALL(hmm.Emission()[col].Probability(obs) -
-          hmm2.Emission()[col].Probability(obs), 0.01);
+          hmm2.Emission()[col].Probability(obs), 0.02);
     }
   }
 }

--- a/src/mlpack/tests/main_tests/gmm_train_test.cpp
+++ b/src/mlpack/tests/main_tests/gmm_train_test.cpp
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(GmmTrainTrialsTest)
 
     ResetGmmTrainSetting();
 
-    SetInputParam("input", std::move(inputData));
+    SetInputParam("input", inputData);
     SetInputParam("gaussians", (int) 5);
     SetInputParam("trials", (int) 100);
     SetInputParam("max_iterations", (int) 1);


### PR DESCRIPTION
It took me a long time to debug `GmmTrainMainTest/GmmTrainTrialsTest` because it was quite hard to reproduce.  Once I finally did get it reproduced, the error turned out to be pretty simple... just an invalid `std::move()`.

Also, I updated the tolerance for one of the HMM tests based on @sriramsk1999's report in IRC.

I think this is probably the last fix to solve #1993; or, at least, it's the last regularly failing tests I am seeing right now. :)