### PR TITLE
Markdown issue fix

### DIFF
--- a/doc/tutorials/ann/ann.txt
+++ b/doc/tutorials/ann/ann.txt
@@ -204,17 +204,19 @@ using namespace mlpack::ann;
 
 int main()
 {
-  // Load the training set.
-  arma::mat dataset;
-  data::Load("thyroid_train.csv", dataset, true);
+  // Load the training set and testing set.
+  arma::mat trainData;
+  data::Load("thyroid_train.csv", trainData, true);
+  arma::mat testData;
+  data::Load("thyroid_test.csv", testData, true);
 
-  // Split the labels from the training set.
-  arma::mat trainData = dataset.submat(0, 0, dataset.n_rows - 4,
-      dataset.n_cols - 1);
+  // Split the labels from the training set and testing set respectively.
+  arma::mat trainLabels = trainData.row(trainData.n_rows - 1);
+  arma::mat testLabels = testData.row(testData.n_rows - 1);
 
-  // Split the data from the training set.
-  arma::mat trainLabels = dataset.submat(dataset.n_rows - 3, 0,
-      dataset.n_rows - 1, dataset.n_cols - 1);
+  // Split the data from the training set and testing set respectively.
+  trainData.shed_row(trainData.n_rows - 1);
+  testData.shed_row(testData.n_rows - 1);
 
   // Initialize the network.
   FFN<> model;
@@ -226,14 +228,52 @@ int main()
   // Train the model.
   model.Train(trainData, trainLabels);
 
-  // Use the Predict method to get the assignments.
-  arma::mat assignments;
-  model.Predict(trainData, assignments);
+  // Use the Predict method to get the predictions.
+  arma::mat predictionTemp;
+  model.Predict(testData, predictionTemp);
+
+  /* 
+    Since the predictionsTemp is of dimensions (3 x number_of_data_points) 
+    with continuous values, we first need to reduce it to a dimension of 
+    (1 x number_of_data_points) with scalar values, to be able to compare with
+    testLabels.
+
+    The first step towards doing this is to create a matrix of zeros with the 
+    desired dimensions (1 x number_of_data_points).
+  */
+  arma::mat prediction = arma::zeros<arma::mat>(1, predictionTemp.n_cols);
+
+  // Find index of max prediction for each data point and store in "prediction"
+  for (size_t i = 0; i < predictionTemp.n_cols; ++i)
+  {
+    // we add 1 to the max index, so that it matches the actual test labels.
+    prediction(i) = arma::as_scalar(arma::find(
+        arma::max(predictionTemp.col(i)) == predictionTemp.col(i), 1)) + 1;
+  }
+
+  /* 
+    Compute the error between predictions and testLabels, 
+    now that we have the desired predictions.
+  */
+  size_t error = 0;
+  for (size_t i = 0; i < testData.n_cols; i++)
+  {
+    if (int(arma::as_scalar(prediction.col(i))) == int(arma::as_scalar(testLabels.col(i))))
+    {
+        error++;
+    }
+  } 
+  double classificationError = 1 - double(error) / testData.n_cols;
+
+  // Print out the classification error for the testing dataset.
+  cout << "Classification Error for the Test set: " << classificationError << endl;
+  return 0;
 }
 @endcode
 
-Now, the matrix assignments holds the classification of each point in the
-dataset.
+Now, the matrix prediction holds the classification of each point in the
+dataset. Subsequently, we find the classfication error by comparing it 
+with testLabels.
 
 In the next example, we create simple noisy sine sequences, which are trained
 later on, using the RNN class in the `RNNModel()` method.

--- a/src/mlpack/bindings/markdown/print_docs.cpp
+++ b/src/mlpack/bindings/markdown/print_docs.cpp
@@ -126,7 +126,8 @@ void PrintDocs(const std::string& bindingName,
       cout << "| ";
       cout << ParamString(it->second.name) << " | ";
       cout << ParamType(it->second) << " | ";
-      cout << it->second.desc; // just a string
+      string desc = boost::replace_all_copy(it->second.desc, "|", "\\|");
+      cout << desc << endl; // just a string
       // Print whether or not it's a "special" language-only parameter.
       if (it->second.name == "copy_all_inputs" || it->second.name == "help" ||
           it->second.name == "info" || it->second.name == "version")
@@ -180,7 +181,8 @@ void PrintDocs(const std::string& bindingName,
     cout << "{: #" << languages[i] << "_" << bindingName
         << "_detailed-documentation }" << endl;
     cout << endl;
-    cout << programDoc.documentation() << endl;
+    string desc = boost::replace_all_copy(programDoc.documentation(), "|", "\\|");
+    cout << desc << endl;
     cout << endl;
 
     cout << "### See also" << endl;


### PR DESCRIPTION
> 2. Make it so that any time programInfo.documentation() is called from any function in src/mlpack/bindings/markdown/, any instances of | are properly escaped (assuming that escaping works with Kramdown). Note that in src/mlpack/bindings/markdown/, any functions just call out to different bindings languages.

This hopefully fixes issue #2270 (escaping does work in kramdown :)). This should take care of the "|" symbol issue in the markdown for all bindings.