### PR TITLE
Sponsor button - custom link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: [numfocus] 
+github: [numfocus]
+custom: https://numfocus.org/donate-to-mlpack


### PR DESCRIPTION
Add a custom link to point to the form located at numfocus.org, which is now online.