### PR TITLE
Fixed markdown pipe symbol issue

### DIFF
--- a/src/mlpack/bindings/markdown/print_docs.cpp
+++ b/src/mlpack/bindings/markdown/print_docs.cpp
@@ -181,7 +181,8 @@ void PrintDocs(const std::string& bindingName,
     cout << "{: #" << languages[i] << "_" << bindingName
         << "_detailed-documentation }" << endl;
     cout << endl;
-    string doc = boost::replace_all_copy(programDoc.documentation(), "|", "\\|");
+    string doc = boost::replace_all_copy(programDoc.documentation(), 
+                                         "|", "\\|");
     cout << doc << endl;
     cout << endl;
 

--- a/src/mlpack/bindings/markdown/print_docs.cpp
+++ b/src/mlpack/bindings/markdown/print_docs.cpp
@@ -181,7 +181,7 @@ void PrintDocs(const std::string& bindingName,
     cout << "{: #" << languages[i] << "_" << bindingName
         << "_detailed-documentation }" << endl;
     cout << endl;
-    string doc = boost::replace_all_copy(programDoc.documentation(), 
+    string doc = boost::replace_all_copy(programDoc.documentation(),
                                          "|", "\\|");
     cout << doc << endl;
     cout << endl;

--- a/src/mlpack/bindings/markdown/print_docs.cpp
+++ b/src/mlpack/bindings/markdown/print_docs.cpp
@@ -127,7 +127,7 @@ void PrintDocs(const std::string& bindingName,
       cout << ParamString(it->second.name) << " | ";
       cout << ParamType(it->second) << " | ";
       string desc = boost::replace_all_copy(it->second.desc, "|", "\\|");
-      cout << desc << endl; // just a string
+      cout << desc; // just a string
       // Print whether or not it's a "special" language-only parameter.
       if (it->second.name == "copy_all_inputs" || it->second.name == "help" ||
           it->second.name == "info" || it->second.name == "version")

--- a/src/mlpack/bindings/markdown/print_docs.cpp
+++ b/src/mlpack/bindings/markdown/print_docs.cpp
@@ -126,7 +126,8 @@ void PrintDocs(const std::string& bindingName,
       cout << "| ";
       cout << ParamString(it->second.name) << " | ";
       cout << ParamType(it->second) << " | ";
-      cout << it->second.desc; // just a string
+      string desc = boost::replace_all_copy(it->second.desc, "|", "\\|");
+      cout << desc << endl; // just a string
       // Print whether or not it's a "special" language-only parameter.
       if (it->second.name == "copy_all_inputs" || it->second.name == "help" ||
           it->second.name == "info" || it->second.name == "version")
@@ -180,7 +181,8 @@ void PrintDocs(const std::string& bindingName,
     cout << "{: #" << languages[i] << "_" << bindingName
         << "_detailed-documentation }" << endl;
     cout << endl;
-    cout << programDoc.documentation() << endl;
+    string doc = boost::replace_all_copy(programDoc.documentation(), "|", "\\|");
+    cout << doc << endl;
     cout << endl;
 
     cout << "### See also" << endl;


### PR DESCRIPTION
> 2. Make it so that any time programInfo.documentation() is called from any function in src/mlpack/bindings/markdown/, any instances of | are properly escaped (assuming that escaping works with Kramdown). Note that in src/mlpack/bindings/markdown/, any functions just call out to different bindings languages.

This hopefully fixes issue #2270 (escaping does work in kramdown! :)). This should take care of the "|" symbol issue in the markdown for all bindings.