### PR TITLE
Use Cint to match C++'s int type, not Julia's Int.

### DIFF
--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -66,6 +66,7 @@ steps:
     -DARMADILLO_LIBRARY="..\armadillo-8.400.0\Release\armadillo.lib" `
     -DBOOST_INCLUDEDIR=$(Agent.ToolsDirectory)\boost.1.60.0.0\lib\native\include `
     -DBOOST_LIBRARYDIR=$(Agent.ToolsDirectory)\boost_libs `
+    -DBUILD_JULIA_BINDINGS=OFF `
     -DCMAKE_BUILD_TYPE=Release ..
   displayName: 'Configure mlpack'
 

--- a/src/mlpack/bindings/julia/CMakeLists.txt
+++ b/src/mlpack/bindings/julia/CMakeLists.txt
@@ -154,6 +154,6 @@ if (BUILD_JULIA_BINDINGS)
 endif ()
 endmacro ()
 
-if (BUILD_TESTS)
+if (BUILD_TESTS AND BUILD_JULIA_BINDINGS)
   add_subdirectory(tests)
 endif ()

--- a/src/mlpack/bindings/julia/julia_util.cpp
+++ b/src/mlpack/bindings/julia/julia_util.cpp
@@ -246,7 +246,7 @@ size_t CLI_GetParamVectorStrLen(const char* paramName)
 /**
  * Call CLI::GetParam<std::vector<std::string>>() and get the i'th string.
  */
-const char* CLI_GetParamVectorStrStr(const char* paramName, const int i)
+const char* CLI_GetParamVectorStrStr(const char* paramName, const size_t i)
 {
   return CLI::GetParam<std::vector<std::string>>(paramName)[i].c_str();
 }

--- a/src/mlpack/bindings/julia/julia_util.h
+++ b/src/mlpack/bindings/julia/julia_util.h
@@ -149,7 +149,7 @@ size_t CLI_GetParamVectorStrLen(const char* paramName);
 /**
  * Call CLI::GetParam<std::vector<std::string>>() and get the i'th string.
  */
-const char* CLI_GetParamVectorStrStr(const char* paramName, const int i);
+const char* CLI_GetParamVectorStrStr(const char* paramName, const size_t i);
 
 /**
  * Call CLI::GetParam<std::vector<int>>() and get the length of the vector.

--- a/src/mlpack/bindings/julia/mlpack/cli.jl.in
+++ b/src/mlpack/bindings/julia/mlpack/cli.jl.in
@@ -126,9 +126,10 @@ function CLISetParam(paramName::String,
 end
 
 function CLISetParam(paramName::String,
-                     vector::Vector{Cint})
+                     vector::Vector{Int})
+  cint_vec = convert(Vector{Cint}, vector)
   ccall((:CLI_SetParamVectorInt, library), Nothing, (Cstring, Ptr{Cint},
-      Csize_t), paramName, Base.pointer(vector), size(vector, 1));
+      Csize_t), paramName, Base.pointer(cint_vec), size(cint_vec, 1));
 end
 
 function CLISetParam(paramName::String,

--- a/src/mlpack/bindings/julia/mlpack/cli.jl.in
+++ b/src/mlpack/bindings/julia/mlpack/cli.jl.in
@@ -66,8 +66,8 @@ function CLIRestoreSettings(programName::String)
 end
 
 function CLISetParam(paramName::String, paramValue::Int)
-  ccall((:CLI_SetParamInt, library), Nothing, (Cstring, Int), paramName,
-      paramValue);
+  ccall((:CLI_SetParamInt, library), Nothing, (Cstring, Cint), paramName,
+      Cint(paramValue));
 end
 
 function CLISetParam(paramName::String, paramValue::Float64)
@@ -126,9 +126,9 @@ function CLISetParam(paramName::String,
 end
 
 function CLISetParam(paramName::String,
-                     vector::Vector{Int})
-  ccall((:CLI_SetParamVectorInt, library), Nothing, (Cstring, Ptr{Int},
-      Int), paramName, Base.pointer(vector), size(vector, 1));
+                     vector::Vector{Cint})
+  ccall((:CLI_SetParamVectorInt, library), Nothing, (Cstring, Ptr{Cint},
+      Csize_t), paramName, Base.pointer(vector), size(vector, 1));
 end
 
 function CLISetParam(paramName::String,
@@ -189,7 +189,7 @@ function CLIGetParamBool(paramName::String)
 end
 
 function CLIGetParamInt(paramName::String)
-  return ccall((:CLI_GetParamInt, library), Int, (Cstring,), paramName)
+  return Int(ccall((:CLI_GetParamInt, library), Cint, (Cstring,), paramName))
 end
 
 function CLIGetParamDouble(paramName::String)
@@ -219,16 +219,17 @@ end
 
 function CLIGetParamVectorInt(paramName::String)
   local size::Csize_t
-  local ptr::Ptr{Int}
+  local ptr::Ptr{Cint}
 
   # Get the size of the vector, then the pointer to it.  We will own the
   # pointer.
   size = ccall((:CLI_GetParamVectorIntLen, library), Csize_t, (Cstring,),
       paramName);
-  ptr = ccall((:CLI_GetParamVectorIntPtr, library), Ptr{Int}, (Cstring,),
+  ptr = ccall((:CLI_GetParamVectorIntPtr, library), Ptr{Cint}, (Cstring,),
       paramName);
 
-  return Base.unsafe_wrap(Array{Int, 1}, ptr, (size), own=true)
+  return convert(Array{Int, 1}, Base.unsafe_wrap(Array{Cint, 1}, ptr, (size),
+      own=true))
 end
 
 function CLIGetParamMat(paramName::String, pointsAsRows::Bool)

--- a/src/mlpack/bindings/julia/print_input_processing_impl.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing_impl.hpp
@@ -47,8 +47,19 @@ void PrintInputProcessing(
     //   CLISetParam("<param_name>", convert(<type>, <param_name>))
     // end
     std::cout << "  if !ismissing(" << juliaName << ")" << std::endl;
-    std::cout << "    CLISetParam(\"" << d.name << "\", convert("
-        << GetJuliaType<T>() << ", " << juliaName << "))" << std::endl;
+    std::cout << "    CLISetParam(\"" << d.name << "\", convert(";
+    if (std::is_same<T, std::vector<int>>::value)
+    {
+      // Special case: the type we will call CLISetParam() with for a
+      // vector<int> is not Julia's "Vector{Int}" type but instead
+      // "Vector{Cint}", so we have to make that conversion manually.
+      std::cout << "Vector{Cint}";
+    }
+    else
+    {
+      std::cout << GetJuliaType<T>();
+    }
+    std::cout << ", " << juliaName << "))" << std::endl;
     std::cout << "  end" << std::endl;
   }
 }

--- a/src/mlpack/bindings/julia/print_input_processing_impl.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing_impl.hpp
@@ -47,19 +47,8 @@ void PrintInputProcessing(
     //   CLISetParam("<param_name>", convert(<type>, <param_name>))
     // end
     std::cout << "  if !ismissing(" << juliaName << ")" << std::endl;
-    std::cout << "    CLISetParam(\"" << d.name << "\", convert(";
-    if (std::is_same<T, std::vector<int>>::value)
-    {
-      // Special case: the type we will call CLISetParam() with for a
-      // vector<int> is not Julia's "Vector{Int}" type but instead
-      // "Vector{Cint}", so we have to make that conversion manually.
-      std::cout << "Vector{Cint}";
-    }
-    else
-    {
-      std::cout << GetJuliaType<T>();
-    }
-    std::cout << ", " << juliaName << "))" << std::endl;
+    std::cout << "    CLISetParam(\"" << d.name << "\", convert("
+        << GetJuliaType<T>() << ", " << juliaName << "))" << std::endl;
     std::cout << "  end" << std::endl;
   }
 }


### PR DESCRIPTION
I mistakenly thought that Julia's `Int` type always matched C/C++'s `int` type; this is incorrect---Julia's `Int` type instead matches `size_t`.  Therefore, we have to use the `Cint` type in Julia.  This PR fixes that and all associated handling, and should fix the currently-failing Julia build.