### PR TITLE
Fix return type of A().

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
@@ -75,9 +75,9 @@ class LogCoshLoss
   OutputDataType& OutputParameter() { return outputParameter; }
 
   //! Get the value of hyperparameter a.
-  bool A() const { return a; }
+  double A() const { return a; }
   //! Modify the value of hyperparameter a.
-  bool& A() { return a; }
+  double& A() { return a; }
 
   /**
    * Serialize the loss function.


### PR DESCRIPTION
I found this morning that the master build fails with gcc 9.2.1.  This change fixes an incorrect return type, which caused the compilation issue.  I'm not sure how many other compilers catch this issue (it seems like most of the CI tests are passing).  Anyway, easy fix.