### PR TITLE
adding bce with logits loss function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Added `bce with logits` loss function (#2197).
+
   * Updated terminal state for Pendulum environment (#2354).
 
   * Added `EliSH` activation function (#2323).
@@ -64,7 +66,6 @@
   * Better error handling of eigendecompositions and Cholesky decompositions
     (#2088, #1840).
 
-<<<<<<< HEAD
   * Add LiSHT activation function (#2182).
 
   * Add Valid and Same Padding for Transposed Convolution layer (#2163).
@@ -93,9 +94,6 @@
 
   * Bugfix for incorrect parameter vector sizes in logistic regression and
     softmax regression (#2359).
-=======
-  * Added Binary Cross Entropy with Logits Loss function (#2197).
->>>>>>> b49118f3b... added to HISTORY.md
 
 ### mlpack 3.2.2
 ###### 2019-11-26

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -64,6 +64,7 @@
   * Better error handling of eigendecompositions and Cholesky decompositions
     (#2088, #1840).
 
+<<<<<<< HEAD
   * Add LiSHT activation function (#2182).
 
   * Add Valid and Same Padding for Transposed Convolution layer (#2163).
@@ -92,6 +93,9 @@
 
   * Bugfix for incorrect parameter vector sizes in logistic regression and
     softmax regression (#2359).
+=======
+  * Added Binary Cross Entropy with Logits Loss function (#2197).
+>>>>>>> b49118f3b... added to HISTORY.md
 
 ### mlpack 3.2.2
 ###### 2019-11-26

--- a/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
+++ b/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Define the files we need to compile
 # Anything not in this list will not be compiled into mlpack.
 set(SOURCES
+  bce_with_logits_loss.hpp
+  bce_with_logits_loss_impl.hpp
   cross_entropy_error.hpp
   cross_entropy_error_impl.hpp
   cosine_embedding_loss.hpp

--- a/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp
@@ -41,13 +41,15 @@ class BCEWithLogitsLoss
    * Create the BCEWithLogitsLoss object.
    *
    * @param weight The manual rescaling factor given to loss.
+   * @param posWeight The weight of positive of examples.
+   *    posWeight = total negative examples / total positive examples.
    * @param reduction The boolean value, when 1, means reduction type is 'mean'
-   *                  else if it is 0 then reduction type is 'sum'.
+   *    else if it is 0 then reduction type is 'sum'.
    */
   BCEWithLogitsLoss(
     const double weight = 1.0,
     const double posWeight = 1.0,
-    const bool reduce = true);
+    const bool reduction = true);
 
   /**
    * Computes the binary cross-entropy with logits loss.
@@ -91,10 +93,10 @@ class BCEWithLogitsLoss
   //! Modify the posWeight.
   double& PosWeight() { return posWeight; }
 
-  //! Get the reduce.
-  bool Reduce() const { return reduce; }
-  //! Modify the reduce.
-  bool& Reduce() { return reduce; }
+  //! Get the reduction.
+  bool Reduction() const { return reduction; }
+  //! Modify the reduction.
+  bool& Reduction() { return reduction; }
 
   /**
    * Serialize the layer.
@@ -116,7 +118,7 @@ class BCEWithLogitsLoss
   double posWeight;
 
   //! The boolean value that tells if reduction is mean or sum.
-  bool reduce;
+  bool reduction;
 }; // class BCEWithLogitsLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp
@@ -1,0 +1,128 @@
+/**
+ * @file bce_with_logits_loss.hpp
+ * @author Mrityunjay Tripathi
+ *
+ * Definition of the Binary Cross Entropy with Logits Loss function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTIONS_BCE_WITH_LOGITS_LOSS_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTIONS_BCE_WITH_LOGITS_LOSS_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * The binary cross-entropy with logits performance function measures the loss
+ * between the input and target distributions, where the labels in target can
+ * be 0 or 1. This loss combines a Sigmoid layer and the BCELoss in one single
+ * class. This version is more numerically stable than using a plain Sigmoid
+ * followed by a BCELoss as, by combining the operations into one layer,
+ * we take advantage of the log-sum-exp trick for numerical stability.
+ *
+ * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template <
+    typename InputDataType = arma::mat,
+    typename OutputDataType = arma::mat
+>
+class BCEWithLogitsLoss
+{
+ public:
+  /**
+   * Create the BCEWithLogitsLoss object.
+   *
+   * @param weight The manual rescaling factor given to loss.
+   * @param reduction The boolean value, when 1, means reduction type is 'mean'
+   *                  else if it is 0 then reduction type is 'sum'.
+   */
+  BCEWithLogitsLoss(
+    const double weight = 1.0,
+    const double posWeight = 1.0,
+    const bool reduce = true);
+
+  /**
+   * Computes the binary cross-entropy with logits loss.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param target The target has 1 or 0 values. If the data is
+   *              multi-class then target should be one-hot encoded.
+   */
+  template<typename InputType, typename TargetType>
+  double Forward(const InputType&& input, const TargetType&& target);
+
+  /**
+   * Ordinary feed backward pass of a neural network.
+   *
+   * @param input The propagated input activation.
+   * @param target The target vector.
+   * @param output The calculated loss.
+   */
+  template<typename InputType, typename TargetType, typename OutputType>
+  void Backward(const InputType&& input,
+                const TargetType&& target,
+                OutputType&& output);
+
+  //! Get the input parameter.
+  InputDataType& InputParameter() const { return inputParameter; }
+  //! Modify the input parameter.
+  InputDataType& InputParameter() { return inputParameter; }
+
+  //! Get the output parameter.
+  OutputDataType& OutputParameter() const { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  //! Get the weight.
+  double Weight() const { return weight; }
+  //! Modify the weight.
+  double& Weight() { return weight; }
+
+  //! Get the posWeight.
+  double PosWeight() const { return posWeight; }
+  //! Modify the posWeight.
+  double& PosWeight() { return posWeight; }
+
+  //! Get the reduce.
+  bool Reduce() const { return reduce; }
+  //! Modify the reduce.
+  bool& Reduce() { return reduce; }
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */);
+
+ private:
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
+
+  //! Locally-stored input parameter object.
+  InputDataType inputParameter;
+
+  //! The manual rescaling factor given to the loss.
+  double weight;
+
+  //! The weight for positive examples.
+  double posWeight;
+
+  //! The boolean value that tells if reduction is mean or sum.
+  bool reduce;
+}; // class BCEWithLogitsLoss
+
+} // namespace ann
+} // namespace mlpack
+
+// Include implementation.
+#include "bce_with_logits_loss_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp
@@ -59,7 +59,8 @@ class BCEWithLogitsLoss
    *              multi-class then target should be one-hot encoded.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  typename InputDataType::elem_type
+  Forward(const InputType&& input, const TargetType&& target);
 
   /**
    * Ordinary feed backward pass of a neural network.

--- a/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss_impl.hpp
@@ -1,0 +1,93 @@
+/**
+ * @file bce_with_logits_loss_impl.hpp
+ * @author Mrityunjay Tripathi
+ *
+ * Implementation of the binary cross-entropy with logits loss function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTIONS_BCE_WITH_LOGITS_LOSS_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTIONS_BCE_WITH_LOGITS_LOSS_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "bce_with_logits_loss.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+BCEWithLogitsLoss<InputDataType, OutputDataType>::BCEWithLogitsLoss(
+    const double weight,
+    const double posWeight,
+    const bool reduce) :
+    weight(weight),
+    posWeight(posWeight),
+    reduce(reduce)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename TargetType>
+double BCEWithLogitsLoss<InputDataType, OutputDataType>::Forward(
+    const InputType&& input, const TargetType&& target)
+{
+  double lossThis;
+  double totalLossReduced = 0;
+  double m = input.max();
+  double logSigmoidX;
+  double logOneMinusSigmoidX;
+
+  for (size_t i = 0; i < input.n_elem; ++i)
+  {
+    logSigmoidX = m - std::log(std::exp(m) + std::exp(m - input[i]));
+    logOneMinusSigmoidX = m - std::log(std::exp(m) + std::exp(m + input[i]));
+
+    lossThis =  - weight * (posWeight * target[i] * logSigmoidX
+        + (1 - target[i]) * logOneMinusSigmoidX);
+
+    totalLossReduced += lossThis;
+  }
+
+  if (reduce)
+  {
+    return totalLossReduced / input.n_elem;
+  }
+  return totalLossReduced;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename TargetType, typename OutputType>
+void BCEWithLogitsLoss<InputDataType, OutputDataType>::Backward(
+    const InputType&& input,
+    const TargetType&& target,
+    OutputType&& output)
+{
+  output.set_size(size(input));
+  double sigmoidX;
+
+  for (size_t i = 0; i < output.n_elem; ++i)
+  {
+    sigmoidX = 1 / (1 + std::exp(-input[i]));
+
+    output[i] = - weight * (posWeight * target[i] * (1 - sigmoidX)
+      - (1 - target[i]) * sigmoidX) / output.n_elem;
+  }
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void BCEWithLogitsLoss<InputDataType, OutputDataType>::serialize(
+    Archive& ar,
+    const unsigned int /* version */)
+{
+  // Nothing to do here.
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/bce_with_logits_loss_impl.hpp
@@ -22,10 +22,10 @@ template<typename InputDataType, typename OutputDataType>
 BCEWithLogitsLoss<InputDataType, OutputDataType>::BCEWithLogitsLoss(
     const double weight,
     const double posWeight,
-    const bool reduce) :
+    const bool reduction) :
     weight(weight),
     posWeight(posWeight),
-    reduce(reduce)
+    reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -51,12 +51,7 @@ double BCEWithLogitsLoss<InputDataType, OutputDataType>::Forward(
 
     totalLossReduced += lossThis;
   }
-
-  if (reduce)
-  {
-    return totalLossReduced / input.n_elem;
-  }
-  return totalLossReduced;
+  return reduction ? totalLossReduced / input.n_elem : totalLossReduced;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(BCEWithLogitsLossTest)
   // Test the Backward function.
   module.Backward(std::move(input), std::move(target), std::move(output));
 
-  // Sum of expected output as calculated using pytorch = 0.3034
+  // Sum of expected output as calculated using pytorch = 0.2313
   double expectedOutputSum = arma::accu(output);
   BOOST_REQUIRE_CLOSE_FRACTION(expectedOutputSum, 0.2313, 0.0001);
 

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -15,6 +15,7 @@
 #include <mlpack/core.hpp>
 
 #include <mlpack/methods/ann/layer/layer.hpp>
+#include <mlpack/methods/ann/loss_functions/bce_with_logits_loss.hpp>
 #include <mlpack/methods/ann/loss_functions/huber_loss.hpp>
 #include <mlpack/methods/ann/loss_functions/kl_divergence.hpp>
 #include <mlpack/methods/ann/loss_functions/earth_mover_distance.hpp>
@@ -64,6 +65,27 @@ BOOST_AUTO_TEST_CASE(HuberLossTest)
   // Sum of Expected Output = -0.07125.
   double expectedOutputSum = arma::accu(output);
   BOOST_REQUIRE_CLOSE_FRACTION(expectedOutputSum, -0.07125, 0.00001);
+}
+
+/**
+ * Binary Cross Entropy with Logits Loss function test.
+ */
+BOOST_AUTO_TEST_CASE(BCEWithLogitsLossTest)
+{
+  arma::mat input, output, target;
+  BCEWithLogitsLoss<> module;
+
+  input = arma::mat("-2.73 -1.05 1.97 0.98");
+  target = arma::mat("0.0 0.0 1.0 0.0");
+  double loss = module.Forward(std::move(input), std::move(target));
+  BOOST_REQUIRE_CLOSE_FRACTION(loss, 0.4481, 0.0001);
+
+  // Test the Backward function.
+  module.Backward(std::move(input), std::move(target), std::move(output));
+
+  // Sum of expected output as calculated using pytorch = 0.3034
+  double expectedOutputSum = arma::accu(output);
+  BOOST_REQUIRE_CLOSE_FRACTION(expectedOutputSum, 0.2313, 0.0001);
 
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols);


### PR DESCRIPTION
Hello, Everyone
I am adding Binary Cross Entropy with Logits Loss function. Generally, it is used to combine the Sigmoid layer and Binary Cross-Entropy Loss in one class. This is numerically more stable than using a Sigmoid layer and a Binary Cross-Entropy layer explicitly as it prevents from imploding small values.