### PR TITLE
Update the tutorial for building mlpack from source on Windows

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -120,6 +120,7 @@ Copyright:
   Copyright 2019, Vikas S Shetty <shettyvikas209@gmail.com>
   Copyright 2019, Tejasvi Tomar <tstomar@outlook.com>
   Copyright 2019, Jai Agarwal <jai.bhageria@gmail.com>
+  Copyright 2019, Ziyang Jiang <zij004@alumni.stanford.edu>
 
 License: BSD-3-clause
   All rights reserved.

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -102,7 +102,8 @@ cmake -G "Visual Studio 16 2019" -A x64 -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpac
 @endcode
 
 @note If you are using different directory paths, a different configuration (e.g. Release)
-or a different VS version, update the cmake command accordingly.
+or a different VS version, update the cmake command accordingly. If CMake cannot identify the 
+compiler version, check if the Visual Studio compiler and Windows SDK are installed correctly.
 
 - Once it has successfully finished, open "C:\mlpack\armadillo\build\armadillo.sln"
 - Build > Build Solution

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -3,6 +3,7 @@
  * @author German Lancioni
  * @author Miguel Canteras
  * @author Shikhar Jaiswal
+ * @author Ziyang Jiang
 
 @page build_windows Building mlpack From Source on Windows
 

--- a/doc/guide/build_windows.hpp
+++ b/doc/guide/build_windows.hpp
@@ -39,11 +39,11 @@ configuration.
 
 This tutorial has been designed and tested using:
 - Windows 10
-- Visual Studio 2017 (toolset v141)
+- Visual Studio 2019 (toolset v142)
 - mlpack
 - OpenBLAS.0.2.14.1
-- boost_1_66_0-msvc-14.1-64
-- armadillo-8.500.1
+- boost_1_71_0-msvc-14.2-64
+- armadillo (newest version)
 - and x64 configuration
 
 The directories and paths used in this tutorial are just for reference purposes.
@@ -51,7 +51,8 @@ The directories and paths used in this tutorial are just for reference purposes.
 @section build_windows_prereqs Pre-requisites
 
 - Install CMake for Windows (win64-x64 version from https://cmake.org/download/)
-and make sure you can use it from the Command Prompt (may need to add to the PATH)
+and make sure you can use it from the Command Prompt (may need to add the PATH to 
+system environment variables or manually set the PATH before running CMake)
 
 - Download the latest mlpack release from here:
 <a href="https://www.mlpack.org/">mlpack website</a>
@@ -64,6 +65,7 @@ and make sure you can use it from the Command Prompt (may need to add to the PAT
  - Project location: "C:\mlpack\mlpack"
  - Project name: mlpack
  - Finish
+- Make sure the solution configuration is "Debug" and the solution platform is "x64" for this Visual Studio project
 - We will use this Visual Studio project to get the OpenBLAS dependency in the next section
 
 @section build_windows_dependencies Dependencies
@@ -80,7 +82,7 @@ and make sure you can use it from the Command Prompt (may need to add to the PAT
 You can either get Boost via NuGet or you can download the prebuilt Windows binaries separately.
 This tutorial follows the second approach for simplicity.
 
-- Download the "Prebuilt Windows binaries" of the Boost library ("boost_1_66_0-msvc-14.1-64") from
+- Download the "Prebuilt Windows binaries" of the Boost library ("boost_1_71_0-msvc-14.2-64") from
 <a href="https://sourceforge.net/projects/boost/files/boost-binaries/">Sourceforge</a>
 
 @note Make sure you download the MSVC version that matches your Visual Studio
@@ -96,7 +98,7 @@ This tutorial follows the second approach for simplicity.
 - Run cmake:
 
 @code
-cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" ..
+cmake -G "Visual Studio 16 2019" -A x64 -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" ..
 @endcode
 
 @note If you are using different directory paths, a different configuration (e.g. Release)
@@ -114,7 +116,7 @@ or a different VS version, update the cmake command accordingly.
 - Run cmake:
 
 @code
-cmake -G "Visual Studio 15 2017 Win64" -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DARMADILLO_INCLUDE_DIR="C:/mlpack/armadillo/include" -DARMADILLO_LIBRARY:FILEPATH="C:/mlpack/armadillo/build/Debug/armadillo.lib" -DBOOST_INCLUDEDIR:PATH="C:/boost/" -DBOOST_LIBRARYDIR:PATH="C:/boost/lib64-msvc-14.1" -DDEBUG=OFF -DPROFILE=OFF ..
+cmake -G "Visual Studio 16 2019" -A x64 -DBLAS_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DLAPACK_LIBRARY:FILEPATH="C:/mlpack/mlpack/packages/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a" -DARMADILLO_INCLUDE_DIR="C:/mlpack/armadillo/include" -DARMADILLO_LIBRARY:FILEPATH="C:/mlpack/armadillo/build/Debug/armadillo.lib" -DBOOST_INCLUDEDIR:PATH="C:/boost/" -DBOOST_LIBRARYDIR:PATH="C:/boost/lib64-msvc-14.2" -DDEBUG=OFF -DPROFILE=OFF ..
 @endcode
 
 @note cmake will attempt to automatically download the ensmallen dependency. If for some reason cmake can't download the dependency, you will need to manually download ensmallen from http://ensmallen.org/ and extract it to "C:\mlpack\mlpack\deps\". Then, specify the path to ensmallen using the flag: -DENSMALLEN_INCLUDE_DIR=C:/mlpack/mlpack/deps/ensmallen/include
@@ -142,16 +144,16 @@ If you prefer to use cmake GUI, follow these instructions:
     - If there is an error and Boost is not found, try "Add Entry" with the
       following variables and reconfigure:
       - Name: `BOOST_INCLUDEDIR`; type `PATH`; value `C:/boost/`
-      - Name: `BOOST_LIBRARYDIR`; type `PATH`; value `C:/boost/lib64-msvc-14.1`
+      - Name: `BOOST_LIBRARYDIR`; type `PATH`; value `C:/boost/lib64-msvc-14.2`
     - If Boost is still not found, try adding the following variables and
       reconfigure:
       - Name: `Boost_INCLUDE_DIR`; type `PATH`; value `C:/boost/`
-      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_program_options-vc141-mt-gd-x64-1_66.lib`
-      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
-      - Name: `Boost_SERIALIZATION_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_serialization-vc141-mt-gd-x64-1_66.lib`
-      - Name: `Boost_SERIALIZATION_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_program_options-vc141-mt-x64-1_66.lib`
-      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-gd-x64-1_66.lib`
-      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.1/boost_unit_test_framework-vc141-mt-x64-1_66.lib`
+      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.2/boost_program_options-vc142-mt-gd-x64-1_71.lib`
+      - Name: `Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.2/boost_program_options-vc142-mt-x64-1_71.lib`
+      - Name: `Boost_SERIALIZATION_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.2/boost_serialization-vc142-mt-gd-x64-1_71.lib`
+      - Name: `Boost_SERIALIZATION_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.2/boost_program_options-vc142-mt-x64-1_71.lib`
+      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.2/boost_unit_test_framework-vc142-mt-gd-x64-1_71.lib`
+      - Name: `Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE`; type `FILEPATH`; value should be `C:/boost/lib64-msvc-14.2/boost_unit_test_framework-vc142-mt-x64-1_71.lib`
     - Once CMake has configured successfully, hit "Generate" to create the `.sln` file.
 
 @section build_windows_additional_information Additional Information


### PR DESCRIPTION
Update the Visual Studio version to VS2019, tool set version to v142, and corresponding CMake commands.
Add extra instructions to ensure CMake can run correctly.
