### PR TITLE
Enforce ensmallen version check

### DIFF
--- a/CMake/FindEnsmallen.cmake
+++ b/CMake/FindEnsmallen.cmake
@@ -52,7 +52,7 @@ endif ()
 
 # Checks 'REQUIRED', 'QUIET' and versions.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ensmallen
+find_package_handle_standard_args(Ensmallen
     REQUIRED_VARS ENSMALLEN_INCLUDE_DIR
     VERSION_VAR ENSMALLEN_VERSION_STRING)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,9 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Enforce CMake version check for ensmallen (#2032).
 
 ### mlpack 3.2.0
 ###### 2019-09-25
-
   * Fix occasionally-failing RADICAL test (#1924).
 
   * Fix gcc 9 OpenMP compilation issue (#1970).


### PR DESCRIPTION
@jeffin143 noticed in IRC that if even old ensmallen versions are installed, CMake will still successfully configure (but then fail to build).

After a little while of digging I discovered that one single character is the culprit:

Since we call `find_package(Ensmallen ...)`, which calls `FindEnsmallen.cmake`, we must use the name `Ensmallen` not `ensmallen` in the call to `find_package_handle_standard_args()`, otherwise the version check is not enforced.