### PR TITLE
Add specific versions of dependencies for Julia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ following Python packages are installed:
       numpy
       pandas >= 0.15.0
 
+If you would like to build the Julia bindings, make sure that Julia >= 1.3.0 is
+installed.
+
 If the STB library headers are available, image loading support will be
 compiled.
 

--- a/src/mlpack/bindings/julia/CMakeLists.txt
+++ b/src/mlpack/bindings/julia/CMakeLists.txt
@@ -2,7 +2,7 @@ if (BUILD_JULIA_BINDINGS)
   ## We need to check here if Julia is even available.  Although actually
   ## technically, I'm not sure if we even need to know!  For the tests though we
   ## do.  So it's probably a good idea to check.
-  find_package(Julia 0.7.0)
+  find_package(Julia 1.3.0)
 
   if (NOT JULIA_FOUND)
     # We can't build anything, so define the macro to do nothing.

--- a/src/mlpack/bindings/julia/mlpack/Project.toml.in
+++ b/src/mlpack/bindings/julia/mlpack/Project.toml.in
@@ -4,3 +4,6 @@ version = "${PACKAGE_VERSION}"
 author = [ "mlpack developers <mlpack@lists.mlpack.org>" ]
 
 [deps]
+
+[compat]
+julia = "1.3"


### PR DESCRIPTION
As part of the Julia package registration process, it was requested that I specify a version of Julia with which the package is compatible.  It turns out that `julia = "1.3"` actually means it'll be compatible with any 1.x release.

The change is already in the new mlpack/mlpack.jl repository, but better to push it back here to reduce the amount of work needed for the manual deployment of new Julia binding versions.