### PR TITLE
Update LSTM documentation to indicate need for IdentityLayer

### DIFF
--- a/src/mlpack/methods/ann/layer/fast_lstm.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm.hpp
@@ -36,6 +36,10 @@ namespace ann /** Artificial Neural Network. */ {
  * Note that FastLSTM network layer does not use peephole connections between
  * the cell and gates.
  *
+ * Note also that if a FastLSTM layer is desired as the first layer of a neural
+ * network, an IdentityLayer should be added to the network as the first layer,
+ * and then the FastLSTM layer should be added.
+ *
  * For more information, see the following.
  *
  * @code

--- a/src/mlpack/methods/ann/layer/lstm.hpp
+++ b/src/mlpack/methods/ann/layer/lstm.hpp
@@ -31,6 +31,10 @@ namespace ann /** Artificial Neural Network. */ {
  * h &=& o \cdot tanh(c)
  * @f}
  *
+ * Note that if an LSTM layer is desired as the first layer of a neural network,
+ * an IdentityLayer should be added to the network as the first layer, and then
+ * the LSTM layer should be added.
+ *
  * For more information, see the following.
  *
  * @code


### PR DESCRIPTION
This comes out of the discussion for #2048, where part of the issue is that the `LSTM` layer must be preceded by the `IdentityLayer` if it's intended to be used as the first layer of the network.  I've just added some documentation to that for the `LSTM` and `FastLSTM` layer.  (I am not sure it applies to both, but I *think* that it does.)

This may not be the best place for this documentation, but I'm not sure where else to put it, so if anyone has any better suggestions just let me know.  Alternately, removing the need for the `IdentityLayer` is a possibility, but I don't know how easy that is.  (I suppose, I could just open an issue for it?)