### PR TITLE
Adding ComputeError function in lars class

### DIFF
--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -28,7 +28,11 @@ steps:
 # Configure armadillo
 - bash: |
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
+<<<<<<< HEAD
 
+=======
+    
+>>>>>>> Adding changes in documentation
     curl -O http://masterblaster.mlpack.org:5005/armadillo-8.400.0.tar.gz -o armadillo-8.400.0.tar.gz
     tar -xzvf armadillo-8.400.0.tar.gz
 

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -28,11 +28,7 @@ steps:
 # Configure armadillo
 - bash: |
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
-<<<<<<< HEAD
 
-=======
-    
->>>>>>> Adding changes in documentation
     curl -O http://masterblaster.mlpack.org:5005/armadillo-8.400.0.tar.gz -o armadillo-8.400.0.tar.gz
     tar -xzvf armadillo-8.400.0.tar.gz
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,9 @@
   * Add functions to access parameters of `Convolution` and `AtrousConvolution`
     layers (#1985).
 
+  * Add Compute Error function in lars regression and changing Train function to
+    return computed error (#2139).
+
   * Add Julia bindings (#1949).  Build settings can be controlled with the
     `BUILD_JULIA_BINDINGS=(ON/OFF)` and `JULIA_EXECUTABLE=/path/to/julia` CMake
     parameters.

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -552,6 +552,6 @@ double LARS::ComputeError(const arma::mat& matX,
   else
     u = betaPath.back().t() * matX;
 
-  cost = arma::accu(arma::abs(y-u));
+  cost = arma::accu((y - u) % (y - u));
   return cost;
 }

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -539,9 +539,19 @@ void LARS::CholeskyDelete(const size_t colToKill)
   }
 }
 
-arma::mat LARS::ComputeError(const arma::mat& matX,
-                             const arma::rowvec& y)
+double LARS::ComputeError(const arma::mat& matX,
+                          const arma::rowvec& y,
+                          const bool rowMajor)
 {
-  arma::mat cost = arma::inv(arma::trans(matX)*matX)*arma::trans(matX)*y;
+  double cost = 0.0;
+  arma::rowvec u;
+  if (rowMajor)
+    u = trans(matX * betaPath.back());
+  else
+    u = betaPath.back().t() * matX;
+  for (size_t i = 0; i < y.size(); i++)
+  {
+    cost = cost + std::fabs(y[i]-u[i])*std::fabs(y[i]-u[i]);
+  }
   return cost;
 }

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -540,9 +540,8 @@ void LARS::CholeskyDelete(const size_t colToKill)
 }
 
 arma::mat LARS::ComputeError(const arma::mat& matX,
-                          const arma::rowvec& y)
+                             const arma::rowvec& y)
 {
-  arma::mat cost = (y-matX)*(y-matX);
-
+  arma::mat cost = arma::inv(arma::trans(matX)*matX)*arma::trans(matX)*y;
   return cost;
 }

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -545,10 +545,13 @@ double LARS::ComputeError(const arma::mat& matX,
 {
   double cost = 0.0;
   arma::rowvec u;
+  
   if (rowMajor)
     u = trans(matX * betaPath.back());
+  
   else
     u = betaPath.back().t() * matX;
+  
   for (size_t i = 0; i < y.size(); i++)
   {
     cost = cost + std::fabs(y[i]-u[i])*std::fabs(y[i]-u[i]);

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -543,15 +543,13 @@ double LARS::ComputeError(const arma::mat& matX,
                           const arma::rowvec& y,
                           const bool rowMajor)
 {
-  double cost = 0.0;
-  arma::rowvec u;
-
   if (rowMajor)
-    u = trans(matX * betaPath.back());
+  {
+    return arma::accu(arma::pow(y - trans(matX * betaPath.back()), 2.0));
+  }
 
   else
-    u = betaPath.back().t() * matX;
-
-  cost = arma::accu((y - u) % (y - u));
-  return cost;
+  {
+    return arma::accu(arma::pow(y - betaPath.back().t() * matX, 2.0));
+  }
 }

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -552,9 +552,6 @@ double LARS::ComputeError(const arma::mat& matX,
   else
     u = betaPath.back().t() * matX;
 
-  for (size_t i = 0; i < y.size(); i++)
-  {
-    cost = cost + std::fabs(y[i]-u[i])*std::fabs(y[i]-u[i]);
-  }
+  cost = arma::accu(arma::abs(y-u));
   return cost;
 }

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -361,7 +361,7 @@ double LARS::Train(const arma::mat& matX,
   beta = betaPath.back();
 
   Timer::Stop("lars_regression");
-  return maxCorr;
+  return ComputeError(matX, y, transposeData);
 }
 
 double LARS::Train(const arma::mat& data,

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -361,7 +361,7 @@ double LARS::Train(const arma::mat& matX,
   beta = betaPath.back();
 
   Timer::Stop("lars_regression");
-  return ComputeError(matX, y, transposeData);
+  return ComputeError(matX, y, !transposeData);
 }
 
 double LARS::Train(const arma::mat& data,

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -538,3 +538,11 @@ void LARS::CholeskyDelete(const size_t colToKill)
     matUtriCholFactor.shed_row(n);
   }
 }
+
+arma::mat LARS::ComputeError(const arma::mat& matX,
+                          const arma::rowvec& y)
+{
+  arma::mat cost = (y-matX)*(y-matX);
+
+  return cost;
+}

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -545,13 +545,13 @@ double LARS::ComputeError(const arma::mat& matX,
 {
   double cost = 0.0;
   arma::rowvec u;
-  
+
   if (rowMajor)
     u = trans(matX * betaPath.back());
-  
+
   else
     u = betaPath.back().t() * matX;
-  
+
   for (size_t i = 0; i < y.size(); i++)
   {
     cost = cost + std::fabs(y[i]-u[i])*std::fabs(y[i]-u[i]);

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -243,6 +243,21 @@ class LARS
    */
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */);
+  /**
+   * Compute cost error in the given data matrix using the
+   * currently-trained LARS model. Only ||y-betaX||2 is used to calculate
+   * cost error.
+   *
+   * @param data Column-major input data (or row-major input data if rowMajor =
+   *     true).
+   * @param responses A vector of targets.
+   * @param rowMajor Should be true if the data points matrix is row-major and
+   *   false otherwise.
+   * @return The cost error.
+   */
+  double ComputeError(const arma::mat& matX,
+                      const arma::rowvec& y,
+                      const bool rowMajor = false);
 
  private:
   //! Gram matrix.
@@ -328,18 +343,7 @@ class LARS
                     arma::mat& G);
 
   void CholeskyDelete(const size_t colToKill);
-  /**
-   * Find cost error while predicting the value using LARS.
-   *
-   * @param data Column-major input data (or row-major input data if rowMajor =
-   *     true).
-   * @param responses A vector of targets.
-   * @param beta Vector to store the solution (the coefficients) in.
-   * @param transposeData Set to false if the data is row-major.
-   * @return The cost error.
-   */
-  arma::mat ComputeError(const arma::mat& matX,
-                         const arma::rowvec& y);
+
 };
 
 } // namespace regression

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -183,7 +183,7 @@ class LARS
    * @param responses A vector of targets.
    * @param beta Vector to store the solution (the coefficients) in.
    * @param transposeData Set to false if the data is row-major.
-   * @return The final absolute maximum correlation.
+   * @return The minimum cost error.
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,
@@ -202,7 +202,7 @@ class LARS
    * @param responses A vector of targets.
    * @param transposeData Should be true if the input data is column-major and
    *     false otherwise.
-   * @return The final absolute maximum correlation.
+   * @return The minimum cost error.
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,
@@ -254,7 +254,7 @@ class LARS
    * @param responses A vector of targets.
    * @param rowMajor Should be true if the data points matrix is row-major and
    *   false otherwise.
-   * @return The cost error.
+   * @return The minimum cost error.
    */
   double ComputeError(const arma::mat& matX,
                       const arma::rowvec& y,

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -243,6 +243,7 @@ class LARS
    */
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */);
+
   /**
    * Compute cost error in the given data matrix using the
    * currently-trained LARS model. Only ||y-betaX||2 is used to calculate
@@ -343,7 +344,6 @@ class LARS
                     arma::mat& G);
 
   void CholeskyDelete(const size_t colToKill);
-
 };
 
 } // namespace regression

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -328,6 +328,18 @@ class LARS
                     arma::mat& G);
 
   void CholeskyDelete(const size_t colToKill);
+  /**
+   * Find cost error while predicting the value using LARS.
+   *
+   * @param data Column-major input data (or row-major input data if rowMajor =
+   *     true).
+   * @param responses A vector of targets.
+   * @param beta Vector to store the solution (the coefficients) in.
+   * @param transposeData Set to false if the data is row-major.
+   * @return The cost error.
+   */
+  arma::mat ComputeError(const arma::mat& matX,
+                         const arma::rowvec& y);
 };
 
 } // namespace regression

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -183,7 +183,7 @@ class LARS
    * @param responses A vector of targets.
    * @param beta Vector to store the solution (the coefficients) in.
    * @param transposeData Set to false if the data is row-major.
-   * @return The minimum cost error.
+   * @return minimum cost error(||y-beta*X||2 is used to calculate error).
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,
@@ -202,7 +202,7 @@ class LARS
    * @param responses A vector of targets.
    * @param transposeData Should be true if the input data is column-major and
    *     false otherwise.
-   * @return The minimum cost error.
+   * @return minimum cost error(||y-beta*X||2 is used to calculate error).
    */
   double Train(const arma::mat& data,
                const arma::rowvec& responses,
@@ -245,8 +245,8 @@ class LARS
   void serialize(Archive& ar, const unsigned int /* version */);
 
   /**
-   * Compute cost error in the given data matrix using the
-   * currently-trained LARS model. Only ||y-betaX||2 is used to calculate
+   * Compute cost error of the given data matrix using the
+   * currently-trained LARS model. Only ||y-beta*X||2 is used to calculate
    * cost error.
    *
    * @param data Column-major input data (or row-major input data if rowMajor =

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(LARSTrainReturnCorrelation)
 }
 
 /**
- * Test that LARS::ComputeError() returns finite error value.
+ * Test that LARS::ComputeError() returns error value less than 1.
  */
 BOOST_AUTO_TEST_CASE(LARSTestComputeError)
 {
@@ -410,14 +410,12 @@ BOOST_AUTO_TEST_CASE(LARSTestComputeError)
 
   arma::rowvec y = Y.row(0);
 
-  double lambda1 = 0.1;
-
-  LARS lars1(true, lambda1, 0.0);
+  LARS lars1(true, 0.1, 0.0);
   arma::vec betaOpt1;
   lars1.Train(X, y, betaOpt1);
   double cost = lars1.ComputeError(X, y);
 
-  BOOST_REQUIRE_EQUAL(std::isfinite(cost), true);
+  BOOST_REQUIRE_EQUAL(cost <= 1 ,true);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(LARSTestComputeError)
   lars1.Train(X, y, betaOpt1);
   double cost = lars1.ComputeError(X, y);
 
-  BOOST_REQUIRE_EQUAL(cost <= 1 ,true);
+  BOOST_REQUIRE_EQUAL(cost <= 1, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -398,7 +398,8 @@ BOOST_AUTO_TEST_CASE(LARSTrainReturnCorrelation)
 }
 
 /**
- * Test that LARS::ComputeError() returns error value less than 1.
+ * Test that LARS::ComputeError() returns error value less than 1
+ * and greater than 0.
  */
 BOOST_AUTO_TEST_CASE(LARSTestComputeError)
 {
@@ -416,6 +417,7 @@ BOOST_AUTO_TEST_CASE(LARSTestComputeError)
   double cost = lars1.ComputeError(X, y);
 
   BOOST_REQUIRE_EQUAL(cost <= 1, true);
+  BOOST_REQUIRE_EQUAL(cost >= 0, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -397,4 +397,25 @@ BOOST_AUTO_TEST_CASE(LARSTrainReturnCorrelation)
   BOOST_REQUIRE_EQUAL(std::isfinite(maxCorr), true);
 }
 
+BOOST_AUTO_TEST_CASE(LARSTestComputeError)
+{
+  arma::mat X;
+  arma::mat Y;
+
+  data::Load("lars_dependent_x.csv", X);
+  data::Load("lars_dependent_y.csv", Y);
+
+  arma::rowvec y = Y.row(0);
+
+  double lambda1 = 0.1;
+
+  LARS lars1(true, lambda1, 0.0);
+  arma::vec betaOpt1;
+  lars1.Train(X, y, betaOpt1);
+  double cost = lars1.ComputeError(X, y);
+
+  BOOST_REQUIRE_EQUAL(std::isfinite(cost), true);
+
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -415,7 +415,6 @@ BOOST_AUTO_TEST_CASE(LARSTestComputeError)
   double cost = lars1.ComputeError(X, y);
 
   BOOST_REQUIRE_EQUAL(std::isfinite(cost), true);
-
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(TrainingConstructorWithNonDefaultsTest)
 }
 
 /**
- * Test that LARS::Train() returns finite correlation value.
+ * Test that LARS::Train() returns finite error value.
  */
 BOOST_AUTO_TEST_CASE(LARSTrainReturnCorrelation)
 {
@@ -371,32 +371,35 @@ BOOST_AUTO_TEST_CASE(LARSTrainReturnCorrelation)
   // Test with Cholesky decomposition and with lasso.
   LARS lars1(true, lambda1, 0.0);
   arma::vec betaOpt1;
-  double maxCorr = lars1.Train(X, y, betaOpt1);
+  double error = lars1.Train(X, y, betaOpt1);
 
-  BOOST_REQUIRE_EQUAL(std::isfinite(maxCorr), true);
+  BOOST_REQUIRE_EQUAL(std::isfinite(error), true);
 
   // Test without Cholesky decomposition and with lasso.
   LARS lars2(false, lambda1, 0.0);
   arma::vec betaOpt2;
-  maxCorr = lars2.Train(X, y, betaOpt2);
+  error = lars2.Train(X, y, betaOpt2);
 
-  BOOST_REQUIRE_EQUAL(std::isfinite(maxCorr), true);
+  BOOST_REQUIRE_EQUAL(std::isfinite(error), true);
 
   // Test with Cholesky decomposition and with elasticnet.
   LARS lars3(true, lambda1, lambda2);
   arma::vec betaOpt3;
-  maxCorr = lars3.Train(X, y, betaOpt3);
+  error = lars3.Train(X, y, betaOpt3);
 
-  BOOST_REQUIRE_EQUAL(std::isfinite(maxCorr), true);
+  BOOST_REQUIRE_EQUAL(std::isfinite(error), true);
 
   // Test without Cholesky decomposition and with elasticnet.
   LARS lars4(false, lambda1, lambda2);
   arma::vec betaOpt4;
-  maxCorr = lars4.Train(X, y, betaOpt4);
+  error = lars4.Train(X, y, betaOpt4);
 
-  BOOST_REQUIRE_EQUAL(std::isfinite(maxCorr), true);
+  BOOST_REQUIRE_EQUAL(std::isfinite(error), true);
 }
 
+/**
+ * Test that LARS::ComputeError() returns finite error value.
+ */
 BOOST_AUTO_TEST_CASE(LARSTestComputeError)
 {
   arma::mat X;

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -413,11 +413,12 @@ BOOST_AUTO_TEST_CASE(LARSTestComputeError)
 
   LARS lars1(true, 0.1, 0.0);
   arma::vec betaOpt1;
-  lars1.Train(X, y, betaOpt1);
+  double train1 = lars1.Train(X, y, betaOpt1);
   double cost = lars1.ComputeError(X, y);
 
   BOOST_REQUIRE_EQUAL(cost <= 1, true);
   BOOST_REQUIRE_EQUAL(cost >= 0, true);
+  BOOST_REQUIRE_EQUAL(cost == train1, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This is basic implementation to compute cost error for lars fix:#1735 . In this method I only implemented 
||Y-beta*x|| method to calculate error