### PR TITLE
Added custom loss function that can be defined externally.

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
+++ b/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SOURCES
   reconstruction_loss_impl.hpp
   sigmoid_cross_entropy_error.hpp
   sigmoid_cross_entropy_error_impl.hpp
+  custom_loss.hpp
+  custom_loss_impl.hpp
 )
 
 # Add directory name to sources.

--- a/src/mlpack/methods/ann/loss_functions/custom_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/custom_loss.hpp
@@ -1,0 +1,95 @@
+/**
+ * @file custom_loss.hpp
+ * @author Prince Gupta
+ *
+ * Definition for custom loss function class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_CUSTOM_LOSS_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_CUSTOM_LOSS_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * We can define any custom loss function after defining how it works
+ * on basic level.
+ * 
+ * @tparam InputDataType Type of input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template <
+    typename InputDataType = arma::mat,
+    typename OutputDataType = arma::mat
+>
+class CustomLoss
+{
+ public:
+  /**
+   * Create the custom loss function with defined forward and backward
+   * propagation functions.
+   * 
+   * @param forward custom forward function for the loss that takes in
+   *        input and target matrices as parameter and returns loss.
+   * @param backward custom backward function for the loss that takes in
+   *        input, target and output matrices as parameter and saves the
+   *        gradient in the ouput matrix.
+   */
+  CustomLoss(std::function<double(const InputDataType&&, const InputDataType&&)> forward,
+             std::function<void(const InputDataType&&, const InputDataType&&, OutputDataType&&)> backward);
+  /**
+   * Computes the specified custom loss function.
+   * 
+   * @param input Input data used for evaluating the specified function.
+   * @param target The target vector.
+   */
+  template<typename InputType, typename TargetType>
+  double Forward(const InputType&& input, const TargetType&& target);
+
+  /**
+   * Ordinary feed backward pass of a neural network.
+   *
+   * @param input The propagated input activation.
+   * @param target The target vector.
+   * @param output The calculated error.
+   */
+  template<typename InputType, typename TargetType, typename OutputType>
+  void Backward(const InputType&& input,
+                const TargetType&& target,
+                OutputType&& output);
+
+  //! Get the output parameter.
+  OutputDataType& OutputParameter() const { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */);
+
+ private:
+  //!Locally-stored output parameter object.
+  OutputDataType outputParameter;
+  //! Locally-stored forward function.
+  std::function<double(const InputDataType&&, const InputDataType&&)> forward;
+  //! Locally-stored backward function.
+  std::function<void(const InputDataType&&, const InputDataType&&, OutputDataType&&)> backward;
+}; // class CustomLoss
+
+} // namespace ann
+} // namespace mlpack
+
+// Include implementation
+#include "custom_loss_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/custom_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/custom_loss.hpp
@@ -43,8 +43,11 @@ class CustomLoss
    *        input, target and output matrices as parameter and saves the
    *        gradient in the ouput matrix.
    */
-  CustomLoss(std::function<double(const InputDataType&&, const InputDataType&&)> forward,
-             std::function<void(const InputDataType&&, const InputDataType&&, OutputDataType&&)> backward);
+  CustomLoss(
+      std::function<double(const InputDataType&&,
+                           const InputDataType&&)> forward,
+      std::function<void(const InputDataType&&,
+                         const InputDataType&&, OutputDataType&&)> backward);
   /**
    * Computes the specified custom loss function.
    * 
@@ -78,12 +81,14 @@ class CustomLoss
   void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
-  //!Locally-stored output parameter object.
+  //! Locally-stored output parameter object.
   OutputDataType outputParameter;
   //! Locally-stored forward function.
   std::function<double(const InputDataType&&, const InputDataType&&)> forward;
   //! Locally-stored backward function.
-  std::function<void(const InputDataType&&, const InputDataType&&, OutputDataType&&)> backward;
+  std::function<void(const InputDataType&&,
+                     const InputDataType&&,
+                     OutputDataType&&)> backward;
 }; // class CustomLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/custom_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/custom_loss_impl.hpp
@@ -21,7 +21,9 @@ namespace ann /** Artificial Neural Network. */ {
 template<typename InputDataType, typename OutputDataType>
 CustomLoss<InputDataType, OutputDataType>::CustomLoss(
     std::function<double(const InputDataType&&, const InputDataType&&)> forward,
-    std::function<void(const InputDataType&&, const InputDataType&&, OutputDataType&&)> backward) : 
+    std::function<void(const InputDataType&&,
+                       const InputDataType&&,
+                       OutputDataType&&)> backward) :
       forward(forward), backward(backward)
 {
   // Nothing to do here.

--- a/src/mlpack/methods/ann/loss_functions/custom_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/custom_loss_impl.hpp
@@ -1,0 +1,60 @@
+/**
+ * @file custom_loss_impl.hpp
+ * @author Prince Gupta
+ *
+ * Implementation of the mean squared error performance function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_CUSTOM_LOSS_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_CUSTOM_LOSS_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "custom_loss.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+CustomLoss<InputDataType, OutputDataType>::CustomLoss(
+    std::function<double(const InputDataType&&, const InputDataType&&)> forward,
+    std::function<void(const InputDataType&&, const InputDataType&&, OutputDataType&&)> backward) : 
+      forward(forward), backward(backward)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename TargetType>
+double CustomLoss<InputDataType, OutputDataType>::Forward(
+    const InputType&& input, const TargetType&& target)
+{
+  return forward(std::move(input), std::move(target));
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename TargetType, typename OutputType>
+void CustomLoss<InputDataType, OutputDataType>::Backward(
+    const InputType&& input,
+    const TargetType&& target,
+    OutputType&& output)
+{
+  backward(std::move(input), std::move(target), std::move(output));
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void CustomLoss<InputDataType, OutputDataType>::serialize(
+    Archive& /* ar */,
+    const unsigned int /* version */)
+{
+  // Nothing to do here.
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif


### PR DESCRIPTION
Hi, I've added Loss layer for which forward and backward functions can be defined externally.
This will allow users to test their own loss functions instead of just being able to use predefined ones.

**Why I did this?**
Keras and Pytorch also have same functionality, except the fact we only need to define forward propagation in them, but in this implementation, user will need to define backward propagation method too.

**How to use this loss layer?**
To implement this, user will have to define his own `double forward(const mat&& input, const mat&& target)` and `void backward(const mat&& input, const mat&& target, mat&& output)` functions.

**Other method I tried**
I also did it in a way such that these functions to be defined only perform calculations on single input and target and not whole matrices, but then that would make user unable to create loss functions like cross entropy for activations like softmax.

Please give any suggestions and review to improve the implementation.