### PR TITLE
Add md5 validation for downloaded libraries

### DIFF
--- a/CMake/CheckHash.cmake
+++ b/CMake/CheckHash.cmake
@@ -21,7 +21,7 @@ macro (check_hash MD5_URL DIR HASH_CHECK_FAIL)
         set(HASH_CHECK_FAIL 1)
         file(REMOVE_RECURSE ${DIR})
         message(WARNING
-            "Could not verify md5 hash!")
+            "md5sum verification error for ${item}!  Got ${LOCAL_HASH}, expected ${EXPECTED_HASH}.")
         break()
       endif()
     endforeach()

--- a/CMake/CheckHash.cmake
+++ b/CMake/CheckHash.cmake
@@ -1,0 +1,16 @@
+# Validate md5 hash given md5file url and the file directory.
+
+# This module does the following:
+# HASH_CHECK_FAIL set to true if the hash check fails.
+# Remove the downloaded files.
+
+macro (check_hash MD5_URL DIR HASH_CHECK_FAIL)
+  file(DOWNLOAD MD5_URL "${DIR}/hash.md5")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum -c "${DIR}/hash.md5"
+      RESULT_VARIABLE HASH_CHECK_FAIL)
+  if (HASH_CHECK_FAIL)
+    file(REMOVE_RECURSE DIR)
+    message(WARNING
+        "Could not verify md5 hash! Error code ${HASH_CHECK_FAIL}")
+  endif ()
+endmacro (check_hash)

--- a/CMake/CheckHash.cmake
+++ b/CMake/CheckHash.cmake
@@ -1,16 +1,35 @@
 # Validate md5 hash given md5file url and the file directory.
 
-# This module does the following:
-# HASH_CHECK_FAIL set to true if the hash check fails.
+# This module does the following on hash failure:
+# Set HASH_CHECK_FAIL to 1.
 # Remove the downloaded files.
 
 macro (check_hash MD5_URL DIR HASH_CHECK_FAIL)
-  file(DOWNLOAD MD5_URL "${DIR}/hash.md5")
-  execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum -c "${DIR}/hash.md5"
-      RESULT_VARIABLE HASH_CHECK_FAIL)
-  if (HASH_CHECK_FAIL)
-    file(REMOVE_RECURSE DIR)
+  set(HASH_CHECK_FAIL 0)
+  file(DOWNLOAD ${MD5_URL}
+      "${DIR}/hash.md5"
+      STATUS MD5_DOWNLOAD_STATUS_LIST)
+  list(GET MD5_DOWNLOAD_STATUS_LIST 0 MD5_DOWNLOAD_STATUS)
+  if (MD5_DOWNLOAD_STATUS EQUAL 0)
+    file(STRINGS "${DIR}/hash.md5" HASH_DATA NEWLINE_CONSUME)
+    string(REGEX REPLACE "\n" ";" HASH_LIST "${HASH_DATA}")
+    foreach(item ${HASH_LIST})
+      string(SUBSTRING ${item} 0 32 EXPECTED_HASH)
+      string(SUBSTRING ${item} 34 -1 FILE_NAME)
+      file(MD5 "${DIR}/${FILE_NAME}" LOCAL_HASH)
+      if (NOT LOCAL_HASH STREQUAL EXPECTED_HASH)
+        set(HASH_CHECK_FAIL 1)
+        file(REMOVE_RECURSE ${DIR})
+        message(WARNING
+            "Could not verify md5 hash!")
+        break()
+      endif()
+    endforeach()
+  else ()
+    set(HASH_CHECK_FAIL 1)
+    file(REMOVE_RECURSE ${DIR})
+    list(GET MD5_DOWNLOAD_STATUS_LIST 1 MD5_DOWNLOAD_ERROR)
     message(WARNING
-        "Could not verify md5 hash! Error code ${HASH_CHECK_FAIL}")
+        "Could not download the md5 for hash verification! Error code ${MD5_DOWNLOAD_STATUS}: ${MD5_DOWNLOAD_ERROR}!")
   endif ()
 endmacro (check_hash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,17 @@ project(mlpack C CXX)
 
 include(CMake/cotire.cmake)
 
+# Validate md5 hash give md5file url and the file directory.
+# If hash check fails set HASH_CHECK_FAIL to non-zero and remove the files.
+macro (check_hash MD5_URL DIR HASH_CHECK_FAIL)
+  file(DOWNLOAD MD5_URL "${DIR}/hash.md5")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum -c "${DIR}/hash.md5"
+      RESULT_VARIABLE HASH_CHECK_FAIL)
+  if (HASH_CHECK_FAIL)
+    file(REMOVE_RECURSE DIR)
+  endif ()
+endmacro (check_hash)
+
 # First, define all the compilation options.
 # We default to debugging mode for developers.
 option(DEBUG "Compile with debugging information." OFF)
@@ -349,8 +360,11 @@ if (NOT STB_IMAGE_FOUND)
         SHOW_PROGRESS)
     list(GET STB_IMAGE_WRITE_DOWNLOAD_STATUS_LIST 0
         STB_IMAGE_WRITE_DOWNLOAD_STATUS)
+    check_hash (http://mlpack.org/files/stb/hash.md5 "${CMAKE_BINARY_DIR}/deps/${STB_DIR}"
+        HASH_CHECK_FAIL)
     if (STB_IMAGE_DOWNLOAD_STATUS EQUAL 0 AND
-        STB_IMAGE_WRITE_DOWNLOAD_STATUS EQUAL 0)
+        STB_IMAGE_WRITE_DOWNLOAD_STATUS EQUAL 0 AND
+        HASH_CHECK_FAIL EQUAL 0)
       set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS}
           "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/")
       message(STATUS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,25 +350,29 @@ if (NOT STB_IMAGE_FOUND)
         SHOW_PROGRESS)
     list(GET STB_IMAGE_WRITE_DOWNLOAD_STATUS_LIST 0
         STB_IMAGE_WRITE_DOWNLOAD_STATUS)
-    check_hash (http://mlpack.org/files/stb/hash.md5 "${CMAKE_BINARY_DIR}/deps/${STB_DIR}"
-        HASH_CHECK_FAIL)
     if (STB_IMAGE_DOWNLOAD_STATUS EQUAL 0 AND
-        STB_IMAGE_WRITE_DOWNLOAD_STATUS EQUAL 0 AND
-        HASH_CHECK_FAIL EQUAL 0)
-      set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS}
-          "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/")
-      message(STATUS
-          "Successfully downloaded stb into ${CMAKE_BINARY_DIR}/deps/${STB_DIR}/")
-      # Now we have to also ensure these header files get installed.
-      install(FILES "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/stb_image.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-      install(FILES "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/stb_image_write.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-      add_definitions(-DHAS_STB)
+        STB_IMAGE_WRITE_DOWNLOAD_STATUS EQUAL 0)
+      check_hash (http://mlpack.org/files/stb/hash.md5 "${CMAKE_BINARY_DIR}/deps/${STB_DIR}"
+          HASH_CHECK_FAIL)
+      if (HASH_CHECK_FAIL EQUAL 0)
+        set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS}
+            "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/")
+        message(STATUS
+            "Successfully downloaded stb into ${CMAKE_BINARY_DIR}/deps/${STB_DIR}/")
+        # Now we have to also ensure these header files get installed.
+        install(FILES "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/stb_image.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+        install(FILES "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/stb_image_write.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+        add_definitions(-DHAS_STB)
+      else ()
+        message(WARNING
+            "stb/stb_image.h is not installed. Image utilities will not be available!")
+      endif ()
     else ()
-      list(GET STB_IMAGE_DOWNLOAD_STATUS_LIST 1 STB_DOWNLOAD_ERROR)
-      message(WARNING
-          "Could not download stb! Error code ${STB_DOWNLOAD_STATUS}: ${STB_DOWNLOAD_ERROR}!  Error log: ${STB_DOWNLOAD_LOG}")
-      message(WARNING
-          "stb/stb_image.h is not installed. Image utilities will not be available!")
+        list(GET STB_IMAGE_DOWNLOAD_STATUS_LIST 1 STB_DOWNLOAD_ERROR)
+        message(WARNING
+            "Could not download stb! Error code ${STB_DOWNLOAD_STATUS}: ${STB_DOWNLOAD_ERROR}!  Error log: ${STB_DOWNLOAD_LOG}")
+        message(WARNING
+            "stb/stb_image.h is not installed. Image utilities will not be available!")
     endif ()
   else ()
     message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,7 @@ cmake_minimum_required(VERSION 3.3.2)
 project(mlpack C CXX)
 
 include(CMake/cotire.cmake)
-
-# Validate md5 hash give md5file url and the file directory.
-# If hash check fails set HASH_CHECK_FAIL to non-zero and remove the files.
-macro (check_hash MD5_URL DIR HASH_CHECK_FAIL)
-  file(DOWNLOAD MD5_URL "${DIR}/hash.md5")
-  execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum -c "${DIR}/hash.md5"
-      RESULT_VARIABLE HASH_CHECK_FAIL)
-  if (HASH_CHECK_FAIL)
-    file(REMOVE_RECURSE DIR)
-  endif ()
-endmacro (check_hash)
+include(CMake/CheckHash.cmake)
 
 # First, define all the compilation options.
 # We default to debugging mode for developers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ if (NOT STB_IMAGE_FOUND)
             "stb/stb_image.h is not installed. Image utilities will not be available!")
       endif ()
     else ()
+        file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/deps/${STB_DIR}/")
         list(GET STB_IMAGE_DOWNLOAD_STATUS_LIST 1 STB_DOWNLOAD_ERROR)
         message(WARNING
             "Could not download stb! Error code ${STB_DOWNLOAD_STATUS}: ${STB_DOWNLOAD_ERROR}!  Error log: ${STB_DOWNLOAD_LOG}")

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -118,6 +118,7 @@ Copyright:
   Copyright 2019, Heet Sankesara <heetsankesara3@gmail.com>
   Copyright 2019, Jeffin Sam <sam.jeffin@gmail.com>
   Copyright 2019, Vikas S Shetty <shettyvikas209@gmail.com>
+  Copyright 2019, Tejasvi Tomar <tstomar@outlook.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,8 @@
 
   * Fix Windows Python build configuration (#1885).
 
+  * Validate md5 of STB library after download (#2087).
+
 ### mlpack 3.2.1
 ###### 2019-10-01
   * Enforce CMake version check for ensmallen (#2032).


### PR DESCRIPTION
Validation is done by a macro which takes .md5 file URL and the file
directory. On hash failure the downloaded files are deleted. Currently
used for stb library only.