### PR TITLE
Fix random failures for RecommendationAccuracyBiasSVDTest`

### DIFF
--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -159,7 +159,7 @@ void GetRecommendationsQueriedUser()
  */
 template<typename DecompositionPolicy,
          typename NormalizationType = NoNormalization>
-void RecommendationAccuracy()
+void RecommendationAccuracy(const size_t allowedFailures = 17)
 {
   DecompositionPolicy decomposition;
 
@@ -214,7 +214,7 @@ void RecommendationAccuracy()
   }
 
   // Make sure the right item showed up in at least 2/3 of the recommendations.
-  BOOST_REQUIRE_LT(failures, 17);
+  BOOST_REQUIRE_LT(failures, allowedFailures);
 }
 
 // Make sure that Predict() is returning reasonable results.
@@ -712,7 +712,9 @@ BOOST_AUTO_TEST_CASE(RecommendationAccuracySVDIncompleteTest)
  */
 BOOST_AUTO_TEST_CASE(RecommendationAccuracyBiasSVDTest)
 {
-  RecommendationAccuracy<BiasSVDPolicy>();
+  // This algorithm seems to be far less effective than others.
+  // We therefore allow failures on 44% of the runs.
+  RecommendationAccuracy<BiasSVDPolicy>(22);
 }
 
 /**


### PR DESCRIPTION
I looked into the random failures that were showing up in #2058 and spent a little while debugging.  The `BiasSVD` algorithm does seem to give worse results than the other algorithms, failing much more often.  So I adjusted the tolerance.

@zoq we can merge this, or you can cherry-pick the commit into #2058 and we can close this---up to you.