### PR TITLE
Fix handling of directories with spaces for CMake Python binding configuration

### DIFF
--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -122,19 +122,19 @@ if (BUILDING_PYTHON_BINDINGS)
       PROPERTY INCLUDE_DIRECTORIES)
   add_custom_target(python_configure
       COMMAND ${CMAKE_COMMAND}
-          -D SETUP_PY_IN="${CMAKE_SOURCE_DIR}/src/mlpack/bindings/python/setup.py.in"
-          -D SETUP_PY_OUT="${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py"
+          -D SETUP_PY_IN=${CMAKE_SOURCE_DIR}/src/mlpack/bindings/python/setup.py.in
+          -D SETUP_PY_OUT=${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py
           -D PACKAGE_VERSION="${PACKAGE_VERSION}"
           -D Boost_SERIALIZATION_LIBRARY="${Boost_SERIALIZATION_LIBRARY_RELEASE}"
           -D Boost_LIBRARY_DIRS="${Boost_LIBRARY_DIRS}"
           -D ARMADILLO_LIBRARIES="${ARMADILLO_LIBRARIES}"
-          -D MLPACK_LIBRARY="$<TARGET_LINKER_FILE:mlpack>"
-          -D MLPACK_LIBDIR="$<TARGET_LINKER_FILE_DIR:mlpack>"
+          -D MLPACK_LIBRARY=$<TARGET_LINKER_FILE:mlpack>
+          -D MLPACK_LIBDIR=$<TARGET_LINKER_FILE_DIR:mlpack>
           -D MLPACK_PYXS="${MLPACK_PYXS}"
           -D OpenMP_CXX_FLAGS="${OpenMP_CXX_FLAGS}"
           -D DISABLE_CFLAGS="${DISABLE_CFLAGS}"
           -D CYTHON_INCLUDE_DIRECTORIES="${CYTHON_INCLUDE_DIRECTORIES}"
-          -D OUTPUT_DIR="${CMAKE_BINARY_DIR}"
+          -D OUTPUT_DIR=${CMAKE_BINARY_DIR}
           -P "${CMAKE_SOURCE_DIR}/src/mlpack/bindings/python/ConfigureSetup.cmake"
       BYPRODUCTS "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py"
       COMMENT "Configuring setup.py...")

--- a/src/mlpack/bindings/python/ConfigureSetup.cmake
+++ b/src/mlpack/bindings/python/ConfigureSetup.cmake
@@ -43,4 +43,4 @@ if (NOT EXISTS "${Boost_SERIALIZATION_LIBRARY}")
   endif ()
 endif ()
 
-configure_file("${SETUP_PY_IN}" "${SETUP_PY_OUT}")
+configure_file(${SETUP_PY_IN} ${SETUP_PY_OUT})

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -30,9 +30,12 @@ if not '${OpenMP_CXX_FLAGS}':
 else:
   extra_link_args=['${OpenMP_CXX_FLAGS}']
 
-# Get list of library dirs.
+# Get list of library dirs.  Note that for the list of directories, any
+# directories with a (valid) space in the name will be given to us as '\ '; so,
+# in order to split these right, we first convert all spaces to ';', then
+# convert '\;' back to ' ', then split on ';'.
 library_dirs = list(filter(None, ['${MLPACK_LIBDIR}'] +
-    '${Boost_LIBRARY_DIRS}'.split(' ')))
+    '${Boost_LIBRARY_DIRS}'.replace(' ', ';').replace('\;', ' ').split(' ')))
 
 # We'll link with the exact paths to each library using extra_objects, instead
 # of linking with 'libraries' and 'library_dirs', because of differences in
@@ -73,7 +76,9 @@ else:
                   include_dirs=[ \
                       np.get_include(), \
                       '${OUTPUT_DIR}/src/mlpack/bindings/python/'] +
-                      '${CYTHON_INCLUDE_DIRECTORIES}'.split(' '),
+                      '${CYTHON_INCLUDE_DIRECTORIES}'.replace(' ', ';')
+                                                     .replace('\;', ' ')
+                                                     .split(';'),
                   library_dirs=library_dirs,
                   # CMAKE_CXX_FLAGS seems to have an extra space.
                   extra_compile_args=extra_args,
@@ -89,7 +94,9 @@ else:
                   include_dirs=[ \
                       np.get_include(), \
                       '${OUTPUT_DIR}/src/mlpack/bindings/python/'] +
-                      '${CYTHON_INCLUDE_DIRECTORIES}'.split(' '),
+                      '${CYTHON_INCLUDE_DIRECTORIES}'.replace(' ', ';')
+                                                     .replace('\;', ' ')
+                                                     .split(';'),
                   library_dirs=library_dirs,
                   # CMAKE_CXX_FLAGS seems to have an extra space.
                   extra_compile_args=extra_args,


### PR DESCRIPTION
All the Jenkins builds started failing yesterday with a mysterious error!  When I dug into it, I found that paths with spaces were not being handled correctly when configuring the Python bindings.  I think that the actual proximate cause of why this build failure started happening now is that a system upgrade on mlpack.org caused the versions of mlpack's Python dependencies to be new enough that the bindings started being built---and since the jobs on Jenkins have spaces in their names, their paths on disks therefore have spaces in the names, and this now caused the code to fail.

The patch here should fix that by handling more carefully when directories have spaces in them.  That required a little bit of strangeness in the `setup.py` itself, but it seems to work.

We'll see if it builds correctly on Jenkins... :)