### PR TITLE
Clarify availability of libensmallen-dev and libstb-dev.

### DIFF
--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -30,7 +30,7 @@ to build mlpack on Windows, see \ref build_windows (alternatively, you can read
 is based on older versions).
 
 You can download the latest mlpack release from here:
-<a href="https://www.mlpack.org/files/mlpack-3.2.1.tar.gz">mlpack-3.2.1</a>
+<a href="https://www.mlpack.org/files/mlpack-3.2.2.tar.gz">mlpack-3.2.2</a>
 
 @section build_simple Simple Linux build instructions
 
@@ -38,9 +38,9 @@ Assuming all dependencies are installed in the system, you can run the commands
 below directly to build and install mlpack.
 
 @code
-$ wget https://www.mlpack.org/files/mlpack-3.2.1.tar.gz
-$ tar -xvzpf mlpack-3.2.1.tar.gz
-$ mkdir mlpack-3.2.1/build && cd mlpack-3.2.1/build
+$ wget https://www.mlpack.org/files/mlpack-3.2.2.tar.gz
+$ tar -xvzpf mlpack-3.2.2.tar.gz
+$ mkdir mlpack-3.2.2/build && cd mlpack-3.2.2/build
 $ cmake ../
 $ make -j4  # The -j is the number of cores you want to use for a build.
 $ sudo make install
@@ -65,8 +65,8 @@ configure mlpack.
 First we should unpack the mlpack source and create a build directory.
 
 @code
-$ tar -xvzpf mlpack-3.2.1.tar.gz
-$ cd mlpack-3.2.1
+$ tar -xvzpf mlpack-3.2.2.tar.gz
+$ cd mlpack-3.2.2
 $ mkdir build
 @endcode
 
@@ -100,8 +100,15 @@ In Ubuntu and Debian, you can get all of these dependencies through apt:
 @code
 # apt-get install libboost-math-dev libboost-program-options-dev
   libboost-test-dev libboost-serialization-dev libarmadillo-dev binutils-dev
-  python-pandas python-numpy cython python-setuptools libensmallen-dev
-  libstb-dev
+  python-pandas python-numpy cython python-setuptools
+@endcode
+
+If you are using Ubuntu 19.10 or newer, you can also install @c libensmallen-dev
+and @c libstb-dev, so that CMake does not need to automatically download those
+packages:
+
+@code
+# apt-get install libensmallen-dev libstb-dev
 @endcode
 
 On Fedora, Red Hat, or CentOS, these same dependencies can be obtained via dnf:


### PR DESCRIPTION
These packages aren't available on the versions of Ubuntu that many people appear to be using (see, for instance, #2232, and the question seems to get asked a lot in IRC).

So, this clarifies the documentation to point out that those packages are only available on 19.10 and newer, and then also points out that CMake will (currently) automatically download those dependencies if they are not found.

It also bumps the version indicated in the documentation, which apparently wasn't done at the time of the last release. :)