### PR TITLE
Fix coverage build by linking against quadmath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ endif()
 
 # Setup build for test coverage
 if(BUILD_WITH_COVERAGE)
-  # Currently coverage only works with GNU g++
+  # Currently coverage only works with GNU g++.
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # Find gcov and lcov
     find_program(GCOV gcov)
@@ -155,6 +155,7 @@ if(BUILD_WITH_COVERAGE)
     endif()
 
     set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} "supc++")
+    set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} "quadmath")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -fkeep-inline-functions")
     message(STATUS "Adding debug compile options for code coverage.")
     # Remove optimizations for better line coverage


### PR DESCRIPTION
It seems like for the coverage build to work correctly, it needs to link against `libquadmath`.  Check out the errors from Jenkins:

```
[ 17%] Linking CXX executable ../../../../bin/mlpack_adaboost                                                                                                 
/usr/bin/ld: CMakeFiles/mlpack_adaboost.dir/adaboost_main.cpp.o: undefined reference to symbol 'isnanq@@QUADMATH_1.0'                                         
//usr/lib/x86_64-linux-gnu/libquadmath.so.0: error adding symbols: DSO missing from command line                                                              
collect2: error: ld returned 1 exit status                                                                                                                    
src/mlpack/methods/adaboost/CMakeFiles/mlpack_adaboost.dir/build.make:103: recipe for target 'bin/mlpack_adaboost' failed                                     
make[2]: *** [bin/mlpack_adaboost] Error 1                                                                                                                    
CMakeFiles/Makefile2:1141: recipe for target 'src/mlpack/methods/adaboost/CMakeFiles/mlpack_adaboost.dir/all' failed                                          
make[1]: *** [src/mlpack/methods/adaboost/CMakeFiles/mlpack_adaboost.dir/all] Error 2                                                                         
Makefile:140: recipe for target 'all' failed                                                                                                                  
make: *** [all] Error 2                                                                                                                                       
Build step 'CMake Build' marked build as failure 
```

Link: http://ci.mlpack.org/job/mlpack%20-%20coverage%20build/5/display/redirect