### PR TITLE
Update documentation to point to correct pip and conda packages

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Update documentation for pip and conda installation packages.
 
 ### mlpack 3.2.1
 ###### 2019-10-01

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ src="https://cdn.rawgit.com/mlpack/mlpack.org/e7d36ed8/mlpack-black.svg" style="
 <p align="center">
   <em>
     Download:
-    <a href="https://www.mlpack.org/files/mlpack-3.2.0.tar.gz">current stable version (3.2.0)</a>
+    <a href="https://www.mlpack.org/files/mlpack-3.2.1.tar.gz">current stable version (3 2.1)</a>
   </em>
 </p>
 

--- a/doc/guide/python_quickstart.hpp
+++ b/doc/guide/python_quickstart.hpp
@@ -17,11 +17,11 @@ Installing the mlpack bindings for Python is straightforward.  It's easy to use
 conda or pip to do this:
 
 @code{.sh}
-pip install mlpack3
+pip install mlpack
 @endcode
 
 @code{.sh}
-conda install -c mlpack mlpack
+conda install -c conda-forge mlpack
 @endcode
 
 Otherwise, we can build the Python bindings from scratch, as follows.  First we


### PR DESCRIPTION
Finally, after quite a long time, I've managed to get control of the `mlpack` package name on PyPI:

https://pypi.org/project/mlpack/

And now that the mlpack/mlpack-wheels repository is successfully uploading wheels, we can update the documentation to point out that you can simply do `pip install mlpack` (at least on OS X and manylinux systems---Windows is still in progress).

I also found that `conda-forge` packages mlpack so we can reference them in our documentation.