### PR TITLE
Update README.md

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -122,6 +122,7 @@ Copyright:
   Copyright 2019, Tejasvi Tomar <tstomar@outlook.com>
   Copyright 2019, Jai Agarwal <jai.bhageria@gmail.com>
   Copyright 2019, Ziyang Jiang <zij004@alumni.stanford.edu>
+  Copyright 2019, Rohit Kartik <rohit.audrey@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ older versions of mlpack:
   - [mlpack documentation](https://www.mlpack.org/docs.html)
   - [Tutorials](https://www.mlpack.org/doc/mlpack-git/doxygen/tutorials.html)
   - [Development Site (Github)](https://www.github.com/mlpack/mlpack/)
-  - [API documentation](https://www.mlpack.org/doc/mlpack-git/doxygen/index.html)
+  - [API documentation (Doxygen)](https://www.mlpack.org/doc/mlpack-git/doxygen/index.html)
 
 ### 8. Bug reporting
 


### PR DESCRIPTION
Added a minor improvement.
Introduction and Further documentation now have the same name for the same link.
This takes care of #2129