### PR TITLE
GitHub + NumFOCUS Sponsor button.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [numfocus] 


### PR DESCRIPTION
GitHub opened up the Sponsors tool. It allows financial support for developers and projects, since we are part of NumFOCUS this will be handled by NumFOCUS.