### PR TITLE
Add attribution for NumFOCUS to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ functions as a "swiss army knife" for machine learning researchers.  In addition
 to its powerful C++ interface, mlpack also provides command-line programs and
 Python bindings.
 
+mlpack uses as [open governance model](./GOVERNANCE.md) and is fiscally
+sponsored by [NumFOCUS](https://numfocus.org/).  Consider making a
+[tax-deductible donation](https://numfocus.org/donate-to-mlpack) to help the
+project pay for developer time, professional services, travel, workshops, and a
+variety of other needs.
+
+<div align="center">
+  <a href="https://numfocus.org/donate-to-mlpack">
+    <img height="60px"
+         src="https://raw.githubusercontent.com/numfocus/templates/master/numfocus-logo.png"
+         align="center">
+  </a>
+</div>
+<br>
+
 ### 0. Contents
 
   1. [Introduction](#1-introduction)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ functions as a "swiss army knife" for machine learning researchers.  In addition
 to its powerful C++ interface, mlpack also provides command-line programs and
 Python bindings.
 
-mlpack uses as [open governance model](./GOVERNANCE.md) and is fiscally
+mlpack uses an [open governance model](./GOVERNANCE.md) and is fiscally
 sponsored by [NumFOCUS](https://numfocus.org/).  Consider making a
 [tax-deductible donation](https://numfocus.org/donate-to-mlpack) to help the
 project pay for developer time, professional services, travel, workshops, and a

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ variety of other needs.
 <div align="center">
   <a href="https://numfocus.org/donate-to-mlpack">
     <img height="60px"
-         src="https://raw.githubusercontent.com/numfocus/templates/master/numfocus-logo.png"
+         src="https://raw.githubusercontent.com/numfocus/templates/master/images/numfocus-logo.png"
          align="center">
   </a>
 </div>


### PR DESCRIPTION
While waiting for my space station in Kerbal Space Program to achieve the right orbit, I modified the `README.md` to include attribution for NumFOCUS as described here: https://github.com/numfocus/templates/blob/master/fiscal-sponsor-readme-attribution.md