### PR TITLE
Serialize padding layer in convolution layer and atrous convolution layer.

### DIFF
--- a/src/mlpack/methods/ann/layer/atrous_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution.hpp
@@ -309,6 +309,28 @@ class AtrousConvolution
 } // namespace ann
 } // namespace mlpack
 
+//! Set the serialization version of the AtrousConvolution class.
+namespace boost {
+namespace serialization {
+
+template<
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+struct version<
+    mlpack::ann::AtrousConvolution<ForwardConvolutionRule,
+        BackwardConvolutionRule, GradientConvolutionRule, InputDataType,
+        OutputDataType> >
+{
+  BOOST_STATIC_CONSTANT(int, value = 1);
+};
+
+} // namespace serialization
+} // namespace boost
+
 // Include implementation
 #include "atrous_convolution_impl.hpp"
 

--- a/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
@@ -339,8 +339,7 @@ void AtrousConvolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->::serialize(
-    Archive& ar, const unsigned int /* version */)
+>::serialize(Archive& ar, const unsigned int version)
 {
   ar & BOOST_SERIALIZATION_NVP(inSize);
   ar & BOOST_SERIALIZATION_NVP(outSize);
@@ -357,6 +356,9 @@ void AtrousConvolution<
   ar & BOOST_SERIALIZATION_NVP(outputHeight);
   ar & BOOST_SERIALIZATION_NVP(dilationW);
   ar & BOOST_SERIALIZATION_NVP(dilationH);
+
+  if (version > 0)
+    ar & BOOST_SERIALIZATION_NVP(padding);
 
   if (Archive::is_loading::value)
     weights.set_size((outSize * inSize * kW * kH) + outSize, 1);

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -300,6 +300,27 @@ class Convolution
 } // namespace ann
 } // namespace mlpack
 
+//! Set the serialization version of the Convolution class.
+namespace boost {
+namespace serialization {
+
+template<
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+struct version<
+    mlpack::ann::Convolution<ForwardConvolutionRule, BackwardConvolutionRule,
+        GradientConvolutionRule, InputDataType, OutputDataType> >
+{
+  BOOST_STATIC_CONSTANT(int, value = 1);
+};
+
+} // namespace serialization
+} // namespace boost
+
 // Include implementation.
 #include "convolution_impl.hpp"
 

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -319,8 +319,7 @@ void Convolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->::serialize(
-    Archive& ar, const unsigned int /* version */)
+>::serialize(Archive& ar, const unsigned int version)
 {
   ar & BOOST_SERIALIZATION_NVP(inSize);
   ar & BOOST_SERIALIZATION_NVP(outSize);
@@ -335,6 +334,9 @@ void Convolution<
   ar & BOOST_SERIALIZATION_NVP(inputHeight);
   ar & BOOST_SERIALIZATION_NVP(outputWidth);
   ar & BOOST_SERIALIZATION_NVP(outputHeight);
+
+  if (version > 0)
+    ar & BOOST_SERIALIZATION_NVP(padding);
 
   if (Archive::is_loading::value)
     weights.set_size((outSize * inSize * kW * kH) + outSize, 1);


### PR DESCRIPTION
It looks like `padding` layer is not serialized in the `convolution` and `atrous` convolution layer. Due to this #1770 was failing.
I have pushed similar changes in #1770 as weil so we can merge this or directly we can merge #1770.