### PR TITLE
Move/Copy Assignment operators for CoverTree and SpillTree

### DIFF
--- a/src/mlpack/core/tree/cover_tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree.hpp
@@ -239,6 +239,20 @@ class CoverTree
   CoverTree(CoverTree&& other);
 
   /**
+   * Copy the given Cover Tree.
+   *
+   * @param other The tree to be copied.
+   */
+  CoverTree& operator=(const CoverTree& other);
+
+  /**
+   * Take ownership of the given Cover Tree.
+   *
+   * @param other The tree to take ownership of.
+   */
+  CoverTree& operator=(CoverTree&& other);
+
+  /**
    * Create a cover tree from a boost::serialization archive.
    */
   template<typename Archive>

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -630,9 +630,6 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
     metric(other.metric),
     distanceComps(other.distanceComps)
 {
-  if (this == &other)
-    return *this;
-
   // Set proper parent pointer.
   for (size_t i = 0; i < children.size(); ++i)
     children[i]->Parent() = this;
@@ -661,6 +658,9 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>&
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
 operator=(CoverTree&& other)
 {
+  if (this == &other)
+    return *this;
+  
   dataset = other.dataset;
   point = other.point;
   children = std::move(other.children);

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -566,9 +566,7 @@ operator=(const CoverTree& other)
   delete dataset;
   delete metric;
   for (size_t i = 0; i < children.size(); ++i)
-  {
     delete children[i];
-  }
   children.clear();
 
   dataset = ((other.parent == NULL && other.localDataset) ?
@@ -674,9 +672,7 @@ operator=(CoverTree&& other)
   delete dataset;
   delete metric;
   for (size_t i = 0; i < children.size(); ++i)
-  {
     delete children[i];
-  }
   children.clear();
 
   dataset = other.dataset;

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -516,9 +516,9 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
     parent(other.parent),
     parentDistance(other.parentDistance),
     furthestDescendantDistance(other.furthestDescendantDistance),
-    localMetric(false),
+    localMetric(other.localMetric),
     localDataset(other.parent == NULL && other.localDataset),
-    metric(other.metric),
+    metric((other.localMetric ? new MetricType() : other.metric)),
     distanceComps(0)
 {
   // Copy each child by hand.
@@ -563,8 +563,12 @@ operator=(const CoverTree& other)
     return *this;
 
   // Freeing memory that will not be used anymore.
-  delete dataset;
-  delete metric;
+  if (localDataset)
+    delete dataset;
+
+  if (localMetric)
+    delete metric;
+
   for (size_t i = 0; i < children.size(); ++i)
     delete children[i];
   children.clear();
@@ -579,9 +583,9 @@ operator=(const CoverTree& other)
   parent = other.parent;
   parentDistance = other.parentDistance;
   furthestDescendantDistance = other.furthestDescendantDistance;
-  localMetric = false;
+  localMetric = other.localMetric;
   localDataset = (other.parent == NULL && other.localDataset);
-  metric = other.metric;
+  metric = (other.localMetric ? new MetricType() : other.metric);
   distanceComps = 0;
 
   // Copy each child by hand.
@@ -669,8 +673,12 @@ operator=(CoverTree&& other)
     return *this;
 
   // Freeing memory that will not be used anymore.
-  delete dataset;
-  delete metric;
+  if (localDataset)
+    delete dataset;
+
+  if (localMetric)
+    delete metric;
+
   for (size_t i = 0; i < children.size(); ++i)
     delete children[i];
   children.clear();

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -562,6 +562,13 @@ operator=(const CoverTree& other)
   if (this == &other)
     return *this;
 
+  // Freeing memory that will not be used anymore.
+  delete dataset;
+  for (size_t i = 0; i < children.size(); ++i)
+  {
+    delete children[i];
+  }
+
   dataset = ((other.parent == NULL && other.localDataset) ?
       new MatType(*other.dataset) : other.dataset);
   point = other.point;
@@ -660,6 +667,13 @@ operator=(CoverTree&& other)
 {
   if (this == &other)
     return *this;
+
+  // Freeing memory that will not be used anymore.
+  delete dataset;
+  for (size_t i = 0; i < children.size(); ++i)
+  {
+    delete children[i];
+  }
 
   dataset = other.dataset;
   point = other.point;

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -559,20 +559,23 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>&
 CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::
 operator=(const CoverTree& other)
 {
-    dataset = ((other.parent == NULL && other.localDataset) ?
-        new MatType(*other.dataset) : other.dataset);
-    point = other.point;
-    scale = other.scale;
-    base = other.base;
-    stat = other.stat;
-    numDescendants = other.numDescendants;
-    parent = other.parent;
-    parentDistance = other.parentDistance;
-    furthestDescendantDistance = other.furthestDescendantDistance;
-    localMetric = false;
-    localDataset = (other.parent == NULL && other.localDataset);
-    metric = other.metric;
-    distanceComps = 0;
+  if (this == &other)
+    return *this;
+
+  dataset = ((other.parent == NULL && other.localDataset) ?
+      new MatType(*other.dataset) : other.dataset);
+  point = other.point;
+  scale = other.scale;
+  base = other.base;
+  stat = other.stat;
+  numDescendants = other.numDescendants;
+  parent = other.parent;
+  parentDistance = other.parentDistance;
+  furthestDescendantDistance = other.furthestDescendantDistance;
+  localMetric = false;
+  localDataset = (other.parent == NULL && other.localDataset);
+  metric = other.metric;
+  distanceComps = 0;
 
   // Copy each child by hand.
   for (size_t i = 0; i < other.NumChildren(); ++i)
@@ -627,6 +630,9 @@ CoverTree<MetricType, StatisticType, MatType, RootPointPolicy>::CoverTree(
     metric(other.metric),
     distanceComps(other.distanceComps)
 {
+  if (this == &other)
+    return *this;
+
   // Set proper parent pointer.
   for (size_t i = 0; i < children.size(); ++i)
     children[i]->Parent() = this;

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -564,7 +564,7 @@ operator=(const CoverTree& other)
 
   // Freeing memory that will not be used anymore.
   delete dataset;
-  delete metric; 
+  delete metric;
   for (size_t i = 0; i < children.size(); ++i)
   {
     delete children[i];

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -564,10 +564,12 @@ operator=(const CoverTree& other)
 
   // Freeing memory that will not be used anymore.
   delete dataset;
+  delete metric; 
   for (size_t i = 0; i < children.size(); ++i)
   {
     delete children[i];
   }
+  children.clear();
 
   dataset = ((other.parent == NULL && other.localDataset) ?
       new MatType(*other.dataset) : other.dataset);
@@ -670,10 +672,12 @@ operator=(CoverTree&& other)
 
   // Freeing memory that will not be used anymore.
   delete dataset;
+  delete metric;
   for (size_t i = 0; i < children.size(); ++i)
   {
     delete children[i];
   }
+  children.clear();
 
   dataset = other.dataset;
   point = other.point;

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -681,7 +681,6 @@ operator=(CoverTree&& other)
 
   for (size_t i = 0; i < children.size(); ++i)
     delete children[i];
-  children.clear();
 
   dataset = other.dataset;
   point = other.point;

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -660,7 +660,7 @@ operator=(CoverTree&& other)
 {
   if (this == &other)
     return *this;
-  
+
   dataset = other.dataset;
   point = other.point;
   children = std::move(other.children);

--- a/src/mlpack/core/tree/spill_tree/spill_tree.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree.hpp
@@ -221,7 +221,7 @@ class SpillTree
    *
    * @param other The tree to take ownership of.
    */
-  SpillTree& operator=(SpillTree&& other); 
+  SpillTree& operator=(SpillTree&& other);
 
   /**
    * Initialize the tree from a boost::serialization archive.

--- a/src/mlpack/core/tree/spill_tree/spill_tree.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree.hpp
@@ -209,6 +209,20 @@ class SpillTree
    */
   SpillTree(SpillTree&& other);
 
+   /**
+   * Copy the given Spill Tree.
+   *
+   * @param other The tree to be copied.
+   */
+  SpillTree& operator=(const SpillTree& other);
+
+  /**
+   * Take ownership of the given Spill Tree.
+   *
+   * @param other The tree to take ownership of.
+   */
+  SpillTree& operator=(SpillTree&& other); 
+
   /**
    * Initialize the tree from a boost::serialization archive.
    *

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -240,7 +240,7 @@ operator=(const SpillTree& other)
     pointsIndex = new arma::Col<size_t>(*other.pointsIndex);
 
   // Propagate matrix, but only if we are the root.
-/*  if (parent == NULL && localDataset)
+  if (parent == NULL && localDataset)
   {
     std::queue<SpillTree*> queue;
     if (left)
@@ -258,7 +258,7 @@ operator=(const SpillTree& other)
       if (node->right)
         queue.push(node->right);
     }
-*/
+  }
   return *this;
 }
 

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -319,7 +319,7 @@ template<typename MetricType,
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
 operator=(SpillTree&& other){
-  left = other.left; 
+  left = other.left;
   right = other.right;
   parent = other.parent;
   count = other.count;

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -240,7 +240,7 @@ operator=(const SpillTree& other)
     pointsIndex = new arma::Col<size_t>(*other.pointsIndex);
 
   // Propagate matrix, but only if we are the root.
-  if (parent == NULL && localDataset)
+/*  if (parent == NULL && localDataset)
   {
     std::queue<SpillTree*> queue;
     if (left)
@@ -258,7 +258,7 @@ operator=(const SpillTree& other)
       if (node->right)
         queue.push(node->right);
     }
-
+*/
   return *this;
 }
 
@@ -318,7 +318,7 @@ template<typename MetricType,
              class SplitType>
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
-{
+operator=(SpillTree&& other){
   left = other.left; 
   right = other.right;
   parent = other.parent;

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -205,6 +205,9 @@ SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
 operator=(const SpillTree& other)
 {
+  if (this == &other)
+    return *this;
+
   left = NULL;
   right = NULL;
   parent = other.parent;
@@ -321,6 +324,9 @@ SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
 operator=(SpillTree&& other)
 {
+  if (this == &other)
+    return *this;
+
   left = other.left;
   right = other.right;
   parent = other.parent;

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -208,6 +208,13 @@ operator=(const SpillTree& other)
   if (this == &other)
     return *this;
 
+  // Freeing memory that will not be used anymore.
+  delete dataset;
+  delete pointsIndex;
+  delete left;
+  delete right;
+  delete parent;
+
   left = NULL;
   right = NULL;
   parent = other.parent;
@@ -326,6 +333,13 @@ operator=(SpillTree&& other)
 {
   if (this == &other)
     return *this;
+
+  // Freeing memory that will not be used anymore.
+  delete dataset;
+  delete pointsIndex;
+  delete left;
+  delete right;
+  delete parent;
 
   left = other.left;
   right = other.right;

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -193,7 +193,7 @@ SpillTree(const SpillTree& other) :
 }
 
 /**
- *   Copy Assignment
+ * Copy Assignment
  * */
 template<typename MetricType,
          typename StatisticType,
@@ -216,6 +216,7 @@ operator=(const SpillTree& other)
   stat = other.stat;
   parentDistance = other.parentDistance;
   furthestDescendantDistance = other.furthestDescendantDistance;
+
   // Copy matrix, but only if we are the root and the other tree has its own
   // copy of the dataset.
   dataset = (other.parent == NULL && other.localDataset) ?
@@ -308,7 +309,7 @@ SpillTree(SpillTree&& other) :
 }
 
 /**
- *  Move Assignment
+ * Move Assignment
  * */
 template<typename MetricType,
          typename StatisticType,

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -209,7 +209,9 @@ operator=(const SpillTree& other)
     return *this;
 
   // Freeing memory that will not be used anymore.
-  delete dataset;
+  if (localDataset)
+    delete dataset;
+
   delete pointsIndex;
   delete left;
   delete right;
@@ -334,7 +336,9 @@ operator=(SpillTree&& other)
     return *this;
 
   // Freeing memory that will not be used anymore.
-  delete dataset;
+  if (localDataset)
+    delete dataset;
+
   delete pointsIndex;
   delete left;
   delete right;

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -213,7 +213,6 @@ operator=(const SpillTree& other)
   delete pointsIndex;
   delete left;
   delete right;
-  delete parent;
 
   left = NULL;
   right = NULL;
@@ -339,7 +338,6 @@ operator=(SpillTree&& other)
   delete pointsIndex;
   delete left;
   delete right;
-  delete parent;
 
   left = other.left;
   right = other.right;

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -319,7 +319,8 @@ template<typename MetricType,
              class SplitType>
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
 SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
-operator=(SpillTree&& other){
+operator=(SpillTree&& other)
+{
   left = other.left;
   right = other.right;
   parent = other.parent;
@@ -355,7 +356,6 @@ operator=(SpillTree&& other){
 
   return *this;
 }
-
 
 /**
  * Initialize the tree from an archive.

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -193,8 +193,8 @@ SpillTree(const SpillTree& other) :
 }
 
 /**
- * Copy Assignment
- * */
+ * Copy Assignment.
+ */
 template<typename MetricType,
          typename StatisticType,
          typename MatType,
@@ -309,8 +309,8 @@ SpillTree(SpillTree&& other) :
 }
 
 /**
- * Move Assignment
- * */
+ * Move Assignment.
+ */
 template<typename MetricType,
          typename StatisticType,
          typename MatType,

--- a/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree_impl.hpp
@@ -193,6 +193,76 @@ SpillTree(const SpillTree& other) :
 }
 
 /**
+ *   Copy Assignment
+ * */
+template<typename MetricType,
+         typename StatisticType,
+         typename MatType,
+         template<typename HyperplaneMetricType> class HyperplaneType,
+         template<typename SplitMetricType, typename SplitMatType>
+             class SplitType>
+SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
+SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
+operator=(const SpillTree& other)
+{
+  left = NULL;
+  right = NULL;
+  parent = other.parent;
+  count = other.count;
+  pointsIndex = NULL;
+  overlappingNode = other.overlappingNode;
+  hyperplane = other.hyperplane;
+  bound = other.bound;
+  stat = other.stat;
+  parentDistance = other.parentDistance;
+  furthestDescendantDistance = other.furthestDescendantDistance;
+  // Copy matrix, but only if we are the root and the other tree has its own
+  // copy of the dataset.
+  dataset = (other.parent == NULL && other.localDataset) ?
+      new MatType(*other.dataset) : other.dataset;
+  localDataset = other.parent == NULL && other.localDataset;
+
+  // Create left and right children (if any).
+  if (other.Left())
+  {
+    left = new SpillTree(*other.Left());
+    left->Parent() = this; // Set parent to this, not other tree.
+  }
+
+  if (other.Right())
+  {
+    right = new SpillTree(*other.Right());
+    right->Parent() = this; // Set parent to this, not other tree.
+  }
+
+  // If vector of indexes, copy it.
+  if (other.pointsIndex)
+    pointsIndex = new arma::Col<size_t>(*other.pointsIndex);
+
+  // Propagate matrix, but only if we are the root.
+  if (parent == NULL && localDataset)
+  {
+    std::queue<SpillTree*> queue;
+    if (left)
+      queue.push(left);
+    if (right)
+      queue.push(right);
+    while (!queue.empty())
+    {
+      SpillTree* node = queue.front();
+      queue.pop();
+
+      node->dataset = dataset;
+      if (node->left)
+        queue.push(node->left);
+      if (node->right)
+        queue.push(node->right);
+    }
+
+  return *this;
+}
+
+/**
  * Move constructor.
  */
 template<typename MetricType,
@@ -236,6 +306,55 @@ SpillTree(SpillTree&& other) :
   if (right)
     right->parent = this;
 }
+
+/**
+ *  Move Assignment
+ * */
+template<typename MetricType,
+         typename StatisticType,
+         typename MatType,
+         template<typename HyperplaneMetricType> class HyperplaneType,
+         template<typename SplitMetricType, typename SplitMatType>
+             class SplitType>
+SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>&
+SpillTree<MetricType, StatisticType, MatType, HyperplaneType, SplitType>::
+{
+  left = other.left; 
+  right = other.right;
+  parent = other.parent;
+  count = other.count;
+  pointsIndex = other.pointsIndex;
+  overlappingNode = other.overlappingNode;
+  hyperplane = other.hyperplane;
+  bound = std::move(other.bound);
+  stat = std::move(other.stat);
+  parentDistance = other.parentDistance;
+  furthestDescendantDistance = other.furthestDescendantDistance;
+  minimumBoundDistance = other.minimumBoundDistance;
+  dataset = other.dataset;
+  localDataset = other.localDataset;
+
+  // Now we are a clone of the other tree.  But we must also clear the other
+  // tree's contents, so it doesn't delete anything when it is destructed.
+  other.left = NULL;
+  other.right = NULL;
+  other.count = 0;
+  other.pointsIndex = NULL;
+  other.parentDistance = 0.0;
+  other.furthestDescendantDistance = 0.0;
+  other.minimumBoundDistance = 0.0;
+  other.dataset = NULL;
+  other.localDataset = false;
+
+  // Set new parent.
+  if (left)
+    left->parent = this;
+  if (right)
+    right->parent = this;
+
+  return *this;
+}
+
 
 /**
  * Initialize the tree from an archive.

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -1330,62 +1330,6 @@ BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorRTreeTest)
 }
 
 /**
- * Test the copy constructor and copy operator using the BinarySpaceTree.
- */
-BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorBinarySpaceTreeTest)
-{
-  arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      KDTree> NeighborSearchType;
-  NeighborSearchType knn(std::move(dataset));
-
-  // Copy constructor and operator.
-  NeighborSearchType knn2(knn);
-  NeighborSearchType knn3 = knn;
-
-  // Get results.
-  arma::mat distances, distances2, distances3;
-  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
-
-  knn.Search(3, neighbors, distances);
-  knn2.Search(3, neighbors2, distances2);
-  knn3.Search(3, neighbors3, distances3);
-
-  CheckMatrices(neighbors, neighbors2);
-  CheckMatrices(neighbors, neighbors3);
-  CheckMatrices(distances, distances2);
-  CheckMatrices(distances, distances3);
-}
-
-/**
- * Test the copy constructor and copy operator using the Octree.
- */
-BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorOctreeTest)
-{
-  arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      Octree> NeighborSearchType;
-  NeighborSearchType knn(std::move(dataset));
-
-  // Copy constructor and operator.
-  NeighborSearchType knn2(knn);
-  NeighborSearchType knn3 = knn;
-
-  // Get results.
-  arma::mat distances, distances2, distances3;
-  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
-
-  knn.Search(3, neighbors, distances);
-  knn2.Search(3, neighbors2, distances2);
-  knn3.Search(3, neighbors3, distances3);
-
-  CheckMatrices(neighbors, neighbors2);
-  CheckMatrices(neighbors, neighbors3);
-  CheckMatrices(distances, distances2);
-  CheckMatrices(distances, distances3);
-}
-
-/**
  * Test the copy constructor and copy operator using the Cover Tree.
  */
 BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorCoverTreeTest)

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -1330,6 +1330,118 @@ BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorRTreeTest)
 }
 
 /**
+ * Test the copy constructor and copy operator using the BinarySpaceTree.
+ */
+BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorBinarySpaceTreeTest)
+{
+  arma::mat dataset = arma::randu<arma::mat>(5, 500);
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      KDTree> NeighborSearchType;
+  NeighborSearchType knn(std::move(dataset));
+
+  // Copy constructor and operator.
+  NeighborSearchType knn2(knn);
+  NeighborSearchType knn3 = knn;
+
+  // Get results.
+  arma::mat distances, distances2, distances3;
+  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
+
+  knn.Search(3, neighbors, distances);
+  knn2.Search(3, neighbors2, distances2);
+  knn3.Search(3, neighbors3, distances3);
+
+  CheckMatrices(neighbors, neighbors2);
+  CheckMatrices(neighbors, neighbors3);
+  CheckMatrices(distances, distances2);
+  CheckMatrices(distances, distances3);
+}
+
+/**
+ * Test the copy constructor and copy operator using the Octree.
+ */
+BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorOctreeTest)
+{
+  arma::mat dataset = arma::randu<arma::mat>(5, 500);
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      Octree> NeighborSearchType;
+  NeighborSearchType knn(std::move(dataset));
+
+  // Copy constructor and operator.
+  NeighborSearchType knn2(knn);
+  NeighborSearchType knn3 = knn;
+
+  // Get results.
+  arma::mat distances, distances2, distances3;
+  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
+
+  knn.Search(3, neighbors, distances);
+  knn2.Search(3, neighbors2, distances2);
+  knn3.Search(3, neighbors3, distances3);
+
+  CheckMatrices(neighbors, neighbors2);
+  CheckMatrices(neighbors, neighbors3);
+  CheckMatrices(distances, distances2);
+  CheckMatrices(distances, distances3);
+}
+
+/**
+ * Test the copy constructor and copy operator using the Cover Tree.
+ */
+BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorCoverTreeTest)
+{
+  arma::mat dataset = arma::randu<arma::mat>(5, 500);
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      StandardCoverTree> NeighborSearchType;
+  NeighborSearchType knn(std::move(dataset));
+
+  // Copy constructor and operator.
+  NeighborSearchType knn2(knn);
+  NeighborSearchType knn3 = knn;
+
+  // Get results.
+  arma::mat distances, distances2, distances3;
+  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
+
+  knn.Search(3, neighbors, distances);
+  knn2.Search(3, neighbors2, distances2);
+  knn3.Search(3, neighbors3, distances3);
+
+  CheckMatrices(neighbors, neighbors2);
+  CheckMatrices(neighbors, neighbors3);
+  CheckMatrices(distances, distances2);
+  CheckMatrices(distances, distances3);
+}
+
+/**
+ * Test the copy constructor and copy operator using the Spill Tree.
+ */
+BOOST_AUTO_TEST_CASE(CopyConstructorAndOperatorSpillTreeTest)
+{
+  arma::mat dataset = arma::randu<arma::mat>(5, 500);
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      SPTree> NeighborSearchType;
+  NeighborSearchType knn(std::move(dataset));
+
+  // Copy constructor and operator.
+  NeighborSearchType knn2(knn);
+  NeighborSearchType knn3 = knn;
+
+  // Get results.
+  arma::mat distances, distances2, distances3;
+  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
+
+  knn.Search(3, neighbors, distances);
+  knn2.Search(3, neighbors2, distances2);
+  knn3.Search(3, neighbors3, distances3);
+
+  CheckMatrices(neighbors, neighbors2);
+  CheckMatrices(neighbors, neighbors3);
+  CheckMatrices(distances, distances2);
+  CheckMatrices(distances, distances3);
+}
+
+/**
  * Test the move constructor.
  */
 BOOST_AUTO_TEST_CASE(MoveConstructorTest)
@@ -1381,6 +1493,72 @@ BOOST_AUTO_TEST_CASE(MoveConstructorRTreeTest)
   CheckMatrices(distances, distances2);
 }
 
+
+/**
+ * Test the move constructor & move assignment using Cover Tree.
+ */
+BOOST_AUTO_TEST_CASE(MoveConstructorCoverTreeTest)
+{
+  arma::mat dataset = arma::randu<arma::mat>(5, 500);
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      StandardCoverTree> NeighborSearchType;
+  NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
+
+  // Get predictions.
+  arma::mat distances, distances2, distances3;
+  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
+
+  knn->Search(3, neighbors, distances);
+
+  // Use move constructor.
+  NeighborSearchType knn2(std::move(*knn));
+
+  delete knn;
+
+  knn2.Search(3, neighbors2, distances2);
+
+  // Use move assignment.
+  NeighborSearchType knn3 = std::move(knn2);
+  knn3.Search(3, neighbors3, distances3);
+
+  CheckMatrices(neighbors, neighbors2);
+  CheckMatrices(neighbors, neighbors3);
+  CheckMatrices(distances, distances2);
+  CheckMatrices(distances, distances3);
+}
+
+/**
+ * Test the move constructor & move assignment using Spill Tree.
+ */
+BOOST_AUTO_TEST_CASE(MoveConstructorSpillTreeTest)
+{
+  arma::mat dataset = arma::randu<arma::mat>(5, 500);
+  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+      SPTree> NeighborSearchType;
+  NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
+
+  // Get predictions.
+  arma::mat distances, distances2, distances3;
+  arma::Mat<size_t> neighbors, neighbors2, neighbors3;
+
+  knn->Search(3, neighbors, distances);
+
+  // Use move constructor.
+  NeighborSearchType knn2(std::move(*knn));
+
+  delete knn;
+
+  knn2.Search(3, neighbors2, distances2);
+
+  // Use move assignment.
+  NeighborSearchType knn3 = std::move(knn2);
+  knn3.Search(3, neighbors3, distances3);
+
+  CheckMatrices(neighbors, neighbors2);
+  CheckMatrices(neighbors, neighbors3);
+  CheckMatrices(distances, distances2);
+  CheckMatrices(distances, distances3);
+}
 
 /**
  * Test the move operator.


### PR DESCRIPTION
This, along with #2023 is for resolving #1957. In this PR:

 - Move/Copy Assignment for SpillTree/CoverTree
 - Tests for both

However, on compiling, I get a massive number of errors which fill my terminal window completely. These errors take place for the target mlpack_approx_kfn.  

I have narrowed down the problem area to the commented code in Copy Assignment of SpillTree. I would like some help debugging this error :) 