### PR TITLE
documentation to compile, link and run c++ files

### DIFF
--- a/doc/guide/sample.hpp
+++ b/doc/guide/sample.hpp
@@ -60,7 +60,19 @@ and @c -lblas would be required instead of @c -larmadillo
 In /src
   - filename.cpp
   - CMakeLists.txt
+  - /cmake/FindArmadillo.cmake
+  - /cmake/FindMLPACK.cmake
 
+@note
+Create folders @c /src and @c /src/cmake . 
+Place the files @c FindArmadillo.cmake and @c FindMLPACK.cmake 
+in @c /src/cmake .
+. The required files could be found at 
+ - <a href="https://github.com/mlpack/mlpack/blob/master/CMake/FindArmadillo.cmake"> 
+      FindArmadillo.cmake</a> and
+ - <a href="https://github.com/mlpack/models/blob/master/CMake/FindMLPACK.cmake"> 
+      FindMLPACK.cmake</a>
+      
 @code
 # CMakeLists.txt
 cmake_minimum_required(VERSION 3.10)
@@ -68,15 +80,25 @@ cmake_minimum_required(VERSION 3.10)
 # set the project name
 project(Project_Name VERSION 1.0)
 
+# specify the search path for CMake modules to be loaded by find_package()
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+find_package(Armadillo REQUIRED)
+find_package(MLPACK REQUIRED)
+
+#List of preprocessor include file search directories
+include_directories(${ARMADILLO_INCLUDE_DIRS})
+include_directories(${MLPACK_INCLUDE_DIRS})
+
 add_executable(Project_Name filename.cpp)
 
-target_link_libraries(Project_Name -lmlpack)
-target_link_libraries(Project_Name -larmadillo)
+#Specify libraries to use when linking a target Project_Name
+target_link_libraries(Project_Name ${ARMADILLO_LIBRARIES})
+target_link_libraries(Project_Name ${MLPACK_LIBRARIES})
 @endcode
 
-Steps to build and run using CMake:
+In target directory for executable, run the command:
 @code{.sh}
-#In target directory for executable, run the command:
 cmake path/to/src 
 cmake --build .
 ./Project_Name

--- a/doc/guide/sample.hpp
+++ b/doc/guide/sample.hpp
@@ -20,18 +20,24 @@ compiled easily with g++ or clang from the command line.
 
 Typically the following commands would be used to compile and run the C++ files.
 
-@code{.sh}
-g++ -std=c++11 filename.cpp -o filename
-./filename
-@endcode
-
-If the above commands don't work, it is probably a linker issue. For this, you
-could link the necessary libraries using the following commands.
+@subsection compile_using_gcc Compile Using GCC
 
 @code{.sh}
 g++ -std=c++11 filename.cpp -o filename -lmlpack -larmadillo
 ./filename
 @endcode
+
+@subsection compile_using_clang Compile Using Clang
+
+@code{.sh}
+clang++ -Wall filename.cpp -o filename -lmlpack -larmadillo
+./filename
+@endcode
+
+@note
+Flags like @c -lboost_serialization might be required depending upon the 
+code. If you are using LAPACK and BLAS instead of Armadillo the @c -llapack
+and @c -lblas would be required instead of @c -larmadillo
 
 @section covariance Covariance Computation
 

--- a/doc/guide/sample.hpp
+++ b/doc/guide/sample.hpp
@@ -16,6 +16,23 @@ e.g., @c make @c mlpack_knn or @c make @c mlpack_test; see @ref build.  However,
 any program that uses mlpack (and is not a part of the library itself) can be
 compiled easily with g++ or clang from the command line.
 
+@section compile_link_and_run Compile, Link and Run C++ Files 
+
+Typically the following commands would be used to compile and run the C++ files.
+
+@code{.sh}
+g++ -std=c++11 filename.cpp -o filename
+./filename
+@endcode
+
+If the above commands don't work, it is probably a linker issue. For this, you
+could link the necessary libraries using the following commands.
+
+@code{.sh}
+g++ -std=c++11 filename.cpp -o filename -lmlpack -larmadillo
+./filename
+@endcode
+
 @section covariance Covariance Computation
 
 A simple program to compute the covariance of a data matrix ("data.csv"),

--- a/doc/guide/sample.hpp
+++ b/doc/guide/sample.hpp
@@ -27,6 +27,14 @@ g++ -std=c++11 filename.cpp -o filename -lmlpack -larmadillo
 ./filename
 @endcode
 
+If @c pkg-config is installed:
+
+@code{.sh}
+g++ -std=c++11 filename.cpp -o filename \
+`pkg-config --cflags --libs mlpack armadillo`
+./filename
+@endcode
+
 @subsection compile_using_clang Compile Using Clang
 
 @code{.sh}
@@ -34,10 +42,45 @@ clang++ -Wall filename.cpp -o filename -lmlpack -larmadillo
 ./filename
 @endcode
 
+If @c pkg-config is installed:
+
+@code{.sh}
+clang++ -Wall filename.cpp -o filename \
+`pkg-config --cflags --libs mlpack armadillo`
+./filename
+@endcode
+
 @note
 Flags like @c -lboost_serialization might be required depending upon the 
 code. If you are using LAPACK and BLAS instead of Armadillo the @c -llapack
 and @c -lblas would be required instead of @c -larmadillo
+
+@subsection compile_using_cmake Compile Using Cmake
+
+In /src
+  - filename.cpp
+  - CMakeLists.txt
+
+@code
+# CMakeLists.txt
+cmake_minimum_required(VERSION 3.10)
+
+# set the project name
+project(Project_Name VERSION 1.0)
+
+add_executable(Project_Name filename.cpp)
+
+target_link_libraries(Project_Name -lmlpack)
+target_link_libraries(Project_Name -larmadillo)
+@endcode
+
+Steps to build and run using CMake:
+@code{.sh}
+#In target directory for executable, run the command:
+cmake path/to/src 
+cmake --build .
+./Project_Name
+@endcode
 
 @section covariance Covariance Computation
 


### PR DESCRIPTION
Documented commands to run the simple mlpack examples. Mentioned the solution for linker issues encountered while running the files.