### PR TITLE
Improved ANN Tutorial for FFN - Thyroid Dataset Example

### DIFF
--- a/doc/tutorials/ann/ann.txt
+++ b/doc/tutorials/ann/ann.txt
@@ -213,8 +213,6 @@ int main()
   // Split the labels from the training set and testing set respectively.
   arma::mat trainLabels = trainData.row(trainData.n_rows - 1);
   arma::mat testLabels = testData.row(testData.n_rows - 1);
-
-  // Split the data from the training set and testing set respectively.
   trainData.shed_row(trainData.n_rows - 1);
   testData.shed_row(testData.n_rows - 1);
 
@@ -240,6 +238,9 @@ int main()
 
     The first step towards doing this is to create a matrix of zeros with the 
     desired dimensions (1 x number_of_data_points).
+
+    In predictionsTemp, the 3 dimensions for each data point correspond to the
+    probabilities of belonging to the three possible classes.
   */
   arma::mat prediction = arma::zeros<arma::mat>(1, predictionTemp.n_cols);
 
@@ -255,24 +256,21 @@ int main()
     Compute the error between predictions and testLabels, 
     now that we have the desired predictions.
   */
-  size_t error = 0;
+  size_t correct = 0;
   for (size_t i = 0; i < testData.n_cols; i++)
   {
-    if (int(arma::as_scalar(prediction.col(i))) == int(arma::as_scalar(testLabels.col(i))))
-    {
-        error++;
-    }
+    correct = arma::accu(prediction == testLabels);
   } 
-  double classificationError = 1 - double(error) / testData.n_cols;
+  double classificationError = 1 - double(correct) / testData.n_cols;
 
   // Print out the classification error for the testing dataset.
-  cout << "Classification Error for the Test set: " << classificationError << endl;
+  std::cout << "Classification Error for the Test set: " << classificationError << std::endl;
   return 0;
 }
 @endcode
 
 Now, the matrix prediction holds the classification of each point in the
-dataset. Subsequently, we find the classfication error by comparing it 
+dataset. Subsequently, we find the classification error by comparing it 
 with testLabels.
 
 In the next example, we create simple noisy sine sequences, which are trained

--- a/doc/tutorials/ann/ann.txt
+++ b/doc/tutorials/ann/ann.txt
@@ -256,11 +256,7 @@ int main()
     Compute the error between predictions and testLabels, 
     now that we have the desired predictions.
   */
-  size_t correct = 0;
-  for (size_t i = 0; i < testData.n_cols; i++)
-  {
-    correct = arma::accu(prediction == testLabels);
-  } 
+  size_t correct = arma::accu(prediction == testLabels);
   double classificationError = 1 - double(correct) / testData.n_cols;
 
   // Print out the classification error for the testing dataset.

--- a/doc/tutorials/ann/ann.txt
+++ b/doc/tutorials/ann/ann.txt
@@ -204,17 +204,19 @@ using namespace mlpack::ann;
 
 int main()
 {
-  // Load the training set.
-  arma::mat dataset;
-  data::Load("thyroid_train.csv", dataset, true);
+  // Load the training set and testing set.
+  arma::mat trainData;
+  data::Load("thyroid_train.csv", trainData, true);
+  arma::mat testData;
+  data::Load("thyroid_test.csv", testData, true);
 
-  // Split the labels from the training set.
-  arma::mat trainData = dataset.submat(0, 0, dataset.n_rows - 4,
-      dataset.n_cols - 1);
+  // Split the labels from the training set and testing set respectively.
+  arma::mat trainLabels = trainData.row(trainData.n_rows - 1);
+  arma::mat testLabels = testData.row(testData.n_rows - 1);
 
-  // Split the data from the training set.
-  arma::mat trainLabels = dataset.submat(dataset.n_rows - 3, 0,
-      dataset.n_rows - 1, dataset.n_cols - 1);
+  // Split the data from the training set and testing set respectively.
+  trainData.shed_row(trainData.n_rows - 1);
+  testData.shed_row(testData.n_rows - 1);
 
   // Initialize the network.
   FFN<> model;
@@ -226,14 +228,52 @@ int main()
   // Train the model.
   model.Train(trainData, trainLabels);
 
-  // Use the Predict method to get the assignments.
-  arma::mat assignments;
-  model.Predict(trainData, assignments);
+  // Use the Predict method to get the predictions.
+  arma::mat predictionTemp;
+  model.Predict(testData, predictionTemp);
+
+  /* 
+    Since the predictionsTemp is of dimensions (3 x number_of_data_points) 
+    with continuous values, we first need to reduce it to a dimension of 
+    (1 x number_of_data_points) with scalar values, to be able to compare with
+    testLabels.
+
+    The first step towards doing this is to create a matrix of zeros with the 
+    desired dimensions (1 x number_of_data_points).
+  */
+  arma::mat prediction = arma::zeros<arma::mat>(1, predictionTemp.n_cols);
+
+  // Find index of max prediction for each data point and store in "prediction"
+  for (size_t i = 0; i < predictionTemp.n_cols; ++i)
+  {
+    // we add 1 to the max index, so that it matches the actual test labels.
+    prediction(i) = arma::as_scalar(arma::find(
+        arma::max(predictionTemp.col(i)) == predictionTemp.col(i), 1)) + 1;
+  }
+
+  /* 
+    Compute the error between predictions and testLabels, 
+    now that we have the desired predictions.
+  */
+  size_t error = 0;
+  for (size_t i = 0; i < testData.n_cols; i++)
+  {
+    if (int(arma::as_scalar(prediction.col(i))) == int(arma::as_scalar(testLabels.col(i))))
+    {
+        error++;
+    }
+  } 
+  double classificationError = 1 - double(error) / testData.n_cols;
+
+  // Print out the classification error for the testing dataset.
+  cout << "Classification Error for the Test set: " << classificationError << endl;
+  return 0;
 }
 @endcode
 
-Now, the matrix assignments holds the classification of each point in the
-dataset.
+Now, the matrix prediction holds the classification of each point in the
+dataset. Subsequently, we find the classfication error by comparing it 
+with testLabels.
 
 In the next example, we create simple noisy sine sequences, which are trained
 later on, using the RNN class in the `RNNModel()` method.


### PR DESCRIPTION
I followed a few closed issues #1415 , #1525, #1532 where people had trouble with the first tutorial (a simple feed forward network for the thyroid dataset) on this page `https://www.mlpack.org/doc/mlpack-3.2.2/doxygen/anntutorial.html`. I believe this chain of issues culminated with @rcurtin 's closed pull-request #1534 , where he changed the dataset itself from three rows of "one-hot-encodings labels" to a single row of "scalar labels". This led to more cleaner code in the corresponding test files (you could checkout the pull request).

If I'm not mistaken the tutorial on the mlpack page hasn't caught up with this change, and so trip up beginners when trying to get the example to run. I noticed that #2150 had a made a few changes in this regard (included headers and fixed variable names). 

I've accounted for the change in dataset, and modified the tutorial by referring to the `src/mlpack/tests/feedforward_network_test.cpp` file, with hopefully helpful comments.

I also took the liberty to expand the tutorial to include "error computation" incorporating the test dataset as well. I thought this would make the tutorial more wholesome.