### PR TITLE
Add mutator and accessor functions for some layers

### DIFF
--- a/src/mlpack/methods/ann/layer/atrous_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution.hpp
@@ -205,7 +205,7 @@ class AtrousConvolution
   //! Modify the output height.
   size_t& OutputHeight() { return outputHeight; }
 
-  //! Get the input size
+  //! Get the input size.
   const size_t& InputSize() const { return inSize; }
 
   //! Get the output size.
@@ -250,7 +250,7 @@ class AtrousConvolution
   arma::mat& Bias() { return bias; }
 
   /**
-   * Serialize the layer
+   * Serialize the layer.
    */
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */);
@@ -415,7 +415,7 @@ struct version<
 } // namespace serialization
 } // namespace boost
 
-// Include implementation
+// Include implementation.
 #include "atrous_convolution_impl.hpp"
 
 #endif

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -222,6 +222,26 @@ class Convolution
   //! Modify the stride height.
   size_t& StrideHeight() { return strideHeight; }
 
+  //! Get the top padding height.
+  size_t PadHTop() const { return padHTop; }
+  //! Modify the top padding height.
+  size_t& PadHTop() { return padHTop; }
+
+  //! Get the bottom padding height.
+  size_t PadHBottom() const { return padHBottom; }
+  //! Modify the bottom padding height.
+  size_t& PadHBottom() { return padHBottom; }
+
+  //! Get the left padding width.
+  size_t PadWLeft() const { return padWLeft; }
+  //! Modify the left padding width.
+  size_t& PadWLeft() { return padWLeft; }
+
+  //! Get the right padding width.
+  size_t PadWRight() const { return padWRight; }
+  //! Modify the right padding width.
+  size_t& PadWRight() { return padWRight; }
+
   //! Modify the bias weights of the layer.
   arma::mat& Bias() { return bias; }
 

--- a/src/mlpack/methods/ann/layer/linear_no_bias.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias.hpp
@@ -111,6 +111,12 @@ class LinearNoBias
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
 
+  //! Get the input size.
+  size_t InputSize() const { return inSize; }
+
+  //! Get the output size.
+  size_t OutputSize() const { return outSize; }
+
   //! Get the gradient.
   OutputDataType const& Gradient() const { return gradient; }
   //! Modify the gradient.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -2859,6 +2859,10 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerParametersTest)
   BOOST_REQUIRE_EQUAL(layer1.KernelHeight(), 4);
   BOOST_REQUIRE_EQUAL(layer1.StrideWidth(), 5);
   BOOST_REQUIRE_EQUAL(layer1.StrideHeight(), 6);
+  BOOST_REQUIRE_EQUAL(layer1.PadWLeft(), 7);
+  BOOST_REQUIRE_EQUAL(layer1.PadWRight(), 8);
+  BOOST_REQUIRE_EQUAL(layer1.PadHTop(), 9);
+  BOOST_REQUIRE_EQUAL(layer1.PadHBottom(), 10);
 
   // Now modify the parameters to match the second layer.
   layer1.InputWidth() = 12;
@@ -2867,6 +2871,10 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerParametersTest)
   layer1.KernelHeight() = 5;
   layer1.StrideWidth() = 6;
   layer1.StrideHeight() = 7;
+  layer1.PadWLeft() = 8;
+  layer1.PadWRight() = 9;
+  layer1.PadHTop() = 10;
+  layer1.PadHBottom() = 11;
 
   // Now ensure all results are the same.
   BOOST_REQUIRE_EQUAL(layer1.InputWidth(), layer2.InputWidth());
@@ -2875,6 +2883,10 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerParametersTest)
   BOOST_REQUIRE_EQUAL(layer1.KernelHeight(), layer2.KernelHeight());
   BOOST_REQUIRE_EQUAL(layer1.StrideWidth(), layer2.StrideWidth());
   BOOST_REQUIRE_EQUAL(layer1.StrideHeight(), layer2.StrideHeight());
+  BOOST_REQUIRE_EQUAL(layer1.PadWLeft(), layer2.PadWLeft());
+  BOOST_REQUIRE_EQUAL(layer1.PadWRight(), layer2.PadWRight());
+  BOOST_REQUIRE_EQUAL(layer1.PadHTop(), layer2.PadHTop());
+  BOOST_REQUIRE_EQUAL(layer1.PadHBottom(), layer2.PadHBottom());
 }
 
 /**


### PR DESCRIPTION
1. Add accessor and mutator functions for the padding dimensions of the Convolution Layer.
2. Add accessor function for obtaining the input and output dimensions of the LinearNoBias layer.