### PR TITLE
Better handling of STB when not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,10 +348,12 @@ if (NOT STB_IMAGE_FOUND)
       list(GET STB_IMAGE_DOWNLOAD_STATUS_LIST 1 STB_DOWNLOAD_ERROR)
       message(WARNING
           "Could not download stb! Error code ${STB_DOWNLOAD_STATUS}: ${STB_DOWNLOAD_ERROR}!  Error log: ${STB_DOWNLOAD_LOG}")
+      message(WARNING
+          "stb/stb_image.h is not installed. Image utilities will not be available!")
     endif ()
   else ()
     message(WARNING
-        "stb/stb_image.h is not installed. Image utilites will not be available!")
+        "stb/stb_image.h is not installed. Image utilities will not be available!")
   endif ()
 else ()
   # Already has STB installed.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Better handling of when STB is not installed (#2033).
 
 ### mlpack 3.2.0
 ###### 2019-09-25

--- a/src/mlpack/core/data/image_info.hpp
+++ b/src/mlpack/core/data/image_info.hpp
@@ -18,6 +18,8 @@
 
 #include "extension.hpp"
 
+#ifdef HAS_STB // Compile this only if stb is present.
+
 #define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
@@ -25,6 +27,8 @@
 #define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
+
+#endif
 
 namespace mlpack {
 namespace data {
@@ -39,6 +43,8 @@ namespace data {
  */
 inline bool ImageFormatSupported(const std::string& fileName,
                                  const bool save = false);
+
+#endif
 
 /**
  * Implements meta-data of images required by data::Load and
@@ -94,10 +100,6 @@ class ImageInfo
   // Compression of the image if saved as jpg (0 - 100).
   size_t quality;
 };
-#else
-class ImageInfo { };
-
-#endif // HAS_STB.
 
 } // namespace data
 } // namespace mlpack

--- a/src/mlpack/core/data/image_info_impl.hpp
+++ b/src/mlpack/core/data/image_info_impl.hpp
@@ -51,7 +51,13 @@ inline bool ImageFormatSupported(const std::string& fileName, const bool save)
   return false;
 }
 
+} // namespace data
+} // namespace mlpack
+
 #endif // HAS_STB.
+
+namespace mlpack {
+namespace data {
 
 inline ImageInfo::ImageInfo(const size_t width,
                             const size_t height,

--- a/src/mlpack/core/data/image_info_impl.hpp
+++ b/src/mlpack/core/data/image_info_impl.hpp
@@ -51,6 +51,8 @@ inline bool ImageFormatSupported(const std::string& fileName, const bool save)
   return false;
 }
 
+#endif // HAS_STB.
+
 inline ImageInfo::ImageInfo(const size_t width,
                             const size_t height,
                             const size_t channels,
@@ -65,7 +67,5 @@ inline ImageInfo::ImageInfo(const size_t width,
 
 } // namespace data
 } // namespace mlpack
-
-#endif // HAS_STB.
 
 #endif

--- a/src/mlpack/core/data/load_image_impl.hpp
+++ b/src/mlpack/core/data/load_image_impl.hpp
@@ -13,7 +13,6 @@
 #ifndef MLPACK_CORE_DATA_LOAD_IMAGE_IMPL_HPP
 #define MLPACK_CORE_DATA_LOAD_IMAGE_IMPL_HPP
 
-
 // In case it hasn't been included yet.
 #include "load.hpp"
 


### PR DESCRIPTION
I tried to build mlpack 3.2.0 for Fedora and found that it actually didn't compile when I disabled downloading of STB.  This is an attempt to fix that.  I made sure that the STB headers aren't included unless `HAS_STB` is defined, and also I made it so that the `ImageInfo` ABI is the same whether `HAS_STB` is defined or not.  (I think that there *could* be some very strange linking problems otherwise, like if mlpack was built without `HAS_STB` but then someone compiled something against mlpack with `HAS_STB`, for instance.)