### PR TITLE
Safer adding of stb/ suffix to include directory.

### DIFF
--- a/CMake/FindStbImage.cmake
+++ b/CMake/FindStbImage.cmake
@@ -14,7 +14,6 @@ find_path(STB_IMAGE_INCLUDE_DIR
 
 if(STB_IMAGE_INCLUDE_DIR)
   set(STB_IMAGE_FOUND YES)
-  set(STB_IMAGE_INCLUDE_DIR "${STB_IMAGE_INCLUDE_DIR}/stb/")
 else ()
   find_path(STB_IMAGE_INCLUDE_DIR
         NAMES stb_image.h stb_image_write.h
@@ -22,6 +21,16 @@ else ()
 
   if(STB_IMAGE_INCLUDE_DIR)
     set(STB_IMAGE_FOUND YES)
+  endif ()
+endif ()
+
+# Make sure that stb/ is the last part of the include directory, if it was
+# found.
+if (STB_IMAGE_INCLUDE_DIR)
+  string(REGEX MATCH ".*stb[/]?" STB_INCLUDE_HAS_TRAILING_STB
+      "${STB_IMAGE_INCLUDE_DIR}")
+  if (NOT STB_INCLUDE_HAS_TRAILING_STB)
+    set(STB_IMAGE_INCLUDE_DIR "${STB_IMAGE_INCLUDE_DIR}/stb/")
   endif ()
 endif ()
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,8 @@
     `BUILD_JULIA_BINDINGS=(ON/OFF)` and `JULIA_EXECUTABLE=/path/to/julia` CMake
     parameters.
 
+  * CMake fix for finding STB include directory (#2145).
+
 ### mlpack 3.2.2
 ###### 2019-11-26
   * Add `valid` and `same` padding option in `Convolution` and `Atrous


### PR DESCRIPTION
I noticed that people often get STB include bugs.  This happens because the `FindStbImage.cmake` file will actually append `stb/` to the end of the CMake variable representing the STB include path.  When CMake reconfigures, it will append `stb/` even if the include directory has already been found, so you can end up with STB include directories like `/home/ryan/src/mlpack/build/deps/stb/stb/` which isn't correct.

So, I replaced that functionality with a regex that checks to see whether the include directory ends in `stb`, and only adds `stb/` if that is *not* the case.

@mulx10 let me know what you think of this. :+1: