### PR TITLE
Pooling Tests fail on Rectangular inputs?

### DIFF
--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -179,29 +179,29 @@ class MaxPooling
                         arma::Mat<eT>& output,
                         arma::Mat<eT>& poolingIndices)
   {
+    const size_t rStep = kernelWidth;
+    const size_t cStep = kernelHeight;
     for (size_t j = 0, colidx = 0; j < output.n_cols;
-         ++j, colidx += strideWidth)
+        ++j, colidx += strideHeight)
     {
       for (size_t i = 0, rowidx = 0; i < output.n_rows;
-           ++i, rowidx += strideHeight)
+          ++i, rowidx += strideWidth)
       {
         arma::mat subInput = input(
-            arma::span(rowidx, rowidx + kernelWidth - 1 - offset),
-            arma::span(colidx, colidx + kernelHeight - 1 - offset));
-
+            arma::span(rowidx, rowidx + rStep - 1 - offset),
+            arma::span(colidx, colidx + cStep - 1 - offset));
         const size_t idx = pooling.Pooling(subInput);
         output(i, j) = subInput(idx);
 
         if (!deterministic)
         {
           arma::Mat<size_t> subIndices = indices(arma::span(rowidx,
-              rowidx + kernelWidth - 1 - offset),
-              arma::span(colidx, colidx + kernelHeight - 1 - offset));
-
+            rowidx + rStep - 1),
+            arma::span(colidx, colidx + cStep - 1));
           poolingIndices(i, j) = subIndices(idx);
-        }
-      }
-    }
+         }
+       }
+     }
   }
 
   /**

--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -196,8 +196,8 @@ class MaxPooling
         if (!deterministic)
         {
           arma::Mat<size_t> subIndices = indices(arma::span(rowidx,
-            rowidx + rStep - 1),
-            arma::span(colidx, colidx + cStep - 1));
+            rowidx + rStep - 1 - offset),
+            arma::span(colidx, colidx + cStep - 1 - offset));
           poolingIndices(i, j) = subIndices(idx);
          }
        }

--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -199,9 +199,9 @@ class MaxPooling
             rowidx + rStep - 1 - offset),
             arma::span(colidx, colidx + cStep - 1 - offset));
           poolingIndices(i, j) = subIndices(idx);
-         }
-       }
-     }
+        }
+      }
+    }
   }
 
   /**

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3072,12 +3072,12 @@ BOOST_AUTO_TEST_CASE(MaxPoolingTestCase)
   input(6) = 3;
   // Output-Size should be 1 x 2.
   // Rectangular output.
-  MaxPooling<> module2(2, 2, 1, 1);
+  MaxPooling<> module2(3, 2, 3, 1);
   module2.InputHeight() = 3;
   module2.InputWidth() = 3;
   module2.Forward(std::move(input), std::move(output));
   // Calculated using torch.nn.MaxPool2d().
-  BOOST_REQUIRE_EQUAL(arma::accu(output), 15.0);
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 12.0);
   BOOST_REQUIRE_EQUAL(output.n_elem, 2);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
 

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3112,7 +3112,7 @@ BOOST_AUTO_TEST_CASE(MaxPoolingTestCase)
   module4.InputHeight() = 2;
   module4.InputWidth() = 3;
   module4.Forward(std::move(input), std::move(output));
-  // Calculated using torch.nn.AdaptiveMaxPool2d().
+  // Calculated using torch.nn.MaxPool2d().
   BOOST_REQUIRE_EQUAL(arma::accu(output), 3);
   BOOST_REQUIRE_EQUAL(output.n_elem, 4);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3034,8 +3034,8 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
 }
 
 /**
-  * Simple test for Max Pooling layer.
-  */
+ * Simple test for Max Pooling layer.
+ */
 BOOST_AUTO_TEST_CASE(MaxPoolingTestCase)
 {
   // For rectangular input.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3032,4 +3032,89 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionLayerPaddingTest)
   module6.Backward(std::move(input), std::move(output), std::move(delta));
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 0.0);
 }
+
+/**
+  * Simple test for Max Pooling layer.
+  */
+BOOST_AUTO_TEST_CASE(MaxPoolingTestCase)
+{
+  // For rectangular input.
+  arma::mat input = arma::mat(12, 1);
+  arma::mat output;
+  input.zeros();
+  input(0) = 1;
+  input(1) = 2;
+  input(2) = 3;
+  input(3) = input(8) = 7;
+  input(4) = 4;
+  input(5) = 5;
+  input(6) = input(7) = 6;
+  input(10) = 8;
+  input(11) = 9;
+  // Output-Size should be 2 x 2.
+  // Square output.
+  MaxPooling<> module1(2, 2, 2, 1);
+  module1.InputHeight() = 3;
+  module1.InputWidth() = 4;
+  module1.Forward(std::move(input), std::move(output));
+  // Calculated using torch.nn.MaxPool2d().
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 28);
+  BOOST_REQUIRE_EQUAL(output.n_elem, 4);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // For Square input.
+  input = arma::mat(9, 1);
+  input.zeros();
+  input(0) = 6;
+  input(1) = 3;
+  input(2) = 9;
+  input(3) = 3;
+  input(6) = 3;
+  // Output-Size should be 1 x 2.
+  // Rectangular output.
+  MaxPooling<> module2(2, 2, 1, 1);
+  module2.InputHeight() = 3;
+  module2.InputWidth() = 3;
+  module2.Forward(std::move(input), std::move(output));
+  // Calculated using torch.nn.MaxPool2d().
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 15.0);
+  BOOST_REQUIRE_EQUAL(output.n_elem, 2);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // For Square input.
+  input = arma::mat(16, 1);
+  input.zeros();
+  input(0) = 6;
+  input(1) = 3;
+  input(2) = 9;
+  input(4) = 3;
+  input(8) = 3;
+  // Output-Size should be 3 x 3.
+  // Square output.
+  MaxPooling<> module3(2, 2, 1, 1);
+  module3.InputHeight() = 4;
+  module3.InputWidth() = 4;
+  module3.Forward(std::move(input), std::move(output));
+  // Calculated using torch.nn.MaxPool2d().
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 30.0);
+  BOOST_REQUIRE_EQUAL(output.n_elem, 9);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+
+  // For Rectangular input.
+  input = arma::mat(6, 1);
+  input.zeros();
+  input(0) = 1;
+  input(1) = 1;
+  input(3) = 1;
+  // Output-Size should be 2 x 2.
+  // Square output.
+  MaxPooling<> module4(2, 1, 1, 1);
+  module4.InputHeight() = 2;
+  module4.InputWidth() = 3;
+  module4.Forward(std::move(input), std::move(output));
+  // Calculated using torch.nn.AdaptiveMaxPool2d().
+  BOOST_REQUIRE_EQUAL(arma::accu(output), 3);
+  BOOST_REQUIRE_EQUAL(output.n_elem, 4);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+}
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
In order to solve #2252, I started testing pooling layers with some inputs. Mean pooling layer works fine for all kind of inputs however maxpooling layer gives the following error on testing with rectangular inputs.
```
fatal error: in "ANNLayerTest/MaxPoolingTestCase": std::logic_error: Mat::submat(): indices out of bounds or incorrectly used
/Users/Open-Source/mlpack/src/mlpack/tests/ann_layer_test.cpp:3039: last checkpoint: "MaxPoolingTestCase" test entry
```
The same inputs work on PyTorch.

I think I have the fix, if it fails across multiple devices I will add it in the next commit.
Please forgive me if I have made a blunder that makes this happen.
Thanks.