### PR TITLE
Add mlpack version to __init__.py

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,8 @@
 
   * Fix Windows Python build configuration (#1885).
 
+  * Add `__version__` to `__init__.py` (#2092).
+
 ### mlpack 3.2.1
 ###### 2019-10-01
   * Enforce CMake version check for ensmallen (#2032).

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -140,6 +140,9 @@ if (BUILDING_PYTHON_BINDINGS)
       COMMENT "Configuring setup.py...")
   add_dependencies(python_configure python_copy)
   add_dependencies(python_configured python_configure)
+
+  file(APPEND ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/__init__.py
+  "__version__='${PACKAGE_VERSION}'\n")
 endif ()
 
 # If we are building Markdown documentation, we have to run some setup after we

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -141,6 +141,7 @@ if (BUILDING_PYTHON_BINDINGS)
   add_dependencies(python_configure python_copy)
   add_dependencies(python_configured python_configure)
 
+  # Append the package version to __init__.py after all the imports are loaded.
   file(APPEND ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/__init__.py
   "__version__='${PACKAGE_VERSION}'\n")
 endif ()


### PR DESCRIPTION
I edited `src/mlpack/bindings/python/CMakeLists.txt` to append the mlpack version to `__init__.py`. By doing that, we can check the mlpack version in Python code, using the command below. (However, although I tried to place the `__version__` at the bottom of the file, I couldn't find any good way.)

**[Result]**
![result2](https://user-images.githubusercontent.com/26578203/69450614-eb30e500-0da0-11ea-9644-3c9cc832bda6.png)



**[Image]**
![result](https://user-images.githubusercontent.com/26578203/69450379-5c23cd00-0da0-11ea-951b-4751ca629fd1.png)