### PR TITLE
Adding a warning in ffn_impl.hpp, rnn_impl.hpp and brnn_impl.hpp regarding the MaxIterations() parameter for the issue #2226.

### DIFF
--- a/src/mlpack/methods/ann/brnn_impl.hpp
+++ b/src/mlpack/methods/ann/brnn_impl.hpp
@@ -83,6 +83,15 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     ResetParameters();
   }
 
+  if (optimizer.MaxIterations() < this->predictors.n_cols)
+  {
+    Log::Warn << "The number of iterations is less than the size of the "
+              << "dataset, the optimizer might not pass over the entire "
+              << "dataset. Please modify the number of iterations to be "
+              << "at least equal to the number of columns of your "
+              << "dataset." << std::endl;
+  }
+
   // Train the model.
   Timer::Start("BRNN_optimization");
   const double out = optimizer.Optimize(*this, parameter);
@@ -116,6 +125,15 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
   }
 
   OptimizerType optimizer;
+
+  if (optimizer.MaxIterations() < this->predictors.n_cols)
+  {
+    Log::Warn << "The number of iterations is less than the size of the "
+              << "dataset, the optimizer might not pass over the entire "
+              << "dataset. Please modify the number of iterations to be "
+              << "at least equal to the number of columns of your "
+              << "dataset." << std::endl;
+  }
 
   // Train the model.
   const double out = optimizer.Optimize(*this, parameter);

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -78,6 +78,15 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 {
   ResetData(std::move(predictors), std::move(responses));
 
+  if (optimizer.MaxIterations() != predictors.n_cols)
+  {
+    Log::Warn << "The number of iterations is less than the size of the "
+              << "dataset, the optimizer might not pass over the entire "
+              << "dataset. Please modify the number of iterations to be "
+              << "at least equal to the number of columns of your dataset." 
+              << std::endl;
+  }
+
   // Train the model.
   Timer::Start("ffn_optimization");
   const double out = optimizer.Optimize(*this, parameter, callbacks...);
@@ -99,6 +108,15 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
   ResetData(std::move(predictors), std::move(responses));
 
   OptimizerType optimizer;
+
+  if (optimizer.MaxIterations() != predictors.n_cols)
+  {
+    Log::Warn << "The number of iterations is less than the size of the "
+              << "dataset, the optimizer might not pass over the entire "
+              << "dataset. Please modify the number of iterations to be "
+              << "at least equal to the number of columns of your dataset." 
+              << std::endl;
+  }
 
   // Train the model.
   Timer::Start("ffn_optimization");

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -78,7 +78,7 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 {
   ResetData(std::move(predictors), std::move(responses));
 
-  if (optimizer.MaxIterations() < predictors.n_cols)
+  if (optimizer.MaxIterations() < this->predictors.n_cols)
   {
     Log::Warn << "The number of iterations is less than the size of the "
               << "dataset, the optimizer might not pass over the entire "
@@ -109,7 +109,7 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   OptimizerType optimizer;
 
-  if (optimizer.MaxIterations() < predictors.n_cols)
+  if (optimizer.MaxIterations() < this->predictors.n_cols)
   {
     Log::Warn << "The number of iterations is less than the size of the "
               << "dataset, the optimizer might not pass over the entire "

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -78,13 +78,13 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 {
   ResetData(std::move(predictors), std::move(responses));
 
-  if (optimizer.MaxIterations() != predictors.n_cols)
+  if (optimizer.MaxIterations() < predictors.n_cols)
   {
     Log::Warn << "The number of iterations is less than the size of the "
               << "dataset, the optimizer might not pass over the entire "
               << "dataset. Please modify the number of iterations to be "
-              << "at least equal to the number of columns of your dataset." 
-              << std::endl;
+              << "at least equal to the number of columns of your "
+              << "dataset." << std::endl;
   }
 
   // Train the model.
@@ -109,13 +109,13 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
   OptimizerType optimizer;
 
-  if (optimizer.MaxIterations() != predictors.n_cols)
+  if (optimizer.MaxIterations() < predictors.n_cols)
   {
     Log::Warn << "The number of iterations is less than the size of the "
               << "dataset, the optimizer might not pass over the entire "
               << "dataset. Please modify the number of iterations to be "
-              << "at least equal to the number of columns of your dataset." 
-              << std::endl;
+              << "at least equal to the number of columns of your "
+              << "dataset." << std::endl;
   }
 
   // Train the model.

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -83,6 +83,15 @@ double RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
     ResetParameters();
   }
 
+  if (optimizer.MaxIterations() < this->predictors.n_cols)
+  {
+    Log::Warn << "The number of iterations is less than the size of the "
+              << "dataset, the optimizer might not pass over the entire "
+              << "dataset. Please modify the number of iterations to be "
+              << "at least equal to the number of columns of your "
+              << "dataset." << std::endl;
+  }
+
   // Train the model.
   Timer::Start("rnn_optimization");
   const double out = optimizer.Optimize(*this, parameter, callbacks...);
@@ -126,6 +135,15 @@ double RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
   }
 
   OptimizerType optimizer;
+
+  if (optimizer.MaxIterations() < this->predictors.n_cols)
+  {
+    Log::Warn << "The number of iterations is less than the size of the "
+              << "dataset, the optimizer might not pass over the entire "
+              << "dataset. Please modify the number of iterations to be "
+              << "at least equal to the number of columns of your "
+              << "dataset." << std::endl;
+  }
 
   // Train the model.
   Timer::Start("rnn_optimization");


### PR DESCRIPTION
I have added a warning message in 'ffn_impl.hpp', 'rnn_impl.hpp' and 'brnn_impl.hpp' stating that the `MaxIterations()` parameter should be equal to the number of columns in the dataset for proper functioning. If there are any more changes kindly suggest.