### PR TITLE
unset BOOST_ROOT (azure pipelines)

### DIFF
--- a/.ci/ci.yaml
+++ b/.ci/ci.yaml
@@ -1,5 +1,6 @@
 jobs:
 - job: Linux
+  timeoutInMinutes: 360
   pool:
     vmImage: ubuntu-16.04
   strategy:
@@ -21,6 +22,7 @@ jobs:
   - template: linux-steps.yaml
 
 - job: macOS
+  timeoutInMinutes: 360
   pool:
     vmImage: macOS-10.13
   strategy:

--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -12,7 +12,8 @@ steps:
 # Install build dependencies
 - script: |
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
-
+    
+    sudo add-apt-repository ppa:mhier/libboost-latest
     sudo apt-get update
 
     # Remove BOOST_ROOT from the environment to prevent attempting to use a

--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -14,7 +14,12 @@ steps:
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
 
     sudo apt-get update
+
+    # Remove BOOST_ROOT from the environment to prevent attempting to use a
+    # boost which is incompatible with the compiler.
     unset BOOST_ROOT
+    echo "##vso[task.setvariable variable=BOOST_ROOT]"$BOOST_ROOT
+
     sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-math-dev libboost-program-options-dev libboost-test-dev libboost-serialization-dev libarmadillo-dev xz-utils
 
     if [ '$(python.version)' == '2.7' ]; then

--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -21,7 +21,7 @@ steps:
     unset BOOST_ROOT
     echo "##vso[task.setvariable variable=BOOST_ROOT]"$BOOST_ROOT
 
-    sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-math-dev libboost-program-options-dev libboost-test-dev libboost-serialization-dev libarmadillo-dev xz-utils
+    sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost1.70-dev libarmadillo-dev xz-utils
 
     if [ '$(python.version)' == '2.7' ]; then
       sudo apt-get install -y --allow-unauthenticated python-pip cython python-numpy python-pandas

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -185,8 +185,7 @@ using MoreTypes = boost::variant<
         Sequential<arma::mat, arma::mat, true>*,
         Subview<arma::mat, arma::mat>*,
         VRClassReward<arma::mat, arma::mat>*,
-        VirtualBatchNorm<arma::mat, arma::mat>*,
-        WeightNorm<arma::mat, arma::mat>*
+        VirtualBatchNorm<arma::mat, arma::mat>*
 >;
 
 template <typename... CustomLayers>
@@ -242,6 +241,7 @@ using LayerTypes = boost::variant<
     NegativeLogLikelihood<arma::mat, arma::mat>*,
     Padding<arma::mat, arma::mat>*,
     PReLU<arma::mat, arma::mat>*,
+    WeightNorm<arma::mat, arma::mat>*,
     MoreTypes,
     CustomLayers*...
 >;

--- a/src/mlpack/methods/ann/layer/weight_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/weight_norm_impl.hpp
@@ -152,7 +152,7 @@ void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::serialize(
     boost::apply_visitor(deleteVisitor, wrappedLayer);
   }
 
-  ar & BOOST_SERIALIZATION_NVP(wrappedLayer);
+  //ar & BOOST_SERIALIZATION_NVP(wrappedLayer);
   ar & BOOST_SERIALIZATION_NVP(layerWeightSize);
 
   // If we are loading, we need to initialize the weights.

--- a/src/mlpack/methods/ann/layer/weight_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/weight_norm_impl.hpp
@@ -152,7 +152,7 @@ void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::serialize(
     boost::apply_visitor(deleteVisitor, wrappedLayer);
   }
 
-  //ar & BOOST_SERIALIZATION_NVP(wrappedLayer);
+  ar & BOOST_SERIALIZATION_NVP(wrappedLayer);
   ar & BOOST_SERIALIZATION_NVP(layerWeightSize);
 
   // If we are loading, we need to initialize the weights.

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -201,6 +201,7 @@ set(parallel_tests
   "SVDBatchTest;"
   "LocalCoordinateCodingTest;"
   "FeedForwardNetworkTest;"
+  "RecurrentNetworkTest;"
   "SparseAutoencoderTest;"
   "GMMTest;"
   "CFTest;"


### PR DESCRIPTION
BOOST_ROOT is now set in the azure v2017 image (relevant change seems to be [1], pre-installing boost).

Remove BOOST_ROOT from the environment to prevent attempting to use a
boost which is incompatible with the compiler.

[1] microsoft/azure-pipelines-image-generation#732