### PR TITLE
Force Boost_NO_BOOST_CMAKE to be on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,12 @@ set(Boost_ADDITIONAL_VERSIONS
   "1.51.1" "1.51.0" "1.51"
   "1.50.1" "1.50.0" "1.50"
   "1.49.1" "1.49.0" "1.49")
+# Disable forced config-mode CMake search for Boost, which only imports targets
+# and does not set the variables that we need.
+#
+# TODO for the brave: transition all mlpack's CMake to 'target-based modern
+# CMake'.  Good luck!  You'll need it.
+set(Boost_NO_BOOST_CMAKE 1)
 find_package(Boost 1.49
     COMPONENTS
       program_options


### PR DESCRIPTION
After dealing with some Boost CMake issues with Boost 1.70 for a while (and the comment in #2097), I spent some time today reading into what is actually going on.  My conclusion is this:

 * CMake 3 is a complete redesign of CMake and prescribes a totally new way of writing CMake configuration scripts that depend on imported targets, instead of `find_package()` calls that set a bunch of variables.

 * According to that line of thought, the entire way we are doing our CMake configuration is dogmatically "wrong": https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/

 * Boost 1.70 now, by default, uses this new CMake approach to import targets, even when the `MODULE` parameter is passed to `find_package()` (which is supposed to force "the old way").

 * I don't have any desire to spend two months adapting and refactoring a CMake approach that already works, when I can't seem to find what the benefit of "modern CMake" would be for us.  I'd rather write actual code.

 * So this patch disables that functionality in Boost's CMake scripts, allowing us to proceed as before, and giving us probably at least a handful of months before the CMake developers decide that they want me to stop working on actual code, disable "the old way", and force me to waste some godawful amount of time on refactoring a working build system.

 * If someone wanted to ever port our build system to use new CMake I'd be more than happy to review it and merge it but I can only imagine how much of a nightmare this would be given what we have to do with CMake for the bindings.  It would probably also break the years of fixes we've added to aid compilation on various systems.

It's possible I'm a little frustrated by this...