### PR TITLE
Quick-Fix OSX-python27 Bind error.

### DIFF
--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -14,7 +14,7 @@ steps:
     set -e
     sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
     unset BOOST_ROOT
-    pip install cython numpy pandas
+    pip install cython numpy pandas zipp
     brew install openblas armadillo boost
 
     if [ "a$(julia.version)" != "a" ]; then


### PR DESCRIPTION
Hi everyone, since across multiple PRs the CTest fails on OSX-python27, I found a quick fix to remedy the situation. Kindly have a look.
Thanks.