### PR TITLE
Add Cosine Embeddings.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -72,6 +72,8 @@
 
   * Add Hinge Embedding Loss Function (#2229).
 
+  * Add Cosine Embedding Loss Function (#2209).
+
 ### mlpack 3.2.2
 ###### 2019-11-26
   * Add `valid` and `same` padding option in `Convolution` and `Atrous

--- a/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
+++ b/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
@@ -3,6 +3,8 @@
 set(SOURCES
   cross_entropy_error.hpp
   cross_entropy_error_impl.hpp
+  cosine_embedding_loss.hpp
+  cosine_embedding_loss_impl.hpp
   dice_loss.hpp
   dice_loss_impl.hpp
   earth_mover_distance.hpp

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -19,7 +19,7 @@ namespace ann /** Artificial Neural Network. */ {
 
 /**
  * Cosine Embeddings Loss function is used for measuring whether two inputs are
- * similar or dissimilar, using using the cosine distance, and is typically used
+ * similar or dissimilar, using the cosine distance, and is typically used
  * for learning nonlinear embeddings or semi-supervised learning.
  *
  * @f{eqnarray*}{
@@ -41,96 +41,77 @@ class CosineEmbeddingLoss
  public:
   /**
    * Create the CosineEmbeddingLoss object.
-   * 
+   *
    * @param margin Increases cosine distance in case of dissimilarity.
    *               Refer definition of cosine-embedding-loss above.
+   * @param similarity Determines whether to use similarity or dissimilarity for
+   *                   comparision.
    * @param takeMean Boolean variable to specify whether to take mean or not.
    *                 Specifies reduction method i.e. sum or mean corresponding
    *                 to 0 and 1 respectively. Default value = 0.
    */
-  CosineEmbeddingLoss(const double margin = 0.0, const bool takeMean = false);
+  CosineEmbeddingLoss(const double margin = 0.0,
+                       const bool similarity = true,
+                       const bool takeMean = false);
 
   /**
    * Ordinary feed forward pass of a neural network.
    *
-   * @param x1 Input data used for evaluating the given function.
-   * @param x2 Input data used for evaluating the given function.
-   * @param y Input data used to determine whether to calculate
-   *          cosine similarity or dissimilarity. It should only
-   *          contain values equal to 1 or -1.
+   * @param input Input data used for evaluating the specified function.
+   * @param target The target vector.
    */
-  template<
-    typename FirstTensor,
-    typename SecondTensor,
-    typename ThirdTensor
-  >
-  double Forward(const FirstTensor&& x1, const SecondTensor&& x2,
-      const ThirdTensor&& y);
+  template <typename InputType, typename TargetType>
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
-   * Ordinary feed backward pass of a neural network. The negative log
-   * likelihood layer expects that the input contains log-probabilities for
-   * each class. The layer also expects a class index, in the range between 1
-   * and the number of classes, as target when calling the Forward function.
+   * Ordinary feed backward pass of a neural network.
    *
-   * @param x1 The propagated input activation.
-   * @param x2 The propagated input activation.
-   * @param y The target vector, that contains the class index in the range
-   *        between 1 and the number of classes.
+   * @param input The propagated input activation.
+   * @param target The target vector.
    * @param output The calculated error.
    */
-  template<
-    typename FirstTensor,
-    typename SecondTensor,
-    typename ThirdTensor,
-    typename OutputTensor
-  >
-  void Backward(const FirstTensor&& x1,
-                const SecondTensor&& x2,
-                const ThirdTensor&& y,
-                const OutputTensor&& output);
+  template<typename InputType, typename TargetType, typename OutputType>
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the input parameter.
-  InputDataType& InputParameter() const { return inputParameter; }
+  InputDataType &InputParameter() const { return inputParameter; }
   //! Modify the input parameter.
-  InputDataType& InputParameter() { return inputParameter; }
+  InputDataType &InputParameter() { return inputParameter; }
 
   //! Get the output parameter.
-  OutputDataType& OutputParameter() const { return outputParameter; }
+  OutputDataType &OutputParameter() const { return outputParameter; }
   //! Modify the output parameter.
-  OutputDataType& OutputParameter() { return outputParameter; }
+  OutputDataType &OutputParameter() { return outputParameter; }
 
   //! Get the delta.
-  OutputDataType& Delta() const { return delta; }
+  OutputDataType &Delta() const { return delta; }
   //! Modify the delta.
-  OutputDataType& Delta() { return delta; }
+  OutputDataType &Delta() { return delta; }
 
   //! Get the value of takeMean.
   bool TakeMean() const { return takeMean; }
   //! Modify the value of takeMean.
-  bool& TakeMean() { return takeMean; }
+  bool &TakeMean() { return takeMean; }
 
   //! Get the value of margin.
-  bool Margin() const { return margin; }
+  double Margin() const { return margin; }
   //! Modify the value of takeMean.
-  bool& Margin() { return margin; }
-  
+  double &Margin() { return margin; }
+
+  //! Get the value of similarity hyperparameter.
+  bool Similarity() const { return similarity; }
+  //! Modify the value of takeMean.
+  bool &Similarity() { return similarity; }
 
   /**
    * Serialize the layer.
    */
   template<typename Archive>
-  void serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
-  // Returns Cosine-Distance between two vectors.
-  template <typename FirstTensor, typename SecondTensor>
-  double CosineDistance(const FirstTensor&& x1,
-                        const SecondTensor&& x2)
-  {
-    return arma::dot(arma::normalise(x1), arma::normalise(x2));
-  }
-
   //! Locally-stored delta object.
   OutputDataType delta;
 
@@ -140,10 +121,13 @@ class CosineEmbeddingLoss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Locally-stored value of margin parameter.
+  //! Locally-stored value of similarity hyper-parameter.
+  bool similarity;
+
+  //! Locally-stored value of margin hyper-parameter.
   double margin;
 
-  //! Locally-stored value of takeMean parameter.
+  //! Locally-stored value of takeMean hyper-parameter.
   bool takeMean;
 }; // class CosineEmbeddingLoss
 

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -59,9 +59,13 @@ class CosineEmbeddingLoss
    *          cosine similarity or dissimilarity. It should only
    *          contain values equal to 1 or -1.
    */
-  template<typename InputType, typename TargetType>
-  double Forward(const InputType&& x1, const InputType x2,
-      const TargetType&& y);
+  template<
+    typename FirstTensor,
+    typename SecondTensor,
+    typename ThirdTensor
+  >
+  double Forward(const FirstTensor&& x1, const SecondTensor&& x2,
+      const ThirdTensor&& y);
 
   /**
    * Ordinary feed backward pass of a neural network. The negative log
@@ -69,15 +73,22 @@ class CosineEmbeddingLoss
    * each class. The layer also expects a class index, in the range between 1
    * and the number of classes, as target when calling the Forward function.
    *
-   * @param input The propagated input activation.
-   * @param target The target vector, that contains the class index in the range
+   * @param x1 The propagated input activation.
+   * @param x2 The propagated input activation.
+   * @param y The target vector, that contains the class index in the range
    *        between 1 and the number of classes.
    * @param output The calculated error.
    */
-  template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  template<
+    typename FirstTensor,
+    typename SecondTensor,
+    typename ThirdTensor,
+    typename OutputTensor
+  >
+  void Backward(const FirstTensor&& x1,
+                const SecondTensor&& x2,
+                const ThirdTensor&& y,
+                const OutputTensor&& output);
 
   //! Get the input parameter.
   InputDataType& InputParameter() const { return inputParameter; }
@@ -113,11 +124,11 @@ class CosineEmbeddingLoss
 
  private:
   // Returns Cosine-Distance between two vectors.
-  template <typename InputType>
-  double CosineDistance(InputType x1, InputType x2)
+  template <typename FirstTensor, typename SecondTensor>
+  double CosineDistance(const FirstTensor&& x1,
+                        const SecondTensor&& x2)
   {
-    return 1.0 - arma::accu(x1 % x2) /
-        std::sqrt(arma::accu(arma::pow(x1, 2)) * arma::accu(arma::pow(x2, 2)));
+    return arma::dot(arma::normalise(x1), arma::normalise(x2));
   }
 
   //! Locally-stored delta object.

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -1,0 +1,145 @@
+/**
+ * @file cosine_embedding_loss.hpp
+ * @author Kartik Dutt
+ *
+ * Definition of the Cosine Embedding loss function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_COSINE_EMBEDDING_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_COSINE_EMBEDDING_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * Cosine Embeddings Loss function is used for measuring whether two inputs are
+ * similar or dissimilar, using using the cosine distance, and is typically used
+ * for learning nonlinear embeddings or semi-supervised learning.
+ *
+ * @f{eqnarray*}{
+ * f(x) = 1 - cos(x1, x2) , for y = 1
+ * f(x) = max(0, cos(x1, x2) - margin) , for y = -1
+ * @f}
+ * 
+ * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template <
+    typename InputDataType = arma::mat,
+    typename OutputDataType = arma::mat
+>
+class CosineEmbeddingLoss
+{
+ public:
+  /**
+   * Create the CosineEmbeddingLoss object.
+   * 
+   * @param margin Increases cosine distance in case of dissimilarity.
+   *               Refer definition of cosine-embedding-loss above.
+   * @param takeMean Boolean variable to specify whether to take mean or not.
+   *                 Specifies reduction method i.e. sum or mean corresponding
+   *                 to 0 and 1 respectively. Default value = 0.
+   */
+  CosineEmbeddingLoss(const double margin = 0.0, const bool takeMean = false);
+
+  /**
+   * Ordinary feed forward pass of a neural network.
+   *
+   * @param x1 Input data used for evaluating the given function.
+   * @param x2 Input data used for evaluating the given function.
+   * @param y Input data used to determine whether to calculate
+   *          cosine similarity or dissimilarity. It should only
+   *          contain values equal to 1 or -1.
+   */
+  template<typename InputType, typename TargetType>
+  double Forward(const InputType&& x1, const InputType x2,
+      const TargetType&& y);
+
+  /**
+   * Ordinary feed backward pass of a neural network. The negative log
+   * likelihood layer expects that the input contains log-probabilities for
+   * each class. The layer also expects a class index, in the range between 1
+   * and the number of classes, as target when calling the Forward function.
+   *
+   * @param input The propagated input activation.
+   * @param target The target vector, that contains the class index in the range
+   *        between 1 and the number of classes.
+   * @param output The calculated error.
+   */
+  template<typename InputType, typename TargetType, typename OutputType>
+  void Backward(const InputType&& input,
+                const TargetType&& target,
+                OutputType&& output);
+
+  //! Get the input parameter.
+  InputDataType& InputParameter() const { return inputParameter; }
+  //! Modify the input parameter.
+  InputDataType& InputParameter() { return inputParameter; }
+
+  //! Get the output parameter.
+  OutputDataType& OutputParameter() const { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  //! Get the delta.
+  OutputDataType& Delta() const { return delta; }
+  //! Modify the delta.
+  OutputDataType& Delta() { return delta; }
+
+  //! Get the value of takeMean.
+  bool TakeMean() const { return takeMean; }
+  //! Modify the value of takeMean.
+  bool& TakeMean() { return takeMean; }
+
+  //! Get the value of margin.
+  bool Margin() const { return margin; }
+  //! Modify the value of takeMean.
+  bool& Margin() { return margin; }
+  
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& /* ar */, const unsigned int /* version */);
+
+ private:
+  // Returns Cosine-Distance between two vectors.
+  template <typename InputType>
+  double CosineDistance(InputType x1, InputType x2)
+  {
+    return 1.0 - arma::accu(x1 % x2) /
+        std::sqrt(arma::accu(arma::pow(x1, 2)) * arma::accu(arma::pow(x2, 2)));
+  }
+
+  //! Locally-stored delta object.
+  OutputDataType delta;
+
+  //! Locally-stored input parameter object.
+  InputDataType inputParameter;
+
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
+
+  //! Locally-stored value of margin parameter.
+  double margin;
+
+  //! Locally-stored value of takeMean parameter.
+  bool takeMean;
+}; // class CosineEmbeddingLoss
+
+} // namespace ann
+} // namespace mlpack
+
+// Include implementation.
+#include "cosine_embedding_loss_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -18,7 +18,7 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 /**
- * Cosine Embeddings Loss function is used for measuring whether two inputs are
+ * Cosine Embedding Loss function is used for measuring whether two inputs are
  * similar or dissimilar, using the cosine distance, and is typically used
  * for learning nonlinear embeddings or semi-supervised learning.
  *
@@ -51,8 +51,8 @@ class CosineEmbeddingLoss
    *                 to 0 and 1 respectively. Default value = 0.
    */
   CosineEmbeddingLoss(const double margin = 0.0,
-                       const bool similarity = true,
-                       const bool takeMean = false);
+                      const bool similarity = true,
+                      const bool takeMean = false);
 
   /**
    * Ordinary feed forward pass of a neural network.
@@ -61,7 +61,8 @@ class CosineEmbeddingLoss
    * @param target The target vector.
    */
   template <typename InputType, typename TargetType>
-  double Forward(const InputType& input, const TargetType& target);
+  typename InputType::elem_type Forward(const InputType& input,
+                                        const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -76,34 +77,34 @@ class CosineEmbeddingLoss
                 OutputType& output);
 
   //! Get the input parameter.
-  InputDataType &InputParameter() const { return inputParameter; }
+  InputDataType& InputParameter() const { return inputParameter; }
   //! Modify the input parameter.
-  InputDataType &InputParameter() { return inputParameter; }
+  InputDataType& InputParameter() { return inputParameter; }
 
   //! Get the output parameter.
-  OutputDataType &OutputParameter() const { return outputParameter; }
+  OutputDataType& OutputParameter() const { return outputParameter; }
   //! Modify the output parameter.
-  OutputDataType &OutputParameter() { return outputParameter; }
+  OutputDataType& OutputParameter() { return outputParameter; }
 
   //! Get the delta.
-  OutputDataType &Delta() const { return delta; }
+  OutputDataType& Delta() const { return delta; }
   //! Modify the delta.
-  OutputDataType &Delta() { return delta; }
+  OutputDataType& Delta() { return delta; }
 
   //! Get the value of takeMean.
   bool TakeMean() const { return takeMean; }
   //! Modify the value of takeMean.
-  bool &TakeMean() { return takeMean; }
+  bool& TakeMean() { return takeMean; }
 
   //! Get the value of margin.
   double Margin() const { return margin; }
   //! Modify the value of takeMean.
-  double &Margin() { return margin; }
+  double& Margin() { return margin; }
 
   //! Get the value of similarity hyperparameter.
   bool Similarity() const { return similarity; }
   //! Modify the value of takeMean.
-  bool &Similarity() { return similarity; }
+  bool& Similarity() { return similarity; }
 
   /**
    * Serialize the layer.

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
@@ -1,0 +1,88 @@
+/**
+ * @file cosine_embedding_loss_impl.hpp
+ * @author Kartik Dutt
+ *
+ * Implementation of the Cosine Embedding loss function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_COSINE_EMBEDDING_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_COSINE_EMBEDDING_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "cosine_embedding_loss.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+CosineEmbeddingLoss<InputDataType, OutputDataType>::CosineEmbeddingLoss(
+    const double margin, const bool takeMean):
+    margin(margin), takeMean(takeMean)
+{
+  // Nothing to do here.
+}
+
+template <typename InputDataType, typename OutputDataType>
+template <typename InputType, typename TargetType>
+double CosineEmbeddingLoss<InputDataType, OutputDataType>::Forward(
+    const InputType &&x1, const InputType &&x2, const TargetType &&y)
+{
+  if (x1.n_rows != x2.n_rows || x1.n_cols != x2.n_cols ||
+      x1.n_slices != x2.n_slices)
+  {
+    Log::Fatal << "Input Dimensions must be same." << std::endl;
+  }
+
+  if(y.n_elem != x1.n_rows * x1.n_slices)
+  {
+    Log::Fatal << "Number of rows mismatch." << std::endl;
+  }
+  
+  arma::colvec inputTemp1 = arma::vectorise(x1);
+  arma::colvec inputTemp2 = arma::vectorise(x2);
+  double loss = 0.0;
+  const size_t cols = x1.n_cols;
+  const size_t batchSize = x1.n_rows * x1.n_slices;
+
+  for(size_t i = 0; i < batchSize; i += cols)
+  {
+    if (y(i / cols) == 1)
+    {
+      loss += 1 - CosineDistance(inputTemp1(arma::span(i, i + cols - 1)),
+          inputTemp2(arma::span(i, i + cols -1)));
+    }
+    else if (y(i / cols) == -1)
+    {
+      loss += std::max(CosineDistance(inputTemp1(arma::span(i, i + cols - 1)),
+          inputTemp2(arma::span(i, i + cols -1))) - margin, 0);
+    }
+    else
+    {
+      Log::Fatal << "y should only contain 1 and -1." << std::endl;
+    }
+  }
+
+  if(takeMean)
+  {
+    loss = (double)loss / y.n_elem;
+  }
+  return loss;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void CosineEmbeddingLoss<InputDataType, OutputDataType>::serialize(
+    Archive& /* ar */,
+    const unsigned int /* version */)
+{
+  // Nothing to do here.
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
@@ -26,18 +26,26 @@ CosineEmbeddingLoss<InputDataType, OutputDataType>::CosineEmbeddingLoss(
   // Nothing to do here.
 }
 
-template <typename InputDataType, typename OutputDataType>
-template <typename InputType, typename TargetType>
+template<typename InputDataType, typename OutputDataType>
+template<
+    typename FirstTensor,
+    typename SecondTensor,
+    typename ThirdTensor
+>
 double CosineEmbeddingLoss<InputDataType, OutputDataType>::Forward(
-    const InputType &&x1, const InputType &&x2, const TargetType &&y)
+    const FirstTensor&& x1,
+    const SecondTensor&& x2,
+    const ThirdTensor&& y)
 {
+  const size_t cols = x1.n_cols;
+  const size_t batchSize = x1.n_elem / cols;
   if (x1.n_rows != x2.n_rows || x1.n_cols != x2.n_cols ||
-      x1.n_slices != x2.n_slices)
+      x1.n_elem != x2.n_elem)
   {
     Log::Fatal << "Input Dimensions must be same." << std::endl;
   }
 
-  if(y.n_elem != x1.n_rows * x1.n_slices)
+  if (y.n_elem < batchSize)
   {
     Log::Fatal << "Number of rows mismatch." << std::endl;
   }
@@ -45,20 +53,19 @@ double CosineEmbeddingLoss<InputDataType, OutputDataType>::Forward(
   arma::colvec inputTemp1 = arma::vectorise(x1);
   arma::colvec inputTemp2 = arma::vectorise(x2);
   double loss = 0.0;
-  const size_t cols = x1.n_cols;
-  const size_t batchSize = x1.n_rows * x1.n_slices;
 
-  for(size_t i = 0; i < batchSize; i += cols)
+  for(size_t i = 0; i < inputTemp1.n_elem; i+=cols)
   {
     if (y(i / cols) == 1)
     {
       loss += 1 - CosineDistance(inputTemp1(arma::span(i, i + cols - 1)),
-          inputTemp2(arma::span(i, i + cols -1)));
+          inputTemp2(arma::span(i, i + cols - 1)));
     }
     else if (y(i / cols) == -1)
     {
-      loss += std::max(CosineDistance(inputTemp1(arma::span(i, i + cols - 1)),
-          inputTemp2(arma::span(i, i + cols -1))) - margin, 0);
+      double currentLoss = CosineDistance(inputTemp1(arma::span(i, i + cols - 1)),
+          inputTemp2(arma::span(i, i + cols - 1))) - margin;
+      loss += currentLoss > 0 ? currentLoss : 0;
     }
     else
     {
@@ -66,11 +73,58 @@ double CosineEmbeddingLoss<InputDataType, OutputDataType>::Forward(
     }
   }
 
-  if(takeMean)
+  if (takeMean)
   {
     loss = (double)loss / y.n_elem;
   }
   return loss;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<
+    typename FirstTensor,
+    typename SecondTensor,
+    typename ThirdTensor,
+    typename OutputTensor
+>
+void CosineEmbeddingLoss<InputDataType, OutputDataType>::Backward(
+    const FirstTensor&& x1,
+    const SecondTensor&& x2,
+    const ThirdTensor&& y,
+    const OutputTensor&& output)
+{
+  const size_t cols = x1.n_cols;
+  const size_t batchSize = x1.n_elem / cols;
+  if (x1.n_rows != x2.n_rows || x1.n_cols != x2.n_cols ||
+      x1.n_elem != x2.n_elem)
+  {
+    Log::Fatal << "Input Dimensions must be same." << std::endl;
+  }
+
+  if (y.n_elem < batchSize)
+  {
+    Log::Fatal << "Number of rows mismatch." << std::endl;
+  }
+  
+  arma::colvec inputTemp1 = arma::vectorise(x1);
+  arma::colvec inputTemp2 = arma::vectorise(x2);
+  arma::colvec outputTemp(inputTemp1.n_elem, 1);
+
+  for(size_t i = 0; i < inputTemp1.n_elem; i+=cols)
+  {
+    if (y(i / cols) != 1 && y(i / cols) != -1)
+    {
+      Log::Fatal << "y should only contain 1 and -1." << std::endl;
+    }
+
+    outputTemp(arma::span(i, i + cols -1)) = arma::sign(y(i / cols)) *
+        (arma::normalise(inputTemp2(arma::span(i, i + cols - 1))) -
+        arma::normalise(inputTemp1(arma::span(i, i + cols - 1))) *
+        CosineDistance(inputTemp1(arma::span(i, i + cols - 1)),
+        inputTemp2(arma::span(i, i + cols - 1)))) /
+        std::sqrt(arma::accu(arma::pow(inputTemp1(arma::span(i, i + cols - 1)),
+        2)));
+  }
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -25,8 +25,15 @@
 #include <mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp>
 #include <mlpack/methods/ann/loss_functions/mean_bias_error.hpp>
 #include <mlpack/methods/ann/loss_functions/dice_loss.hpp>
+<<<<<<< HEAD
 #include <mlpack/methods/ann/loss_functions/log_cosh_loss.hpp>
+<<<<<<< HEAD
 #include <mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp>
+=======
+=======
+#include <mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp>
+>>>>>>> Add Cosine Embeddings
+>>>>>>> Add Cosine Embeddings
 #include <mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp>
 #include <mlpack/methods/ann/ffn.hpp>
 
@@ -578,4 +585,23 @@ BOOST_AUTO_TEST_CASE(HingeEmbeddingLossTest)
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols);
 }
+
+/**
+ * Simple test for the Cosine Embedding loss function.
+ */
+BOOST_AUTO_TEST_CASE(CosineEmbeddingLossTest)
+{
+  arma::mat input1, input2, y, target, output;
+  double loss;
+  CosineEmbeddingLoss<> module;
+
+  // Test the Forward function. Loss should be 0 if input1 = input2 and y = 1.
+  input1 = arma::ones(10, 1);
+  input2 = arma::ones(10, 1);
+  y = arma::ones(1);
+  loss = module.Forward(std::move(input1),std::move(input1),
+      std::move(target));
+  BOOST_REQUIRE_CLOSE(loss, 0.0, 1e-4);
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -621,7 +621,7 @@ BOOST_AUTO_TEST_CASE(CosineEmbeddingLossTest)
   input2(1) = 2;
   input2(2) = 2;
   loss = module.Forward(input1, input2);
-  // Caclulated using torch.nn.CosineEmbeddingLoss().
+  // Calculated using torch.nn.CosineEmbeddingLoss().
   BOOST_REQUIRE_CLOSE(loss, 2.897367, 1e-3);
 
   // Test the Backward function.
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE(CosineEmbeddingLossTest)
   input4(9) = 2;
   input4(11) = 2;
   loss = module2.Forward(input3, input4);
-  // Caclulated using torch.nn.CosineEmbeddingLoss().
+  // Calculated using torch.nn.CosineEmbeddingLoss().
   BOOST_REQUIRE_CLOSE(loss, 0.55395, 1e-3);
 
   // Test the Backward function.


### PR DESCRIPTION
In reference to issue #2200, I have implemented cosine embeddings.
Use Cases:
1. Get Cosine Similarity or dissimilarity between two vectors.
2. Useful in text classification.
3. Useful in face recognition (embedding based).
4. Clustering.

It is implemented in Pytorch, documentation can be found [here](https://pytorch.org/docs/stable/nn.html#cosineembeddingloss).
Test cases can be found [here](https://colab.research.google.com/drive/1Epmw0TKK20OILNOc1hTLA_cnBCmuBtE3#scrollTo=pyjnHHpQJvOm).