### PR TITLE
A small fix to arma deprecated guess_file_type api.

### DIFF
--- a/src/mlpack/core/data/load_impl.hpp
+++ b/src/mlpack/core/data/load_impl.hpp
@@ -34,9 +34,11 @@ using namespace arma;
 class newDiskio: public arma::diskio{
 public:
 // In future if guess_file_type is removed, the code will compile.
-inline static arma::file_type guess_file_type(std::istream& ) __attribute__((weak)); 
-// For runtime checking if the function is present in current version of armadillo.
-inline static arma::file_type guess_file_type_internal(std::istream& ) __attribute__((weak));
+inline static arma::file_type 
+  guess_file_type (std::istream& ) __attribute__((weak)); 
+// For runtime checking, is function present in current version of armadillo.
+inline static arma::file_type 
+  guess_file_type_internal (std::istream& ) __attribute__((weak));
 };//class newDiskio
 }//namespace new_arma
 
@@ -102,11 +104,11 @@ bool Load(const std::string& filename,
   if (new_arma::newDiskio::guess_file_type_internal)
   {
     // If declaration of geuss_file_type_internal is present.
-    guess_file_type=new_arma::newDiskio::guess_file_type_internal;
+    guess_file_type = new_arma::newDiskio::guess_file_type_internal;
   }
   else 
   {
-    guess_file_type=new_arma::newDiskio::guess_file_type;
+    guess_file_type = new_arma::newDiskio::guess_file_type;
   }
 
   // Get the extension.

--- a/src/mlpack/core/data/load_impl.hpp
+++ b/src/mlpack/core/data/load_impl.hpp
@@ -113,7 +113,8 @@ bool Load(const std::string& filename,
 
   if (extension == "csv" || extension == "tsv")
   {
-    loadType = arma::diskio::guess_file_type(stream);
+    // In latest Armadillo-9.850.1 guess_file_type is declared arma_deprecated.
+    loadType = arma::diskio::guess_file_type_internal(stream);
     if (loadType == arma::csv_ascii)
     {
       if (extension == "tsv")
@@ -177,7 +178,7 @@ bool Load(const std::string& filename,
     }
     else // It's not arma_ascii.  Now we let Armadillo guess.
     {
-      loadType = arma::diskio::guess_file_type(stream);
+      loadType = arma::diskio::guess_file_type_internal(stream);
 
       if (loadType == arma::raw_ascii) // Raw ASCII (space-separated).
         stringType = "raw ASCII formatted data";


### PR DESCRIPTION
This PR is related to the fix of using higher/latest version of armadillo dependency. The azure pipeline macOS instances which are currently using the latest armadillo (`armadillo-9.850.1_1.high_sierra.bottle.tar.gz`) throws a warning

`2020-03-11T07:33:38.0368220Z /Users/runner/runners/2.165.0/work/1/s/src/mlpack/core/data/load_impl.hpp:116:30: warning: 'guess_file_type' is deprecated [-Wdeprecated-declarations]
2020-03-11T07:33:38.0368970Z     loadType = arma::diskio::guess_file_type(stream);
2020-03-11T07:33:38.0369280Z                              ^
2020-03-11T07:33:38.0370320Z /usr/local/include/armadillo_bits/diskio_meat.hpp:216:1: note: 'guess_file_type' has been explicitly marked deprecated here`.

And in armadillo-9.850.1, `diskio_meat.hpp` declared 2 functions as `arma-deprecated`, [here](https://fossies.org/linux/armadillo/include/armadillo_bits/diskio_meat.hpp)

1. arma::diskio::guess_file_type(): it has been modified to `guess_file_type_internal()`.

2. arma::diskio::convert_naninf(): Not an issue since mlpack is using its own customized version `mlpack/src/mlpack/core/data/is_naninf.hpp`

I think this can be helpful if the core team thinks of changing dependency requirement (from armadillo 8.4.0) for linux and windows too in near future.
Thanks.