### PR TITLE
Update minimum version of ensmallen.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,7 @@ endif ()
 # Find ensmallen.
 # Once ensmallen is readily available in package repos, the automatic downloader
 # here can be removed.
-find_package(Ensmallen 1.10.0)
+find_package(Ensmallen 2.10.0)
 if (NOT ENSMALLEN_FOUND)
   if (DOWNLOAD_ENSMALLEN)
     file(DOWNLOAD http://www.ensmallen.org/files/ensmallen-latest.tar.gz

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ mlpack has the following dependencies:
       Boost (program_options, math_c99, unit_test_framework, serialization,
              spirit)
       CMake         >= 3.3.2
-      ensmallen     >= 1.10.0
+      ensmallen     >= 2.10.0
 
 All of those should be available in your distribution's package manager.  If
 not, you will have to compile each of them by hand.  See the documentation for

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -79,7 +79,7 @@ system and have headers present:
  - Armadillo >= 8.400.0 (with LAPACK support)
  - Boost (math_c99, program_options, serialization, unit_test_framework, heap,
           spirit) >= 1.49
- - ensmallen (will be downloaded if not found)
+ - ensmallen >= 2.10.0 (will be downloaded if not found)
 
 In addition, mlpack has the following optional dependencies:
 


### PR DESCRIPTION
This updates the documentation and the CMake configuration to require ensmallen 2.10.0 or greater.