### PR TITLE
Remove "smart" handling of `BUILD_JULIA_BINDINGS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(DISABLE_DOWNLOADS "Disable downloads of dependencies during build." OFF)
 option(DOWNLOAD_ENSMALLEN "If ensmallen is not found, download it." ON)
 option(DOWNLOAD_STB_IMAGE "Download stb_image for image loading." ON)
 option(BUILD_PYTHON_BINDINGS "Build Python bindings." ON)
+option(BUILD_JULIA_BINDINGS "Build Julia bindings." ON)
 
 if (WIN32)
   option(BUILD_SHARED_LIBS
@@ -28,15 +29,6 @@ else ()
   option(BUILD_SHARED_LIBS
       "Compile shared libraries (if OFF, static libraries are compiled)." ON)
 endif()
-
-# Detect whether the user passed BUILD_JULIA_BINDINGS in order to determine if
-# we should fail if Julia isn't found.
-if (BUILD_JULIA_BINDINGS AND NOT DEFINED FORCE_BUILD_JULIA_BINDINGS)
-  set(FORCE_BUILD_JULIA_BINDINGS ON CACHE BOOL "Force building Julia bindings.")
-else()
-  set(FORCE_BUILD_JULIA_BINDINGS OFF CACHE BOOL "Force building Julia binidngs.")
-endif()
-option(BUILD_JULIA_BINDINGS "Build Julia bindings." ON)
 
 # Build Markdown bindings for documentation.  This is used as part of website
 # generation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,10 @@ endif()
 
 # Detect whether the user passed BUILD_JULIA_BINDINGS in order to determine if
 # we should fail if Julia isn't found.
-if (BUILD_JULIA_BINDINGS)
-  set(FORCE_BUILD_JULIA_BINDINGS ON)
+if (BUILD_JULIA_BINDINGS AND NOT DEFINED FORCE_BUILD_JULIA_BINDINGS)
+  set(FORCE_BUILD_JULIA_BINDINGS ON CACHE BOOL "Force building Julia bindings.")
 else()
-  set(FORCE_BUILD_JULIA_BINDINGS OFF)
+  set(FORCE_BUILD_JULIA_BINDINGS OFF CACHE BOOL "Force building Julia binidngs.")
 endif()
 option(BUILD_JULIA_BINDINGS "Build Julia bindings." ON)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,10 @@
   * Use log-space to represent HMM initial state and transition probabilities
     (#2081).
 
+  * Add Julia bindings (#1949).  Build settings can be controlled with the
+    `BUILD_JULIA_BINDINGS=(ON/OFF)` and `JULIA_EXECUTABLE=/path/to/julia` CMake
+    parameters.
+
 ### mlpack 3.2.2
 ###### 2019-11-26
   * Add `valid` and `same` padding option in `Convolution` and `Atrous

--- a/src/mlpack/bindings/julia/CMakeLists.txt
+++ b/src/mlpack/bindings/julia/CMakeLists.txt
@@ -2,11 +2,7 @@ if (BUILD_JULIA_BINDINGS)
   ## We need to check here if Julia is even available.  Although actually
   ## technically, I'm not sure if we even need to know!  For the tests though we
   ## do.  So it's probably a good idea to check.
-  if (FORCE_BUILD_JULIA_BINDINGS)
-    find_package(Julia 0.7.0 REQUIRED)
-  else ()
-    find_package(Julia 0.7.0)
-  endif ()
+  find_package(Julia 0.7.0)
 
   if (NOT JULIA_FOUND)
     # We can't build anything, so define the macro to do nothing.


### PR DESCRIPTION
#1949 attempted to add the following behavior:

 - If the user does not set `BUILD_JULIA_BINDINGS`, then build Julia bindings if Julia is available, but if Julia isn't available, don't crash during configuration.
 - If the user *does* set `BUILD_JULIA_BINDINGS` to `ON`, then fail during configuration if Julia isn't found.
 - If the user sets `BUILD_JULIA_BINDINGS` to `OFF`, don't search for Julia or build Julia bindings at all.

It turns out that this behavior is actually quite difficult to get, and actually the current implementation has a bug so that if you run `cmake` twice and don't have Julia available, there will be a configuration failure.  So I have removed the auxiliary variables that control it and set the behavior to the same as the Python bindings, which is that they are built if Julia is available and not if Julia is not available.