### PR TITLE
Refactor ANN code to avoid rvalue references.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,9 +2,9 @@
 ###### ????-??-??
   * Added `mean squared logarithmic error` loss function for neural networks
     (#2210).
-    
+
   * Added `mean bias loss function` for neural networks (#2210).
-  
+
   * The DecisionStump class has been marked deprecated; use the `DecisionTree`
     class with `NoRecursion=true` or use `ID3DecisionStump` instead (#2099).
 
@@ -42,10 +42,13 @@
 
   * Better error handling of eigendecompositions and Cholesky decompositions
     (#2088, #1840).
-  
+
   * Add LiSHT activation function (#2182).
 
   * Add Valid and Same Padding for Transposed Convolution layer (#2163).
+
+  * Change neural network types to avoid unnecessary use of rvalue references
+    (#TODO).
 
 ### mlpack 3.2.2
 ###### 2019-11-26

--- a/doc/tutorials/ann/ann.txt
+++ b/doc/tutorials/ann/ann.txt
@@ -328,7 +328,7 @@ implementation of a \c Forward() method. The interface looks like:
 
 @code
 template<typename eT>
-void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 @endcode
 
 The method should calculate the output of the layer given the input matrix and
@@ -339,9 +339,9 @@ through f:
 
 @code
 template<typename eT>
-void Backward(const arma::Mat<eT>&& input,
-              arma::Mat<eT>&& gy,
-              arma::Mat<eT>&& g);
+void Backward(const arma::Mat<eT>& input,
+              const arma::Mat<eT>& gy,
+              arma::Mat<eT>& g);
 @endcode
 
 Finally, if the layer is differentiable, the layer must also implement
@@ -349,9 +349,9 @@ a Gradient() method:
 
 @code
 template<typename eT>
-void Gradient(const arma::Mat<eT>&& input,
-              arma::Mat<eT>&& error,
-              arma::Mat<eT>&& gradient);
+void Gradient(const arma::Mat<eT>& input,
+              const arma::Mat<eT>& error,
+              arma::Mat<eT>& gradient);
 @endcode
 
 The Gradient function should calculate the gradient with respect to the input
@@ -434,21 +434,21 @@ API, so we must implement some additional functions.
 
 @code
 template<typename InputType, typename OutputType>
-void Forward(const InputType&& input, OutputType&& output)
+void Forward(const InputType& input, OutputType& output)
 {
   output = arma::ones(input.n_rows, input.n_cols);
 }
 
 template<typename InputType, typename ErrorType, typename GradientType>
-void Backward(const InputType&& input, ErrorType&& gy, GradientType&& g)
+void Backward(const InputType& input, const ErrorType& gy, GradientType& g)
 {
   g = arma::zeros(gy.n_rows, gy.n_cols) + gy;
 }
 
 template<typename InputType, typename ErrorType, typename GradientType>
-void Gradient(const InputType&& input,
-              ErrorType&& error,
-              GradientType&& gradient)
+void Gradient(const InputType& input,
+              ErrorType& error,
+              GradientType& gradient)
 {
   gradient = arma::zeros(input.n_rows, input.n_cols) * error;
 }

--- a/src/mlpack/methods/ann/brnn_impl.hpp
+++ b/src/mlpack/methods/ann/brnn_impl.hpp
@@ -173,9 +173,9 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
           predictors.slice(rho - seqNum - 1).colptr(begin),
           predictors.n_rows, effectiveBatchSize, false, true)));
 
-      boost::apply_visitor(SaveOutputParameterVisitor( results1),
+      boost::apply_visitor(SaveOutputParameterVisitor(results1),
           forwardRNN.network.back());
-      boost::apply_visitor(SaveOutputParameterVisitor( results2),
+      boost::apply_visitor(SaveOutputParameterVisitor(results2),
           backwardRNN.network.back());
     }
     reverse(results1.begin(), results1.end());
@@ -183,9 +183,9 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     // Forward outputs from both RNN's through merge layer for each time step.
     for (size_t seqNum = 0; seqNum < rho; ++seqNum)
     {
-      boost::apply_visitor(LoadOutputParameterVisitor( results1),
+      boost::apply_visitor(LoadOutputParameterVisitor(results1),
           forwardRNN.network.back());
-      boost::apply_visitor(LoadOutputParameterVisitor( results2),
+      boost::apply_visitor(LoadOutputParameterVisitor(results2),
           backwardRNN.network.back());
 
       boost::apply_visitor(ForwardVisitor(std::move(input),
@@ -250,9 +250,9 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
         predictors.slice(rho - seqNum - 1).colptr(begin),
         predictors.n_rows, batchSize, false, true));
 
-    boost::apply_visitor(SaveOutputParameterVisitor( results1),
+    boost::apply_visitor(SaveOutputParameterVisitor(results1),
         forwardRNN.network.back());
-    boost::apply_visitor(SaveOutputParameterVisitor( results2),
+    boost::apply_visitor(SaveOutputParameterVisitor(results2),
         backwardRNN.network.back());
   }
   if (outputSize == 0)
@@ -271,9 +271,9 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     {
       responseSeq = seqNum;
     }
-    boost::apply_visitor(LoadOutputParameterVisitor( results1),
+    boost::apply_visitor(LoadOutputParameterVisitor(results1),
         forwardRNN.network.back());
-    boost::apply_visitor(LoadOutputParameterVisitor( results2),
+    boost::apply_visitor(LoadOutputParameterVisitor(results2),
         backwardRNN.network.back());
 
     boost::apply_visitor(ForwardVisitor(std::move(input),
@@ -375,9 +375,9 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
       boost::apply_visitor(SaveOutputParameterVisitor(
           backwardRNNOutputParameter), backwardRNN.network[l]);
     }
-    boost::apply_visitor(SaveOutputParameterVisitor( results1),
+    boost::apply_visitor(SaveOutputParameterVisitor(results1),
         forwardRNN.network.back());
-    boost::apply_visitor(SaveOutputParameterVisitor( results2),
+    boost::apply_visitor(SaveOutputParameterVisitor(results2),
         backwardRNN.network.back());
   }
   if (outputSize == 0)

--- a/src/mlpack/methods/ann/brnn_impl.hpp
+++ b/src/mlpack/methods/ann/brnn_impl.hpp
@@ -166,34 +166,34 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
         size_t(predictors.n_cols - begin));
     for (size_t seqNum = 0; seqNum < rho; ++seqNum)
     {
-      forwardRNN.Forward(std::move(arma::mat(
+      forwardRNN.Forward(arma::mat(
           predictors.slice(seqNum).colptr(begin),
-          predictors.n_rows, effectiveBatchSize, false, true)));
+          predictors.n_rows, effectiveBatchSize, false, true));
       backwardRNN.Forward(std::move(arma::mat(
           predictors.slice(rho - seqNum - 1).colptr(begin),
           predictors.n_rows, effectiveBatchSize, false, true)));
 
-      boost::apply_visitor(SaveOutputParameterVisitor(
-          std::move(results1)), forwardRNN.network.back());
-      boost::apply_visitor(SaveOutputParameterVisitor(
-          std::move(results2)), backwardRNN.network.back());
+      boost::apply_visitor(SaveOutputParameterVisitor( results1),
+          forwardRNN.network.back());
+      boost::apply_visitor(SaveOutputParameterVisitor( results2),
+          backwardRNN.network.back());
     }
     reverse(results1.begin(), results1.end());
 
     // Forward outputs from both RNN's through merge layer for each time step.
     for (size_t seqNum = 0; seqNum < rho; ++seqNum)
     {
-      boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(results1)), forwardRNN.network.back());
-      boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(results2)), backwardRNN.network.back());
+      boost::apply_visitor(LoadOutputParameterVisitor( results1),
+          forwardRNN.network.back());
+      boost::apply_visitor(LoadOutputParameterVisitor( results2),
+          backwardRNN.network.back());
 
       boost::apply_visitor(ForwardVisitor(std::move(input),
-          std::move(boost::apply_visitor(outputParameterVisitor, mergeLayer))),
+          boost::apply_visitor(outputParameterVisitor, mergeLayer)),
           mergeLayer);
       boost::apply_visitor(ForwardVisitor(
-          std::move(boost::apply_visitor(outputParameterVisitor, mergeLayer)),
-          std::move(boost::apply_visitor(outputParameterVisitor, mergeOutput))),
+          boost::apply_visitor(outputParameterVisitor, mergeLayer),
+          boost::apply_visitor(outputParameterVisitor, mergeOutput)),
           mergeOutput);
       results.slice(seqNum).submat(0, begin, results.n_rows - 1, begin +
           effectiveBatchSize - 1) =
@@ -243,17 +243,17 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
   std::vector<arma::mat> results1, results2;
   for (size_t seqNum = 0; seqNum < rho; ++seqNum)
   {
-    forwardRNN.Forward(std::move(arma::mat(
+    forwardRNN.Forward(arma::mat(
         predictors.slice(seqNum).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
-    backwardRNN.Forward(std::move(arma::mat(
+        predictors.n_rows, batchSize, false, true));
+    backwardRNN.Forward(arma::mat(
         predictors.slice(rho - seqNum - 1).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
+        predictors.n_rows, batchSize, false, true));
 
-    boost::apply_visitor(SaveOutputParameterVisitor(
-        std::move(results1)), forwardRNN.network.back());
-    boost::apply_visitor(SaveOutputParameterVisitor(
-        std::move(results2)), backwardRNN.network.back());
+    boost::apply_visitor(SaveOutputParameterVisitor( results1),
+        forwardRNN.network.back());
+    boost::apply_visitor(SaveOutputParameterVisitor( results2),
+        backwardRNN.network.back());
   }
   if (outputSize == 0)
   {
@@ -271,22 +271,22 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     {
       responseSeq = seqNum;
     }
-    boost::apply_visitor(LoadOutputParameterVisitor(
-        std::move(results1)), forwardRNN.network.back());
-    boost::apply_visitor(LoadOutputParameterVisitor(
-        std::move(results2)), backwardRNN.network.back());
+    boost::apply_visitor(LoadOutputParameterVisitor( results1),
+        forwardRNN.network.back());
+    boost::apply_visitor(LoadOutputParameterVisitor( results2),
+        backwardRNN.network.back());
 
     boost::apply_visitor(ForwardVisitor(std::move(input),
-        std::move(boost::apply_visitor(outputParameterVisitor, mergeLayer))),
+        boost::apply_visitor(outputParameterVisitor, mergeLayer)),
         mergeLayer);
     boost::apply_visitor(ForwardVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor, mergeLayer)),
-        std::move(boost::apply_visitor(outputParameterVisitor, mergeOutput))),
+        boost::apply_visitor(outputParameterVisitor, mergeLayer),
+        boost::apply_visitor(outputParameterVisitor, mergeOutput)),
         mergeOutput);
     performance += outputLayer.Forward(std::move(
         boost::apply_visitor(outputParameterVisitor, mergeOutput)),
-        std::move(arma::mat(responses.slice(responseSeq).colptr(begin),
-        responses.n_rows, batchSize, false, true)));
+        arma::mat(responses.slice(responseSeq).colptr(begin),
+        responses.n_rows, batchSize, false, true));
   }
   return performance;
 }
@@ -361,24 +361,24 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
   std::vector<arma::mat> results1, results2;
   for (size_t seqNum = 0; seqNum < rho; ++seqNum)
   {
-    forwardRNN.Forward(std::move(arma::mat(
+    forwardRNN.Forward(arma::mat(
         predictors.slice(seqNum).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
-    backwardRNN.Forward(std::move(arma::mat(
+        predictors.n_rows, batchSize, false, true));
+    backwardRNN.Forward(arma::mat(
         predictors.slice(rho - seqNum - 1).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
+        predictors.n_rows, batchSize, false, true));
 
     for (size_t l = 0; l < networkSize; ++l)
     {
       boost::apply_visitor(SaveOutputParameterVisitor(
-          std::move(forwardRNNOutputParameter)), forwardRNN.network[l]);
+          forwardRNNOutputParameter), forwardRNN.network[l]);
       boost::apply_visitor(SaveOutputParameterVisitor(
-          std::move(backwardRNNOutputParameter)), backwardRNN.network[l]);
+          backwardRNNOutputParameter), backwardRNN.network[l]);
     }
-    boost::apply_visitor(SaveOutputParameterVisitor(
-        std::move(results1)), forwardRNN.network.back());
-    boost::apply_visitor(SaveOutputParameterVisitor(
-        std::move(results2)), backwardRNN.network.back());
+    boost::apply_visitor(SaveOutputParameterVisitor( results1),
+        forwardRNN.network.back());
+    boost::apply_visitor(SaveOutputParameterVisitor( results2),
+        backwardRNN.network.back());
   }
   if (outputSize == 0)
   {
@@ -410,18 +410,18 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
       responseSeq = seqNum;
     }
     boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(results1)), forwardRNN.network.back());
+          results1), forwardRNN.network.back());
     boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(results2)), backwardRNN.network.back());
-    boost::apply_visitor(ForwardVisitor(std::move(input),
-        std::move(boost::apply_visitor(outputParameterVisitor, mergeLayer))),
+          results2), backwardRNN.network.back());
+    boost::apply_visitor(ForwardVisitor(input,
+        boost::apply_visitor(outputParameterVisitor, mergeLayer)),
         mergeLayer);
     boost::apply_visitor(ForwardVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor, mergeLayer)),
-        std::move(results.slice(seqNum))), mergeOutput);
-    performance += outputLayer.Forward(std::move(results.slice(seqNum)),
-        std::move(arma::mat(responses.slice(responseSeq).colptr(begin),
-        responses.n_rows, batchSize, false, true)));
+        boost::apply_visitor(outputParameterVisitor, mergeLayer),
+        results.slice(seqNum)), mergeOutput);
+    performance += outputLayer.Forward(results.slice(seqNum),
+        arma::mat(responses.slice(responseSeq).colptr(begin),
+        responses.n_rows, batchSize, false, true));
   }
 
   // Calculate and storing delta parameters from output for t = 1 to T.
@@ -436,25 +436,25 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     }
     else if (single && seqNum == 0)
     {
-      outputLayer.Backward(std::move(results.slice(seqNum)),
-          std::move(arma::mat(responses.slice(0).colptr(begin),
-          responses.n_rows, batchSize, false, true)), std::move(error));
+      outputLayer.Backward(results.slice(seqNum),
+          arma::mat(responses.slice(0).colptr(begin),
+          responses.n_rows, batchSize, false, true), error);
     }
     else
     {
-      outputLayer.Backward(std::move(results.slice(seqNum)),
-          std::move(arma::mat(responses.slice(seqNum).colptr(begin),
-          responses.n_rows, batchSize, false, true)), std::move(error));
+      outputLayer.Backward(results.slice(seqNum),
+          arma::mat(responses.slice(seqNum).colptr(begin),
+          responses.n_rows, batchSize, false, true), error);
     }
 
-    boost::apply_visitor(BackwardVisitor(std::move(results.slice(seqNum)),
-        std::move(error), std::move(delta)), mergeOutput);
+    boost::apply_visitor(BackwardVisitor(results.slice(seqNum), error, delta),
+        mergeOutput);
     allDelta.push_back(arma::mat(delta));
   }
 
   // BPTT ForwardRNN from t = T to 1.
   totalGradient = arma::mat(gradient.memptr(),
-      parameter.n_elem/2, 1, false, false);
+      parameter.n_elem / 2, 1, false, false);
 
   forwardGradient.zeros();
   forwardRNN.ResetGradients(forwardGradient);
@@ -467,32 +467,32 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     for (size_t l = 0; l < networkSize; ++l)
     {
       boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(forwardRNNOutputParameter)),
+          forwardRNNOutputParameter),
           forwardRNN.network[networkSize - 1 - l]);
     }
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, forwardRNN.network.back())),
-        std::move(allDelta[rho - seqNum - 1]), std::move(delta), 0),
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, forwardRNN.network.back()),
+        allDelta[rho - seqNum - 1], delta, 0),
         mergeLayer);
 
     for (size_t i = 2; i < networkSize; ++i)
     {
       boost::apply_visitor(BackwardVisitor(
-          std::move(boost::apply_visitor(outputParameterVisitor,
-          forwardRNN.network[networkSize - i])),
-          std::move(boost::apply_visitor(deltaVisitor,
-          forwardRNN.network[networkSize - i + 1])), std::move(
+          boost::apply_visitor(outputParameterVisitor,
+          forwardRNN.network[networkSize - i]),
           boost::apply_visitor(deltaVisitor,
-          forwardRNN.network[networkSize - i]))),
+          forwardRNN.network[networkSize - i + 1]),
+          boost::apply_visitor(deltaVisitor,
+          forwardRNN.network[networkSize - i])),
           forwardRNN.network[networkSize - i]);
     }
-    forwardRNN.Gradient(std::move(
+    forwardRNN.Gradient(
         arma::mat(predictors.slice(rho - seqNum - 1).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
+        predictors.n_rows, batchSize, false, true));
     boost::apply_visitor(GradientVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor,
-        forwardRNN.network[networkSize - 2])),
-        std::move(allDelta[rho - seqNum - 1]), 0), mergeLayer);
+        boost::apply_visitor(outputParameterVisitor,
+        forwardRNN.network[networkSize - 2]),
+        allDelta[rho - seqNum - 1], 0), mergeLayer);
     totalGradient += forwardGradient;
   }
 
@@ -506,31 +506,31 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     for (size_t l = 0; l < networkSize; ++l)
     {
       boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(backwardRNNOutputParameter)),
+          backwardRNNOutputParameter),
           backwardRNN.network[networkSize - 1 - l]);
     }
-    boost::apply_visitor(BackwardVisitor(std::move(
+    boost::apply_visitor(BackwardVisitor(
         boost::apply_visitor(outputParameterVisitor,
-        backwardRNN.network.back())),
-        std::move(allDelta[seqNum]), std::move(delta), 1), mergeLayer);
+        backwardRNN.network.back()),
+        allDelta[seqNum], delta, 1), mergeLayer);
     for (size_t i = 2; i < networkSize; ++i)
     {
       boost::apply_visitor(BackwardVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor,
-        backwardRNN.network[networkSize - i])), std::move(boost::apply_visitor(
-        deltaVisitor, backwardRNN.network[networkSize - i + 1])), std::move(
+        boost::apply_visitor(outputParameterVisitor,
+        backwardRNN.network[networkSize - i]), boost::apply_visitor(
+        deltaVisitor, backwardRNN.network[networkSize - i + 1]),
         boost::apply_visitor(deltaVisitor,
-        backwardRNN.network[networkSize - i]))),
+        backwardRNN.network[networkSize - i])),
         backwardRNN.network[networkSize - i]);
     }
 
-    backwardRNN.Gradient(std::move(
+    backwardRNN.Gradient(
         arma::mat(predictors.slice(seqNum).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
+        predictors.n_rows, batchSize, false, true));
     boost::apply_visitor(GradientVisitor(
         std::move(boost::apply_visitor(outputParameterVisitor,
         backwardRNN.network[networkSize - 2])),
-        std::move(allDelta[seqNum]), 1), mergeLayer);
+        allDelta[seqNum], 1), mergeLayer);
     totalGradient += backwardGradient;
   }
   return performance;

--- a/src/mlpack/methods/ann/dists/bernoulli_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/bernoulli_distribution.hpp
@@ -60,7 +60,7 @@ class BernoulliDistribution
    * @param eps The minimum value used for computing logarithms and
    *        denominators.
    */
-  BernoulliDistribution(const DataType&& param,
+  BernoulliDistribution(const DataType& param,
                         const bool applyLogistic = true,
                         const double eps = 1e-10);
 
@@ -69,7 +69,7 @@ class BernoulliDistribution
    *
    * @param observation The observation matrix.
    */
-  double Probability(const DataType&& observation) const
+  double Probability(const DataType& observation) const
   {
     return std::exp(LogProbability(observation));
   }
@@ -79,7 +79,7 @@ class BernoulliDistribution
    *
    * @param observation The observation matrix.
    */
-  double LogProbability(const DataType&& observation) const;
+  double LogProbability(const DataType& observation) const;
 
   /**
    * Stores the gradient of the log probabilities of the observations in the
@@ -88,7 +88,7 @@ class BernoulliDistribution
    * @param observation The observation matrix.
    * @param output The output matrix where the gradients are stored.
    */
-  void LogProbBackward(const DataType&& observation, DataType&& output) const;
+  void LogProbBackward(const DataType& observation, DataType& output) const;
 
   /**
    * Return a matrix of randomly generated samples according to the

--- a/src/mlpack/methods/ann/dists/bernoulli_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/bernoulli_distribution_impl.hpp
@@ -28,7 +28,7 @@ BernoulliDistribution<DataType>::BernoulliDistribution() :
 
 template<typename DataType>
 BernoulliDistribution<DataType>::BernoulliDistribution(
-    const DataType&& param,
+    const DataType& param,
     const bool applyLogistic,
     const double eps) :
     logits(param),
@@ -36,7 +36,9 @@ BernoulliDistribution<DataType>::BernoulliDistribution(
     eps(eps)
 {
   if (applyLogistic)
+  {
     LogisticFunction::Fn(logits, probability);
+  }
   else
   {
     probability = arma::mat(logits.memptr(), logits.n_rows,
@@ -58,7 +60,7 @@ DataType BernoulliDistribution<DataType>::Sample() const
 
 template<typename DataType>
 double BernoulliDistribution<DataType>::LogProbability(
-    const DataType&& observation) const
+    const DataType& observation) const
 {
   return arma::accu(arma::log(probability + eps) % observation +
       arma::log(1 - probability + eps) % (1 - observation)) /
@@ -67,7 +69,7 @@ double BernoulliDistribution<DataType>::LogProbability(
 
 template<typename DataType>
 void BernoulliDistribution<DataType>::LogProbBackward(
-    const DataType&& observation, DataType&& output) const
+    const DataType& observation, DataType& output) const
 {
   if (!applyLogistic)
   {

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -153,7 +153,9 @@ class FFN
    * @param predictors Input variables.
    * @param responses Target outputs for input variables.
    */
-  double Evaluate(arma::mat predictors, arma::mat responses);
+  template<typename PredictorsType, typename ResponsesType>
+  double Evaluate(const PredictorsType& predictors,
+                  const ResponsesType& responses);
 
   /**
    * Evaluate the feedforward network with the given parameters. This function
@@ -313,7 +315,8 @@ class FFN
    * @param inputs The input data.
    * @param results The predicted results.
    */
-  void Forward(arma::mat inputs, arma::mat& results);
+  template<typename PredictorsType, typename ResponsesType>
+  void Forward(const PredictorsType& inputs, ResponsesType& results);
 
   /**
    * Perform a partial forward pass of the data.
@@ -326,8 +329,9 @@ class FFN
    * @param begin The index of the first layer.
    * @param end The index of the last layer.
    */
-  void Forward(arma::mat inputs,
-               arma::mat& results,
+  template<typename PredictorsType, typename ResponsesType>
+  void Forward(const PredictorsType& inputs ,
+               ResponsesType& results,
                const size_t begin,
                const size_t end);
 
@@ -342,7 +346,12 @@ class FFN
    * @param gradients Computed gradients.
    * @return Training error of the current pass.
    */
-  double Backward(arma::mat targets, arma::mat& gradients);
+  template<typename PredictorsType,
+           typename TargetsType,
+           typename GradientsType>
+  double Backward(const PredictorsType& inputs,
+                  const TargetsType& targets,
+                  GradientsType& gradients);
 
  private:
   // Helper functions.
@@ -352,7 +361,8 @@ class FFN
    *
    * @param input Data sequence to compute probabilities for.
    */
-  void Forward(arma::mat&& input);
+  template<typename InputType>
+  void Forward(const InputType& input);
 
   /**
    * Prepare the network for the given data.
@@ -373,7 +383,8 @@ class FFN
    * Iterate through all layer modules and update the the gradient using the
    * layer defined optimizer.
    */
-  void Gradient(arma::mat&& input);
+  template<typename InputType>
+  void Gradient(const InputType& input);
 
   /**
    * Reset the module status by setting the current deterministic parameter
@@ -426,9 +437,6 @@ class FFN
 
   //! The current error for the backward pass.
   arma::mat error;
-
-  //! THe current input of the forward/backward pass.
-  arma::mat currentInput;
 
   //! Locally-stored delta visitor.
   DeltaVisitor deltaVisitor;
@@ -496,7 +504,7 @@ template<typename OutputLayerType,
 struct version<
     mlpack::ann::FFN<OutputLayerType, InitializationRuleType, CustomLayer...>>
 {
-  BOOST_STATIC_CONSTANT(int, value = 1);
+  BOOST_STATIC_CONSTANT(int, value = 2);
 };
 
 } // namespace serialization

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -41,7 +41,7 @@ FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::FFN(
     numFunctions(0),
     deterministic(true)
 {
-  /* Nothing to do here */
+  /* Nothing to do here. */
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
@@ -112,8 +112,9 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Train(
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename PredictorsType, typename ResponsesType>
 void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Forward(
-    arma::mat inputs, arma::mat& results)
+    const PredictorsType& inputs, ResponsesType& results)
 {
   if (parameter.is_empty())
     ResetParameters();
@@ -124,25 +125,28 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Forward(
     ResetDeterministic();
   }
 
-  currentInput = std::move(inputs);
-  Forward(std::move(currentInput));
+  Forward(inputs);
   results = boost::apply_visitor(outputParameterVisitor, network.back());
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename PredictorsType, typename ResponsesType>
 void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Forward(
-    arma::mat inputs, arma::mat& results, const size_t begin, const size_t end)
+    const PredictorsType& inputs,
+    ResponsesType& results,
+    const size_t begin,
+    const size_t end)
 {
-  boost::apply_visitor(ForwardVisitor(std::move(inputs), std::move(
-      boost::apply_visitor(outputParameterVisitor, network[begin]))),
+  boost::apply_visitor(ForwardVisitor(inputs,
+      boost::apply_visitor(outputParameterVisitor, network[begin])),
       network[begin]);
 
   for (size_t i = 1; i < end - begin + 1; ++i)
   {
-    boost::apply_visitor(ForwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[begin + i - 1])), std::move(
-        boost::apply_visitor(outputParameterVisitor, network[begin + i]))),
+    boost::apply_visitor(ForwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[begin + i - 1]),
+        boost::apply_visitor(outputParameterVisitor, network[begin + i])),
         network[begin + i]);
   }
 
@@ -151,25 +155,28 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Forward(
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename PredictorsType, typename TargetsType, typename GradientsType>
 double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Backward(
-    arma::mat targets, arma::mat& gradients)
+    const PredictorsType& inputs,
+    const TargetsType& targets,
+    GradientsType& gradients)
 {
-  double res = outputLayer.Forward(std::move(boost::apply_visitor(
-      outputParameterVisitor, network.back())), std::move(targets));
+  double res = outputLayer.Forward(boost::apply_visitor(
+      outputParameterVisitor, network.back()), targets);
 
   for (size_t i = 0; i < network.size(); ++i)
   {
     res += boost::apply_visitor(lossVisitor, network[i]);
   }
 
-  outputLayer.Backward(std::move(boost::apply_visitor(outputParameterVisitor,
-      network.back())), std::move(targets), std::move(error));
+  outputLayer.Backward(boost::apply_visitor(outputParameterVisitor,
+      network.back()), targets, error);
 
   gradients = arma::zeros<arma::mat>(parameter.n_rows, parameter.n_cols);
 
   Backward();
   ResetGradients(gradients);
-  Gradient(std::move(currentInput));
+  Gradient(inputs);
 
   return res;
 }
@@ -189,8 +196,7 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Predict(
   }
 
   arma::mat resultsTemp;
-  Forward(std::move(arma::mat(predictors.colptr(0),
-      predictors.n_rows, 1, false, true)));
+  Forward(arma::mat(predictors.colptr(0), predictors.n_rows, 1, false, true));
   resultsTemp = boost::apply_visitor(outputParameterVisitor,
       network.back()).col(0);
 
@@ -199,8 +205,7 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Predict(
 
   for (size_t i = 1; i < predictors.n_cols; i++)
   {
-    Forward(std::move(arma::mat(predictors.colptr(i),
-        predictors.n_rows, 1, false, true)));
+    Forward(arma::mat(predictors.colptr(i), predictors.n_rows, 1, false, true));
 
     resultsTemp = boost::apply_visitor(outputParameterVisitor,
         network.back());
@@ -210,8 +215,9 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Predict(
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename PredictorsType, typename ResponsesType>
 double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Evaluate(
-    arma::mat predictors, arma::mat responses)
+    const PredictorsType& predictors, const ResponsesType& responses)
 {
   if (parameter.is_empty())
     ResetParameters();
@@ -222,10 +228,10 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Evaluate(
     ResetDeterministic();
   }
 
-  Forward(std::move(predictors));
+  Forward(predictors);
 
-  double res = outputLayer.Forward(std::move(boost::apply_visitor(
-      outputParameterVisitor, network.back())), std::move(responses));
+  double res = outputLayer.Forward(boost::apply_visitor(
+      outputParameterVisitor, network.back()), responses);
 
   for (size_t i = 0; i < network.size(); ++i)
   {
@@ -264,10 +270,10 @@ double FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Evaluate(
     ResetDeterministic();
   }
 
-  Forward(std::move(predictors.cols(begin, begin + batchSize - 1)));
+  Forward(predictors.cols(begin, begin + batchSize - 1));
   double res = outputLayer.Forward(
-      std::move(boost::apply_visitor(outputParameterVisitor, network.back())),
-      std::move(responses.cols(begin, begin + batchSize - 1)));
+      boost::apply_visitor(outputParameterVisitor, network.back()),
+      responses.cols(begin, begin + batchSize - 1));
 
   for (size_t i = 0; i < network.size(); ++i)
   {
@@ -325,10 +331,10 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     ResetDeterministic();
   }
 
-  Forward(std::move(predictors.cols(begin, begin + batchSize - 1)));
+  Forward(predictors.cols(begin, begin + batchSize - 1));
   double res = outputLayer.Forward(
-      std::move(boost::apply_visitor(outputParameterVisitor, network.back())),
-      std::move(responses.cols(begin, begin + batchSize - 1)));
+      boost::apply_visitor(outputParameterVisitor, network.back()),
+      responses.cols(begin, begin + batchSize - 1));
 
   for (size_t i = 0; i < network.size(); ++i)
   {
@@ -336,13 +342,13 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
   }
 
   outputLayer.Backward(
-      std::move(boost::apply_visitor(outputParameterVisitor, network.back())),
-      std::move(responses.cols(begin, begin + batchSize - 1)),
-      std::move(error));
+      boost::apply_visitor(outputParameterVisitor, network.back()),
+      responses.cols(begin, begin + batchSize - 1),
+      error);
 
   Backward();
   ResetGradients(gradient);
-  Gradient(std::move(predictors.cols(begin, begin + batchSize - 1)));
+  Gradient(predictors.cols(begin, begin + batchSize - 1));
 
   return res;
 }
@@ -396,18 +402,19 @@ void FFN<OutputLayerType, InitializationRuleType,
   size_t offset = 0;
   for (size_t i = 0; i < network.size(); ++i)
   {
-    offset += boost::apply_visitor(GradientSetVisitor(std::move(gradient),
-        offset), network[i]);
+    offset += boost::apply_visitor(GradientSetVisitor(gradient, offset),
+        network[i]);
   }
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename InputType>
 void FFN<OutputLayerType, InitializationRuleType,
-         CustomLayers...>::Forward(arma::mat&& input)
+         CustomLayers...>::Forward(const InputType& input)
 {
-  boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-      boost::apply_visitor(outputParameterVisitor, network.front()))),
+  boost::apply_visitor(ForwardVisitor(input,
+      boost::apply_visitor(outputParameterVisitor, network.front())),
       network.front());
 
   if (!reset)
@@ -434,9 +441,9 @@ void FFN<OutputLayerType, InitializationRuleType,
       boost::apply_visitor(SetInputHeightVisitor(height), network[i]);
     }
 
-    boost::apply_visitor(ForwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[i - 1])), std::move(
-        boost::apply_visitor(outputParameterVisitor, network[i]))), network[i]);
+    boost::apply_visitor(ForwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[i - 1]),
+        boost::apply_visitor(outputParameterVisitor, network[i])), network[i]);
 
     if (!reset)
     {
@@ -462,37 +469,38 @@ template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::Backward()
 {
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, network.back())), std::move(error), std::move(
-      boost::apply_visitor(deltaVisitor, network.back()))), network.back());
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, network.back()), error,
+      boost::apply_visitor(deltaVisitor, network.back())), network.back());
 
   for (size_t i = 2; i < network.size(); ++i)
   {
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[network.size() - i])), std::move(
-        boost::apply_visitor(deltaVisitor, network[network.size() - i + 1])),
-        std::move(boost::apply_visitor(deltaVisitor,
-        network[network.size() - i]))), network[network.size() - i]);
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[network.size() - i]),
+        boost::apply_visitor(deltaVisitor, network[network.size() - i + 1]),
+        boost::apply_visitor(deltaVisitor, network[network.size() - i])),
+        network[network.size() - i]);
   }
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename InputType>
 void FFN<OutputLayerType, InitializationRuleType,
-         CustomLayers...>::Gradient(arma::mat&& input)
+         CustomLayers...>::Gradient(const InputType& input)
 {
-  boost::apply_visitor(GradientVisitor(std::move(input), std::move(
-      boost::apply_visitor(deltaVisitor, network[1]))), network.front());
+  boost::apply_visitor(GradientVisitor(input,
+      boost::apply_visitor(deltaVisitor, network[1])), network.front());
 
   for (size_t i = 1; i < network.size() - 1; ++i)
   {
-    boost::apply_visitor(GradientVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[i - 1])), std::move(
-        boost::apply_visitor(deltaVisitor, network[i + 1]))), network[i]);
+    boost::apply_visitor(GradientVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[i - 1]),
+        boost::apply_visitor(deltaVisitor, network[i + 1])), network[i]);
   }
 
-  boost::apply_visitor(GradientVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, network[network.size() - 2])), std::move(error)),
+  boost::apply_visitor(GradientVisitor(boost::apply_visitor(
+      outputParameterVisitor, network[network.size() - 2]), error),
       network[network.size() - 1]);
 }
 
@@ -505,7 +513,13 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::serialize(
   ar & BOOST_SERIALIZATION_NVP(parameter);
   ar & BOOST_SERIALIZATION_NVP(width);
   ar & BOOST_SERIALIZATION_NVP(height);
-  ar & BOOST_SERIALIZATION_NVP(currentInput);
+
+  // Early versions used the currentInput member, which is now no longer needed.
+  if (version < 2)
+  {
+    arma::mat currentInput; // Temporary matrix to output.
+    ar & BOOST_SERIALIZATION_NVP(currentInput);
+  }
 
   // Earlier versions of the FFN code did not serialize whether or not the model
   // was reset.
@@ -535,8 +549,8 @@ void FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::serialize(
     size_t offset = 0;
     for (size_t i = 0; i < network.size(); ++i)
     {
-      offset += boost::apply_visitor(WeightSetVisitor(std::move(parameter),
-          offset), network[i]);
+      offset += boost::apply_visitor(WeightSetVisitor(parameter, offset),
+          network[i]);
 
       boost::apply_visitor(resetVisitor, network[i]);
     }
@@ -562,7 +576,6 @@ void FFN<OutputLayerType, InitializationRuleType,
   std::swap(parameter, network.parameter);
   std::swap(numFunctions, network.numFunctions);
   std::swap(error, network.error);
-  std::swap(currentInput, network.currentInput);
   std::swap(deterministic, network.deterministic);
   std::swap(delta, network.delta);
   std::swap(inputParameter, network.inputParameter);
@@ -584,7 +597,6 @@ FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::FFN(
     parameter(network.parameter),
     numFunctions(network.numFunctions),
     error(network.error),
-    currentInput(network.currentInput),
     deterministic(network.deterministic),
     delta(network.delta),
     inputParameter(network.inputParameter),
@@ -613,7 +625,6 @@ FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::FFN(
     parameter(std::move(network.parameter)),
     numFunctions(network.numFunctions),
     error(std::move(network.error)),
-    currentInput(std::move(network.currentInput)),
     deterministic(network.deterministic),
     delta(std::move(network.delta)),
     inputParameter(std::move(network.inputParameter)),

--- a/src/mlpack/methods/ann/gan/gan.hpp
+++ b/src/mlpack/methods/ann/gan/gan.hpp
@@ -289,7 +289,7 @@ class GAN
    *
    * @param input Sampled noise.
    */
-  void Forward(arma::mat&& input);
+  void Forward(const arma::mat& input);
 
   /**
    * This function predicts the output of the network on the given input.

--- a/src/mlpack/methods/ann/gan/wgan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/wgan_impl.hpp
@@ -50,28 +50,28 @@ GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
   currentTarget = arma::mat(responses.memptr() + i, 1, batchSize, false,
       false);
 
-  discriminator.Forward(std::move(currentInput));
+  discriminator.Forward(currentInput);
   double res = discriminator.outputLayer.Forward(
-      std::move(boost::apply_visitor(
+      boost::apply_visitor(
       outputParameterVisitor,
-      discriminator.network.back())), std::move(currentTarget));
+      discriminator.network.back()), currentTarget);
 
   noise.imbue( [&]() { return noiseFunction();} );
-  generator.Forward(std::move(noise));
+  generator.Forward(noise);
 
   predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  discriminator.Forward(std::move(predictors.cols(numFunctions,
-      numFunctions + batchSize - 1)));
+  discriminator.Forward(predictors.cols(numFunctions,
+      numFunctions + batchSize - 1));
   responses.cols(numFunctions, numFunctions + batchSize - 1) =
       -arma::ones(1, batchSize);
 
   currentTarget = arma::mat(responses.memptr() + numFunctions,
       1, batchSize, false, false);
   res += discriminator.outputLayer.Forward(
-      std::move(boost::apply_visitor(
+      boost::apply_visitor(
       outputParameterVisitor,
-      discriminator.network.back())), std::move(currentTarget));
+      discriminator.network.back()), currentTarget);
 
   return res;
 }
@@ -132,7 +132,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
       i, gradientDiscriminator, batchSize);
 
   noise.imbue( [&]() { return noiseFunction();} );
-  generator.Forward(std::move(noise));
+  generator.Forward(noise);
   predictors.cols(numFunctions, numFunctions + batchSize - 1) =
       boost::apply_visitor(outputParameterVisitor, generator.network.back());
   responses.cols(numFunctions, numFunctions + batchSize - 1) =

--- a/src/mlpack/methods/ann/init_rules/network_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/network_init.hpp
@@ -92,8 +92,8 @@ class NetworkInitialization
     // hold various other modules.
     for (size_t i = 0, offset = parameterOffset; i < network.size(); ++i)
     {
-      offset += boost::apply_visitor(WeightSetVisitor(std::move(parameter),
-          offset), network[i]);
+      offset += boost::apply_visitor(WeightSetVisitor(parameter, offset),
+          network[i]);
 
       boost::apply_visitor(resetVisitor, network[i]);
     }

--- a/src/mlpack/methods/ann/layer/add.hpp
+++ b/src/mlpack/methods/ann/layer/add.hpp
@@ -49,7 +49,7 @@ class Add
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -61,9 +61,9 @@ class Add
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                const arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activation.
@@ -73,9 +73,9 @@ class Add
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/add_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_impl.hpp
@@ -29,7 +29,7 @@ Add<InputDataType, OutputDataType>::Add(const size_t outSize) :
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Add<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   output = input;
   output.each_col() += weights;
@@ -38,9 +38,9 @@ void Add<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Add<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    const arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   g = gy;
 }
@@ -48,9 +48,9 @@ void Add<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Add<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient = error;
 }

--- a/src/mlpack/methods/ann/layer/add_merge.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge.hpp
@@ -61,7 +61,7 @@ class AddMerge
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(InputType&& /* input */, OutputType&& output);
+  void Forward(const InputType& /* input */, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -73,9 +73,9 @@ class AddMerge
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * This is the overload of Backward() that runs only a specific layer with
@@ -87,9 +87,9 @@ class AddMerge
    * @param The index of the layer to run.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g,
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g,
                 const size_t index);
 
   /*
@@ -100,9 +100,9 @@ class AddMerge
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   /*
    * This is the overload of Gradient() that runs a specific layer with the
@@ -114,9 +114,9 @@ class AddMerge
    * @param The index of the layer to run.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient,
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient,
                 const size_t index);
 
   /*

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -47,14 +47,14 @@ template <typename InputDataType, typename OutputDataType,
           typename... CustomLayers>
 template<typename InputType, typename OutputType>
 void AddMerge<InputDataType, OutputDataType, CustomLayers...>::Forward(
-    InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-          boost::apply_visitor(outputParameterVisitor, network[i]))),
+      boost::apply_visitor(ForwardVisitor(input,
+          boost::apply_visitor(outputParameterVisitor, network[i])),
           network[i]);
     }
   }
@@ -70,15 +70,17 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void AddMerge<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-          outputParameterVisitor, network[i])), std::move(gy), std::move(
-          boost::apply_visitor(deltaVisitor, network[i]))), network[i]);
+      boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+          outputParameterVisitor, network[i]), gy,
+          boost::apply_visitor(deltaVisitor, network[i])), network[i]);
     }
 
     g = boost::apply_visitor(deltaVisitor, network[0]);
@@ -95,12 +97,14 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void AddMerge<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g,
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g,
     const size_t index)
 {
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, network[index])), std::move(gy), std::move(
-      boost::apply_visitor(deltaVisitor, network[index]))), network[index]);
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, network[index]), gy,
+      boost::apply_visitor(deltaVisitor, network[index])), network[index]);
   g = boost::apply_visitor(deltaVisitor, network[index]);
 }
 
@@ -108,16 +112,15 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void AddMerge<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */ )
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */ )
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(GradientVisitor(std::move(input), std::move(error)),
-          network[i]);
+      boost::apply_visitor(GradientVisitor(input, error), network[i]);
     }
   }
 }
@@ -126,13 +129,12 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void AddMerge<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */,
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */,
     const size_t index)
 {
-  boost::apply_visitor(GradientVisitor(std::move(input), std::move(error)),
-      network[index]);
+  boost::apply_visitor(GradientVisitor(input, error), network[index]);
 }
 
 template<typename InputDataType, typename OutputDataType,

--- a/src/mlpack/methods/ann/layer/alpha_dropout.hpp
+++ b/src/mlpack/methods/ann/layer/alpha_dropout.hpp
@@ -65,7 +65,7 @@ class AlphaDropout
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of the alpha_dropout layer.
@@ -75,9 +75,9 @@ class AlphaDropout
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/alpha_dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/alpha_dropout_impl.hpp
@@ -36,7 +36,7 @@ AlphaDropout<InputDataType, OutputDataType>::AlphaDropout(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void AlphaDropout<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   // The dropout mask will not be multiplied in the deterministic mode
   // (during testing).
@@ -58,7 +58,7 @@ void AlphaDropout<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void AlphaDropout<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   g = gy % mask * a;
 }

--- a/src/mlpack/methods/ann/layer/atrous_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution.hpp
@@ -137,7 +137,7 @@ class AtrousConvolution
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -149,9 +149,9 @@ class AtrousConvolution
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -161,9 +161,9 @@ class AtrousConvolution
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   const OutputDataType& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
@@ -184,10 +184,10 @@ void AtrousConvolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->::Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+>::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (padding.PadWLeft() != 0 || padding.PadWRight() != 0 ||
@@ -200,8 +200,7 @@ void AtrousConvolution<
 
     for (size_t i = 0; i < inputTemp.n_slices; ++i)
     {
-      padding.Forward(std::move(inputTemp.slice(i)),
-          std::move(inputPaddedTemp.slice(i)));
+      padding.Forward(inputTemp.slice(i), inputPaddedTemp.slice(i));
     }
   }
 
@@ -267,10 +266,10 @@ void AtrousConvolution<
     InputDataType,
     OutputDataType
 >::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
-  arma::cube mappedError(gy.memptr(), outputWidth, outputHeight,
-      outSize * batchSize, false, false);
+  arma::cube mappedError(((arma::Mat<eT>&) gy).memptr(), outputWidth,
+      outputHeight, outSize * batchSize, false, false);
 
   g.set_size(inputTemp.n_rows * inputTemp.n_cols * inSize, batchSize);
   gTemp = arma::Cube<eT>(g.memptr(), inputTemp.n_rows,
@@ -326,12 +325,12 @@ void AtrousConvolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
-  arma::cube mappedError(error.memptr(), outputWidth, outputHeight,
-      outSize * batchSize, false, false);
+  arma::cube mappedError(((arma::Mat<eT>&) error).memptr(), outputWidth,
+      outputHeight, outSize * batchSize, false, false);
 
   gradient.set_size(weights.n_elem, 1);
   gradientTemp = arma::Cube<eT>(gradient.memptr(), weight.n_rows,

--- a/src/mlpack/methods/ann/layer/base_layer.hpp
+++ b/src/mlpack/methods/ann/layer/base_layer.hpp
@@ -69,7 +69,7 @@ class BaseLayer
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output)
+  void Forward(const InputType& input, OutputType& output)
   {
     ActivationFunction::Fn(input, output);
   }
@@ -84,9 +84,9 @@ class BaseLayer
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g)
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g)
   {
     arma::Mat<eT> derivative;
     ActivationFunction::Deriv(input, derivative);

--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -81,7 +81,7 @@ class BatchNorm
    * @param output Resulting output activations.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Backward pass through the layer.
@@ -91,9 +91,9 @@ class BatchNorm
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activations.
@@ -103,9 +103,9 @@ class BatchNorm
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -63,7 +63,7 @@ void BatchNorm<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void BatchNorm<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   // Mean and variance over the entire training set will be used to compute
   // the forward pass when deterministic is set to true.
@@ -106,7 +106,7 @@ void BatchNorm<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void BatchNorm<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& input, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   const arma::mat stdInv = 1.0 / arma::sqrt(variance + eps);
 
@@ -130,9 +130,9 @@ void BatchNorm<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void BatchNorm<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient.set_size(size + size, 1);
 

--- a/src/mlpack/methods/ann/layer/bilinear_interpolation.hpp
+++ b/src/mlpack/methods/ann/layer/bilinear_interpolation.hpp
@@ -65,7 +65,7 @@ class BilinearInterpolation
    * @param output The resulting interpolated output matrix.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -79,9 +79,9 @@ class BilinearInterpolation
    * @param output The resulting down-sampled output.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /*input*/,
-                arma::Mat<eT>&& gradient,
-                arma::Mat<eT>&& output);
+  void Backward(const arma::Mat<eT>& /*input*/,
+                const arma::Mat<eT>& gradient,
+                arma::Mat<eT>& output);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/bilinear_interpolation_impl.hpp
+++ b/src/mlpack/methods/ann/layer/bilinear_interpolation_impl.hpp
@@ -54,7 +54,7 @@ BilinearInterpolation(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void BilinearInterpolation<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
   if (output.is_empty())
@@ -68,7 +68,7 @@ void BilinearInterpolation<InputDataType, OutputDataType>::Forward(
   assert(inRowSize >= 2);
   assert(inColSize >= 2);
 
-  arma::cube inputAsCube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  arma::cube inputAsCube(const_cast<arma::Mat<eT>&>(input).memptr(),
       inRowSize, inColSize, depth * batchSize, false, false);
   arma::cube outputAsCube(output.memptr(), outRowSize, outColSize,
                           depth * batchSize, false, true);
@@ -114,9 +114,9 @@ void BilinearInterpolation<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void BilinearInterpolation<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /*input*/,
-    arma::Mat<eT>&& gradient,
-    arma::Mat<eT>&& output)
+    const arma::Mat<eT>& /*input*/,
+    const arma::Mat<eT>& gradient,
+    arma::Mat<eT>& output)
 {
   if (output.is_empty())
     output.set_size(inRowSize * inColSize * depth, batchSize);
@@ -129,8 +129,8 @@ void BilinearInterpolation<InputDataType, OutputDataType>::Backward(
   assert(outRowSize >= 2);
   assert(outColSize >= 2);
 
-  arma::cube gradientAsCube(gradient.memptr(), outRowSize, outColSize,
-                            depth * batchSize, false, false);
+  arma::cube gradientAsCube(((arma::Mat<eT>&) gradient).memptr(), outRowSize,
+      outColSize, depth * batchSize, false, false);
   arma::cube outputAsCube(output.memptr(), inRowSize, inColSize,
                           depth * batchSize, false, true);
 

--- a/src/mlpack/methods/ann/layer/c_relu.hpp
+++ b/src/mlpack/methods/ann/layer/c_relu.hpp
@@ -63,7 +63,7 @@ class CReLU
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -75,7 +75,7 @@ class CReLU
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input, DataType&& gy, DataType&& g);
+  void Backward(const DataType& input, const DataType& gy, DataType& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/c_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/c_relu_impl.hpp
@@ -27,7 +27,7 @@ CReLU<InputDataType, OutputDataType>::CReLU()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void CReLU<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output = arma::join_cols(arma::max(input, 0.0 * input), arma::max(
       (-1 * input), 0.0 * input));
@@ -36,7 +36,7 @@ void CReLU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void CReLU<InputDataType, OutputDataType>::Backward(
-    const DataType&& input, DataType&& gy, DataType&& g)
+    const DataType& input, const DataType& gy, DataType& g)
 {
   DataType temp;
   temp = gy % (input >= 0.0);

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -80,7 +80,7 @@ class Concat
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, using 3rd-order tensors as
@@ -92,9 +92,9 @@ class Concat
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * This is the overload of Backward() that runs only a specific layer with
@@ -106,9 +106,9 @@ class Concat
    * @param The index of the layer to run.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g,
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g,
                 const size_t index);
 
   /*
@@ -119,9 +119,9 @@ class Concat
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& /* gradient */);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& /* gradient */);
 
   /*
    * This is the overload of Gradient() that runs a specific layer with the
@@ -133,9 +133,9 @@ class Concat
    * @param The index of the layer to run.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient,
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient,
                 const size_t index);
 
   /*

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -99,14 +99,14 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Concat<InputDataType, OutputDataType, CustomLayers...>::Forward(
-    arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-          boost::apply_visitor(outputParameterVisitor, network[i]))),
+      boost::apply_visitor(ForwardVisitor(input,
+          boost::apply_visitor(outputParameterVisitor, network[i])),
           network[i]);
     }
   }
@@ -134,13 +134,14 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   size_t rowCount = 0;
   if (run)
   {
     arma::Mat<eT> delta;
-    gy.reshape(gy.n_rows / channels, gy.n_cols * channels);
+    arma::Mat<eT> gyTmp(((arma::Mat<eT>&) gy).memptr(), gy.n_rows / channels,
+        gy.n_cols * channels, false, false);
     for (size_t i = 0; i < network.size(); ++i)
     {
       // Use rows from the error corresponding to the output from each layer.
@@ -148,13 +149,13 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
           outputParameterVisitor, network[i]).n_rows;
 
       // Extract from gy the parameters for the i-th network.
-      delta = gy.rows(rowCount / channels, (rowCount + rows) / channels - 1);
+      delta = gyTmp.rows(rowCount / channels, (rowCount + rows) / channels - 1);
       delta.reshape(delta.n_rows * channels, delta.n_cols / channels);
 
-      boost::apply_visitor(BackwardVisitor(std::move(
+      boost::apply_visitor(BackwardVisitor(
           boost::apply_visitor(outputParameterVisitor,
-          network[i])), std::move(delta), std::move(
-          boost::apply_visitor(deltaVisitor, network[i]))), network[i]);
+          network[i]), delta,
+          boost::apply_visitor(deltaVisitor, network[i])), network[i]);
       rowCount += rows;
     }
 
@@ -163,7 +164,6 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
     {
       g += boost::apply_visitor(deltaVisitor, network[i]);
     }
-    gy.reshape(gy.n_rows * channels, gy.n_cols / channels);
   }
   else
   {
@@ -175,7 +175,9 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g,
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g,
     const size_t index)
 {
   size_t rowCount = 0, rows = 0;
@@ -188,18 +190,16 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Backward(
   rows = boost::apply_visitor(outputParameterVisitor, network[index]).n_rows;
 
   // Reshape gy to extract the i-th layer gy.
-  gy.reshape(gy.n_rows / channels, gy.n_cols * channels);
+  arma::Mat<eT> gyTmp(((arma::Mat<eT>&) gy).memptr(), gy.n_rows / channels,
+      gy.n_cols * channels, false, false);
 
-  arma::Mat<eT> delta = gy.rows(rowCount / channels, (rowCount + rows) /
+  arma::Mat<eT> delta = gyTmp.rows(rowCount / channels, (rowCount + rows) /
       channels - 1);
   delta.reshape(delta.n_rows * channels, delta.n_cols / channels);
 
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, network[index])), std::move(delta), std::move(
-      boost::apply_visitor(deltaVisitor, network[index]))), network[index]);
-
-  // Reshape gy to its original shape.
-  gy.reshape(gy.n_rows * channels, gy.n_cols / channels);
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, network[index]), delta,
+      boost::apply_visitor(deltaVisitor, network[index])), network[index]);
 
   g = boost::apply_visitor(deltaVisitor, network[index]);
 }
@@ -208,32 +208,29 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */)
 {
   if (run)
   {
     size_t rowCount = 0;
     // Reshape error to extract the i-th layer error.
-    error.reshape(error.n_rows / channels, error.n_cols * channels);
+    arma::Mat<eT> errorTmp(((arma::Mat<eT>&) error).memptr(),
+        error.n_rows / channels, error.n_cols * channels, false, false);
     for (size_t i = 0; i < network.size(); ++i)
     {
       size_t rows = boost::apply_visitor(
           outputParameterVisitor, network[i]).n_rows;
 
       // Extract from error the parameters for the i-th network.
-      arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) /
+      arma::Mat<eT> err = errorTmp.rows(rowCount / channels, (rowCount + rows) /
           channels - 1);
       err.reshape(err.n_rows * channels, err.n_cols / channels);
 
-      boost::apply_visitor(GradientVisitor(std::move(input),
-          std::move(err)), network[i]);
+      boost::apply_visitor(GradientVisitor(input, err), network[i]);
       rowCount += rows;
     }
-
-    // Reshape error to its original shape.
-    error.reshape(error.n_rows * channels, error.n_cols / channels);
   }
 }
 
@@ -241,9 +238,9 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */,
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */,
     const size_t index)
 {
   size_t rowCount = 0;
@@ -255,15 +252,13 @@ void Concat<InputDataType, OutputDataType, CustomLayers...>::Gradient(
   size_t rows = boost::apply_visitor(
       outputParameterVisitor, network[index]).n_rows;
 
-  error.reshape(error.n_rows / channels, error.n_cols * channels);
-  arma::Mat<eT> err = error.rows(rowCount / channels, (rowCount + rows) /
+  arma::Mat<eT> errorTmp(((arma::Mat<eT>&) error).memptr(),
+      error.n_rows / channels, error.n_cols * channels, false, false);
+  arma::Mat<eT> err = errorTmp.rows(rowCount / channels, (rowCount + rows) /
       channels - 1);
   err.reshape(err.n_rows * channels, err.n_cols / channels);
 
-  boost::apply_visitor(GradientVisitor(std::move(input),
-      std::move(err)), network[index]);
-
-  error.reshape(error.n_rows * channels, error.n_cols / channels);
+  boost::apply_visitor(GradientVisitor(input, err), network[index]);
 }
 
 template<typename InputDataType, typename OutputDataType,

--- a/src/mlpack/methods/ann/layer/concat_performance.hpp
+++ b/src/mlpack/methods/ann/layer/concat_performance.hpp
@@ -55,7 +55,8 @@ class ConcatPerformance
    * @param output Resulting output activation.
    */
   template<typename eT>
-  double Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& target);
+  double Forward(const arma::Mat<eT>& input, arma::Mat<eT>& target);
+
   /**
    * Ordinary feed backward pass of a neural network. The negative log
    * likelihood layer expectes that the input contains log-probabilities for
@@ -68,9 +69,9 @@ class ConcatPerformance
    * @param output The calculated error.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                const arma::Mat<eT>&& target,
-                arma::Mat<eT>&& output);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& target,
+                arma::Mat<eT>& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/concat_performance_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_performance_impl.hpp
@@ -44,7 +44,7 @@ double ConcatPerformance<
     OutputLayerType,
     InputDataType,
     OutputDataType
->::Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& target)
+>::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& target)
 {
   const size_t elements = input.n_elem / inSize;
 
@@ -52,7 +52,7 @@ double ConcatPerformance<
   for (size_t i = 0; i < input.n_elem; i+= elements)
   {
     arma::mat subInput = input.submat(i, 0, i + elements - 1, 0);
-    output += outputLayer.Forward(std::move(subInput), std::move(target));
+    output += outputLayer.Forward(subInput, target);
   }
 
   return output;
@@ -69,17 +69,16 @@ void ConcatPerformance<
     InputDataType,
     OutputDataType
 >::Backward(
-    const arma::Mat<eT>&& input,
-    const arma::Mat<eT>&& target,
-    arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& target,
+    arma::Mat<eT>& output)
 {
   const size_t elements = input.n_elem / inSize;
 
   arma::mat subInput = input.submat(0, 0, elements - 1, 0);
   arma::mat subOutput;
 
-  outputLayer.Backward(std::move(subInput), std::move(target),
-      std::move(subOutput));
+  outputLayer.Backward(subInput, target, subOutput);
 
   output = arma::zeros(subOutput.n_elem, inSize);
   output.col(0) = subOutput;
@@ -87,8 +86,7 @@ void ConcatPerformance<
   for (size_t i = elements, j = 0; i < input.n_elem; i+= elements, j++)
   {
     subInput = input.submat(i, 0, i + elements - 1, 0);
-    outputLayer.Backward(std::move(subInput), std::move(target),
-      std::move(subOutput));
+    outputLayer.Backward(subInput, target, subOutput);
 
     output.col(j) = subOutput;
   }

--- a/src/mlpack/methods/ann/layer/concatenate.hpp
+++ b/src/mlpack/methods/ann/layer/concatenate.hpp
@@ -49,7 +49,7 @@ class Concatenate
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -61,9 +61,9 @@ class Concatenate
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                const arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/concatenate_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concatenate_impl.hpp
@@ -28,7 +28,7 @@ Concatenate<InputDataType, OutputDataType>::Concatenate()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Concatenate<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (concat.is_empty())
     Log::Warn << "The concat matrix has not been provided." << std::endl;
@@ -46,9 +46,9 @@ void Concatenate<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Concatenate<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    const arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   g = gy.submat(0, 0, inRows - 1, concat.n_cols - 1);
 }

--- a/src/mlpack/methods/ann/layer/constant.hpp
+++ b/src/mlpack/methods/ann/layer/constant.hpp
@@ -51,7 +51,7 @@ class Constant
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network. The backward pass of the
@@ -62,9 +62,9 @@ class Constant
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& /* input */,
-                DataType&& /* gy */,
-                DataType&& g);
+  void Backward(const DataType& /* input */,
+                const DataType& /* gy */,
+                DataType& g);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/constant_impl.hpp
@@ -33,7 +33,7 @@ Constant<InputDataType, OutputDataType>::Constant(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void Constant<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   if (inSize == 0)
   {
@@ -46,7 +46,7 @@ void Constant<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void Constant<InputDataType, OutputDataType>::Backward(
-    const DataType&& /* input */, DataType&& /* gy */, DataType&& g)
+    const DataType& /* input */, const DataType& /* gy */, DataType& g)
 {
   g = arma::zeros<DataType>(inSize, 1);
 }

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -123,7 +123,7 @@ class Convolution
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -135,9 +135,9 @@ class Convolution
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -147,9 +147,9 @@ class Convolution
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   const OutputDataType& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -71,7 +71,8 @@ Convolution<
       std::tuple<size_t, size_t>(padW, padW),
       std::tuple<size_t, size_t>(padH, padH),
       inputWidth,
-      inputHeight)
+      inputHeight,
+      paddingType)
 {
   // Nothing to do here.
 }
@@ -174,10 +175,10 @@ void Convolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->::Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+>::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
@@ -187,8 +188,7 @@ void Convolution<
 
     for (size_t i = 0; i < inputTemp.n_slices; ++i)
     {
-      padding.Forward(std::move(inputTemp.slice(i)),
-          std::move(inputPaddedTemp.slice(i)));
+      padding.Forward(inputTemp.slice(i), inputPaddedTemp.slice(i));
     }
   }
 
@@ -253,10 +253,10 @@ void Convolution<
     InputDataType,
     OutputDataType
 >::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
-  arma::cube mappedError(gy.memptr(), outputWidth, outputHeight,
-      outSize * batchSize, false, false);
+  arma::cube mappedError(((arma::Mat<eT>&) gy).memptr(), outputWidth,
+      outputHeight, outSize * batchSize, false, false);
 
   g.set_size(inputTemp.n_rows * inputTemp.n_cols * inSize, batchSize);
   gTemp = arma::Cube<eT>(g.memptr(), inputTemp.n_rows,
@@ -308,11 +308,11 @@ void Convolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
-  arma::cube mappedError(error.memptr(), outputWidth,
+  arma::cube mappedError(((arma::Mat<eT>&) error).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 
   gradient.set_size(weights.n_elem, 1);

--- a/src/mlpack/methods/ann/layer/dropconnect.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect.hpp
@@ -86,7 +86,7 @@ class DropConnect
   * @param output Resulting output activation.
   */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of the DropConnect layer.
@@ -96,9 +96,9 @@ class DropConnect
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activation.
@@ -108,9 +108,9 @@ class DropConnect
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& /* gradient */);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& /* gradient */);
 
   //! Get the model modules.
   std::vector<LayerTypes<> >& Model() { return network; }

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -57,31 +57,29 @@ DropConnect<InputDataType, OutputDataType>::~DropConnect()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void DropConnect<InputDataType, OutputDataType>::Forward(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input,
+    arma::Mat<eT>& output)
 {
   // The DropConnect mask will not be multiplied in the deterministic mode
   // (during testing).
   if (deterministic)
   {
-    boost::apply_visitor(ForwardVisitor(std::move(input), std::move(output)),
-        baseLayer);
+    boost::apply_visitor(ForwardVisitor(input, output), baseLayer);
   }
   else
   {
     // Save weights for denoising.
-    boost::apply_visitor(ParametersVisitor(std::move(denoise)), baseLayer);
+    boost::apply_visitor(ParametersVisitor(denoise), baseLayer);
 
     // Scale with input / (1 - ratio) and set values to zero with
     // probability ratio.
     mask = arma::randu<arma::Mat<eT> >(denoise.n_rows, denoise.n_cols);
     mask.transform([&](double val) { return (val > ratio); });
 
-    boost::apply_visitor(ParametersSetVisitor(std::move(denoise % mask)),
-        baseLayer);
+    arma::mat tmp = denoise % mask;
+    boost::apply_visitor(ParametersSetVisitor(tmp), baseLayer);
 
-    boost::apply_visitor(ForwardVisitor(std::move(input), std::move(output)),
-        baseLayer);
+    boost::apply_visitor(ForwardVisitor(input, output), baseLayer);
 
     output = output * scale;
   }
@@ -90,26 +88,25 @@ void DropConnect<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void DropConnect<InputDataType, OutputDataType>::Backward(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
-  boost::apply_visitor(BackwardVisitor(std::move(input), std::move(gy),
-      std::move(g)), baseLayer);
+  boost::apply_visitor(BackwardVisitor(input, gy, g), baseLayer);
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void DropConnect<InputDataType, OutputDataType>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */)
 {
-  boost::apply_visitor(GradientVisitor(std::move(input), std::move(error)),
+  boost::apply_visitor(GradientVisitor(input, error),
       baseLayer);
 
   // Denoise the weights.
-  boost::apply_visitor(ParametersSetVisitor(std::move(denoise)), baseLayer);
+  boost::apply_visitor(ParametersSetVisitor(denoise), baseLayer);
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -66,7 +66,7 @@ class Dropout
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of the dropout layer.
@@ -76,9 +76,9 @@ class Dropout
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -32,8 +32,8 @@ Dropout<InputDataType, OutputDataType>::Dropout(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Dropout<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input,
+    arma::Mat<eT>& output)
 {
   // The dropout mask will not be multiplied in the deterministic mode
   // (during testing).
@@ -54,9 +54,9 @@ void Dropout<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Dropout<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   g = gy % mask * scale;
 }

--- a/src/mlpack/methods/ann/layer/elu.hpp
+++ b/src/mlpack/methods/ann/layer/elu.hpp
@@ -134,7 +134,7 @@ class ELU
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -146,7 +146,7 @@ class ELU
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input, DataType&& gy, DataType&& g);
+  void Backward(const DataType& input, const DataType& gy, DataType& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/elu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/elu_impl.hpp
@@ -49,7 +49,7 @@ ELU<InputDataType, OutputDataType>::ELU(const double alpha) :
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void ELU<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output.set_size(arma::size(input));
   for (size_t i = 0; i < input.n_elem; i++)
@@ -77,7 +77,7 @@ void ELU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void ELU<InputDataType, OutputDataType>::Backward(
-    const DataType&& /* input */, DataType&& gy, DataType&& g)
+    const DataType& /* input */, const DataType& gy, DataType& g)
 {
   g = gy % derivative;
 }

--- a/src/mlpack/methods/ann/layer/fast_lstm.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm.hpp
@@ -91,7 +91,7 @@ class FastLSTM
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -103,9 +103,9 @@ class FastLSTM
    * @param g The calculated gradient.
    */
   template<typename InputType, typename ErrorType, typename GradientType>
-  void Backward(const InputType&& input,
-                ErrorType&& gy,
-                GradientType&& g);
+  void Backward(const InputType& input,
+                const ErrorType& gy,
+                GradientType& g);
 
   /*
    * Reset the layer parameter.
@@ -128,9 +128,9 @@ class FastLSTM
    * @param gradient The calculated gradient.
    */
   template<typename InputType, typename ErrorType, typename GradientType>
-  void Gradient(InputType&& input,
-                ErrorType&& error,
-                GradientType&& gradient);
+  void Gradient(const InputType& input,
+                const ErrorType& error,
+                GradientType& gradient);
 
   //! Get the maximum number of steps to backpropagate through time (BPTT).
   size_t Rho() const { return rho; }
@@ -171,7 +171,7 @@ class FastLSTM
    * @param sigmoid The matrix to store the sigmoid approximation into.
    */
   template<typename InputType, typename OutputType>
-  void FastSigmoid(InputType&& input, OutputType&& sigmoids)
+  void FastSigmoid(const InputType& input, OutputType& sigmoids)
   {
     for (size_t i = 0; i < input.n_elem; ++i)
       sigmoids(i) = FastSigmoid(input(i));

--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -112,7 +112,7 @@ void FastLSTM<InputDataType, OutputDataType>::ResetCell(const size_t size)
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void FastLSTM<InputDataType, OutputDataType>::Forward(
-    InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   // Check if the batch size changed, the number of cols is defines the input
   // batch size.
@@ -128,9 +128,11 @@ void FastLSTM<InputDataType, OutputDataType>::Forward(
       forwardStep, forwardStep + batchStep);
   gate.cols(forwardStep, forwardStep + batchStep).each_col() += input2GateBias;
 
-  FastSigmoid(std::move(
-      gate.submat(0, forwardStep, 3 * outSize - 1, forwardStep + batchStep)),
-      std::move(gateActivation.cols(forwardStep, forwardStep + batchStep)));
+  arma::subview<double> sigmoidOut = gateActivation.cols(forwardStep,
+      forwardStep + batchStep);
+  FastSigmoid(
+      gate.submat(0, forwardStep, 3 * outSize - 1, forwardStep + batchStep),
+      sigmoidOut);
 
   stateActivation.cols(forwardStep, forwardStep + batchStep) = arma::tanh(
       gate.submat(3 * outSize, forwardStep, 4 * outSize - 1,
@@ -178,14 +180,20 @@ void FastLSTM<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename ErrorType, typename GradientType>
 void FastLSTM<InputDataType, OutputDataType>::Backward(
-  const InputType&& /* input */, ErrorType&& gy, GradientType&& g)
+  const InputType& /* input */, const ErrorType& gy, GradientType& g)
 {
+  ErrorType gyLocal;
   if (gradientStepIdx > 0)
   {
-    gy += output2GateWeight.t() * prevError;
+    gyLocal = gy + output2GateWeight.t() * prevError;
+  }
+  else
+  {
+    gyLocal = ErrorType(((ErrorType&) gy).memptr(), gy.n_rows, gy.n_cols, false,
+        false);
   }
 
-  cellActivationError = gy % gateActivation.submat(outSize,
+  cellActivationError = gyLocal % gateActivation.submat(outSize,
       backwardStep - batchStep, 2 * outSize - 1, backwardStep) %
       (1 - arma::pow(cellActivation.cols(backwardStep - batchStep,
       backwardStep), 2));
@@ -225,7 +233,7 @@ void FastLSTM<InputDataType, OutputDataType>::Backward(
 
   prevError.submat(outSize, 0, 2 * outSize - 1, batchStep) =
       cellActivation.cols(backwardStep - batchStep,
-      backwardStep) % gy % gateActivation.submat(
+      backwardStep) % gyLocal % gateActivation.submat(
        outSize, backwardStep - batchStep, 2 * outSize - 1, backwardStep) %
       (1.0 - gateActivation.submat(
       outSize, backwardStep - batchStep, 2 * outSize - 1, backwardStep));
@@ -244,7 +252,9 @@ void FastLSTM<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename ErrorType, typename GradientType>
 void FastLSTM<InputDataType, OutputDataType>::Gradient(
-    InputType&& input, ErrorType&& /* error */, GradientType&& gradient)
+    const InputType& input,
+    const ErrorType& /* error */,
+    GradientType& gradient)
 {
   // Gradient of the input to gate layer.
   gradient.submat(0, 0, input2GateWeight.n_elem - 1, 0) =

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -84,7 +84,7 @@ class FlexibleReLU
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -96,7 +96,7 @@ class FlexibleReLU
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input, DataType&& gy, DataType&& g);
+  void Backward(const DataType& input, const DataType& gy, DataType& g);
 
   /**
    * Calculate the gradient using the output delta and the input activation.
@@ -106,9 +106,9 @@ class FlexibleReLU
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return alpha; }

--- a/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu_impl.hpp
@@ -41,7 +41,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void FlexibleReLU<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output = arma::clamp(input, 0.0, DBL_MAX) + alpha(0);
 }
@@ -49,7 +49,7 @@ void FlexibleReLU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void FlexibleReLU<InputDataType, OutputDataType>::Backward(
-    const DataType&& input, DataType&& gy, DataType&& g)
+    const DataType& input, const DataType& gy, DataType& g)
 {
   //! Compute the first derivative of FlexibleReLU function.
   g = gy % arma::clamp(arma::sign(input), 0.0, 1.0);
@@ -58,9 +58,9 @@ void FlexibleReLU<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void FlexibleReLU<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   if (gradient.n_elem == 0)
   {

--- a/src/mlpack/methods/ann/layer/glimpse.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse.hpp
@@ -113,7 +113,7 @@ class Glimpse
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of the glimpse layer.
@@ -123,9 +123,9 @@ class Glimpse
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const {return outputParameter; }

--- a/src/mlpack/methods/ann/layer/glimpse_impl.hpp
+++ b/src/mlpack/methods/ann/layer/glimpse_impl.hpp
@@ -45,7 +45,7 @@ Glimpse<InputDataType, OutputDataType>::Glimpse(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Glimpse<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   inputTemp = arma::cube(input.colptr(0), inputWidth, inputHeight, inSize);
   outputTemp = arma::Cube<eT>(size, size, depth * inputTemp.n_slices);
@@ -129,7 +129,7 @@ void Glimpse<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Glimpse<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   // Generate a cube using the backpropagated error matrix.
   arma::Cube<eT> mappedError = arma::zeros<arma::cube>(outputWidth,

--- a/src/mlpack/methods/ann/layer/gru.hpp
+++ b/src/mlpack/methods/ann/layer/gru.hpp
@@ -84,7 +84,7 @@ class GRU
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -96,9 +96,9 @@ class GRU
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -108,9 +108,9 @@ class GRU
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& /* error */,
-                arma::Mat<eT>&& /* gradient */);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& /* error */,
+                arma::Mat<eT>& /* gradient */);
 
   /*
    * Resets the cell to accept a new input. This breaks the BPTT chain starts a

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -90,7 +90,7 @@ GRU<InputDataType, OutputDataType>::~GRU()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void GRU<InputDataType, OutputDataType>::Forward(
-    arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (input.n_cols != batchSize)
   {
@@ -114,13 +114,13 @@ void GRU<InputDataType, OutputDataType>::Forward(
   }
 
   // Process the input linearly(zt, rt, ot).
-  boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-      boost::apply_visitor(outputParameterVisitor, input2GateModule))),
+  boost::apply_visitor(ForwardVisitor(input,
+      boost::apply_visitor(outputParameterVisitor, input2GateModule)),
       input2GateModule);
 
   // Process the output(zt, rt) linearly.
-  boost::apply_visitor(ForwardVisitor(std::move(*prevOutput), std::move(
-      boost::apply_visitor(outputParameterVisitor, output2GateModule))),
+  boost::apply_visitor(ForwardVisitor(*prevOutput,
+      boost::apply_visitor(outputParameterVisitor, output2GateModule)),
       output2GateModule);
 
   // Merge the outputs(zt and rt).
@@ -129,22 +129,22 @@ void GRU<InputDataType, OutputDataType>::Forward(
       boost::apply_visitor(outputParameterVisitor, output2GateModule));
 
   // Pass the first outSize through inputGate(it).
-  boost::apply_visitor(ForwardVisitor(std::move(output.submat(
-      0, 0, 1 * outSize - 1, batchSize - 1)), std::move(boost::apply_visitor(
-      outputParameterVisitor, inputGateModule))), inputGateModule);
+  boost::apply_visitor(ForwardVisitor(output.submat(
+      0, 0, 1 * outSize - 1, batchSize - 1), boost::apply_visitor(
+      outputParameterVisitor, inputGateModule)), inputGateModule);
 
   // Pass the second through forgetGate.
-  boost::apply_visitor(ForwardVisitor(std::move(output.submat(
-      1 * outSize, 0, 2 * outSize - 1, batchSize - 1)), std::move(
-      boost::apply_visitor(outputParameterVisitor, forgetGateModule))),
+  boost::apply_visitor(ForwardVisitor(output.submat(
+      1 * outSize, 0, 2 * outSize - 1, batchSize - 1),
+      boost::apply_visitor(outputParameterVisitor, forgetGateModule)),
       forgetGateModule);
 
   arma::mat modInput = (boost::apply_visitor(outputParameterVisitor,
       forgetGateModule) % *prevOutput);
 
   // Pass that through the outputHidden2GateModule.
-  boost::apply_visitor(ForwardVisitor(std::move(modInput), std::move(
-      boost::apply_visitor(outputParameterVisitor, outputHidden2GateModule))),
+  boost::apply_visitor(ForwardVisitor(modInput,
+      boost::apply_visitor(outputParameterVisitor, outputHidden2GateModule)),
       outputHidden2GateModule);
 
   // Merge for ot.
@@ -153,8 +153,8 @@ void GRU<InputDataType, OutputDataType>::Forward(
       boost::apply_visitor(outputParameterVisitor, outputHidden2GateModule);
 
   // Pass it through hiddenGate.
-  boost::apply_visitor(ForwardVisitor(std::move(outputH), std::move(
-      boost::apply_visitor(outputParameterVisitor, hiddenStateModule))),
+  boost::apply_visitor(ForwardVisitor(outputH,
+      boost::apply_visitor(outputParameterVisitor, hiddenStateModule)),
       hiddenStateModule);
 
   // Update the output (nextOutput): cmul1 + cmul2
@@ -205,7 +205,7 @@ void GRU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void GRU<InputDataType, OutputDataType>::Backward(
-  const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+  const arma::Mat<eT>& input, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   if (input.n_cols != batchSize)
   {
@@ -228,9 +228,15 @@ void GRU<InputDataType, OutputDataType>::Backward(
     gradIterator = outParameter.end();
   }
 
+  arma::Mat<eT> gyLocal;
   if ((outParameter.size() - backwardStep  - 1) % rho != 0 && backwardStep != 0)
   {
-    gy += boost::apply_visitor(deltaVisitor, output2GateModule);
+    gyLocal = gy + boost::apply_visitor(deltaVisitor, output2GateModule);
+  }
+  else
+  {
+    gyLocal = arma::Mat<eT>(((arma::Mat<eT>&) gy).memptr(), gy.n_rows,
+        gy.n_cols, false, false);
   }
 
   if (backIterator == outParameter.end())
@@ -239,31 +245,31 @@ void GRU<InputDataType, OutputDataType>::Backward(
   }
 
   // Delta zt.
-  arma::mat dZt = gy % (*backIterator -
+  arma::mat dZt = gyLocal % (*backIterator -
       boost::apply_visitor(outputParameterVisitor,
       hiddenStateModule));
 
   // Delta ot.
-  arma::mat dOt = gy % (arma::ones<arma::mat>(outSize, batchSize) -
+  arma::mat dOt = gyLocal % (arma::ones<arma::mat>(outSize, batchSize) -
       boost::apply_visitor(outputParameterVisitor, inputGateModule));
 
   // Delta of input gate.
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, inputGateModule)), std::move(dZt),
-      std::move(boost::apply_visitor(deltaVisitor, inputGateModule))),
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, inputGateModule), dZt,
+      boost::apply_visitor(deltaVisitor, inputGateModule)),
       inputGateModule);
 
   // Delta of hidden gate.
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, hiddenStateModule)), std::move(dOt),
-      std::move(boost::apply_visitor(deltaVisitor, hiddenStateModule))),
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, hiddenStateModule), dOt,
+      boost::apply_visitor(deltaVisitor, hiddenStateModule)),
       hiddenStateModule);
 
   // Delta of outputHidden2GateModule.
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, outputHidden2GateModule)),
-      std::move(boost::apply_visitor(deltaVisitor, hiddenStateModule)),
-      std::move(boost::apply_visitor(deltaVisitor, outputHidden2GateModule))),
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, outputHidden2GateModule),
+      boost::apply_visitor(deltaVisitor, hiddenStateModule),
+      boost::apply_visitor(deltaVisitor, outputHidden2GateModule)),
       outputHidden2GateModule);
 
   // Delta rt.
@@ -271,9 +277,9 @@ void GRU<InputDataType, OutputDataType>::Backward(
       *backIterator;
 
   // Delta of forget gate.
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, forgetGateModule)), std::move(dRt),
-      std::move(boost::apply_visitor(deltaVisitor, forgetGateModule))),
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, forgetGateModule), dRt,
+      boost::apply_visitor(deltaVisitor, forgetGateModule)),
       forgetGateModule);
 
   // Put delta zt.
@@ -289,10 +295,12 @@ void GRU<InputDataType, OutputDataType>::Backward(
       boost::apply_visitor(deltaVisitor, hiddenStateModule);
 
   // Get delta ht - 1 for input gate and forget gate.
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, input2GateModule)),
-      std::move(prevError.submat(0, 0, 2 * outSize - 1, batchSize - 1)),
-      std::move(boost::apply_visitor(deltaVisitor, output2GateModule))),
+  arma::mat prevErrorSubview = prevError.submat(0, 0, 2 * outSize - 1,
+      batchSize - 1);
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, input2GateModule),
+      prevErrorSubview,
+      boost::apply_visitor(deltaVisitor, output2GateModule)),
       output2GateModule);
 
   // Add delta ht - 1 from hidden state.
@@ -301,13 +309,13 @@ void GRU<InputDataType, OutputDataType>::Backward(
       boost::apply_visitor(outputParameterVisitor, forgetGateModule);
 
   // Add delta ht - 1 from ht.
-  boost::apply_visitor(deltaVisitor, output2GateModule) += gy %
+  boost::apply_visitor(deltaVisitor, output2GateModule) += gyLocal %
       boost::apply_visitor(outputParameterVisitor, inputGateModule);
 
   // Get delta input.
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, input2GateModule)), std::move(prevError),
-      std::move(boost::apply_visitor(deltaVisitor, input2GateModule))),
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, input2GateModule), prevError,
+      boost::apply_visitor(deltaVisitor, input2GateModule)),
       input2GateModule);
 
   backwardStep++;
@@ -319,9 +327,9 @@ void GRU<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void GRU<InputDataType, OutputDataType>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& /* error */,
-    arma::Mat<eT>&& /* gradient */)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& /* error */,
+    arma::Mat<eT>& /* gradient */)
 {
   if (input.n_cols != batchSize)
   {
@@ -349,19 +357,18 @@ void GRU<InputDataType, OutputDataType>::Gradient(
     gradIterator = --(--outParameter.end());
   }
 
-  boost::apply_visitor(GradientVisitor(std::move(input), std::move(prevError)),
-      input2GateModule);
+  boost::apply_visitor(GradientVisitor(input, prevError), input2GateModule);
 
   boost::apply_visitor(GradientVisitor(
-      std::move(*gradIterator),
-      std::move(prevError.submat(0, 0, 2 * outSize - 1, batchSize - 1))),
+      *gradIterator,
+      prevError.submat(0, 0, 2 * outSize - 1, batchSize - 1)),
       output2GateModule);
 
   boost::apply_visitor(GradientVisitor(
       *gradIterator % boost::apply_visitor(outputParameterVisitor,
       forgetGateModule),
-      std::move(prevError.submat(2 * outSize, 0, 3 * outSize - 1,
-      batchSize - 1))), outputHidden2GateModule);
+      prevError.submat(2 * outSize, 0, 3 * outSize - 1, batchSize - 1)),
+      outputHidden2GateModule);
 
   gradIterator--;
 }

--- a/src/mlpack/methods/ann/layer/hard_tanh.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh.hpp
@@ -67,7 +67,7 @@ class HardTanH
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -79,9 +79,9 @@ class HardTanH
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input,
-                DataType&& gy,
-                DataType&& g);
+  void Backward(const DataType& input,
+                const DataType& gy,
+                DataType& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/hard_tanh_impl.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh_impl.hpp
@@ -31,7 +31,7 @@ HardTanH<InputDataType, OutputDataType>::HardTanH(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void HardTanH<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output = input;
   for (size_t i = 0; i < input.n_elem; i++)
@@ -44,7 +44,7 @@ void HardTanH<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void HardTanH<InputDataType, OutputDataType>::Backward(
-    const DataType&& input, DataType&& gy, DataType&& g)
+    const DataType& input, const DataType& gy, DataType& g)
 {
   g = gy;
   for (size_t i = 0; i < input.n_elem; i++)

--- a/src/mlpack/methods/ann/layer/highway.hpp
+++ b/src/mlpack/methods/ann/layer/highway.hpp
@@ -92,7 +92,7 @@ class Highway
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed-backward pass of a neural network, calculating the function
@@ -104,9 +104,9 @@ class Highway
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activation.
@@ -116,9 +116,9 @@ class Highway
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   /**
    * Add a new module to the model.

--- a/src/mlpack/methods/ann/layer/highway_impl.hpp
+++ b/src/mlpack/methods/ann/layer/highway_impl.hpp
@@ -91,10 +91,10 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Highway<InputDataType, OutputDataType, CustomLayers...>::Forward(
-    arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
-  boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-      boost::apply_visitor(outputParameterVisitor, network.front()))),
+  boost::apply_visitor(ForwardVisitor(input,
+      boost::apply_visitor(outputParameterVisitor, network.front())),
       network.front());
 
   if (!reset)
@@ -121,9 +121,9 @@ void Highway<InputDataType, OutputDataType, CustomLayers...>::Forward(
       boost::apply_visitor(SetInputHeightVisitor(height), network[i]);
     }
 
-    boost::apply_visitor(ForwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[i - 1])), std::move(
-        boost::apply_visitor(outputParameterVisitor, network[i]))),
+    boost::apply_visitor(ForwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[i - 1]),
+        boost::apply_visitor(outputParameterVisitor, network[i])),
         network[i]);
 
     if (!reset)
@@ -167,23 +167,24 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Highway<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, network.back())),
-      std::move(gy % transformGateActivation),
-      std::move(boost::apply_visitor(deltaVisitor, network.back()))),
+  arma::Mat<eT> gyTransform = gy % transformGateActivation;
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, network.back()),
+      gyTransform,
+      boost::apply_visitor(deltaVisitor, network.back())),
       network.back());
 
   for (size_t i = 2; i < network.size() + 1; ++i)
   {
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[network.size() - i])), std::move(
-        boost::apply_visitor(deltaVisitor, network[network.size() - i + 1])),
-        std::move(boost::apply_visitor(deltaVisitor,
-        network[network.size() - i]))), network[network.size() - i]);
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[network.size() - i]),
+        boost::apply_visitor(deltaVisitor, network[network.size() - i + 1]),
+        boost::apply_visitor(deltaVisitor,
+        network[network.size() - i])), network[network.size() - i]);
   }
 
   g = boost::apply_visitor(deltaVisitor, network.front());
@@ -198,24 +199,25 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Highway<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
-  boost::apply_visitor(GradientVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, network[network.size() - 2])),
-      std::move(error % transformGateActivation)), network.back());
+  arma::Mat<eT> errorTransform = error % transformGateActivation;
+  boost::apply_visitor(GradientVisitor(boost::apply_visitor(
+      outputParameterVisitor, network[network.size() - 2]),
+      errorTransform), network.back());
 
   for (size_t i = 2; i < network.size(); ++i)
   {
-    boost::apply_visitor(GradientVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, network[network.size() - i - 1])), std::move(
-        boost::apply_visitor(deltaVisitor, network[network.size() - i + 1]))),
+    boost::apply_visitor(GradientVisitor(boost::apply_visitor(
+        outputParameterVisitor, network[network.size() - i - 1]),
+        boost::apply_visitor(deltaVisitor, network[network.size() - i + 1])),
         network[network.size() - i]);
   }
 
-  boost::apply_visitor(GradientVisitor(std::move(input), std::move(
-      boost::apply_visitor(deltaVisitor, network[1]))), network.front());
+  boost::apply_visitor(GradientVisitor(input,
+      boost::apply_visitor(deltaVisitor, network[1])), network.front());
 
   gradient.submat(0, 0, transformWeight.n_elem - 1, 0) = arma::vectorise(
       transformGateError * input.t());

--- a/src/mlpack/methods/ann/layer/join.hpp
+++ b/src/mlpack/methods/ann/layer/join.hpp
@@ -44,7 +44,7 @@ class Join
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -56,9 +56,9 @@ class Join
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/join_impl.hpp
+++ b/src/mlpack/methods/ann/layer/join_impl.hpp
@@ -29,7 +29,7 @@ Join<InputDataType, OutputDataType>::Join() :
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void Join<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   inSizeRows = input.n_rows;
   inSizeCols = input.n_cols;
@@ -39,11 +39,12 @@ void Join<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Join<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
-  g = arma::mat(gy.memptr(), inSizeRows, inSizeCols, false, false);
+  g = arma::mat(((arma::Mat<eT>&) gy).memptr(), inSizeRows, inSizeCols, false,
+      false);
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/layer_norm.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm.hpp
@@ -90,7 +90,7 @@ class LayerNorm
    * @param output Resulting output activations.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Backward pass through the layer.
@@ -100,9 +100,9 @@ class LayerNorm
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activations.
@@ -112,9 +112,9 @@ class LayerNorm
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm_impl.hpp
@@ -57,7 +57,7 @@ void LayerNorm<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void LayerNorm<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   mean = arma::mean(input, 0);
   variance = arma::var(input, 1, 0);
@@ -78,7 +78,7 @@ void LayerNorm<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void LayerNorm<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& input, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   const arma::mat stdInv = 1.0 / arma::sqrt(variance + eps);
 
@@ -102,9 +102,9 @@ void LayerNorm<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void LayerNorm<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient.set_size(size + size, 1);
 

--- a/src/mlpack/methods/ann/layer/leaky_relu.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu.hpp
@@ -61,7 +61,7 @@ class LeakyReLU
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -73,7 +73,7 @@ class LeakyReLU
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input, DataType&& gy, DataType&& g);
+  void Backward(const DataType& input, const DataType& gy, DataType& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
@@ -30,7 +30,7 @@ LeakyReLU<InputDataType, OutputDataType>::LeakyReLU(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void LeakyReLU<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output = arma::max(input, alpha * input);
 }
@@ -38,7 +38,7 @@ void LeakyReLU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void LeakyReLU<InputDataType, OutputDataType>::Backward(
-    const DataType&& input, DataType&& gy, DataType&& g)
+    const DataType& input, const DataType& gy, DataType& g)
 {
   DataType derivative;
   derivative.set_size(arma::size(input));

--- a/src/mlpack/methods/ann/layer/linear.hpp
+++ b/src/mlpack/methods/ann/layer/linear.hpp
@@ -64,7 +64,7 @@ class Linear
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -76,9 +76,9 @@ class Linear
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -88,9 +88,9 @@ class Linear
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/linear_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_impl.hpp
@@ -54,7 +54,7 @@ template<typename InputDataType, typename OutputDataType,
     typename RegularizerType>
 template<typename eT>
 void Linear<InputDataType, OutputDataType, RegularizerType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   output = weight * input;
   output.each_col() += bias;
@@ -64,7 +64,7 @@ template<typename InputDataType, typename OutputDataType,
     typename RegularizerType>
 template<typename eT>
 void Linear<InputDataType, OutputDataType, RegularizerType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   g = weight.t() * gy;
 }
@@ -73,9 +73,9 @@ template<typename InputDataType, typename OutputDataType,
     typename RegularizerType>
 template<typename eT>
 void Linear<InputDataType, OutputDataType, RegularizerType>::Gradient(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient.submat(0, 0, weight.n_elem - 1, 0) = arma::vectorise(
       error * input.t());

--- a/src/mlpack/methods/ann/layer/linear_no_bias.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias.hpp
@@ -63,7 +63,7 @@ class LinearNoBias
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -75,9 +75,9 @@ class LinearNoBias
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -87,9 +87,9 @@ class LinearNoBias
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias_impl.hpp
@@ -52,7 +52,7 @@ template<typename InputDataType, typename OutputDataType,
     typename RegularizerType>
 template<typename eT>
 void LinearNoBias<InputDataType, OutputDataType, RegularizerType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   output = weight * input;
 }
@@ -61,7 +61,7 @@ template<typename InputDataType, typename OutputDataType,
     typename RegularizerType>
 template<typename eT>
 void LinearNoBias<InputDataType, OutputDataType, RegularizerType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   g = weight.t() * gy;
 }
@@ -70,9 +70,9 @@ template<typename InputDataType, typename OutputDataType,
     typename RegularizerType>
 template<typename eT>
 void LinearNoBias<InputDataType, OutputDataType, RegularizerType>::Gradient(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient.submat(0, 0, weight.n_elem - 1, 0) = arma::vectorise(
       error * input.t());

--- a/src/mlpack/methods/ann/layer/log_softmax.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax.hpp
@@ -49,7 +49,7 @@ class LogSoftMax
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -61,9 +61,9 @@ class LogSoftMax
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
@@ -27,7 +27,7 @@ LogSoftMax<InputDataType, OutputDataType>::LogSoftMax()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void LogSoftMax<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   arma::mat maxInput = arma::repmat(arma::max(input), input.n_rows, 1);
   output = (maxInput - input);
@@ -64,9 +64,9 @@ void LogSoftMax<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void LogSoftMax<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   g = arma::exp(input) + gy;
 }

--- a/src/mlpack/methods/ann/layer/lookup.hpp
+++ b/src/mlpack/methods/ann/layer/lookup.hpp
@@ -52,7 +52,7 @@ class Lookup
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -64,9 +64,9 @@ class Lookup
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                const arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -76,9 +76,9 @@ class Lookup
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/lookup_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lookup_impl.hpp
@@ -32,7 +32,7 @@ Lookup<InputDataType, OutputDataType>::Lookup(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Lookup<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   output = weights.cols(arma::conv_to<arma::uvec>::from(input) - 1);
 }
@@ -40,9 +40,9 @@ void Lookup<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Lookup<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    const arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   g = gy;
 }
@@ -50,9 +50,9 @@ void Lookup<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Lookup<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient = arma::zeros<arma::Mat<eT> >(weights.n_rows, weights.n_cols);
   gradient.cols(arma::conv_to<arma::uvec>::from(input) - 1) = error;

--- a/src/mlpack/methods/ann/layer/lstm.hpp
+++ b/src/mlpack/methods/ann/layer/lstm.hpp
@@ -84,7 +84,7 @@ class LSTM
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed-forward pass of a neural network, evaluating the function
@@ -96,9 +96,9 @@ class LSTM
    * @param useCellState Use the cellState passed in the LSTM cell.
    */
   template<typename InputType, typename OutputType>
-  void Forward(InputType&& input,
-               OutputType&& output,
-               OutputType&& cellState,
+  void Forward(const InputType& input,
+               OutputType& output,
+               OutputType& cellState,
                bool useCellState = false);
 
   /**
@@ -111,9 +111,9 @@ class LSTM
    * @param g The calculated gradient.
    */
   template<typename InputType, typename ErrorType, typename GradientType>
-  void Backward(const InputType&& input,
-                ErrorType&& gy,
-                GradientType&& g);
+  void Backward(const InputType& input,
+                const ErrorType& gy,
+                GradientType& g);
 
   /*
    * Reset the layer parameter.
@@ -136,9 +136,9 @@ class LSTM
    * @param gradient The calculated gradient.
    */
   template<typename InputType, typename ErrorType, typename GradientType>
-  void Gradient(InputType&& input,
-                ErrorType&& error,
-                GradientType&& gradient);
+  void Gradient(const InputType& input,
+                const ErrorType& error,
+                GradientType& gradient);
 
   //! Get the maximum number of steps to backpropagate through time (BPTT).
   size_t Rho() const { return rho; }

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -163,19 +163,19 @@ void LSTM<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void LSTM<InputDataType, OutputDataType>::Forward(
-    InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   //! Locally-stored cellState.
   OutputType cellState;
-  Forward(std::move(input), std::move(output), std::move(cellState), false);
+  Forward(input, output, cellState, false);
 }
 
 // Forward when cellState is needed overloaded LSTM::Forward().
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
-void LSTM<InputDataType, OutputDataType>::Forward(InputType&& input,
-                                                  OutputType&& output,
-                                                  OutputType&& cellState,
+void LSTM<InputDataType, OutputDataType>::Forward(const InputType& input,
+                                                  OutputType& output,
+                                                  OutputType& cellState,
                                                   bool useCellState)
 {
   // Check if the batch size changed, the number of cols is defines the input
@@ -288,20 +288,27 @@ void LSTM<InputDataType, OutputDataType>::Forward(InputType&& input,
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename ErrorType, typename GradientType>
 void LSTM<InputDataType, OutputDataType>::Backward(
-  const InputType&& /* input */, ErrorType&& gy, GradientType&& g)
+  const InputType& /* input */, const ErrorType& gy, GradientType& g)
 {
+  ErrorType gyLocal;
   if (gradientStepIdx > 0)
   {
-    gy += prevError;
+    gyLocal = gy + prevError;
+  }
+  else
+  {
+    // Make an alias.
+    gyLocal = ErrorType(((ErrorType&) gy).memptr(), gy.n_rows, gy.n_cols, false,
+        false);
   }
 
   outputGateError =
-      gy % cellActivation.cols(backwardStep - batchStep, backwardStep) %
+      gyLocal % cellActivation.cols(backwardStep - batchStep, backwardStep) %
       (outputGateActivation.cols(backwardStep - batchStep, backwardStep) %
       (1.0 - outputGateActivation.cols(backwardStep - batchStep,
       backwardStep)));
 
-  OutputDataType cellError = gy %
+  OutputDataType cellError = gyLocal %
       outputGateActivation.cols(backwardStep - batchStep, backwardStep) %
       (1 - arma::pow(cellActivation.cols(backwardStep -
       batchStep, backwardStep), 2)) + outputGateError.each_col() %
@@ -359,7 +366,9 @@ void LSTM<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename ErrorType, typename GradientType>
 void LSTM<InputDataType, OutputDataType>::Gradient(
-    InputType&& input, ErrorType&& /* error */, GradientType&& gradient)
+    const InputType& input,
+    const ErrorType& /* error */,
+    GradientType& gradient)
 {
   // Input2GateOutputWeight and input2GateOutputBias gradients.
   gradient.submat(0, 0, input2GateOutputWeight.n_elem - 1, 0) =

--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -78,7 +78,7 @@ class MaxPooling
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, using 3rd-order tensors as
@@ -90,9 +90,9 @@ class MaxPooling
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   const OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling_impl.hpp
@@ -54,11 +54,11 @@ MaxPooling<InputDataType, OutputDataType>::MaxPooling(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MaxPooling<InputDataType, OutputDataType>::Forward(
-  const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+  const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
   inSize = input.n_elem / (inputWidth * inputHeight * batchSize);
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, batchSize * inSize, false, false);
 
   if (floor)
@@ -122,10 +122,10 @@ void MaxPooling<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MaxPooling<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
-  arma::cube mappedError = arma::cube(gy.memptr(), outputWidth,
-      outputHeight, outSize, false, false);
+  arma::cube mappedError = arma::cube(((arma::Mat<eT>&) gy).memptr(),
+      outputWidth, outputHeight, outSize, false, false);
 
   gTemp = arma::zeros<arma::cube>(inputTemp.n_rows,
       inputTemp.n_cols, inputTemp.n_slices);

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -58,7 +58,7 @@ class MeanPooling
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, using 3rd-order tensors as
@@ -70,9 +70,9 @@ class MeanPooling
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
@@ -54,11 +54,11 @@ MeanPooling<InputDataType, OutputDataType>::MeanPooling(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MeanPooling<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
   inSize = input.n_elem / (inputWidth * inputHeight * batchSize);
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, batchSize * inSize, false, false);
 
   if (floor)
@@ -97,12 +97,12 @@ void MeanPooling<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MeanPooling<InputDataType, OutputDataType>::Backward(
-  const arma::Mat<eT>&& /* input */,
-  arma::Mat<eT>&& gy,
-  arma::Mat<eT>&& g)
+  const arma::Mat<eT>& /* input */,
+  const arma::Mat<eT>& gy,
+  arma::Mat<eT>& g)
 {
-  arma::cube mappedError = arma::cube(gy.memptr(), outputWidth,
-      outputHeight, outSize, false, false);
+  arma::cube mappedError = arma::cube(((arma::Mat<eT>&) gy).memptr(),
+      outputWidth, outputHeight, outSize, false, false);
 
   gTemp = arma::zeros<arma::cube>(inputTemp.n_rows,
       inputTemp.n_cols, inputTemp.n_slices);

--- a/src/mlpack/methods/ann/layer/minibatch_discrimination.hpp
+++ b/src/mlpack/methods/ann/layer/minibatch_discrimination.hpp
@@ -81,7 +81,7 @@ class MiniBatchDiscrimination
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed-backward pass of a neural network, calculating the function
@@ -93,9 +93,9 @@ class MiniBatchDiscrimination
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activation.
@@ -105,9 +105,9 @@ class MiniBatchDiscrimination
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& /* error */,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& /* error */,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/minibatch_discrimination_impl.hpp
+++ b/src/mlpack/methods/ann/layer/minibatch_discrimination_impl.hpp
@@ -52,7 +52,7 @@ void MiniBatchDiscrimination<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MiniBatchDiscrimination<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
   tempM = weight * input;
@@ -88,7 +88,7 @@ void MiniBatchDiscrimination<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MiniBatchDiscrimination<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   g = gy.head_rows(A);
   arma::Mat<eT> gM = gy.tail_rows(B);
@@ -117,9 +117,9 @@ void MiniBatchDiscrimination<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void MiniBatchDiscrimination<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& input,
-    arma::Mat<eT>&& /* error */,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& /* error */,
+    arma::Mat<eT>& gradient)
 {
   gradient = arma::vectorise(deltaTemp * input.t());
 }

--- a/src/mlpack/methods/ann/layer/multiply_constant.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant.hpp
@@ -47,7 +47,7 @@ class MultiplyConstant
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network. The backward pass
@@ -58,7 +58,7 @@ class MultiplyConstant
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& /* input */, DataType&& gy, DataType&& g);
+  void Backward(const DataType& /* input */, const DataType& gy, DataType& g);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
@@ -29,7 +29,7 @@ MultiplyConstant<InputDataType, OutputDataType>::MultiplyConstant(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void MultiplyConstant<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output = input * scalar;
 }
@@ -37,7 +37,7 @@ void MultiplyConstant<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void MultiplyConstant<InputDataType, OutputDataType>::Backward(
-    const DataType&& /* input */, DataType&& gy, DataType&& g)
+    const DataType& /* input */, const DataType& gy, DataType& g)
 {
   g = gy * scalar;
 }

--- a/src/mlpack/methods/ann/layer/multiply_merge.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_merge.hpp
@@ -61,7 +61,7 @@ class MultiplyMerge
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(InputType&& /* input */, OutputType&& output);
+  void Forward(const InputType& /* input */, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -73,9 +73,9 @@ class MultiplyMerge
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -85,9 +85,9 @@ class MultiplyMerge
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   /*
    * Add a new module to the model.

--- a/src/mlpack/methods/ann/layer/multiply_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_merge_impl.hpp
@@ -47,14 +47,14 @@ template <typename InputDataType, typename OutputDataType,
           typename... CustomLayers>
 template<typename InputType, typename OutputType>
 void MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::Forward(
-    InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-          boost::apply_visitor(outputParameterVisitor, network[i]))),
+      boost::apply_visitor(ForwardVisitor(input,
+          boost::apply_visitor(outputParameterVisitor, network[i])),
           network[i]);
     }
   }
@@ -70,15 +70,15 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-          outputParameterVisitor, network[i])), std::move(gy), std::move(
-          boost::apply_visitor(deltaVisitor, network[i]))), network[i]);
+      boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+          outputParameterVisitor, network[i]), gy,
+          boost::apply_visitor(deltaVisitor, network[i])), network[i]);
     }
 
     g = boost::apply_visitor(deltaVisitor, network[0]);
@@ -95,16 +95,15 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */ )
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */ )
 {
   if (run)
   {
     for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(GradientVisitor(std::move(input), std::move(error)),
-          network[i]);
+      boost::apply_visitor(GradientVisitor(input, error), network[i]);
     }
   }
 }

--- a/src/mlpack/methods/ann/layer/padding.hpp
+++ b/src/mlpack/methods/ann/layer/padding.hpp
@@ -55,7 +55,7 @@ class Padding
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -67,9 +67,9 @@ class Padding
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                const arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -38,7 +38,7 @@ Padding<InputDataType, OutputDataType>::Padding(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Padding<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   nRows = input.n_rows;
   nCols = input.n_cols;
@@ -51,9 +51,9 @@ void Padding<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Padding<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    const arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   g = gy.submat(padWLeft, padHTop, padWLeft + nRows - 1,
       padHTop + nCols - 1);

--- a/src/mlpack/methods/ann/layer/parametric_relu.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu.hpp
@@ -68,7 +68,7 @@ class PReLU
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(const InputType&& input, OutputType&& output);
+  void Forward(const InputType& input, OutputType& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -80,7 +80,7 @@ class PReLU
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input, DataType&& gy, DataType&& g);
+  void Backward(const DataType& input, const DataType& gy, DataType& g);
 
   /**
    * Calculate the gradient using the output delta and the input activation.
@@ -90,9 +90,9 @@ class PReLU
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return alpha; }

--- a/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
@@ -39,7 +39,7 @@ void PReLU<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void PReLU<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, OutputType&& output)
+    const InputType& input, OutputType& output)
 {
   output = input;
   arma::uvec negative = arma::find(input < 0);
@@ -49,7 +49,7 @@ void PReLU<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void PReLU<InputDataType, OutputDataType>::Backward(
-    const DataType&& input, DataType&& gy, DataType&& g)
+    const DataType& input, const DataType& gy, DataType& g)
 {
   DataType derivative;
   derivative.set_size(arma::size(input));
@@ -64,8 +64,9 @@ void PReLU<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void PReLU<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   if (gradient.n_elem == 0)
   {

--- a/src/mlpack/methods/ann/layer/recurrent.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent.hpp
@@ -83,7 +83,7 @@ class Recurrent
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -95,9 +95,9 @@ class Recurrent
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -107,9 +107,9 @@ class Recurrent
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& /* gradient */);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& /* gradient */);
 
   //! Get the model modules.
   std::vector<LayerTypes<CustomLayers...> >& Model() { return network; }

--- a/src/mlpack/methods/ann/layer/recurrent_attention.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention.hpp
@@ -83,7 +83,7 @@ class RecurrentAttention
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -95,9 +95,9 @@ class RecurrentAttention
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -107,9 +107,9 @@ class RecurrentAttention
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& /* error */,
-                arma::Mat<eT>&& /* gradient */);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& /* error */,
+                arma::Mat<eT>& /* gradient */);
 
   //! Get the model modules.
   std::vector<LayerTypes<>>& Model() { return network; }
@@ -154,19 +154,19 @@ class RecurrentAttention
     // Gradient of the action module.
     if (backwardStep == (rho - 1))
     {
-      boost::apply_visitor(GradientVisitor(std::move(initialInput),
-          std::move(actionError)), actionModule);
+      boost::apply_visitor(GradientVisitor(initialInput, actionError),
+          actionModule);
     }
     else
     {
-      boost::apply_visitor(GradientVisitor(std::move(boost::apply_visitor(
-          outputParameterVisitor, actionModule)), std::move(actionError)),
+      boost::apply_visitor(GradientVisitor(boost::apply_visitor(
+          outputParameterVisitor, actionModule), actionError),
           actionModule);
     }
 
     // Gradient of the recurrent module.
-    boost::apply_visitor(GradientVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, rnnModule)), std::move(recurrentError)),
+    boost::apply_visitor(GradientVisitor(boost::apply_visitor(
+        outputParameterVisitor, rnnModule), recurrentError),
         rnnModule);
 
     attentionGradient += intermediateGradient;

--- a/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_attention_impl.hpp
@@ -58,7 +58,7 @@ RecurrentAttention<InputDataType, OutputDataType>::RecurrentAttention(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void RecurrentAttention<InputDataType, OutputDataType>::Forward(
-    arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   // Initialize the action input.
   if (initialInput.is_empty())
@@ -71,15 +71,15 @@ void RecurrentAttention<InputDataType, OutputDataType>::Forward(
   {
     if (forwardStep == 0)
     {
-      boost::apply_visitor(ForwardVisitor(std::move(initialInput), std::move(
-          boost::apply_visitor(outputParameterVisitor, actionModule))),
+      boost::apply_visitor(ForwardVisitor(initialInput,
+          boost::apply_visitor(outputParameterVisitor, actionModule)),
           actionModule);
     }
     else
     {
-      boost::apply_visitor(ForwardVisitor(std::move(boost::apply_visitor(
-          outputParameterVisitor, rnnModule)), std::move(boost::apply_visitor(
-          outputParameterVisitor, actionModule))), actionModule);
+      boost::apply_visitor(ForwardVisitor(boost::apply_visitor(
+          outputParameterVisitor, rnnModule), boost::apply_visitor(
+          outputParameterVisitor, actionModule)), actionModule);
     }
 
     // Initialize the glimpse input.
@@ -89,8 +89,8 @@ void RecurrentAttention<InputDataType, OutputDataType>::Forward(
         actionModule).n_elem - 1, 1) = boost::apply_visitor(
         outputParameterVisitor, actionModule);
 
-    boost::apply_visitor(ForwardVisitor(std::move(glimpseInput),
-        std::move(boost::apply_visitor(outputParameterVisitor, rnnModule))),
+    boost::apply_visitor(ForwardVisitor(glimpseInput,
+        boost::apply_visitor(outputParameterVisitor, rnnModule)),
         rnnModule);
 
     // Save the output parameter when training the module.
@@ -99,7 +99,7 @@ void RecurrentAttention<InputDataType, OutputDataType>::Forward(
       for (size_t l = 0; l < network.size(); ++l)
       {
         boost::apply_visitor(SaveOutputParameterVisitor(
-            std::move(moduleOutputParameter)), network[l]);
+            moduleOutputParameter), network[l]);
       }
     }
   }
@@ -113,9 +113,9 @@ void RecurrentAttention<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void RecurrentAttention<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   if (intermediateGradient.is_empty() && backwardStep == 0)
   {
@@ -137,9 +137,9 @@ void RecurrentAttention<InputDataType, OutputDataType>::Backward(
   {
     size_t offset = 0;
     offset += boost::apply_visitor(GradientSetVisitor(
-        std::move(intermediateGradient), offset), rnnModule);
+        intermediateGradient, offset), rnnModule);
     boost::apply_visitor(GradientSetVisitor(
-        std::move(intermediateGradient), offset), actionModule);
+        intermediateGradient, offset), actionModule);
 
     attentionGradient.zeros();
   }
@@ -159,24 +159,24 @@ void RecurrentAttention<InputDataType, OutputDataType>::Backward(
     for (size_t l = 0; l < network.size(); ++l)
     {
       boost::apply_visitor(LoadOutputParameterVisitor(
-         std::move(moduleOutputParameter)), network[network.size() - 1 - l]);
+         moduleOutputParameter), network[network.size() - 1 - l]);
     }
 
     if (backwardStep == (rho - 1))
     {
-      boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-          outputParameterVisitor, actionModule)), std::move(actionError),
-          std::move(actionDelta)), actionModule);
+      boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+          outputParameterVisitor, actionModule), actionError,
+          actionDelta), actionModule);
     }
     else
     {
-      boost::apply_visitor(BackwardVisitor(std::move(initialInput),
-          std::move(actionError), std::move(actionDelta)), actionModule);
+      boost::apply_visitor(BackwardVisitor(initialInput, actionError,
+          actionDelta), actionModule);
     }
 
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, rnnModule)), std::move(recurrentError),
-        std::move(rnnDelta)), rnnModule);
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, rnnModule), recurrentError, rnnDelta),
+        rnnModule);
 
     if (backwardStep == 0)
     {
@@ -194,15 +194,15 @@ void RecurrentAttention<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void RecurrentAttention<InputDataType, OutputDataType>::Gradient(
-    arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& /* error */,
-    arma::Mat<eT>&& /* gradient */)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& /* error */,
+    arma::Mat<eT>& /* gradient */)
 {
   size_t offset = 0;
   offset += boost::apply_visitor(GradientUpdateVisitor(
-      std::move(attentionGradient), offset), rnnModule);
+      attentionGradient, offset), rnnModule);
   boost::apply_visitor(GradientUpdateVisitor(
-      std::move(attentionGradient), offset), actionModule);
+      attentionGradient, offset), actionModule);
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/recurrent_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_impl.hpp
@@ -143,26 +143,24 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Recurrent<InputDataType, OutputDataType, CustomLayers...>::Forward(
-    arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (forwardStep == 0)
   {
-    boost::apply_visitor(ForwardVisitor(std::move(input), std::move(output)),
-        initialModule);
+    boost::apply_visitor(ForwardVisitor(input, output), initialModule);
   }
   else
   {
-    boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-        boost::apply_visitor(outputParameterVisitor, inputModule))),
+    boost::apply_visitor(ForwardVisitor(input,
+        boost::apply_visitor(outputParameterVisitor, inputModule)),
         inputModule);
 
-    boost::apply_visitor(ForwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, transferModule)), std::move(
-        boost::apply_visitor(outputParameterVisitor, feedbackModule))),
+    boost::apply_visitor(ForwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, transferModule),
+        boost::apply_visitor(outputParameterVisitor, feedbackModule)),
         feedbackModule);
 
-    boost::apply_visitor(ForwardVisitor(std::move(input), std::move(output)),
-        recurrentModule);
+    boost::apply_visitor(ForwardVisitor(input, output), recurrentModule);
   }
 
   output = boost::apply_visitor(outputParameterVisitor, transferModule);
@@ -190,7 +188,7 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Recurrent<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   if (!recurrentError.is_empty())
   {
@@ -203,26 +201,26 @@ void Recurrent<InputDataType, OutputDataType, CustomLayers...>::Backward(
 
   if (backwardStep < (rho - 1))
   {
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, recurrentModule)), std::move(recurrentError),
-        std::move(boost::apply_visitor(deltaVisitor, recurrentModule))),
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, recurrentModule), recurrentError,
+        boost::apply_visitor(deltaVisitor, recurrentModule)),
         recurrentModule);
 
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, inputModule)), std::move(
-        boost::apply_visitor(deltaVisitor, recurrentModule)), std::move(g)),
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, inputModule),
+        boost::apply_visitor(deltaVisitor, recurrentModule), g),
         inputModule);
 
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, feedbackModule)), std::move(
-        boost::apply_visitor(deltaVisitor, recurrentModule)), std::move(
-        boost::apply_visitor(deltaVisitor, feedbackModule))), feedbackModule);
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, feedbackModule),
+        boost::apply_visitor(deltaVisitor, recurrentModule),
+        boost::apply_visitor(deltaVisitor, feedbackModule)), feedbackModule);
   }
   else
   {
-    boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-        outputParameterVisitor, initialModule)), std::move(recurrentError),
-        std::move(g)), initialModule);
+    boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+        outputParameterVisitor, initialModule), recurrentError, g),
+        initialModule);
   }
 
   recurrentError = boost::apply_visitor(deltaVisitor, feedbackModule);
@@ -233,22 +231,21 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void Recurrent<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& /* gradient */)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& /* gradient */)
 {
   if (gradientStep < (rho - 1))
   {
-    boost::apply_visitor(GradientVisitor(std::move(input), std::move(error)),
-        recurrentModule);
+    boost::apply_visitor(GradientVisitor(input, error), recurrentModule);
 
-    boost::apply_visitor(GradientVisitor(std::move(input), std::move(
-        boost::apply_visitor(deltaVisitor, mergeModule))), inputModule);
+    boost::apply_visitor(GradientVisitor(input,
+        boost::apply_visitor(deltaVisitor, mergeModule)), inputModule);
 
-    boost::apply_visitor(GradientVisitor(std::move(
+    boost::apply_visitor(GradientVisitor(
         feedbackOutputParameter[feedbackOutputParameter.size() - 2 -
-        gradientStep]), std::move(boost::apply_visitor(deltaVisitor,
-        mergeModule))), feedbackModule);
+        gradientStep], boost::apply_visitor(deltaVisitor,
+        mergeModule)), feedbackModule);
   }
   else
   {
@@ -256,8 +253,8 @@ void Recurrent<InputDataType, OutputDataType, CustomLayers...>::Gradient(
     boost::apply_visitor(GradientZeroVisitor(), inputModule);
     boost::apply_visitor(GradientZeroVisitor(), feedbackModule);
 
-    boost::apply_visitor(GradientVisitor(std::move(input), std::move(
-        boost::apply_visitor(deltaVisitor, startModule))), initialModule);
+    boost::apply_visitor(GradientVisitor(input,
+        boost::apply_visitor(deltaVisitor, startModule)), initialModule);
   }
 
   gradientStep++;

--- a/src/mlpack/methods/ann/layer/reinforce_normal.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal.hpp
@@ -49,7 +49,7 @@ class ReinforceNormal
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -61,7 +61,7 @@ class ReinforceNormal
    * @param g The calculated gradient.
    */
   template<typename DataType>
-  void Backward(const DataType&& input, DataType&& /* gy */, DataType&& g);
+  void Backward(const DataType& input, const DataType& /* gy */, DataType& g);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/reinforce_normal_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal_impl.hpp
@@ -29,7 +29,7 @@ ReinforceNormal<InputDataType, OutputDataType>::ReinforceNormal(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void ReinforceNormal<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (!deterministic)
   {
@@ -49,7 +49,7 @@ void ReinforceNormal<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
 void ReinforceNormal<InputDataType, OutputDataType>::Backward(
-    const DataType&& input, DataType&& /* gy */, DataType&& g)
+    const DataType& input, const DataType& /* gy */, DataType& g)
 {
   g = (input - moduleInputParameter.back()) / std::pow(stdev, 2.0);
 

--- a/src/mlpack/methods/ann/layer/reparametrization.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization.hpp
@@ -79,7 +79,7 @@ class Reparametrization
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -91,9 +91,9 @@ class Reparametrization
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType const& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -50,7 +50,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Reparametrization<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (input.n_rows != 2 * latentSize)
   {
@@ -74,7 +74,7 @@ void Reparametrization<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Reparametrization<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   SoftplusFunction::Deriv(preStdDev, g);
 

--- a/src/mlpack/methods/ann/layer/select.hpp
+++ b/src/mlpack/methods/ann/layer/select.hpp
@@ -48,7 +48,7 @@ class Select
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -60,9 +60,9 @@ class Select
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -31,7 +31,7 @@ Select<InputDataType, OutputDataType>::Select(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Select<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   if (elements == 0)
   {
@@ -46,9 +46,9 @@ void Select<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Select<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& gy,
-    arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
 {
   if (elements == 0)
   {

--- a/src/mlpack/methods/ann/layer/sequential.hpp
+++ b/src/mlpack/methods/ann/layer/sequential.hpp
@@ -89,7 +89,7 @@ class Sequential
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, using 3rd-order tensors as
@@ -101,9 +101,9 @@ class Sequential
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -113,9 +113,9 @@ class Sequential
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& /* gradient */);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& /* gradient */);
 
   /*
    * Add a new module to the model.

--- a/src/mlpack/methods/ann/layer/subview.hpp
+++ b/src/mlpack/methods/ann/layer/subview.hpp
@@ -66,7 +66,7 @@ class Subview
    * @param output Resulting output activation.
    */
   template<typename InputType, typename OutputType>
-  void Forward(InputType&& input, OutputType&& output)
+  void Forward(const InputType& input, OutputType& output)
   {
     size_t batchSize = input.n_cols / inSize;
 
@@ -112,9 +112,9 @@ class Subview
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g)
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g)
   {
     g = gy;
   }

--- a/src/mlpack/methods/ann/layer/transposed_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/transposed_convolution.hpp
@@ -144,7 +144,7 @@ class TransposedConvolution
    * @param output Resulting output activation.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Ordinary feed backward pass of a neural network, calculating the function
@@ -156,9 +156,9 @@ class TransposedConvolution
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /*
    * Calculate the gradient using the output delta and the input activation.
@@ -168,9 +168,9 @@ class TransposedConvolution
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
@@ -207,10 +207,10 @@ void TransposedConvolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->::Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+>::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&&>(input).memptr(),
+  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (strideWidth > 1 || strideHeight > 1)
@@ -227,8 +227,8 @@ void TransposedConvolution<
 
       for (size_t i = 0; i < inputExpandedTemp.n_slices; ++i)
       {
-        paddingForward.Forward(std::move(inputExpandedTemp.slice(i)),
-            std::move(inputPaddedTemp.slice(i)));
+        paddingForward.Forward(inputExpandedTemp.slice(i),
+            inputPaddedTemp.slice(i));
       }
     }
     else
@@ -250,8 +250,7 @@ void TransposedConvolution<
 
     for (size_t i = 0; i < inputTemp.n_slices; ++i)
     {
-      paddingForward.Forward(std::move(inputTemp.slice(i)),
-          std::move(inputPaddedTemp.slice(i)));
+      paddingForward.Forward(inputTemp.slice(i), inputPaddedTemp.slice(i));
     }
   }
 
@@ -312,10 +311,10 @@ void TransposedConvolution<
     InputDataType,
     OutputDataType
 >::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
-  arma::Cube<eT> mappedError(gy.memptr(), outputWidth, outputHeight,
-      outSize * batchSize, false, false);
+  arma::Cube<eT> mappedError(((arma::Mat<eT>&) gy).memptr(), outputWidth,
+      outputHeight, outSize * batchSize, false, false);
   arma::Cube<eT> mappedErrorPadded;
   if (paddingBackward.PadWLeft() != 0 || paddingBackward.PadWRight() != 0 ||
       paddingBackward.PadHTop() != 0 || paddingBackward.PadHBottom() != 0)
@@ -327,8 +326,8 @@ void TransposedConvolution<
 
     for (size_t i = 0; i < mappedError.n_slices; ++i)
     {
-      paddingBackward.Forward(std::move(mappedError.slice(i)),
-          std::move(mappedErrorPadded.slice(i)));
+      paddingBackward.Forward(mappedError.slice(i),
+          mappedErrorPadded.slice(i));
     }
   }
   g.set_size(inputTemp.n_rows * inputTemp.n_cols * inSize, batchSize);
@@ -382,11 +381,11 @@ void TransposedConvolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
-  arma::Cube<eT> mappedError(error.memptr(), outputWidth,
+  arma::Cube<eT> mappedError(((arma::Mat<eT>&) error).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 
   gradient.set_size(weights.n_elem, 1);

--- a/src/mlpack/methods/ann/layer/virtual_batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/virtual_batch_norm.hpp
@@ -76,7 +76,7 @@ class VirtualBatchNorm
    * @param output Resulting output activations.
    */
   template<typename eT>
-  void Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Backward pass through the layer.
@@ -86,9 +86,9 @@ class VirtualBatchNorm
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta and the input activations.
@@ -98,9 +98,9 @@ class VirtualBatchNorm
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(const arma::Mat<eT>&& /* input */,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& /* input */,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the parameters.
   OutputDataType const& Parameters() const { return weights; }

--- a/src/mlpack/methods/ann/layer/virtual_batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/virtual_batch_norm_impl.hpp
@@ -65,7 +65,7 @@ void VirtualBatchNorm<InputDataType, OutputDataType>::Reset()
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void VirtualBatchNorm<InputDataType, OutputDataType>::Forward(
-    const arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   inputParameter = input;
   arma::mat inputMean = arma::mean(input, 1);
@@ -90,7 +90,7 @@ void VirtualBatchNorm<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void VirtualBatchNorm<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
   const arma::mat stdInv = 1.0 / arma::sqrt(variance + eps);
 
@@ -115,9 +115,9 @@ void VirtualBatchNorm<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void VirtualBatchNorm<InputDataType, OutputDataType>::Gradient(
-    const arma::Mat<eT>&& /* input */,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   gradient.set_size(size + size, 1);
 

--- a/src/mlpack/methods/ann/layer/vr_class_reward.hpp
+++ b/src/mlpack/methods/ann/layer/vr_class_reward.hpp
@@ -55,7 +55,7 @@ class VRClassReward
    *        between 1 and the number of classes.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network. The negative log
@@ -69,9 +69,9 @@ class VRClassReward
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const {return outputParameter; }

--- a/src/mlpack/methods/ann/layer/vr_class_reward_impl.hpp
+++ b/src/mlpack/methods/ann/layer/vr_class_reward_impl.hpp
@@ -34,7 +34,7 @@ VRClassReward<InputDataType, OutputDataType>::VRClassReward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double VRClassReward<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   double output = 0;
   for (size_t i = 0; i < input.n_cols - 1; ++i)
@@ -66,9 +66,9 @@ double VRClassReward<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void VRClassReward<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   output = arma::zeros<OutputType>(input.n_rows, input.n_cols);
   for (size_t i = 0; i < (input.n_cols - 1); ++i)

--- a/src/mlpack/methods/ann/layer/weight_norm.hpp
+++ b/src/mlpack/methods/ann/layer/weight_norm.hpp
@@ -85,7 +85,7 @@ class WeightNorm
    * @param output Resulting output activations.
    */
   template<typename eT>
-  void Forward(arma::Mat<eT>&& input, arma::Mat<eT>&& output);
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 
   /**
    * Backward pass through the layer. This function calls the Backward()
@@ -96,9 +96,9 @@ class WeightNorm
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>&& input,
-                arma::Mat<eT>&& gy,
-                arma::Mat<eT>&& g);
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
 
   /**
    * Calculate the gradient using the output delta, input activations and the
@@ -109,9 +109,9 @@ class WeightNorm
    * @param gradient The calculated gradient.
    */
   template<typename eT>
-  void Gradient(arma::Mat<eT>&& input,
-                arma::Mat<eT>&& error,
-                arma::Mat<eT>&& gradient);
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
 
   //! Get the delta.
   OutputDataType const& Delta() const { return delta; }

--- a/src/mlpack/methods/ann/layer/weight_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/weight_norm_impl.hpp
@@ -50,13 +50,12 @@ void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::Reset()
 {
   // Set the weights of the inside layer to layerWeights.
   // This is done to set the non-bias terms correctly.
-  boost::apply_visitor(WeightSetVisitor(std::move(layerWeights), 0),
-      wrappedLayer);
+  boost::apply_visitor(WeightSetVisitor(layerWeights, 0), wrappedLayer);
 
   boost::apply_visitor(resetVisitor, wrappedLayer);
 
-  biasWeightSize = boost::apply_visitor(BiasSetVisitor(std::move(weights),
-      0), wrappedLayer);
+  biasWeightSize = boost::apply_visitor(BiasSetVisitor(weights, 0),
+      wrappedLayer);
 
   vectorParameter = arma::mat(weights.memptr() + biasWeightSize,
       layerWeightSize - biasWeightSize, 1, false, false);
@@ -69,15 +68,15 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::Forward(
-    arma::Mat<eT>&& input, arma::Mat<eT>&& output)
+    const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   // Initialize the non-bias weights of wrapped layer.
   const double normVectorParameter = arma::norm(vectorParameter, 2);
   layerWeights.rows(0, layerWeightSize - biasWeightSize - 1) =
       scalarParameter(0) * vectorParameter / normVectorParameter;
 
-  boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-      boost::apply_visitor(outputParameterVisitor, wrappedLayer))),
+  boost::apply_visitor(ForwardVisitor(input,
+      boost::apply_visitor(outputParameterVisitor, wrappedLayer)),
       wrappedLayer);
 
   output = boost::apply_visitor(outputParameterVisitor, wrappedLayer);
@@ -87,11 +86,11 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::Backward(
-    const arma::Mat<eT>&& /* input */, arma::Mat<eT>&& gy, arma::Mat<eT>&& g)
+    const arma::Mat<eT>& /* input */, const arma::Mat<eT>& gy, arma::Mat<eT>& g)
 {
-  boost::apply_visitor(BackwardVisitor(std::move(boost::apply_visitor(
-      outputParameterVisitor, wrappedLayer)), std::move(gy), std::move(
-      boost::apply_visitor(deltaVisitor, wrappedLayer))), wrappedLayer);
+  boost::apply_visitor(BackwardVisitor(boost::apply_visitor(
+      outputParameterVisitor, wrappedLayer), gy,
+      boost::apply_visitor(deltaVisitor, wrappedLayer)), wrappedLayer);
 
   g = boost::apply_visitor(deltaVisitor, wrappedLayer);
 }
@@ -100,15 +99,14 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename eT>
 void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::Gradient(
-    arma::Mat<eT>&& input,
-    arma::Mat<eT>&& error,
-    arma::Mat<eT>&& gradient)
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
 {
   ResetGradients(layerGradients);
 
   // Calculate the gradients of the wrapped layer.
-  boost::apply_visitor(GradientVisitor(std::move(input),
-      std::move(error)), wrappedLayer);
+  boost::apply_visitor(GradientVisitor(input, error), wrappedLayer);
 
   // Store the norm of vector parameter temporarily.
   const double normVectorParameter = arma::norm(vectorParameter, 2);
@@ -137,8 +135,7 @@ template<typename InputDataType, typename OutputDataType,
 void WeightNorm<InputDataType, OutputDataType, CustomLayers...>::ResetGradients(
     arma::mat& gradient)
 {
-  boost::apply_visitor(GradientSetVisitor(std::move(gradient), 0),
-      wrappedLayer);
+  boost::apply_visitor(GradientSetVisitor(gradient, 0), wrappedLayer);
 }
 
 template<typename InputDataType, typename OutputDataType,

--- a/src/mlpack/methods/ann/loss_functions/cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cross_entropy_error.hpp
@@ -49,7 +49,7 @@ class CrossEntropyError
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -59,9 +59,9 @@ class CrossEntropyError
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cross_entropy_error_impl.hpp
@@ -28,7 +28,7 @@ CrossEntropyError<InputDataType, OutputDataType>::CrossEntropyError(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double CrossEntropyError<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   return -arma::accu(target % arma::log(input + eps) +
       (1. - target) % arma::log(1. - input + eps));
@@ -37,9 +37,9 @@ double CrossEntropyError<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void CrossEntropyError<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   output = (1. - target) / (1. - input + eps) - target / (input + eps);
 }

--- a/src/mlpack/methods/ann/loss_functions/dice_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/dice_loss.hpp
@@ -62,7 +62,7 @@ class DiceLoss
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -72,9 +72,9 @@ class DiceLoss
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/dice_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/dice_loss_impl.hpp
@@ -28,7 +28,7 @@ DiceLoss<InputDataType, OutputDataType>::DiceLoss(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double DiceLoss<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   return 1 - ((2 * arma::accu(target % input) + smooth) /
     (arma::accu(target % target) + arma::accu(
@@ -38,9 +38,9 @@ double DiceLoss<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void DiceLoss<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   output = -2 * (target * (arma::accu(input % input) +
     arma::accu(target % target) + smooth) - input *

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
@@ -45,7 +45,7 @@ class EarthMoverDistance
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -55,9 +55,9 @@ class EarthMoverDistance
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance_impl.hpp
@@ -27,7 +27,7 @@ EarthMoverDistance<InputDataType, OutputDataType>::EarthMoverDistance()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double EarthMoverDistance<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   return -arma::accu(target % input);
 }
@@ -35,9 +35,9 @@ double EarthMoverDistance<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void EarthMoverDistance<InputDataType, OutputDataType>::Backward(
-    const InputType&& /* input */,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& /* input */,
+    const TargetType& target,
+    OutputType& output)
 {
   output = -target;
 }

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
@@ -60,7 +60,7 @@ class KLDivergence
    * @param target Target data to compare with.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -70,9 +70,9 @@ class KLDivergence
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
@@ -29,7 +29,7 @@ KLDivergence<InputDataType, OutputDataType>::KLDivergence(const bool takeMean) :
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double KLDivergence<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   if (takeMean)
   {
@@ -45,9 +45,9 @@ double KLDivergence<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void KLDivergence<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   if (takeMean)
   {

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
@@ -45,7 +45,7 @@ class MeanBiasError
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -55,9 +55,9 @@ class MeanBiasError
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
@@ -28,7 +28,7 @@ MeanBiasError<InputDataType, OutputDataType>::MeanBiasError()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double MeanBiasError<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   return arma::accu(target - input) / target.n_cols;
 }
@@ -36,9 +36,9 @@ double MeanBiasError<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void MeanBiasError<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& /* target */,
+    OutputType& output)
 {
   output.set_size(arma::size(input));
   output.fill(-1.0);

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -46,7 +46,7 @@ class MeanSquaredError
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -56,9 +56,9 @@ class MeanSquaredError
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
@@ -27,7 +27,7 @@ MeanSquaredError<InputDataType, OutputDataType>::MeanSquaredError()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double MeanSquaredError<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   return arma::accu(arma::square(input - target)) / target.n_cols;
 }
@@ -35,9 +35,9 @@ double MeanSquaredError<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void MeanSquaredError<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   output = 2 * (input - target) / target.n_cols;
 }

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
@@ -45,7 +45,7 @@ class MeanSquaredLogarithmicError
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -55,9 +55,9 @@ class MeanSquaredLogarithmicError
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
@@ -28,7 +28,7 @@ MeanSquaredLogarithmicError<InputDataType, OutputDataType>
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   return arma::accu(arma::square(arma::log(1. + target) -
       arma::log(1. + input))) / target.n_cols;
@@ -37,9 +37,9 @@ double MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   output = 2 * (arma::log(1. + input) - arma::log(1. + target)) /
       ((1. + input) * target.n_cols);

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -48,7 +48,7 @@ class NegativeLogLikelihood
    *        between 1 and the number of classes.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network. The negative log
@@ -62,9 +62,9 @@ class NegativeLogLikelihood
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the input parameter.
   InputDataType& InputParameter() const { return inputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
@@ -27,7 +27,7 @@ NegativeLogLikelihood<InputDataType, OutputDataType>::NegativeLogLikelihood()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 double NegativeLogLikelihood<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   double output = 0;
   for (size_t i = 0; i < input.n_cols; ++i)
@@ -45,9 +45,9 @@ double NegativeLogLikelihood<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 void NegativeLogLikelihood<InputDataType, OutputDataType>::Backward(
-      const InputType&& input,
-      const TargetType&& target,
-      OutputType&& output)
+      const InputType& input,
+      const TargetType& target,
+      OutputType& output)
 {
   output = arma::zeros<OutputType>(input.n_rows, input.n_cols);
   for (size_t i = 0; i < input.n_cols; ++i)

--- a/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
@@ -49,7 +49,7 @@ class ReconstructionLoss
    * @param target The target matrix.
    */
   template<typename InputType, typename TargetType>
-  double Forward(const InputType&& input, const TargetType&& target);
+  double Forward(const InputType& input, const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
@@ -59,9 +59,9 @@ class ReconstructionLoss
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType&& input,
-                const TargetType&& target,
-                OutputType&& output);
+  void Backward(const InputType& input,
+                const TargetType& target,
+                OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/reconstruction_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/reconstruction_loss_impl.hpp
@@ -31,20 +31,20 @@ ReconstructionLoss<
 template<typename InputDataType, typename OutputDataType, typename DistType>
 template<typename InputType, typename TargetType>
 double ReconstructionLoss<InputDataType, OutputDataType, DistType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
-  dist = DistType(std::move(input));
-  return -dist.LogProbability(std::move(target));
+  dist = DistType(input);
+  return -dist.LogProbability(target);
 }
 
 template<typename InputDataType, typename OutputDataType, typename DistType>
 template<typename InputType, typename TargetType, typename OutputType>
 void ReconstructionLoss<InputDataType, OutputDataType, DistType>::Backward(
-    const InputType&& /* input */,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& /* input */,
+    const TargetType& target,
+    OutputType& output)
 {
-  dist.LogProbBackward(std::move(target), std::move(output));
+  dist.LogProbBackward(target, output);
   output *= -1;
 }
 

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
@@ -64,8 +64,8 @@ class SigmoidCrossEntropyError
    * @param target The target vector.
    */
   template<typename InputType, typename TargetType>
-  inline double Forward(const InputType&& input,
-                        const TargetType&& target);
+  inline double Forward(const InputType& input,
+                        const TargetType& target);
   /**
    * Ordinary feed backward pass of a neural network.
    *
@@ -74,9 +74,9 @@ class SigmoidCrossEntropyError
    * @param output The calculated error.
    */
   template<typename InputType, typename TargetType, typename OutputType>
-  inline void Backward(const InputType&& input,
-                       const TargetType&& target,
-                       OutputType&& output);
+  inline void Backward(const InputType& input,
+                       const TargetType& target,
+                       OutputType& output);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
@@ -30,7 +30,7 @@ SigmoidCrossEntropyError<InputDataType, OutputDataType>
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType>
 inline double SigmoidCrossEntropyError<InputDataType, OutputDataType>::Forward(
-    const InputType&& input, const TargetType&& target)
+    const InputType& input, const TargetType& target)
 {
   double maximum = 0;
   for (size_t i = 0; i < input.n_elem; ++i)
@@ -45,9 +45,9 @@ inline double SigmoidCrossEntropyError<InputDataType, OutputDataType>::Forward(
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename TargetType, typename OutputType>
 inline void SigmoidCrossEntropyError<InputDataType, OutputDataType>::Backward(
-    const InputType&& input,
-    const TargetType&& target,
-    OutputType&& output)
+    const InputType& input,
+    const TargetType& target,
+    OutputType& output)
 {
   output = 1.0 / (1.0 + arma::exp(-input)) - target;
 }

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -295,7 +295,8 @@ class RNN
    *
    * @param input Data sequence to compute probabilities for.
    */
-  void Forward(arma::mat&& input);
+  template<typename InputType>
+  void Forward(const InputType& input);
 
   /**
    * Reset the state of RNN cells in the network for new input sequence.
@@ -313,7 +314,7 @@ class RNN
    * layer defined optimizer.
    */
   template<typename InputType>
-  void Gradient(InputType&& input);
+  void Gradient(const InputType& input);
 
   /**
    * Reset the module status by setting the current deterministic parameter

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -314,7 +314,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
 
     for (size_t l = 0; l < network.size(); ++l)
     {
-      boost::apply_visitor(SaveOutputParameterVisitor( moduleOutputParameter),
+      boost::apply_visitor(SaveOutputParameterVisitor(moduleOutputParameter),
           network[l]);
     }
 

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -158,8 +158,8 @@ void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Predict(
   const size_t effectiveBatchSize = std::min(batchSize,
       size_t(predictors.n_cols));
 
-  Forward(std::move(arma::mat(predictors.slice(0).colptr(0),
-      predictors.n_rows, effectiveBatchSize, false, true)));
+  Forward(arma::mat(predictors.slice(0).colptr(0), predictors.n_rows,
+      effectiveBatchSize, false, true));
   arma::mat resultsTemp = boost::apply_visitor(outputParameterVisitor,
       network.back());
 
@@ -175,8 +175,8 @@ void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Predict(
         size_t(predictors.n_cols - begin));
     for (size_t seqNum = !begin; seqNum < rho; ++seqNum)
     {
-      Forward(std::move(arma::mat(predictors.slice(seqNum).colptr(begin),
-          predictors.n_rows, effectiveBatchSize, false, true)));
+      Forward(arma::mat(predictors.slice(seqNum).colptr(begin),
+          predictors.n_rows, effectiveBatchSize, false, true));
 
       results.slice(seqNum).submat(0, begin, results.n_rows - 1, begin +
           effectiveBatchSize - 1) = boost::apply_visitor(outputParameterVisitor,
@@ -224,16 +224,16 @@ double RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Evaluate(
     // Wrap a matrix around our data to avoid a copy.
     arma::mat stepData(predictors.slice(seqNum).colptr(begin),
         predictors.n_rows, batchSize, false, true);
-    Forward(std::move(stepData));
+    Forward(stepData);
     if (!single)
     {
       responseSeq = seqNum;
     }
 
-    performance += outputLayer.Forward(std::move(boost::apply_visitor(
-        outputParameterVisitor, network.back())),
-        std::move(arma::mat(responses.slice(responseSeq).colptr(begin),
-            responses.n_rows, batchSize, false, true)));
+    performance += outputLayer.Forward(boost::apply_visitor(
+        outputParameterVisitor, network.back()),
+        arma::mat(responses.slice(responseSeq).colptr(begin),
+            responses.n_rows, batchSize, false, true));
   }
 
   if (outputSize == 0)
@@ -306,7 +306,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     // Wrap a matrix around our data to avoid a copy.
     arma::mat stepData(predictors.slice(seqNum).colptr(begin),
         predictors.n_rows, batchSize, false, true);
-    Forward(std::move(stepData));
+    Forward(stepData);
     if (!single)
     {
       responseSeq = seqNum;
@@ -314,14 +314,14 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
 
     for (size_t l = 0; l < network.size(); ++l)
     {
-      boost::apply_visitor(SaveOutputParameterVisitor(
-          std::move(moduleOutputParameter)), network[l]);
+      boost::apply_visitor(SaveOutputParameterVisitor( moduleOutputParameter),
+          network[l]);
     }
 
-    performance += outputLayer.Forward(std::move(boost::apply_visitor(
-        outputParameterVisitor, network.back())),
-        std::move(arma::mat(responses.slice(responseSeq).colptr(begin),
-            responses.n_rows, batchSize, false, true)));
+    performance += outputLayer.Forward(boost::apply_visitor(
+        outputParameterVisitor, network.back()),
+        arma::mat(responses.slice(responseSeq).colptr(begin),
+            responses.n_rows, batchSize, false, true));
   }
 
   if (outputSize == 0)
@@ -344,8 +344,8 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     currentGradient.zeros();
     for (size_t l = 0; l < network.size(); ++l)
     {
-      boost::apply_visitor(LoadOutputParameterVisitor(
-          std::move(moduleOutputParameter)), network[network.size() - 1 - l]);
+      boost::apply_visitor(LoadOutputParameterVisitor(moduleOutputParameter),
+          network[network.size() - 1 - l]);
     }
 
     if (single && seqNum > 0)
@@ -354,24 +354,23 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
     }
     else if (single && seqNum == 0)
     {
-      outputLayer.Backward(std::move(boost::apply_visitor(
-          outputParameterVisitor, network.back())),
-          std::move(arma::mat(responses.slice(0).colptr(begin),
-          responses.n_rows, batchSize, false, true)), std::move(error));
+      outputLayer.Backward(boost::apply_visitor(
+          outputParameterVisitor, network.back()),
+          arma::mat(responses.slice(0).colptr(begin),
+          responses.n_rows, batchSize, false, true), error);
     }
     else
     {
-      outputLayer.Backward(std::move(boost::apply_visitor(
-          outputParameterVisitor, network.back())),
-          std::move(arma::mat(
-          responses.slice(effectiveRho - seqNum - 1).colptr(begin),
-          responses.n_rows, batchSize, false, true)), std::move(error));
+      outputLayer.Backward(boost::apply_visitor(
+          outputParameterVisitor, network.back()),
+          arma::mat(responses.slice(effectiveRho - seqNum - 1).colptr(begin),
+          responses.n_rows, batchSize, false, true), error);
     }
 
     Backward();
-    Gradient(std::move(
+    Gradient(
         arma::mat(predictors.slice(effectiveRho - seqNum - 1).colptr(begin),
-        predictors.n_rows, batchSize, false, true)));
+        predictors.n_rows, batchSize, false, true));
     gradient += currentGradient;
   }
 
@@ -444,25 +443,25 @@ void RNN<OutputLayerType, InitializationRuleType,
   size_t offset = 0;
   for (LayerTypes<CustomLayers...>& layer : network)
   {
-    offset += boost::apply_visitor(GradientSetVisitor(std::move(gradient),
-        offset), layer);
+    offset += boost::apply_visitor(GradientSetVisitor(gradient, offset), layer);
   }
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+template<typename InputType>
 void RNN<OutputLayerType, InitializationRuleType,
-         CustomLayers...>::Forward(arma::mat&& input)
+         CustomLayers...>::Forward(const InputType& input)
 {
-  boost::apply_visitor(ForwardVisitor(std::move(input), std::move(
-      boost::apply_visitor(outputParameterVisitor, network.front()))),
+  boost::apply_visitor(ForwardVisitor(input,
+      boost::apply_visitor(outputParameterVisitor, network.front())),
       network.front());
 
   for (size_t i = 1; i < network.size(); ++i)
   {
     boost::apply_visitor(ForwardVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor, network[i - 1])),
-        std::move(boost::apply_visitor(outputParameterVisitor, network[i]))),
+        boost::apply_visitor(outputParameterVisitor, network[i - 1]),
+        boost::apply_visitor(outputParameterVisitor, network[i])),
         network[i]);
   }
 }
@@ -472,17 +471,17 @@ template<typename OutputLayerType, typename InitializationRuleType,
 void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::Backward()
 {
   boost::apply_visitor(BackwardVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor, network.back())),
-        std::move(error), std::move(boost::apply_visitor(deltaVisitor,
-        network.back()))), network.back());
+        boost::apply_visitor(outputParameterVisitor, network.back()),
+        error, boost::apply_visitor(deltaVisitor,
+        network.back())), network.back());
 
   for (size_t i = 2; i < network.size(); ++i)
   {
     boost::apply_visitor(BackwardVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor,
-        network[network.size() - i])), std::move(boost::apply_visitor(
-        deltaVisitor, network[network.size() - i + 1])), std::move(
-        boost::apply_visitor(deltaVisitor, network[network.size() - i]))),
+        boost::apply_visitor(outputParameterVisitor,
+        network[network.size() - i]), boost::apply_visitor(
+        deltaVisitor, network[network.size() - i + 1]),
+        boost::apply_visitor(deltaVisitor, network[network.size() - i])),
         network[network.size() - i]);
   }
 }
@@ -491,16 +490,16 @@ template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename InputType>
 void RNN<OutputLayerType, InitializationRuleType,
-         CustomLayers...>::Gradient(InputType&& input)
+         CustomLayers...>::Gradient(const InputType& input)
 {
-  boost::apply_visitor(GradientVisitor(std::move(input), std::move(
-      boost::apply_visitor(deltaVisitor, network[1]))), network.front());
+  boost::apply_visitor(GradientVisitor(input,
+      boost::apply_visitor(deltaVisitor, network[1])), network.front());
 
   for (size_t i = 1; i < network.size() - 1; ++i)
   {
     boost::apply_visitor(GradientVisitor(
-        std::move(boost::apply_visitor(outputParameterVisitor, network[i - 1])),
-        std::move(boost::apply_visitor(deltaVisitor, network[i + 1]))),
+        boost::apply_visitor(outputParameterVisitor, network[i - 1]),
+        boost::apply_visitor(deltaVisitor, network[i + 1])),
         network[i]);
   }
 }
@@ -544,8 +543,8 @@ void RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::serialize(
     size_t offset = 0;
     for (LayerTypes<CustomLayers...>& layer : network)
     {
-      offset += boost::apply_visitor(WeightSetVisitor(std::move(parameter),
-          offset), layer);
+      offset += boost::apply_visitor(WeightSetVisitor(parameter, offset),
+          layer);
 
       boost::apply_visitor(resetVisitor, layer);
     }

--- a/src/mlpack/methods/ann/visitor/backward_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/backward_visitor.hpp
@@ -30,11 +30,15 @@ class BackwardVisitor : public boost::static_visitor<void>
  public:
   //! Execute the Backward() function given the input, error and delta
   //! parameter.
-  BackwardVisitor(arma::mat&& input, arma::mat&& error, arma::mat&& delta);
+  BackwardVisitor(const arma::mat& input,
+                  const arma::mat& error,
+                  arma::mat& delta);
 
   //! Execute the Backward() function for the layer with the specified index.
-  BackwardVisitor(arma::mat&& input, arma::mat&& error, arma::mat&& delta,
-      const size_t index);
+  BackwardVisitor(const arma::mat& input,
+                  const arma::mat& error,
+                  arma::mat& delta,
+                  const size_t index);
 
   //! Execute the Backward() function.
   template<typename LayerType>
@@ -44,13 +48,13 @@ class BackwardVisitor : public boost::static_visitor<void>
 
  private:
   //! The input parameter set.
-  arma::mat&& input;
+  const arma::mat& input;
 
   //! The error parameter.
-  arma::mat&& error;
+  const arma::mat& error;
 
   //! The delta parameter.
-  arma::mat&& delta;
+  arma::mat& delta;
 
   //! The index of the layer to run.
   size_t index;

--- a/src/mlpack/methods/ann/visitor/backward_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/backward_visitor_impl.hpp
@@ -19,25 +19,25 @@ namespace mlpack {
 namespace ann {
 
 //! BackwardVisitor visitor class.
-inline BackwardVisitor::BackwardVisitor(arma::mat&& input,
-                                        arma::mat&& error,
-                                        arma::mat&& delta) :
-  input(std::move(input)),
-  error(std::move(error)),
-  delta(std::move(delta)),
+inline BackwardVisitor::BackwardVisitor(const arma::mat& input,
+                                        const arma::mat& error,
+                                        arma::mat& delta) :
+  input(input),
+  error(error),
+  delta(delta),
   index(0),
   hasIndex(false)
 {
   /* Nothing to do here. */
 }
 
-inline BackwardVisitor::BackwardVisitor(arma::mat&& input,
-                                        arma::mat&& error,
-                                        arma::mat&& delta,
+inline BackwardVisitor::BackwardVisitor(const arma::mat& input,
+                                        const arma::mat& error,
+                                        arma::mat& delta,
                                         const size_t index) :
-  input(std::move(input)),
-  error(std::move(error)),
-  delta(std::move(delta)),
+  input(input),
+  error(error),
+  delta(delta),
   index(index),
   hasIndex(true)
 {
@@ -60,7 +60,7 @@ inline typename std::enable_if<
     !HasRunCheck<T, bool&(T::*)(void)>::value, void>::type
 BackwardVisitor::LayerBackward(T* layer, arma::mat& /* input */) const
 {
-  layer->Backward(std::move(input), std::move(error), std::move(delta));
+  layer->Backward(input, error, delta);
 }
 
 template<typename T>
@@ -70,13 +70,11 @@ BackwardVisitor::LayerBackward(T* layer, arma::mat& /* input */) const
 {
   if (!hasIndex)
   {
-    layer->Backward(std::move(input), std::move(error),
-        std::move(delta));
+    layer->Backward(input, error, delta);
   }
   else
   {
-    layer->Backward(std::move(input), std::move(error),
-        std::move(delta), index);
+    layer->Backward(input, error, delta, index);
   }
 }
 

--- a/src/mlpack/methods/ann/visitor/bias_set_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/bias_set_visitor.hpp
@@ -27,7 +27,7 @@ class BiasSetVisitor : public boost::static_visitor<size_t>
 {
  public:
   //! Update the bias parameters given the parameters' set and offset.
-  BiasSetVisitor(arma::mat&& weight, const size_t offset = 0);
+  BiasSetVisitor(arma::mat& weight, const size_t offset = 0);
 
   //! Update the parameters' set.
   template<typename LayerType>
@@ -37,7 +37,7 @@ class BiasSetVisitor : public boost::static_visitor<size_t>
 
  private:
   //! The parameters' set.
-  arma::mat&& weight;
+  arma::mat& weight;
 
   //! The parameters' offset.
   const size_t offset;

--- a/src/mlpack/methods/ann/visitor/bias_set_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/bias_set_visitor_impl.hpp
@@ -19,8 +19,8 @@ namespace mlpack {
 namespace ann {
 
 //! BiasSetVisitor visitor class.
-inline BiasSetVisitor::BiasSetVisitor(arma::mat&& weight, const size_t offset) :
-    weight(std::move(weight)),
+inline BiasSetVisitor::BiasSetVisitor(arma::mat& weight, const size_t offset) :
+    weight(weight),
     offset(offset)
 {
   /* Nothing to do here. */
@@ -57,7 +57,7 @@ BiasSetVisitor::LayerSize(T* layer) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(BiasSetVisitor(
-        std::move(weight), modelOffset + offset), layer->Model()[i]);
+        weight, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;
@@ -89,7 +89,7 @@ BiasSetVisitor::LayerSize(T* layer) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(BiasSetVisitor(
-        std::move(weight), modelOffset + offset), layer->Model()[i]);
+        weight, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;

--- a/src/mlpack/methods/ann/visitor/forward_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/forward_visitor.hpp
@@ -29,7 +29,7 @@ class ForwardVisitor : public boost::static_visitor<void>
 {
  public:
   //! Execute the Forward() function given the input and output parameter.
-  ForwardVisitor(arma::mat&& input, arma::mat&& output);
+  ForwardVisitor(const arma::mat& input, arma::mat& output);
 
   //! Execute the Forward() function.
   template<typename LayerType>
@@ -39,10 +39,10 @@ class ForwardVisitor : public boost::static_visitor<void>
 
  private:
   //! The input parameter set.
-  arma::mat&& input;
+  const arma::mat& input;
 
   //! The output parameter set.
-  arma::mat&& output;
+  arma::mat& output;
 };
 
 } // namespace ann

--- a/src/mlpack/methods/ann/visitor/forward_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/forward_visitor_impl.hpp
@@ -19,9 +19,9 @@ namespace mlpack {
 namespace ann {
 
 //! ForwardVisitor visitor class.
-inline ForwardVisitor::ForwardVisitor(arma::mat&& input, arma::mat&& output) :
-    input(std::move(input)),
-    output(std::move(output))
+inline ForwardVisitor::ForwardVisitor(const arma::mat& input, arma::mat& output) :
+    input(input),
+    output(output)
 {
   /* Nothing to do here. */
 }
@@ -29,7 +29,7 @@ inline ForwardVisitor::ForwardVisitor(arma::mat&& input, arma::mat&& output) :
 template<typename LayerType>
 inline void ForwardVisitor::operator()(LayerType* layer) const
 {
-  layer->Forward(std::move(input), std::move(output));
+  layer->Forward(input, output);
 }
 
 inline void ForwardVisitor::operator()(MoreTypes layer) const

--- a/src/mlpack/methods/ann/visitor/gradient_set_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/gradient_set_visitor.hpp
@@ -27,7 +27,7 @@ class GradientSetVisitor : public boost::static_visitor<size_t>
 {
  public:
   //! Update the gradient parameter given the gradient set.
-  GradientSetVisitor(arma::mat&& gradient, size_t offset = 0);
+  GradientSetVisitor(arma::mat& gradient, size_t offset = 0);
 
   //! Update the gradient parameter.
   template<typename LayerType>
@@ -37,7 +37,7 @@ class GradientSetVisitor : public boost::static_visitor<size_t>
 
  private:
   //! The gradient set.
-  arma::mat&& gradient;
+  arma::mat& gradient;
 
   //! The gradient offset.
   size_t offset;

--- a/src/mlpack/methods/ann/visitor/gradient_set_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/gradient_set_visitor_impl.hpp
@@ -19,9 +19,9 @@ namespace mlpack {
 namespace ann {
 
 //! GradientSetVisitor visitor class.
-inline GradientSetVisitor::GradientSetVisitor(arma::mat&& gradient,
+inline GradientSetVisitor::GradientSetVisitor(arma::mat& gradient,
                                               size_t offset) :
-    gradient(std::move(gradient)),
+    gradient(gradient),
     offset(offset)
 {
   /* Nothing to do here. */
@@ -60,7 +60,7 @@ GradientSetVisitor::LayerGradients(T* layer, arma::mat& /* input */) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(GradientSetVisitor(
-        std::move(gradient), modelOffset + offset), layer->Model()[i]);
+        gradient, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;
@@ -79,7 +79,7 @@ GradientSetVisitor::LayerGradients(T* layer, arma::mat& /* input */) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(GradientSetVisitor(
-        std::move(gradient), modelOffset + offset), layer->Model()[i]);
+        gradient, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;

--- a/src/mlpack/methods/ann/visitor/gradient_update_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/gradient_update_visitor.hpp
@@ -27,7 +27,7 @@ class GradientUpdateVisitor : public boost::static_visitor<size_t>
 {
  public:
   //! Update the gradient parameter given the gradient set.
-  GradientUpdateVisitor(arma::mat&& gradient, size_t offset = 0);
+  GradientUpdateVisitor(arma::mat& gradient, size_t offset = 0);
 
   //! Update the gradient parameter.
   template<typename LayerType>
@@ -37,7 +37,7 @@ class GradientUpdateVisitor : public boost::static_visitor<size_t>
 
  private:
   //! The gradient set.
-  arma::mat&& gradient;
+  arma::mat& gradient;
 
   //! The gradient offset.
   size_t offset;

--- a/src/mlpack/methods/ann/visitor/gradient_update_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/gradient_update_visitor_impl.hpp
@@ -19,9 +19,9 @@ namespace mlpack {
 namespace ann {
 
 //! GradientUpdateVisitor visitor class.
-inline GradientUpdateVisitor::GradientUpdateVisitor(arma::mat&& gradient,
+inline GradientUpdateVisitor::GradientUpdateVisitor(arma::mat& gradient,
                                                     size_t offset) :
-    gradient(std::move(gradient)),
+    gradient(gradient),
     offset(offset)
 {
   /* Nothing to do here. */
@@ -63,7 +63,7 @@ GradientUpdateVisitor::LayerGradients(T* layer, arma::mat& /* input */) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(GradientUpdateVisitor(
-        std::move(gradient), modelOffset + offset), layer->Model()[i]);
+        gradient, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;
@@ -85,7 +85,7 @@ GradientUpdateVisitor::LayerGradients(T* layer, arma::mat& /* input */) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(GradientUpdateVisitor(
-        std::move(gradient), modelOffset + offset), layer->Model()[i]);
+        gradient, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;

--- a/src/mlpack/methods/ann/visitor/gradient_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/gradient_visitor.hpp
@@ -30,10 +30,12 @@ class GradientVisitor : public boost::static_visitor<void>
  public:
   //! Executes the Gradient() method of the given module using the input and
   //! delta parameter.
-  GradientVisitor(arma::mat&& input, arma::mat&& delta);
+  GradientVisitor(const arma::mat& input, const arma::mat& delta);
 
   //! Executes the Gradient() method for the layer with the specified index.
-  GradientVisitor(arma::mat&& input, arma::mat&& delta, const size_t index);
+  GradientVisitor(const arma::mat& input,
+                  const arma::mat& delta,
+                  const size_t index);
 
   //! Executes the Gradient() method.
   template<typename LayerType>
@@ -43,10 +45,10 @@ class GradientVisitor : public boost::static_visitor<void>
 
  private:
   //! The input set.
-  arma::mat&& input;
+  const arma::mat& input;
 
   //! The delta parameter.
-  arma::mat&& delta;
+  const arma::mat& delta;
 
   //! Index of the layer to run.
   size_t index;

--- a/src/mlpack/methods/ann/visitor/gradient_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/gradient_visitor_impl.hpp
@@ -19,19 +19,21 @@ namespace mlpack {
 namespace ann {
 
 //! GradientVisitor visitor class.
-inline GradientVisitor::GradientVisitor(arma::mat&& input, arma::mat&& delta) :
-    input(std::move(input)),
-    delta(std::move(delta)),
+inline GradientVisitor::GradientVisitor(const arma::mat& input,
+                                        const arma::mat& delta) :
+    input(input),
+    delta(delta),
     index(0),
     hasIndex(false)
 {
   /* Nothing to do here. */
 }
 
-inline GradientVisitor::GradientVisitor(arma::mat&& input, arma::mat&& delta,
+inline GradientVisitor::GradientVisitor(const arma::mat& input,
+                                        const arma::mat& delta,
                                         const size_t index) :
-    input(std::move(input)),
-    delta(std::move(delta)),
+    input(input),
+    delta(delta),
     index(index),
     hasIndex(true)
 {
@@ -55,8 +57,7 @@ inline typename std::enable_if<
     !HasRunCheck<T, bool&(T::*)(void)>::value, void>::type
 GradientVisitor::LayerGradients(T* layer, arma::mat& /* input */) const
 {
-  layer->Gradient(std::move(input), std::move(delta),
-      std::move(layer->Gradient()));
+  layer->Gradient(input, delta, layer->Gradient());
 }
 
 template<typename T>
@@ -67,13 +68,11 @@ GradientVisitor::LayerGradients(T* layer, arma::mat& /* input */) const
 {
   if (!hasIndex)
   {
-    layer->Gradient(std::move(input), std::move(delta),
-        std::move(layer->Gradient()));
+    layer->Gradient(input, delta, layer->Gradient());
   }
   else
   {
-    layer->Gradient(std::move(input), std::move(delta),
-        std::move(layer->Gradient()), index);
+    layer->Gradient(input, delta, layer->Gradient(), index);
   }
 }
 

--- a/src/mlpack/methods/ann/visitor/load_output_parameter_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/load_output_parameter_visitor.hpp
@@ -29,7 +29,7 @@ class LoadOutputParameterVisitor : public boost::static_visitor<void>
 {
  public:
   //! Restore the output parameter given a parameter set.
-  LoadOutputParameterVisitor(std::vector<arma::mat>&& parameter);
+  LoadOutputParameterVisitor(std::vector<arma::mat>& parameter);
 
   //! Restore the output parameter.
   template<typename LayerType>
@@ -39,7 +39,7 @@ class LoadOutputParameterVisitor : public boost::static_visitor<void>
 
  private:
   //! The parameter set.
-  std::vector<arma::mat>&& parameter;
+  std::vector<arma::mat>& parameter;
 
   //! Restore the output parameter for a module which doesn't implement the
   //! Model() function.

--- a/src/mlpack/methods/ann/visitor/load_output_parameter_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/load_output_parameter_visitor_impl.hpp
@@ -20,7 +20,7 @@ namespace ann {
 
 //! LoadOutputParameterVisitor visitor class.
 inline LoadOutputParameterVisitor::LoadOutputParameterVisitor(
-    std::vector<arma::mat>&& parameter) : parameter(std::move(parameter))
+    std::vector<arma::mat>& parameter) : parameter(parameter)
 {
   /* Nothing to do here. */
 }
@@ -52,7 +52,7 @@ LoadOutputParameterVisitor::OutputParameter(T* layer) const
 {
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
-    boost::apply_visitor(LoadOutputParameterVisitor(std::move(parameter)),
+    boost::apply_visitor(LoadOutputParameterVisitor(parameter),
         layer->Model()[layer->Model().size() - i - 1]);
   }
 

--- a/src/mlpack/methods/ann/visitor/parameters_set_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/parameters_set_visitor.hpp
@@ -28,7 +28,7 @@ class ParametersSetVisitor : public boost::static_visitor<void>
 {
  public:
   //! Update the parameters set given the parameters matrix.
-  ParametersSetVisitor(arma::mat&& parameters);
+  ParametersSetVisitor(arma::mat& parameters);
 
   //! Update the parameters set.
   template<typename LayerType>
@@ -38,7 +38,7 @@ class ParametersSetVisitor : public boost::static_visitor<void>
 
  private:
   //! The parameters set.
-  arma::mat&& parameters;
+  arma::mat& parameters;
 
   //! Do not update the parameters set if the module doesn't implement the
   //! Parameters() function.

--- a/src/mlpack/methods/ann/visitor/parameters_set_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/parameters_set_visitor_impl.hpp
@@ -19,8 +19,8 @@ namespace mlpack {
 namespace ann {
 
 //! ParametersSetVisitor visitor class.
-inline ParametersSetVisitor::ParametersSetVisitor(arma::mat&& parameters) :
-    parameters(std::move(parameters))
+inline ParametersSetVisitor::ParametersSetVisitor(arma::mat& parameters) :
+    parameters(parameters)
 {
   /* Nothing to do here. */
 }

--- a/src/mlpack/methods/ann/visitor/parameters_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/parameters_visitor.hpp
@@ -29,7 +29,7 @@ class ParametersVisitor : public boost::static_visitor<void>
 {
  public:
   //! Store the parameters set into the given parameters matrix.
-  ParametersVisitor(arma::mat&& parameters);
+  ParametersVisitor(arma::mat& parameters);
 
   //! Set the parameters set.
   template<typename LayerType>
@@ -39,7 +39,7 @@ class ParametersVisitor : public boost::static_visitor<void>
 
  private:
   //! The parameters set.
-  arma::mat&& parameters;
+  arma::mat& parameters;
 
   //! Do not set the parameters set if the module doesn't implement the
   //! Parameters() function.

--- a/src/mlpack/methods/ann/visitor/parameters_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/parameters_visitor_impl.hpp
@@ -19,8 +19,8 @@ namespace mlpack {
 namespace ann {
 
 //! ParametersVisitor visitor class.
-inline ParametersVisitor::ParametersVisitor(arma::mat&& parameters) :
-    parameters(std::move(parameters))
+inline ParametersVisitor::ParametersVisitor(arma::mat& parameters) :
+    parameters(parameters)
 {
   /* Nothing to do here. */
 }

--- a/src/mlpack/methods/ann/visitor/save_output_parameter_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/save_output_parameter_visitor.hpp
@@ -28,7 +28,7 @@ class SaveOutputParameterVisitor : public boost::static_visitor<void>
 {
  public:
   //! Save the output parameter into the given parameter set.
-  SaveOutputParameterVisitor(std::vector<arma::mat>&& parameter);
+  SaveOutputParameterVisitor(std::vector<arma::mat>& parameter);
 
   //! Save the output parameter.
   template<typename LayerType>
@@ -38,7 +38,7 @@ class SaveOutputParameterVisitor : public boost::static_visitor<void>
 
  private:
   //! The parameter set.
-  std::vector<arma::mat>&& parameter;
+  std::vector<arma::mat>& parameter;
 
   //! Save the output parameter for a module which doesn't implement the
   //! Model() function.

--- a/src/mlpack/methods/ann/visitor/save_output_parameter_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/save_output_parameter_visitor_impl.hpp
@@ -20,7 +20,7 @@ namespace ann {
 
 //! SaveOutputParameterVisitor visitor class.
 inline SaveOutputParameterVisitor::SaveOutputParameterVisitor(
-    std::vector<arma::mat>&& parameter) : parameter(std::move(parameter))
+    std::vector<arma::mat>& parameter) : parameter(parameter)
 {
   /* Nothing to do here. */
 }
@@ -53,7 +53,7 @@ SaveOutputParameterVisitor::OutputParameter(T* layer) const
 
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
-    boost::apply_visitor(SaveOutputParameterVisitor(std::move(parameter)),
+    boost::apply_visitor(SaveOutputParameterVisitor(parameter),
         layer->Model()[i]);
   }
 }

--- a/src/mlpack/methods/ann/visitor/weight_set_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/weight_set_visitor.hpp
@@ -27,7 +27,7 @@ class WeightSetVisitor : public boost::static_visitor<size_t>
 {
  public:
   //! Update the parameters given the parameters set and offset.
-  WeightSetVisitor(arma::mat&& weight, const size_t offset = 0);
+  WeightSetVisitor(arma::mat& weight, const size_t offset = 0);
 
   //! Update the parameters set.
   template<typename LayerType>
@@ -37,7 +37,7 @@ class WeightSetVisitor : public boost::static_visitor<size_t>
 
  private:
   //! The parameters set.
-  arma::mat&& weight;
+  arma::mat& weight;
 
   //! The parameters offset.
   const size_t offset;

--- a/src/mlpack/methods/ann/visitor/weight_set_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/weight_set_visitor_impl.hpp
@@ -19,9 +19,9 @@ namespace mlpack {
 namespace ann {
 
 //! WeightSetVisitor visitor class.
-inline WeightSetVisitor::WeightSetVisitor(arma::mat&& weight,
+inline WeightSetVisitor::WeightSetVisitor(arma::mat& weight,
                                           const size_t offset) :
-    weight(std::move(weight)),
+    weight(weight),
     offset(offset)
 {
   /* Nothing to do here. */
@@ -30,7 +30,7 @@ inline WeightSetVisitor::WeightSetVisitor(arma::mat&& weight,
 template<typename LayerType>
 inline size_t WeightSetVisitor::operator()(LayerType* layer) const
 {
-  return LayerSize(layer, std::move(layer->OutputParameter()));
+  return LayerSize(layer, layer->OutputParameter());
 }
 
 inline size_t WeightSetVisitor::operator()(MoreTypes layer) const
@@ -57,7 +57,7 @@ WeightSetVisitor::LayerSize(T* layer, P&& /*output */) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(WeightSetVisitor(
-        std::move(weight), modelOffset + offset), layer->Model()[i]);
+        weight, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;
@@ -88,7 +88,7 @@ WeightSetVisitor::LayerSize(T* layer, P&& /* output */) const
   for (size_t i = 0; i < layer->Model().size(); ++i)
   {
     modelOffset += boost::apply_visitor(WeightSetVisitor(
-        std::move(weight), modelOffset + offset), layer->Model()[i]);
+        weight, modelOffset + offset), layer->Model()[i]);
   }
 
   return modelOffset;

--- a/src/mlpack/methods/reinforcement_learning/q_learning_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/q_learning_impl.hpp
@@ -179,6 +179,7 @@ double QLearning<
   // Compute the update target.
   arma::mat target;
   learningNetwork.Forward(sampledStates, target);
+
   /**
    * If the agent is at a terminal state, then we don't need to add the
    * discounted reward. At terminal state, the agent wont perform any
@@ -199,7 +200,7 @@ double QLearning<
 
   // Learn from experience.
   arma::mat gradients;
-  learningNetwork.Backward(target, gradients);
+  learningNetwork.Backward(sampledStates, target, gradients);
 
   replayMethod.Update(target, sampledActions, nextActionValues, gradients);
 

--- a/src/mlpack/methods/reinforcement_learning/worker/n_step_q_learning_worker.hpp
+++ b/src/mlpack/methods/reinforcement_learning/worker/n_step_q_learning_worker.hpp
@@ -301,12 +301,13 @@ class NStepQLearningWorker
         target = config.Discount() * target + std::get<2>(transition);
 
         // Compute the training target for current state.
-        network.Forward(std::get<0>(transition).Encode(), actionValue);
+        arma::mat input = std::get<0>(transition).Encode();
+        network.Forward(input, actionValue);
         actionValue[std::get<1>(transition)] = target;
 
         // Compute gradient.
         arma::mat gradients;
-        network.Backward(actionValue, gradients);
+        network.Backward(input, actionValue, gradients);
 
         // Accumulate gradients.
         totalGradients += gradients;

--- a/src/mlpack/methods/reinforcement_learning/worker/one_step_q_learning_worker.hpp
+++ b/src/mlpack/methods/reinforcement_learning/worker/one_step_q_learning_worker.hpp
@@ -301,12 +301,13 @@ class OneStepQLearningWorker
             config.Discount() * targetActionValue;
 
         // Compute the training target for current state.
-        network.Forward(std::get<0>(transition).Encode(), actionValue);
+        arma::mat input = std::get<0>(transition).Encode();
+        network.Forward(input, actionValue);
         actionValue[std::get<1>(transition)] = targetActionValue;
 
         // Compute gradient.
         arma::mat gradients;
-        network.Backward(actionValue, gradients);
+        network.Backward(input, actionValue, gradients);
 
         // Accumulate gradients.
         totalGradients += gradients;

--- a/src/mlpack/methods/reinforcement_learning/worker/one_step_sarsa_worker.hpp
+++ b/src/mlpack/methods/reinforcement_learning/worker/one_step_sarsa_worker.hpp
@@ -314,12 +314,13 @@ class OneStepSarsaWorker
             config.Discount() * targetActionValue;
 
         // Compute the training target for current state.
-        network.Forward(std::get<0>(transition).Encode(), actionValue);
+        arma::mat input = std::get<0>(transition).Encode();
+        network.Forward(input, actionValue);
         actionValue[std::get<1>(transition)] = targetActionValue;
 
         // Compute gradient.
         arma::mat gradients;
-        network.Backward(actionValue, gradients);
+        network.Backward(input, actionValue, gradients);
 
         // Accumulate gradients.
         totalGradients += gradients;

--- a/src/mlpack/tests/activation_functions_test.cpp
+++ b/src/mlpack/tests/activation_functions_test.cpp
@@ -133,7 +133,7 @@ void CheckHardTanHActivationCorrect(const arma::colvec input,
 
   // Test the activation function using the entire vector as input.
   arma::colvec activations;
-  htf.Forward(std::move(input), std::move(activations));
+  htf.Forward(input, activations);
   for (size_t i = 0; i < activations.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(activations.at(i), target.at(i), 1e-3);
@@ -157,7 +157,7 @@ void CheckHardTanHDerivativeCorrect(const arma::colvec input,
 
   // This error vector will be set to 1 to get the derivatives.
   arma::colvec error = arma::ones<arma::colvec>(input.n_elem);
-  htf.Backward(std::move(input), std::move(error), std::move(derivatives));
+  htf.Backward(input, error, derivatives);
 
   for (size_t i = 0; i < derivatives.n_elem; i++)
   {
@@ -179,7 +179,7 @@ void CheckLeakyReLUActivationCorrect(const arma::colvec input,
 
   // Test the activation function using the entire vector as input.
   arma::colvec activations;
-  lrf.Forward(std::move(input), std::move(activations));
+  lrf.Forward(input, activations);
   for (size_t i = 0; i < activations.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(activations.at(i), target.at(i), 1e-3);
@@ -204,7 +204,7 @@ void CheckLeakyReLUDerivativeCorrect(const arma::colvec input,
 
   // This error vector will be set to 1 to get the derivatives.
   arma::colvec error = arma::ones<arma::colvec>(input.n_elem);
-  lrf.Backward(std::move(input), std::move(error), std::move(derivatives));
+  lrf.Backward(input, error, derivatives);
   for (size_t i = 0; i < derivatives.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(derivatives.at(i), target.at(i), 1e-3);
@@ -226,7 +226,7 @@ void CheckELUActivationCorrect(const arma::colvec input,
 
   // Test the activation function using the entire vector as input.
   arma::colvec activations;
-  lrf.Forward(std::move(input), std::move(activations));
+  lrf.Forward(input, activations);
   for (size_t i = 0; i < activations.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(activations.at(i), target.at(i), 1e-3);
@@ -251,9 +251,8 @@ void CheckELUDerivativeCorrect(const arma::colvec input,
 
   // This error vector will be set to 1 to get the derivatives.
   arma::colvec error = arma::ones<arma::colvec>(input.n_elem);
-  lrf.Forward(std::move(input), std::move(activations));
-  lrf.Backward(std::move(activations), std::move(error),
-      std::move(derivatives));
+  lrf.Forward(input, activations);
+  lrf.Backward(activations, error, derivatives);
   for (size_t i = 0; i < derivatives.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(derivatives.at(i), target.at(i), 1e-3);
@@ -275,7 +274,7 @@ void CheckPReLUActivationCorrect(const arma::colvec input,
 
   // Test the activation function using the entire vector as input.
   arma::colvec activations;
-  prelu.Forward(std::move(input), std::move(activations));
+  prelu.Forward(input, activations);
   for (size_t i = 0; i < activations.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(activations.at(i), target.at(i), 1e-3);
@@ -301,7 +300,7 @@ void CheckPReLUDerivativeCorrect(const arma::colvec input,
 
   // This error vector will be set to 1 to get the derivatives.
   arma::colvec error = arma::ones<arma::colvec>(input.n_elem);
-  prelu.Backward(std::move(input), std::move(error), std::move(derivatives));
+  prelu.Backward(input, error, derivatives);
   for (size_t i = 0; i < derivatives.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(derivatives.at(i), target.at(i), 1e-3);
@@ -327,7 +326,7 @@ void CheckPReLUGradientCorrect(const arma::colvec input,
 
   // This error vector will be set to 1 to get the gradient.
   arma::colvec error = arma::ones<arma::colvec>(input.n_elem);
-  prelu.Gradient(std::move(input), std::move(error), std::move(gradient));
+  prelu.Gradient(input, error, gradient);
   BOOST_REQUIRE_EQUAL(gradient.n_rows, 1);
   BOOST_REQUIRE_EQUAL(gradient.n_cols, 1);
   BOOST_REQUIRE_CLOSE(gradient(0), target(0), 1e-3);
@@ -345,7 +344,7 @@ BOOST_AUTO_TEST_CASE(SELUFunctionNormalizedTest)
 
   SELU selu;
 
-  selu.Forward(std::move(input), output);
+  selu.Forward(input, output);
 
   BOOST_REQUIRE_LE(arma::as_scalar(arma::abs(arma::mean(input) -
       arma::mean(output))), 0.1);
@@ -367,7 +366,7 @@ BOOST_AUTO_TEST_CASE(SELUFunctionUnnormalizedTest)
 
   SELU selu;
 
-  selu.Forward(std::move(input), output);
+  selu.Forward(input, output);
 
   BOOST_REQUIRE_GE(arma::as_scalar(arma::abs(arma::mean(input) -
       arma::mean(output))), 0.1);
@@ -391,18 +390,16 @@ BOOST_AUTO_TEST_CASE(SELUFunctionDerivativeTest)
 
   SELU selu;
 
-  selu.Forward(std::move(input), activations);
-  selu.Backward(std::move(activations), std::move(error),
-      std::move(derivatives));
+  selu.Forward(input, activations);
+  selu.Backward(activations, error, derivatives);
 
   BOOST_REQUIRE_LE(arma::as_scalar(arma::abs(arma::mean(derivatives) -
       selu.Lambda())), 10e-4);
 
   input.fill(-1);
 
-  selu.Forward(std::move(input), activations);
-  selu.Backward(std::move(activations), std::move(error),
-      std::move(derivatives));
+  selu.Forward(input, activations);
+  selu.Backward(activations, error, derivatives);
 
   BOOST_REQUIRE_LE(arma::as_scalar(arma::abs(arma::mean(derivatives) -
       selu.Lambda() * selu.Alpha() - arma::mean(activations))), 10e-4);
@@ -582,12 +579,11 @@ BOOST_AUTO_TEST_CASE(CReLUFunctionTest)
   CReLU<> crelu;
   // Test the activation function using the entire vector as input.
   arma::colvec activations;
-  crelu.Forward(std::move(activationData), std::move(activations));
+  crelu.Forward(activationData, activations);
   arma::colvec derivatives;
   // This error vector will be set to 1 to get the derivatives.
   arma::colvec error = arma::ones<arma::colvec>(desiredActivations.n_elem);
-  crelu.Backward(std::move(desiredActivations), std::move(error),
-        std::move(derivatives));
+  crelu.Backward(desiredActivations, error, derivatives);
   for (size_t i = 0; i < activations.n_elem; i++)
   {
     BOOST_REQUIRE_CLOSE(activations.at(i), desiredActivations.at(i), 1e-3);

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(ANNDistTest);
 BOOST_AUTO_TEST_CASE(SimpleBernoulliDistributionTest)
 {
   arma::mat param = arma::mat("1 1 0");
-  BernoulliDistribution<> module(std::move(param), false);
+  BernoulliDistribution<> module(param, false);
 
   arma::mat sample = module.Sample();
   // As the probabilities are [1, 1, 0], the bernoulli samples should be
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(JacobianBernoulliDistributionTest)
     arma::mat target;
     target.randn(targetElements, 1);
 
-    BernoulliDistribution<> module(std::move(param), false);
+    BernoulliDistribution<> module(param, false);
 
     const double perturbation = 1e-6;
     double outputA, outputB, original;
@@ -66,16 +66,16 @@ BOOST_AUTO_TEST_CASE(JacobianBernoulliDistributionTest)
     {
       original = module.Probability()(j);
       module.Probability()(j) = original - perturbation;
-      outputA = module.LogProbability(std::move(target));
+      outputA = module.LogProbability(target);
       module.Probability()(j) = original + perturbation;
-      outputB = module.LogProbability(std::move(target));
+      outputB = module.LogProbability(target);
       module.Probability()(j) = original;
       outputB -= outputA;
       outputB /= 2 * perturbation;
       jacobianA(j) = outputB;
     }
 
-    module.LogProbBackward(std::move(target), std::move(jacobianB));
+    module.LogProbBackward(target, jacobianB);
     BOOST_REQUIRE_LE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))),
         1e-5);
   }
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(JacobianBernoulliDistributionLogisticTest)
     arma::mat target;
     target.randn(targetElements, 1);
 
-    BernoulliDistribution<> module(std::move(param));
+    BernoulliDistribution<> module(param);
 
     const double perturbation = 1e-6;
     double outputA, outputB, original;
@@ -110,10 +110,10 @@ BOOST_AUTO_TEST_CASE(JacobianBernoulliDistributionLogisticTest)
       original = module.Logits()(j);
       module.Logits()(j) = original - perturbation;
       LogisticFunction::Fn(module.Logits(), module.Probability());
-      outputA = module.LogProbability(std::move(target));
+      outputA = module.LogProbability(target);
       module.Logits()(j) = original + perturbation;
       LogisticFunction::Fn(module.Logits(), module.Probability());
-      outputB = module.LogProbability(std::move(target));
+      outputB = module.LogProbability(target);
       module.Logits()(j) = original;
       LogisticFunction::Fn(module.Logits(), module.Probability());
       outputB -= outputA;
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(JacobianBernoulliDistributionLogisticTest)
       jacobianA(j) = outputB;
     }
 
-    module.LogProbBackward(std::move(target), std::move(jacobianB));
+    module.LogProbBackward(target, jacobianB);
     BOOST_REQUIRE_LE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))),
         3e-5);
   }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -41,21 +41,21 @@ BOOST_AUTO_TEST_CASE(SimpleAddLayerTest)
 
   // Test the Forward function.
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(module.Parameters()), arma::accu(output));
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(output), arma::accu(delta));
 
   // Test the forward function.
   input = arma::ones(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_CLOSE(10 + arma::accu(module.Parameters()),
       arma::accu(output), 1e-3);
 
   // Test the backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   BOOST_REQUIRE_CLOSE(arma::accu(output), arma::accu(delta), 1e-3);
 }
 
@@ -131,20 +131,20 @@ BOOST_AUTO_TEST_CASE(SimpleConstantLayerTest)
 
   // Test the Forward function.
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(output), 30.0);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 
   // Test the forward function.
   input = arma::ones(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(output), 30.0);
 
   // Test the backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 }
 
@@ -183,19 +183,19 @@ BOOST_AUTO_TEST_CASE(SimpleDropoutLayerTest)
 
   // Test the Forward function.
   arma::mat output;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_LE(
       arma::as_scalar(arma::abs(arma::mean(output) - (1 - p))), 0.05);
 
   // Test the Backward function.
   arma::mat delta;
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
   BOOST_REQUIRE_LE(
       arma::as_scalar(arma::abs(arma::mean(delta) - (1 - p))), 0.05);
 
   // Test the Forward function.
   module.Deterministic() = true;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(input), arma::accu(output));
 }
 
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(DropoutProbabilityTest)
       module.Deterministic() = false;
 
       arma::mat output;
-      module.Forward(std::move(input), std::move(output));
+      module.Forward(input, output);
 
       // Return a column vector containing the indices of elements of X that
       // are non-zero, we just need the number of non-zero values.
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(NoDropoutTest)
   module.Deterministic() = false;
 
   arma::mat output;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), arma::accu(input));
 }
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(SimpleAlphaDropoutLayerTest)
 
   // Test the Forward function when training phase.
   arma::mat output;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   // Check whether mean remains nearly same.
   BOOST_REQUIRE_LE(
       arma::as_scalar(arma::abs(arma::mean(input) - arma::mean(output))), 0.1);
@@ -278,13 +278,13 @@ BOOST_AUTO_TEST_CASE(SimpleAlphaDropoutLayerTest)
 
   // Test the Backward function when training phase.
   arma::mat delta;
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
   BOOST_REQUIRE_LE(
       arma::as_scalar(arma::abs(arma::mean(delta) - 0)), 0.05);
 
   // Test the Forward function when testing phase.
   module.Deterministic() = true;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(input), arma::accu(output));
 }
 
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(AlphaDropoutProbabilityTest)
       module.Deterministic() = false;
 
       arma::mat output;
-      module.Forward(std::move(input), std::move(output));
+      module.Forward(input, output);
 
       // Return a column vector containing the indices of elements of X
       // that are not alphaDash, we just need the number of
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(NoAlphaDropoutTest)
   module.Deterministic() = false;
 
   arma::mat output;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), arma::accu(input));
 }
@@ -353,13 +353,13 @@ BOOST_AUTO_TEST_CASE(SimpleLinearLayerTest)
 
   // Test the Forward function.
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_CLOSE(arma::accu(
       module.Parameters().submat(100, 0, module.Parameters().n_elem - 1, 0)),
       arma::accu(output), 1e-3);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 }
 
@@ -439,11 +439,11 @@ BOOST_AUTO_TEST_CASE(SimpleLinearNoBiasLayerTest)
 
   // Test the Forward function.
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(0, arma::accu(output));
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 }
 
@@ -457,13 +457,13 @@ BOOST_AUTO_TEST_CASE(SimplePaddingLayerTest)
 
   // Test the Forward function.
   input = arma::randu(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(input), arma::accu(output));
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows + 3);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols + 7);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   CheckMatrices(delta, input);
 }
 
@@ -688,20 +688,20 @@ BOOST_AUTO_TEST_CASE(SimpleSelectLayerTest)
 
   // Test the Forward function.
   Select<> moduleA(3);
-  moduleA.Forward(std::move(input), std::move(outputA));
+  moduleA.Forward(input, outputA);
   BOOST_REQUIRE_EQUAL(30, arma::accu(outputA));
 
   // Test the Forward function.
   Select<> moduleB(3, 5);
-  moduleB.Forward(std::move(input), std::move(outputB));
+  moduleB.Forward(input, outputB);
   BOOST_REQUIRE_EQUAL(15, arma::accu(outputB));
 
   // Test the Backward function.
-  moduleA.Backward(std::move(input), std::move(outputA), std::move(delta));
+  moduleA.Backward(input, outputA, delta);
   BOOST_REQUIRE_EQUAL(30, arma::accu(delta));
 
   // Test the Backward function.
-  moduleB.Backward(std::move(input), std::move(outputA), std::move(delta));
+  moduleB.Backward(input, outputA, delta);
   BOOST_REQUIRE_EQUAL(15, arma::accu(delta));
 }
 
@@ -715,14 +715,14 @@ BOOST_AUTO_TEST_CASE(SimpleJoinLayerTest)
 
   // Test the Forward function.
   Join<> module;
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_EQUAL(50, arma::accu(output));
 
   bool b = output.n_rows == 1 || output.n_cols == 1;
   BOOST_REQUIRE_EQUAL(b, true);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(50, arma::accu(delta));
 
   b = delta.n_rows == input.n_rows && input.n_cols;
@@ -744,18 +744,17 @@ BOOST_AUTO_TEST_CASE(SimpleAddMergeLayerTest)
     for (size_t m = 0; m < numMergeModules; ++m)
     {
       IdentityLayer<> identityLayer;
-      identityLayer.Forward(std::move(input),
-          std::move(identityLayer.OutputParameter()));
+      identityLayer.Forward(input, identityLayer.OutputParameter());
 
       module.Add<IdentityLayer<> >(identityLayer);
     }
 
     // Test the Forward function.
-    module.Forward(std::move(input), std::move(output));
+    module.Forward(input, output);
     BOOST_REQUIRE_EQUAL(10 * numMergeModules, arma::accu(output));
 
     // Test the Backward function.
-    module.Backward(std::move(input), std::move(output), std::move(delta));
+    module.Backward(input, output, delta);
     BOOST_REQUIRE_EQUAL(arma::accu(output), arma::accu(delta));
   }
 }
@@ -961,9 +960,9 @@ BOOST_AUTO_TEST_CASE(ReadCellStateParamLSTMLayerTest)
           input.n_rows, input.n_cols, false, true);
 
       // Apply Forward() on LSTM layer.
-      lstm.Forward(std::move(stepData), // Input.
-                   std::move(outLstm),  // Output.
-                   std::move(cellLstm), // Cell state.
+      lstm.Forward(stepData, // Input.
+                   outLstm,  // Output.
+                   cellLstm, // Cell state.
                    false); // Don't write into the cell state.
 
       // Compute the value of cell state and output.
@@ -1043,9 +1042,9 @@ BOOST_AUTO_TEST_CASE(WriteCellStateParamLSTMLayerTest)
       }
 
       // Apply Forward() on the LSTM layer.
-      lstm.Forward(std::move(stepData), // Input.
-                   std::move(outLstm),  // Output.
-                   std::move(cellLstm), // Cell state.
+      lstm.Forward(stepData, // Input.
+                   outLstm,  // Output.
+                   cellLstm, // Cell state.
                    true);  // Write into cell state.
 
       // Compute the value of cell state and output.
@@ -1081,18 +1080,18 @@ BOOST_AUTO_TEST_CASE(WriteCellStateParamLSTMLayerTest)
   arma::mat stepData(input.slice(0).memptr(),
       input.n_rows, input.n_cols, false, true);
 
-  lstm.Forward(std::move(stepData), // Input.
-                   std::move(outLstm),  // Output.
-                   std::move(cellLstm), // Cell state.
-                   true); // Write into cell state.
+  lstm.Forward(stepData, // Input.
+               outLstm,  // Output.
+               cellLstm, // Cell state.
+               true); // Write into cell state.
 
   for (size_t seqNum = 1; seqNum < rho; ++seqNum)
   {
     arma::mat empty;
     // Should throw error.
-    BOOST_REQUIRE_THROW(lstm.Forward(std::move(stepData), // Input.
-                                     std::move(outLstm),  // Output.
-                                     std::move(empty), // Cell state.
+    BOOST_REQUIRE_THROW(lstm.Forward(stepData, // Input.
+                                     outLstm,  // Output.
+                                     empty, // Cell state.
                                      true),  // Write into cell state.
                                      std::runtime_error);
   }
@@ -1160,7 +1159,7 @@ BOOST_AUTO_TEST_CASE(ForwardGRULayerTest)
   arma::mat input = arma::ones(3, 1);
   arma::mat output;
 
-  gru.Forward(std::move(input), std::move(output));
+  gru.Forward(input, output);
 
   // Compute the z_t gate output.
   arma::mat expectedOutput = arma::ones(3, 1);
@@ -1175,7 +1174,7 @@ BOOST_AUTO_TEST_CASE(ForwardGRULayerTest)
 
   expectedOutput = output;
 
-  gru.Forward(std::move(input), std::move(output));
+  gru.Forward(input, output);
 
   double s = arma::as_scalar(arma::sum(expectedOutput));
 
@@ -1218,7 +1217,7 @@ BOOST_AUTO_TEST_CASE(SimpleConcatLayerTest)
 
   // Test the Forward function.
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_CLOSE(arma::accu(
       moduleA.Parameters().submat(100, 0, moduleA.Parameters().n_elem - 1, 0)) +
       arma::accu(moduleB.Parameters().submat(100, 0,
@@ -1227,7 +1226,7 @@ BOOST_AUTO_TEST_CASE(SimpleConcatLayerTest)
 
   // Test the Backward function.
   error = arma::zeros(20, 1);
-  module.Backward(std::move(input), std::move(error), std::move(delta));
+  module.Backward(input, error, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 }
 
@@ -1260,8 +1259,8 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
   moduleB.Parameters().randu();
 
   // Compute output of each layer.
-  moduleA.Forward(std::move(input), std::move(outputA));
-  moduleB.Forward(std::move(input), std::move(outputB));
+  moduleA.Forward(input, outputA);
+  moduleB.Forward(input, outputB);
 
   arma::cube A(outputA.memptr(), outputWidth, outputHeight, outputChannel);
   arma::cube B(outputB.memptr(), outputWidth, outputHeight, outputChannel);
@@ -1305,7 +1304,7 @@ BOOST_AUTO_TEST_CASE(ConcatAlongAxisTest)
     Concat<> module(inputSize, axis);
     module.Add(moduleA);
     module.Add(moduleB);
-    module.Forward(std::move(input), std::move(output));
+    module.Forward(input, output);
     arma::cube concatOut(output.memptr(), x * outputWidth,
         y * outputHeight, z * outputChannel);
 
@@ -1374,12 +1373,12 @@ BOOST_AUTO_TEST_CASE(SimpleConcatenateLayerTest)
   module.Concat() = arma::ones(5, 1) * 0.5;
 
   // Test the Forward function.
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 7.5);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(output), std::move(delta));
+  module.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 5);
 }
 
@@ -1447,7 +1446,7 @@ BOOST_AUTO_TEST_CASE(SimpleLookupLayerTest)
   input(0) = 1;
   input(1) = 3;
 
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   // The Lookup module uses index - 1 for the cols.
   const double outputSum = arma::accu(module.Parameters().col(0)) +
@@ -1456,7 +1455,7 @@ BOOST_AUTO_TEST_CASE(SimpleLookupLayerTest)
   BOOST_REQUIRE_CLOSE(outputSum, arma::accu(output), 1e-3);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(input), arma::accu(input));
 
   // Test the Gradient function.
@@ -1464,7 +1463,7 @@ BOOST_AUTO_TEST_CASE(SimpleLookupLayerTest)
   error = error.t();
   error.col(1) *= 0.5;
 
-  module.Gradient(std::move(input), std::move(error), std::move(gradient));
+  module.Gradient(input, error, gradient);
 
   // The Lookup module uses index - 1 for the cols.
   const double gradientSum = arma::accu(gradient.col(0)) +
@@ -1484,7 +1483,7 @@ BOOST_AUTO_TEST_CASE(SimpleLogSoftmaxLayerTest)
 
   // Test the Forward function.
   input = arma::mat("0.5; 0.5");
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_SMALL(arma::accu(arma::abs(
     arma::mat("-0.6931; -0.6931") - output)), 1e-3);
 
@@ -1492,7 +1491,7 @@ BOOST_AUTO_TEST_CASE(SimpleLogSoftmaxLayerTest)
   error = arma::zeros(input.n_rows, input.n_cols);
   // Assume LogSoftmax layer is always associated with NLL output layer.
   error(1, 0) = -1;
-  module.Backward(std::move(input), std::move(error), std::move(delta));
+  module.Backward(input, error, delta);
   BOOST_REQUIRE_SMALL(arma::accu(arma::abs(
       arma::mat("1.6487; 0.6487") - delta)), 1e-3);
 }
@@ -1521,13 +1520,12 @@ BOOST_AUTO_TEST_CASE(SimpleBilinearInterpolationLayerTest)
       2.0000 2.4000 2.8000 3.0000 3.0000 \
       2.0000 2.4000 2.8000 3.0000 3.0000");
   expectedOutput.reshape(25, 1);
-  layer.Forward(std::move(input), std::move(output));
+  layer.Forward(input, output);
   CheckMatrices(output - expectedOutput, arma::zeros(output.n_rows), 1e-12);
 
   expectedOutput = arma::mat("1.0000 1.9000 1.9000 2.8000");
   expectedOutput.reshape(4, 1);
-  layer.Backward(std::move(output), std::move(output),
-      std::move(unzoomedOutput));
+  layer.Backward(output, output, unzoomedOutput);
   CheckMatrices(unzoomedOutput - expectedOutput,
       arma::zeros(input.n_rows), 1e-12);
 }
@@ -1549,7 +1547,7 @@ BOOST_AUTO_TEST_CASE(BatchNormTest)
 
   // Non-Deteministic Forward Pass Test.
   model.Deterministic() = false;
-  model.Forward(std::move(input), std::move(output));
+  model.Forward(input, output);
   arma::mat result;
   result << 1.1658 << 0.1100 << -1.2758 << arma::endr
          << 1.2579 << -0.0699 << -1.1880 << arma::endr
@@ -1576,7 +1574,7 @@ BOOST_AUTO_TEST_CASE(BatchNormTest)
   result.clear();
 
   model.Deterministic() = true;
-  model.Forward(std::move(input), std::move(output));
+  model.Forward(input, output);
 
   result << 1.1658 << 0.1100 << -1.2757 << arma::endr
          << 1.2579 << -0.0699 << -1.1880 << arma::endr
@@ -1733,12 +1731,12 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module1.Parameters()(0) = 1.0;
   module1.Parameters()(8) = 2.0;
   module1.Reset();
-  module1.Forward(std::move(input), std::move(output));
+  module1.Forward(input, output);
   // Value calculated using tensorflow.nn.conv2d_transpose()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 360.0);
 
   // Test the backward function.
-  module1.Backward(std::move(input), std::move(output), std::move(delta));
+  module1.Backward(input, output, delta);
   // Value calculated using tensorflow.nn.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 720.0);
 
@@ -1753,12 +1751,12 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module2.Parameters()(12) = 1.0;
   module2.Parameters()(15) = 2.0;
   module2.Reset();
-  module2.Forward(std::move(input), std::move(output));
+  module2.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 1512.0);
 
   // Test the backward function.
-  module2.Backward(std::move(input), std::move(output), std::move(delta));
+  module2.Backward(input, output, delta);
   // Value calculated using torch.nn.functional.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 6504.0);
 
@@ -1771,12 +1769,12 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module3.Parameters()(3) = 3.0;
   module3.Parameters()(8) = 1.0;
   module3.Reset();
-  module3.Forward(std::move(input), std::move(output));
+  module3.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 2370.0);
 
   // Test the backward function.
-  module3.Backward(std::move(input), std::move(output), std::move(delta));
+  module3.Backward(input, output, delta);
   // Value calculated using torch.nn.functional.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 19154.0);
 
@@ -1789,12 +1787,12 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module4.Parameters()(6) = 6.0;
   module4.Parameters()(8) = 8.0;
   module4.Reset();
-  module4.Forward(std::move(input), std::move(output));
+  module4.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 6000.0);
 
   // Test the backward function.
-  module4.Backward(std::move(input), std::move(output), std::move(delta));
+  module4.Backward(input, output, delta);
   // Value calculated using torch.nn.functional.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 86208.0);
 
@@ -1807,12 +1805,12 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module5.Parameters()(6) = 4.0;
   module5.Parameters()(8) = 2.0;
   module5.Reset();
-  module5.Forward(std::move(input), std::move(output));
+  module5.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 120.0);
 
   // Test the backward function.
-  module5.Backward(std::move(input), std::move(output), std::move(delta));
+  module5.Backward(input, output, delta);
   // Value calculated using torch.nn.functional.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 960.0);
 
@@ -1825,12 +1823,12 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module6.Parameters()(6) = 2.0;
   module6.Parameters()(8) = 4.0;
   module6.Reset();
-  module6.Forward(std::move(input), std::move(output));
+  module6.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 410.0);
 
   // Test the backward function.
-  module6.Backward(std::move(input), std::move(output), std::move(delta));
+  module6.Backward(input, output, delta);
   // Value calculated using torch.nn.functional.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 4444.0);
 
@@ -1843,11 +1841,11 @@ BOOST_AUTO_TEST_CASE(SimpleTransposedConvolutionLayerTest)
   module7.Parameters()(4) = 2.0;
   module7.Parameters()(8) = 4.0;
   module7.Reset();
-  module7.Forward(std::move(input), std::move(output));
+  module7.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 606.0);
 
-  module7.Backward(std::move(input), std::move(output), std::move(delta));
+  module7.Backward(input, output, delta);
   // Value calculated using torch.nn.functional.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 7732.0);
 }
@@ -1919,18 +1917,17 @@ BOOST_AUTO_TEST_CASE(SimpleMultiplyMergeLayerTest)
     for (size_t m = 0; m < numMergeModules; ++m)
     {
       IdentityLayer<> identityLayer;
-      identityLayer.Forward(std::move(input),
-          std::move(identityLayer.OutputParameter()));
+      identityLayer.Forward(input, identityLayer.OutputParameter());
 
       module.Add<IdentityLayer<> >(identityLayer);
     }
 
     // Test the Forward function.
-    module.Forward(std::move(input), std::move(output));
+    module.Forward(input, output);
     BOOST_REQUIRE_EQUAL(10, arma::accu(output));
 
     // Test the Backward function.
-    module.Backward(std::move(input), std::move(output), std::move(delta));
+    module.Backward(input, output, delta);
     BOOST_REQUIRE_EQUAL(arma::accu(output), arma::accu(delta));
   }
 }
@@ -1949,12 +1946,12 @@ BOOST_AUTO_TEST_CASE(SimpleAtrousConvolutionLayerTest)
   module1.Parameters()(0) = 1.0;
   module1.Parameters()(8) = 2.0;
   module1.Reset();
-  module1.Forward(std::move(input), std::move(output));
+  module1.Forward(input, output);
   // Value calculated using tensorflow.nn.atrous_conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 792.0);
 
   // Test the Backward function.
-  module1.Backward(std::move(input), std::move(output), std::move(delta));
+  module1.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 2376);
 
   AtrousConvolution<> module2(1, 1, 3, 3, 2, 2, 0, 0, 7, 7, 2, 2);
@@ -1965,12 +1962,12 @@ BOOST_AUTO_TEST_CASE(SimpleAtrousConvolutionLayerTest)
   module2.Parameters()(3) = 1.0;
   module2.Parameters()(6) = 1.0;
   module2.Reset();
-  module2.Forward(std::move(input), std::move(output));
+  module2.Forward(input, output);
   // Value calculated using tensorflow.nn.conv2d()
   BOOST_REQUIRE_EQUAL(arma::accu(output), 264.0);
 
   // Test the backward function.
-  module2.Backward(std::move(input), std::move(output), std::move(delta));
+  module2.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 792.0);
 }
 
@@ -2094,14 +2091,14 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 48, 49);
   module1.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module1.Reset();
-  module1.Forward(std::move(input), std::move(output));
+  module1.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 9);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
   // Test the Backward function.
-  module1.Backward(std::move(input), std::move(output), std::move(delta));
+  module1.Backward(input, output, delta);
 
   // Check same padding option.
   AtrousConvolution<> module2(1, 1, 3, 3, 1, 1,
@@ -2112,14 +2109,14 @@ BOOST_AUTO_TEST_CASE(AtrousConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 48, 49);
   module2.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module2.Reset();
-  module2.Forward(std::move(input), std::move(output));
+  module2.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 49);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
   // Test the backward function.
-  module2.Backward(std::move(input), std::move(output), std::move(delta));
+  module2.Backward(input, output, delta);
 }
 
 /**
@@ -2135,7 +2132,7 @@ BOOST_AUTO_TEST_CASE(LayerNormTest)
   LayerNorm<> model(input.n_rows);
   model.Reset();
 
-  model.Forward(std::move(input), std::move(output));
+  model.Forward(input, output);
   arma::mat result;
   result << 1.2247 << 1.2978 << arma::endr
          << 0 << -1.1355 << arma::endr
@@ -2218,13 +2215,13 @@ BOOST_AUTO_TEST_CASE(AddMergeRunTest)
   linear->Reset();
 
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   double parameterSum = arma::accu(linear->Parameters().submat(
       100, 0, linear->Parameters().n_elem - 1, 0));
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
 
   // Clean up before we break,
   delete linear;
@@ -2250,13 +2247,13 @@ BOOST_AUTO_TEST_CASE(MultiplyMergeRunTest)
   linear->Reset();
 
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   double parameterSum = arma::accu(linear->Parameters().submat(
       100, 0, linear->Parameters().n_elem - 1, 0));
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
 
   // Clean up before we break,
   delete linear;
@@ -2275,19 +2272,19 @@ BOOST_AUTO_TEST_CASE(SimpleSubviewLayerTest)
 
   // Test the Forward function for a vector.
   input = arma::ones(20, 1);
-  moduleRow.Forward(std::move(input), std::move(output));
+  moduleRow.Forward(input, output);
   BOOST_REQUIRE_EQUAL(output.n_rows, 10);
 
   Subview<> moduleMat(4, 3, 6, 0, 2);
 
   // Test the Forward function for a matrix.
   input = arma::ones(20, 8);
-  moduleMat.Forward(std::move(input), std::move(outputMat));
+  moduleMat.Forward(input, outputMat);
   BOOST_REQUIRE_EQUAL(outputMat.n_rows, 12);
   BOOST_REQUIRE_EQUAL(outputMat.n_cols, 2);
 
   // Test the Backward function.
-  moduleMat.Backward(std::move(input), std::move(input), std::move(delta));
+  moduleMat.Backward(input, input, delta);
   BOOST_REQUIRE_EQUAL(accu(delta), 160);
   BOOST_REQUIRE_EQUAL(delta.n_rows, 20);
 }
@@ -2304,21 +2301,21 @@ BOOST_AUTO_TEST_CASE(SubviewIndexTest)
   Subview<> moduleStart(1, 0, 9);
   arma::mat subStart = arma::linspace<arma::vec>(1, 10, 10);
 
-  moduleStart.Forward(std::move(input), std::move(outputStart));
+  moduleStart.Forward(input, outputStart);
   CheckMatrices(outputStart, subStart);
 
   // Slicing from the mid indices.
   Subview<> moduleMid(1, 6, 15);
   arma::mat subMid = arma::linspace<arma::vec>(7, 16, 10);
 
-  moduleMid.Forward(std::move(input), std::move(outputMid));
+  moduleMid.Forward(input, outputMid);
   CheckMatrices(outputMid, subMid);
 
   // Slicing from the end indices.
   Subview<> moduleEnd(1, 10, 19);
   arma::mat subEnd = arma::linspace<arma::vec>(11, 20, 10);
 
-  moduleEnd.Forward(std::move(input), std::move(outputEnd));
+  moduleEnd.Forward(input, outputEnd);
   CheckMatrices(outputEnd, subEnd);
 }
 
@@ -2334,14 +2331,14 @@ BOOST_AUTO_TEST_CASE(SubviewBatchTest)
 
   // Test with inSize 1.
   input = arma::ones(20, 8);
-  moduleCol.Forward(std::move(input), std::move(outputCol));
+  moduleCol.Forward(input, outputCol);
   CheckMatrices(outputCol, input);
 
   // Few rows and columns selected.
   Subview<> moduleMat(4, 3, 6, 0, 2);
 
   // Test with inSize greater than 1.
-  moduleMat.Forward(std::move(input), std::move(outputMat));
+  moduleMat.Forward(input, outputMat);
   output = arma::ones(12, 2);
   CheckMatrices(outputMat, output);
 
@@ -2349,7 +2346,7 @@ BOOST_AUTO_TEST_CASE(SubviewBatchTest)
   Subview<> moduleDef(4, 1, 6, 0, 4);
 
   // Test with inSize greater than 1 and endCol >= inSize.
-  moduleDef.Forward(std::move(input), std::move(outputDef));
+  moduleDef.Forward(input, outputDef);
   output = arma::ones(24, 2);
   CheckMatrices(outputDef, output);
 }
@@ -2367,12 +2364,12 @@ BOOST_AUTO_TEST_CASE(SimpleReparametrizationLayerTest)
   // output should be small enough.
   input = join_cols(arma::ones<arma::mat>(5, 1) * -15,
       arma::zeros<arma::mat>(5, 1));
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   BOOST_REQUIRE_LE(arma::accu(output), 1e-5);
 
   // Test the Backward function.
   arma::mat gy = arma::zeros<arma::mat>(5, 1);
-  module.Backward(std::move(input), std::move(gy), std::move(delta));
+  module.Backward(input, gy, delta);
   BOOST_REQUIRE(arma::accu(delta) != 0); // klBackward will be added.
 }
 
@@ -2388,8 +2385,8 @@ BOOST_AUTO_TEST_CASE(ReparametrizationLayerStochasticTest)
       arma::zeros<arma::mat>(5, 1));
 
   // Test if two forward passes generate same output.
-  module.Forward(std::move(input), std::move(outputA));
-  module.Forward(std::move(input), std::move(outputB));
+  module.Forward(input, outputA);
+  module.Forward(input, outputB);
 
   CheckMatrices(outputA, outputB);
 }
@@ -2404,14 +2401,14 @@ BOOST_AUTO_TEST_CASE(ReparametrizationLayerIncludeKlTest)
 
   input = join_cols(arma::ones<arma::mat>(5, 1),
       arma::zeros<arma::mat>(5, 1));
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   // As KL divergence is not included, with the above inputs, the delta
   // matrix should be all zeros.
   gy = arma::zeros(output.n_rows, output.n_cols);
-  module.Backward(std::move(output), std::move(gy), std::move(delta));
+  module.Backward(output, gy, delta);
 
-  BOOST_REQUIRE_EQUAL(arma::accu(std::move(delta)), 0);
+  BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
 }
 
 /**
@@ -2549,14 +2546,14 @@ BOOST_AUTO_TEST_CASE(SimpleResidualLayerTest)
 
   // Test the Forward function (pass the same input to both).
   input = arma::randu(10, 1);
-  sequential->Forward(std::move(input), std::move(outputA));
-  residual->Forward(std::move(input), std::move(outputB));
+  sequential->Forward(input, outputA);
+  residual->Forward(input, outputB);
 
   CheckMatrices(outputA, outputB - input);
 
   // Test the Backward function (pass the same error to both).
-  sequential->Backward(std::move(input), std::move(input), std::move(deltaA));
-  residual->Backward(std::move(input), std::move(input), std::move(deltaB));
+  sequential->Backward(input, input, deltaA);
+  residual->Backward(input, input, deltaB);
 
   CheckMatrices(deltaA, deltaB - input);
 
@@ -2593,8 +2590,8 @@ BOOST_AUTO_TEST_CASE(SimpleHighwayLayerTest)
 
   // Test the Forward function (pass the same input to both).
   input = arma::randu(10, 1);
-  sequential->Forward(std::move(input), std::move(outputA));
-  highway->Forward(std::move(input), std::move(outputB));
+  sequential->Forward(input, outputA);
+  highway->Forward(input, outputB);
 
   CheckMatrices(outputB, input * 0.5 + outputA * 0.5);
 
@@ -2774,10 +2771,10 @@ BOOST_AUTO_TEST_CASE(WeightNormRunTest)
   linear->Bias().zeros();
 
   input = arma::zeros(10, 1);
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(input), std::move(delta));
+  module.Backward(input, input, delta);
 
   BOOST_REQUIRE_EQUAL(0, arma::accu(output));
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0);
@@ -2904,14 +2901,14 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 48, 49);
   module1.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module1.Reset();
-  module1.Forward(std::move(input), std::move(output));
+  module1.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 25);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
   // Test the Backward function.
-  module1.Backward(std::move(input), std::move(output), std::move(delta));
+  module1.Backward(input, output, delta);
 
   // Check same padding option.
   Convolution<> module2(1, 1, 3, 3, 1, 1, std::tuple<size_t, size_t>(0, 0),
@@ -2921,14 +2918,14 @@ BOOST_AUTO_TEST_CASE(ConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 48, 49);
   module2.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module2.Reset();
-  module2.Forward(std::move(input), std::move(output));
+  module2.Forward(input, output);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, 49);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 
   // Test the backward function.
-  module2.Backward(std::move(input), std::move(output), std::move(delta));
+  module2.Backward(input, output, delta);
 }
 
 /**
@@ -2944,12 +2941,12 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 15, 16);
   module1.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module1.Reset();
-  module1.Forward(std::move(input), std::move(output));
+  module1.Forward(input, output);
   // Value calculated using tensorflow.nn.conv2d_transpose().
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0.0);
 
   // Test the Backward Function.
-  module1.Backward(std::move(input), std::move(output), std::move(delta));
+  module1.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0.0);
 
   // Test Valid for non zero padding.
@@ -2964,12 +2961,12 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   module2.Parameters()(6) = 4.0;
   module2.Parameters()(8) = 2.0;
   module2.Reset();
-  module2.Forward(std::move(input), std::move(output));
+  module2.Forward(input, output);
   // Value calculated using torch.nn.functional.conv_transpose2d().
   BOOST_REQUIRE_EQUAL(arma::accu(output), 120.0);
 
   // Test the Backward Function.
-  module2.Backward(std::move(input), std::move(output), std::move(delta));
+  module2.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 960.0);
 
   // Test for same padding type.
@@ -2978,13 +2975,13 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 8, 9);
   module3.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module3.Reset();
-  module3.Forward(std::move(input), std::move(output));
+  module3.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols);
 
   // Test the Backward Function.
-  module3.Backward(std::move(input), std::move(output), std::move(delta));
+  module3.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0.0);
 
   // Output shape should equal input.
@@ -2995,13 +2992,13 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 24, 25);
   module4.Parameters() = arma::mat(9 + 1, 1, arma::fill::zeros);
   module4.Reset();
-  module4.Forward(std::move(input), std::move(output));
+  module4.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols);
 
   // Test the Backward Function.
-  module4.Backward(std::move(input), std::move(output), std::move(delta));
+  module4.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0.0);
 
   TransposedConvolution<> module5(1, 1, 3, 3, 2, 2, 0, 0, 2, 2, 2, 2, "SAME");
@@ -3009,13 +3006,13 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 3, 4);
   module5.Parameters() = arma::mat(25 + 1, 1, arma::fill::zeros);
   module5.Reset();
-  module5.Forward(std::move(input), std::move(output));
+  module5.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols);
 
   // Test the Backward Function.
-  module5.Backward(std::move(input), std::move(output), std::move(delta));
+  module5.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0.0);
 
   TransposedConvolution<> module6(1, 1, 4, 4, 1, 1, 1, 1, 5, 5, 5, 5, "SAME");
@@ -3023,13 +3020,13 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   input = arma::linspace<arma::colvec>(0, 24, 25);
   module6.Parameters() = arma::mat(16 + 1, 1, arma::fill::zeros);
   module6.Reset();
-  module6.Forward(std::move(input), std::move(output));
+  module6.Forward(input, output);
   BOOST_REQUIRE_EQUAL(arma::accu(output), 0);
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input.n_cols);
 
   // Test the Backward Function.
-  module6.Backward(std::move(input), std::move(output), std::move(delta));
+  module6.Backward(input, output, delta);
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0.0);
 }
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/ann_test_tools.hpp
+++ b/src/mlpack/tests/ann_test_tools.hpp
@@ -53,7 +53,7 @@ double JacobianTest(ModuleType& module,
   ResetFunction(module);
 
   // Initialize the jacobian matrix.
-  module.Forward(std::move(input), std::move(output));
+  module.Forward(input, output);
   jacobianA = arma::zeros(input.n_elem, output.n_elem);
 
   // Share the input paramter matrix.
@@ -64,9 +64,9 @@ double JacobianTest(ModuleType& module,
   {
     double original = sin(i);
     sin(i) = original - perturbation;
-    module.Forward(std::move(input), std::move(outputA));
+    module.Forward(input, outputA);
     sin(i) = original + perturbation;
-    module.Forward(std::move(input), std::move(outputB));
+    module.Forward(input, outputB);
     sin(i) = original;
 
     outputB -= outputA;
@@ -90,7 +90,7 @@ double JacobianTest(ModuleType& module,
     derivTemp(i) = 1;
 
     arma::mat delta;
-    module.Backward(std::move(input), std::move(deriv), std::move(delta));
+    module.Backward(input, deriv, delta);
 
     jacobianB.col(i) = delta;
   }
@@ -106,10 +106,10 @@ double JacobianPerformanceTest(ModuleType& module,
                                arma::mat& target,
                                const double eps = 1e-6)
 {
-  module.Forward(std::move(input), std::move(target));
+  module.Forward(input, target);
 
   arma::mat delta;
-  module.Backward(std::move(input), std::move(target), std::move(delta));
+  module.Backward(input, target, delta);
 
   arma::mat centralDifference = arma::zeros(delta.n_rows, delta.n_cols);
   arma::mat inputTemp = arma::mat(input.memptr(), input.n_rows, input.n_cols,
@@ -121,9 +121,9 @@ double JacobianPerformanceTest(ModuleType& module,
   for (size_t i = 0; i < input.n_elem; ++i)
   {
     inputTemp(i) = inputTemp(i) + eps;
-    double outputA = module.Forward(std::move(input), std::move(target));
+    double outputA = module.Forward(input, target);
     inputTemp(i) = inputTemp(i) - (2 * eps);
-    double outputB = module.Forward(std::move(input), std::move(target));
+    double outputB = module.Forward(input, target);
 
     centralDifferenceTemp(i) = (outputA - outputB) / (2 * eps);
     inputTemp(i) = inputTemp(i) + eps;

--- a/src/mlpack/tests/ann_visitor_test.cpp
+++ b/src/mlpack/tests/ann_visitor_test.cpp
@@ -35,22 +35,20 @@ BOOST_AUTO_TEST_CASE(BiasSetVisitorTest)
 
   ResetVisitor resetVisitor;
 
-  boost::apply_visitor(WeightSetVisitor(std::move(layerWeights), 0), linear);
+  boost::apply_visitor(WeightSetVisitor(layerWeights, 0), linear);
 
   boost::apply_visitor(resetVisitor, linear);
 
   arma::mat weight = {"1 2 3 4 5 6 7 8 9 10"};
 
-  size_t biasSize = boost::apply_visitor(BiasSetVisitor(std::move(weight),
-      0), linear);
+  size_t biasSize = boost::apply_visitor(BiasSetVisitor(weight, 0), linear);
 
   BOOST_REQUIRE_EQUAL(biasSize, 10);
 
   arma::mat input(10, 1), output;
   input.randu();
 
-  boost::apply_visitor(ForwardVisitor(std::move(input), std::move(output)),
-      linear);
+  boost::apply_visitor(ForwardVisitor(input, output), linear);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 55);
 }

--- a/src/mlpack/tests/callback_test.cpp
+++ b/src/mlpack/tests/callback_test.cpp
@@ -253,6 +253,7 @@ BOOST_AUTO_TEST_CASE(RBMCallbackTest)
 
   // Call the train function with printloss callback.
   double objVal = model.Train(msgd, ens::ProgressBar(70, stream));
+  BOOST_REQUIRE(!std::isnan(objVal));
   BOOST_REQUIRE_GT(stream.str().length(), 0);
 }
 

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(ForwardBackwardTest)
       arma::mat currentResuls;
       model.Forward(currentData, currentResuls);
       arma::mat gradients;
-      model.Backward(currentLabels, gradients);
+      model.Backward(currentData, currentLabels, gradients);
       #if ENS_VERSION_MAJOR == 1
       opt.Update(model.Parameters(), stepSize, gradients);
       #else
@@ -600,10 +600,8 @@ BOOST_AUTO_TEST_CASE(FFNReturnModel)
   // Get the layer parameter from layer A and layer B and store them in
   // parameterA and parameterB.
   arma::mat parameterA, parameterB;
-  boost::apply_visitor(ParametersVisitor(std::move(parameterA)),
-      model.Model()[0]);
-  boost::apply_visitor(ParametersVisitor(std::move(parameterB)),
-      model.Model()[1]);
+  boost::apply_visitor(ParametersVisitor(parameterA), model.Model()[0]);
+  boost::apply_visitor(ParametersVisitor(parameterB), model.Model()[1]);
 
   CheckMatrices(parameterA, arma::ones(3 * 3 + 3, 1));
   CheckMatrices(parameterB, arma::zeros(3 * 4 + 4, 1));

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(SimpleKLDivergenceTest)
   // Test the Forward function.  Loss should be 0 if input = target.
   input = arma::ones(10, 1);
   target = arma::ones(10, 1);
-  loss = module.Forward(std::move(input), std::move(target));
+  loss = module.Forward(input, target);
   BOOST_REQUIRE_SMALL(loss, 0.00001);
 }
 
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE(SimpleMeanSquaredLogarithmicErrorTest)
   // the manually calculated result.
   input = arma::zeros(1, 8);
   target = arma::zeros(1, 8);
-  double error = module.Forward(std::move(input), std::move(target));
+  double error = module.Forward(input, target);
   BOOST_REQUIRE_SMALL(error, 0.00001);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   // The output should be equal to 0.
   CheckMatrices(input, output);
   BOOST_REQUIRE_EQUAL(output.n_rows, input.n_rows);
@@ -77,11 +77,11 @@ BOOST_AUTO_TEST_CASE(SimpleMeanSquaredLogarithmicErrorTest)
   // Test the error function on a single input.
   input = arma::mat("2");
   target = arma::mat("3");
-  error = module.Forward(std::move(input), std::move(target));
+  error = module.Forward(input, target);
   BOOST_REQUIRE_CLOSE(error, 0.082760974810151655, 0.001);
 
   // Test the Backward function on a single input.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   BOOST_REQUIRE_CLOSE(arma::accu(output), -0.1917880483011872, 0.001);
   BOOST_REQUIRE_EQUAL(output.n_elem, 1);
 }
@@ -99,11 +99,11 @@ BOOST_AUTO_TEST_CASE(KLDivergenceMeanTest)
   input = arma::mat("1 1 1 1 1 1 1 1 1 1");
   target = arma::exp(arma::mat("2 1 1 1 1 1 1 1 1 1"));
 
-  loss = module.Forward(std::move(input), std::move(target));
+  loss = module.Forward(input, target);
   BOOST_REQUIRE_CLOSE_FRACTION(loss, -1.1 , 0.00001);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   BOOST_REQUIRE_CLOSE_FRACTION(arma::as_scalar(output), -0.1, 0.00001);
 }
 
@@ -120,11 +120,11 @@ BOOST_AUTO_TEST_CASE(KLDivergenceNoMeanTest)
   input = arma::mat("1 1 1 1 1 1 1 1 1 1");
   target = arma::exp(arma::mat("2 1 1 1 1 1 1 1 1 1"));
 
-  loss = module.Forward(std::move(input), std::move(target));
+  loss = module.Forward(input, target);
   BOOST_REQUIRE_CLOSE_FRACTION(loss, -11, 0.00001);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   BOOST_REQUIRE_CLOSE_FRACTION(arma::as_scalar(output), -1, 0.00001);
 }
 
@@ -140,11 +140,11 @@ BOOST_AUTO_TEST_CASE(SimpleMeanSquaredErrorTest)
   // the manually calculated result.
   input = arma::mat("1.0 0.0 1.0 0.0 -1.0 0.0 -1.0 0.0");
   target = arma::zeros(1, 8);
-  double error = module.Forward(std::move(input), std::move(target));
+  double error = module.Forward(input, target);
   BOOST_REQUIRE_EQUAL(error, 0.5);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   // We subtract a zero vector, so according to the used backward formula:
   // output = 2 * (input - target) / target.n_cols,
   // output * nofColumns / 2 should be equal to input.
@@ -155,11 +155,11 @@ BOOST_AUTO_TEST_CASE(SimpleMeanSquaredErrorTest)
   // Test the error function on a single input.
   input = arma::mat("2");
   target = arma::mat("3");
-  error = module.Forward(std::move(input), std::move(target));
+  error = module.Forward(input, target);
   BOOST_REQUIRE_EQUAL(error, 1.0);
 
   // Test the Backward function on a single input.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   // Test whether the output is negative.
   BOOST_REQUIRE_EQUAL(arma::accu(output), -2);
   BOOST_REQUIRE_EQUAL(output.n_elem, 1);
@@ -177,16 +177,16 @@ BOOST_AUTO_TEST_CASE(SimpleCrossEntropyErrorTest)
   // the manually calculated result.
   input1 = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5");
   target1 = arma::zeros(1, 8);
-  double error1 = module.Forward(std::move(input1), std::move(target1));
+  double error1 = module.Forward(input1, target1);
   BOOST_REQUIRE_SMALL(error1 - 8 * std::log(2), 2e-5);
 
   input2 = arma::mat("0 1 1 0 1 0 0 1");
   target2 = arma::mat("0 1 1 0 1 0 0 1");
-  double error2 = module.Forward(std::move(input2), std::move(target2));
+  double error2 = module.Forward(input2, target2);
   BOOST_REQUIRE_SMALL(error2, 1e-5);
 
   // Test the Backward function.
-  module.Backward(std::move(input1), std::move(target1), std::move(output));
+  module.Backward(input1, target1, output);
   for (double el : output)
   {
     // For the 0.5 constant vector we should get 1 / (1 - 0.5) = 2 everywhere.
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(SimpleCrossEntropyErrorTest)
   BOOST_REQUIRE_EQUAL(output.n_rows, input1.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input1.n_cols);
 
-  module.Backward(std::move(input2), std::move(target2), std::move(output));
+  module.Backward(input2, target2, output);
   for (size_t i = 0; i < 8; ++i)
   {
     double el = output.at(0, i);
@@ -221,25 +221,25 @@ BOOST_AUTO_TEST_CASE(SimpleSigmoidCrossEntropyErrorTest)
   // the calculated result.
   input1 = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5");
   target1 = arma::zeros(1, 8);
-  double error1 = module.Forward(std::move(input1), std::move(target1));
+  double error1 = module.Forward(input1, target1);
   double expected = 0.97407699;
   // Value computed using tensorflow.
   BOOST_REQUIRE_SMALL(error1 / input1.n_elem - expected, 1e-7);
 
   input2 = arma::mat("1 2 3 4 5");
   target2 = arma::mat("0 0 1 0 1");
-  double error2 = module.Forward(std::move(input2), std::move(target2));
+  double error2 = module.Forward(input2, target2);
   expected = 1.5027283;
   BOOST_REQUIRE_SMALL(error2 / input2.n_elem - expected, 1e-6);
 
   input3 = arma::mat("0 -1 -1 0 -1 0 0 -1");
   target3 = arma::mat("0 -1 -1 0 -1 0 0 -1");
-  double error3 = module.Forward(std::move(input3), std::move(target3));
+  double error3 = module.Forward(input3, target3);
   expected = 0.00320443;
   BOOST_REQUIRE_SMALL(error3 / input3.n_elem - expected, 1e-6);
 
   // Test the Backward function.
-  module.Backward(std::move(input1), std::move(target1), std::move(output));
+  module.Backward(input1, target1, output);
   expected = 0.62245929;
   for (size_t i = 0; i < output.n_elem; i++)
     BOOST_REQUIRE_SMALL(output(i) - expected, 1e-5);
@@ -248,13 +248,13 @@ BOOST_AUTO_TEST_CASE(SimpleSigmoidCrossEntropyErrorTest)
 
   expectedOutput = arma::mat(
       "0.7310586 0.88079709 -0.04742587 0.98201376 -0.00669285");
-  module.Backward(std::move(input2), std::move(target2), std::move(output));
+  module.Backward(input2, target2, output);
   for (size_t i = 0; i < output.n_elem; i++)
     BOOST_REQUIRE_SMALL(output(i) - expectedOutput(i), 1e-5);
   BOOST_REQUIRE_EQUAL(output.n_rows, input2.n_rows);
   BOOST_REQUIRE_EQUAL(output.n_cols, input2.n_cols);
 
-  module.Backward(std::move(input3), std::move(target3), std::move(output));
+  module.Backward(input3, target3, output);
   expectedOutput = arma::mat("0.5 1.2689414");
   for (size_t i = 0; i < 8; ++i)
   {
@@ -280,18 +280,18 @@ BOOST_AUTO_TEST_CASE(SimpleEarthMoverDistanceLayerTest)
   // the manually calculated result.
   input1 = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5");
   target1 = arma::zeros(1, 8);
-  double error1 = module.Forward(std::move(input1), std::move(target1));
+  double error1 = module.Forward(input1, target1);
   double expected = 0.0;
   BOOST_REQUIRE_SMALL(error1 / input1.n_elem - expected, 1e-7);
 
   input2 = arma::mat("1 2 3 4 5");
   target2 = arma::mat("1 0 1 0 1");
-  double error2 = module.Forward(std::move(input2), std::move(target2));
+  double error2 = module.Forward(input2, target2);
   expected = -1.8;
   BOOST_REQUIRE_SMALL(error2 / input2.n_elem - expected, 1e-6);
 
   // Test the Backward function.
-  module.Backward(std::move(input1), std::move(target1), std::move(output));
+  module.Backward(input1, target1, output);
   expected = 0.0;
   for (size_t i = 0; i < output.n_elem; i++)
     BOOST_REQUIRE_SMALL(output(i) - expected, 1e-5);
@@ -299,7 +299,7 @@ BOOST_AUTO_TEST_CASE(SimpleEarthMoverDistanceLayerTest)
   BOOST_REQUIRE_EQUAL(output.n_cols, input1.n_cols);
 
   expectedOutput = arma::mat("-1 0 -1 0 -1");
-  module.Backward(std::move(input2), std::move(target2), std::move(output));
+  module.Backward(input2, target2, output);
   for (size_t i = 0; i < output.n_elem; i++)
     BOOST_REQUIRE_SMALL(output(i) - expectedOutput(i), 1e-5);
   BOOST_REQUIRE_EQUAL(output.n_rows, input2.n_rows);
@@ -404,16 +404,16 @@ BOOST_AUTO_TEST_CASE(DiceLossTest)
   // Test the Forward function. Loss should be 0 if input = target.
   input1 = arma::ones(10, 1);
   target = arma::ones(10, 1);
-  loss = module.Forward(std::move(input1), std::move(target));
+  loss = module.Forward(input1, target);
   BOOST_REQUIRE_SMALL(loss, 0.00001);
 
   // Test the Forward function. Loss should be 0.185185185.
   input2 = arma::ones(10, 1) * 0.5;
-  loss = module.Forward(std::move(input2), std::move(target));
+  loss = module.Forward(input2, target);
   BOOST_REQUIRE_CLOSE(loss, 0.185185185, 0.00001);
 
   // Test the Backward function for input = target.
-  module.Backward(std::move(input1), std::move(target), std::move(output));
+  module.Backward(input1, target, output);
   for (double el : output)
   {
     // For input = target we should get 0.0 everywhere.
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(DiceLossTest)
   BOOST_REQUIRE_EQUAL(output.n_cols, input1.n_cols);
 
   // Test the Backward function.
-  module.Backward(std::move(input2), std::move(target), std::move(output));
+  module.Backward(input2, target, output);
   for (double el : output)
   {
     // For the 0.5 constant vector we should get -0.0877914951989026 everywhere.
@@ -445,11 +445,11 @@ BOOST_AUTO_TEST_CASE(SimpleMeanBiasErrorTest)
   // the manually calculated result.
   input = arma::mat("1.0 0.0 1.0 -1.0 -1.0 0.0 -1.0 0.0");
   target = arma::zeros(1, 8);
-  double error = module.Forward(std::move(input), std::move(target));
+  double error = module.Forward(input, target);
   BOOST_REQUIRE_EQUAL(error, 0.125);
 
   // Test the Backward function.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   // We should get a vector with -1 everywhere.
   for (double el : output)
   {
@@ -461,11 +461,11 @@ BOOST_AUTO_TEST_CASE(SimpleMeanBiasErrorTest)
   // Test the error function on a single input.
   input = arma::mat("2");
   target = arma::mat("3");
-  error = module.Forward(std::move(input), std::move(target));
+  error = module.Forward(input, target);
   BOOST_REQUIRE_EQUAL(error, 1.0);
 
   // Test the Backward function on a single input.
-  module.Backward(std::move(input), std::move(target), std::move(output));
+  module.Backward(input, target, output);
   // Test whether the output is negative.
   BOOST_REQUIRE_EQUAL(arma::accu(output), -1);
   BOOST_REQUIRE_EQUAL(output.n_elem, 1);


### PR DESCRIPTION
Previously, all of the ANN code had signatures like

```
Forward(const arma::Mat<eT>&& input, arma::Mat<eT>&& output);
```

but the use of rvalue references led to some incorrect memory usages, and it was a little confusing as people would call `Forward(std::move(input), std::move(output))`... but `input` would remain unchanged (this is confusing given the expected `std::move()` semantics).

In this PR I've refactored out all unnecessary use of rvalue references.  I think, in some places, this makes copies avoidable and there may be some minor acceleration.  I'm running some quick benchmarks in the `models/` repo and will post the results here when they're done (I don't expect any serious speedup).