### PR TITLE
Fix pkgconfig regular expression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -716,7 +716,7 @@ if (PKG_CONFIG_FOUND)
     if ("${first}" STREQUAL "/")
       # We need to split the directory and the library.
       string(REGEX REPLACE "(.*/)[^/]*$" "\\1" library_dir "${lib}")
-      string(REGEX REPLACE ".*/lib([^/]*).so.*$" "\\1" library_name "${lib}")
+      string(REGEX REPLACE ".*/lib([^/]*)[.][a-z]*[.]*$" "\\1" library_name "${lib}")
 
       list(APPEND MLPACK_LIBRARIES_LIST "-L${library_dir}")
       list(APPEND MLPACK_LIBRARIES_LIST "-l${library_name}")


### PR DESCRIPTION
This fixes #2097.  Our CMake configuration looks at the list of libraries used at link time, and then converts things like `/usr/local/lib/libarmadillo.so` into `-L/usr/local/lib/ -larmadillo`.  The only thing is, the regular expression I wrote hardcoded the `.so` extension, but that's not right for OS X, where the extension is `.dylib`.  I adjusted the regular expression to handle any extension, and also fixed uses of `.` (which matches any character) to `[.]` (which only matches the period).

Thanks @tomjpsun for pointing out the issue! :+1: