### PR TITLE
Quick Fix Python Ctest Binding Failure

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -26,6 +26,7 @@ steps:
     if [ '$(python.version)' == '2.7' ]; then
       sudo apt-get install -y --allow-unauthenticated python-pip cython python-numpy python-pandas
       sudo pip install --upgrade --ignore-installed setuptools cython
+      sudo pip install "zipp<3.1"
     fi
 
     if [ '$(python.version)' == '3.7' ]; then


### PR DESCRIPTION
Python Bindings test fails across multiple PR ever since zipp released 3.1 version. The issue can be referenced from this [link](https://github.com/jaraco/zipp/issues/48). I think they will fix it soon but incase it takes a while here is a solution that should work.