### PR TITLE
added api to access cov specs of gmm

### DIFF
--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -168,12 +168,11 @@ class GaussianDistribution
 
   void Covariance(arma::mat&& covariance);
 
-+   //! Return the invCov.
-+  const arma::mat& InvCov() const { return invCov; }
-+
-+   //! Return the logDetCov.
-+  double LogDetCov() const { return logDetCov; }
-+
+   //! Return the invCov.
+  const arma::mat& InvCov() const { return invCov; }
+
+   //! Return the logDetCov.
+  double LogDetCov() const { return logDetCov; }
 
   /**
    * Serialize the distribution.

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -168,10 +168,10 @@ class GaussianDistribution
 
   void Covariance(arma::mat&& covariance);
 
-   //! Return the invCov.
+  //! Return the invCov.
   const arma::mat& InvCov() const { return invCov; }
 
-   //! Return the logDetCov.
+  //! Return the logDetCov.
   double LogDetCov() const { return logDetCov; }
 
   /**

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -168,14 +168,10 @@ class GaussianDistribution
 
   void Covariance(arma::mat&& covariance);
 
-+  /**
-+   * Return the invCov.
-+   */
++   //!Return the invCov.
 +  const arma::mat& InvCov() const { return invCov; }
 +
-+  /**
-+   * Return the logDetCov.
-+   */
++   //!Return the logDetCov.
 +  double LogDetCov() const { return logDetCov; }
 +
 

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -168,10 +168,10 @@ class GaussianDistribution
 
   void Covariance(arma::mat&& covariance);
 
-+   //!Return the invCov.
++   //! Return the invCov.
 +  const arma::mat& InvCov() const { return invCov; }
 +
-+   //!Return the logDetCov.
++   //! Return the logDetCov.
 +  double LogDetCov() const { return logDetCov; }
 +
 

--- a/src/mlpack/core/dists/gaussian_distribution.hpp
+++ b/src/mlpack/core/dists/gaussian_distribution.hpp
@@ -168,6 +168,17 @@ class GaussianDistribution
 
   void Covariance(arma::mat&& covariance);
 
++  /**
++   * Return the invCov.
++   */
++  const arma::mat& InvCov() const { return invCov; }
++
++  /**
++   * Return the logDetCov.
++   */
++  double LogDetCov() const { return logDetCov; }
++
+
   /**
    * Serialize the distribution.
    */


### PR DESCRIPTION
this APIs are needed when one wants to deploy a trained hmm model into a different implementation using the parameters obtained by mlpack training methods.
I am personally using it to deploy a HMM model into a bare metal embedded platform written in C. 