### PR TITLE
Fix memory handling issues of RangeSearch and NeighborSearch.

### DIFF
--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -115,7 +115,7 @@ SingleTreeTraversalType>::NeighborSearch(const NeighborSearchMode mode,
                                          const double epsilon,
                                          const MetricType metric) :
     referenceTree(NULL),
-    referenceSet(new MatType()), // Empty matrix.
+    referenceSet(mode == NAIVE_MODE ? new MatType() : NULL), // Empty matrix.
     searchMode(mode),
     epsilon(epsilon),
     metric(metric),
@@ -129,9 +129,8 @@ SingleTreeTraversalType>::NeighborSearch(const NeighborSearchMode mode,
   // Build the tree on the empty dataset, if necessary.
   if (mode != NAIVE_MODE)
   {
-    referenceTree = BuildTree<Tree>(std::move(*referenceSet),
+    referenceTree = BuildTree<Tree>(std::move(arma::mat()),
         oldFromNewReferences);
-    delete referenceSet;
     referenceSet = &referenceTree->Dataset();
   }
 }
@@ -277,8 +276,11 @@ NeighborSearch<SortPolicy,
   scores = other.scores;
   treeNeedsReset = other.treeNeedsReset;
 
-  // Reset the other object.
-  other.referenceTree = BuildTree<Tree>(*other.referenceSet,
+  // Reset the other object.  Clean memory if needed.
+  if (!other.referenceTree)
+    delete other.referenceSet;
+
+  other.referenceTree = BuildTree<Tree>(std::move(arma::mat()),
       other.oldFromNewReferences);
   other.referenceSet = &other.referenceTree->Dataset();
   other.searchMode = DUAL_TREE_MODE,

--- a/src/mlpack/methods/range_search/range_search_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_impl.hpp
@@ -97,7 +97,7 @@ RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
     const bool singleMode,
     const MetricType metric) :
     referenceTree(NULL),
-    referenceSet(new MatType()), // Empty matrix.
+    referenceSet(naive ? new MatType() : NULL), // Empty matrix.
     treeOwner(false),
     naive(naive),
     singleMode(singleMode),
@@ -108,8 +108,9 @@ RangeSearch<MetricType, MatType, TreeType>::RangeSearch(
   // Build the tree on the empty dataset, if necessary.
   if (!naive)
   {
-    referenceTree = BuildTree<Tree>(const_cast<MatType&>(*referenceSet),
+    referenceTree = BuildTree<Tree>(std::move(arma::mat()),
         oldFromNewReferences);
+    referenceSet = &referenceTree->Dataset();
     treeOwner = true;
   }
 }
@@ -152,10 +153,9 @@ RangeSearch<MetricType, MatType, TreeType>::RangeSearch(RangeSearch&& other) :
     scores(other.scores)
 {
   // Clear other object.
-  other.referenceSet = new MatType();
   other.referenceTree =
-      BuildTree<Tree>(const_cast<MatType&>(*other.referenceSet),
-      other.oldFromNewReferences);
+      BuildTree<Tree>(std::move(arma::mat()), other.oldFromNewReferences);
+  other.referenceSet = &other.referenceTree->Dataset();
   other.treeOwner = true;
   other.naive = false;
   other.singleMode = false;


### PR DESCRIPTION
This fixes #2078.  Thanks @HugoSoszynski for pointing this out.  It was pretty straightforward to dig into `RangeSearch` and figure out that we were leaving the `referenceSet` pointer dangling and not deleting it.

So, instead, when a `RangeSearch` object is being constructed with default arguments, we avoid allocating a matrix for `referenceSet` unless `naive` is true, and instead construct `referenceTree` on a temporary `arma::mat()` that we `std::move()` to the tree constructor.

The same issue existed in `NeighborSearch` so I modified that also.