### PR TITLE
Naive method open mp

### DIFF
--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -39,8 +39,7 @@ class GiniGain
       return 0.0;
 
     CountType impurity = 0.0;
-    #pragma omp parallel for reduction(+:impurity)
-    for (omp_size_t i = 0; i < countLength; ++i)
+    for (size_t i = 0; i < countLength; ++i)
       impurity += counts[i] * (totalCount - counts[i]);
 
     return -((double) impurity / ((double) std::pow(totalCount, 2)));
@@ -59,7 +58,7 @@ class GiniGain
    * @param numClasses Number of classes in the dataset.
    * @param weights Weight of labels.
    */
-template<bool UseWeights, typename RowType, typename WeightVecType>
+  template<bool UseWeights, typename RowType, typename WeightVecType>
   static double Evaluate(const RowType& labels,
                          const size_t numClasses,
                          const WeightVecType& weights)
@@ -89,21 +88,17 @@ template<bool UseWeights, typename RowType, typename WeightVecType>
 
       // SIMD loop: add counts for four elements simultaneously (if the compiler
       // manages to vectorize the loop).
-      #pragma omp parallel for reduction (+:accWeights)
-      for (omp_size_t i = 3; i < labels.n_elem; i += 4)
+      for (size_t i = 3; i < labels.n_elem; i += 4)
       {
         const double weight1 = weights[i - 3];
         const double weight2 = weights[i - 2];
         const double weight3 = weights[i - 1];
         const double weight4 = weights[i];
 
-        #pragma omp critical
-        {
         counts[labels[i - 3]] += weight1;
         counts2[labels[i - 2]] += weight2;
         counts3[labels[i - 1]] += weight3;
         counts4[labels[i]] += weight4;
-        }
 
         accWeights[0] += weight1;
         accWeights[1] += weight2;
@@ -161,7 +156,6 @@ template<bool UseWeights, typename RowType, typename WeightVecType>
     {
       // SIMD loop: add counts for four elements simultaneously (if the compiler
       // manages to vectorize the loop).
-
       for (size_t i = 3; i < labels.n_elem; i += 4)
       {
         counts[labels[i - 3]]++;
@@ -199,7 +193,6 @@ template<bool UseWeights, typename RowType, typename WeightVecType>
     return -impurity;
   }
 
-
   /**
    * Return the range of the Gini impurity for the given number of classes.
    * (That is, the difference between the maximum possible value and the minimum
@@ -220,4 +213,3 @@ template<bool UseWeights, typename RowType, typename WeightVecType>
 } // namespace mlpack
 
 #endif
-

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -97,13 +97,13 @@ class GiniGain
         const double weight3 = weights[i - 1];
         const double weight4 = weights[i];
 
-        #pragma omp atomic
+        // #pragma omp atomic
         counts[labels[i - 3]] += weight1;
-        #pragma omp atomic
+        // #pragma omp atomic
         counts2[labels[i - 2]] += weight2;
-        #pragma omp atomic
+        // #pragma omp atomic
         counts3[labels[i - 1]] += weight3;
-        #pragma omp atomic
+        // #pragma omp atomic
         counts4[labels[i]] += weight4;
         // cannot add any counts in reduction as it shows some error.
 

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -157,7 +157,7 @@ class GiniGain
       // Catch edge case: if there are no weights, the impurity is zero.
       if (accWeights[0] == 0.0)
         return 0.0;
-      //can parallelize
+      #pragma omp parallel for reduction(+:impurity)
       for (size_t i = 0; i < numClasses; ++i)
       {
         const double f = ((double) counts[i] / (double) accWeights[0]);
@@ -168,7 +168,6 @@ class GiniGain
     {
       // SIMD loop: add counts for four elements simultaneously (if the compiler
       // manages to vectorize the loop).
-      //can parallelize
       //#pragma omp parallel for reduction (+:counts) 
       for (size_t i = 3; i < labels.n_elem; i += 4)
       {
@@ -197,6 +196,7 @@ class GiniGain
 
       counts += counts2 + counts3 + counts4;
       //can parallelize
+      #pragma omp parallel for reduction(+:impurity)
       for (size_t i = 0; i < numClasses; ++i)
       {
         const double f = ((double) counts[i] / (double) labels.n_elem);

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -163,7 +163,7 @@ class GiniGain
     {
       // SIMD loop: add counts for four elements simultaneously (if the compiler
       // manages to vectorize the loop).
-      // #pragma omp parallel for reduction (+:counts) 
+      // #pragma omp parallel for reduction (+:counts)
       for (size_t i = 3; i < labels.n_elem; i += 4)
       {
         counts[labels[i - 3]]++;

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -103,8 +103,8 @@ template<bool UseWeights, typename RowType, typename WeightVecType>
         counts2[labels[i - 2]] += weight2;
         counts3[labels[i - 1]] += weight3;
         counts4[labels[i]] += weight4;
-    	}
-        
+        }
+
         accWeights[0] += weight1;
         accWeights[1] += weight2;
         accWeights[2] += weight3;

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -111,21 +111,32 @@ class GiniGain
         // accWeights[1] += weight2;
         // accWeights[2] += weight3;
         // accWeights[3] += weight4;
-        if(i%4==0)
+        switch(i%4){
+          case 0:
+          {
           #pragma omp atomic
-          counts[labels[i]] += weight1;
-        else if(i%4==1)
-          #pragma omp atomic
-          counts2[labels[i]] += weight1;
-        else if(i%4==2)
-          #pragma omp atomic
-          counts3[labels[i]] += weight1;
-        else if(i%4==3)
-          #pragma omp atomic
-          counts4[labels[i]] += weight1;
-        
-        
-        
+            counts[labels[i]] += weight1;
+            break;
+          }
+          case 1:
+          {
+            #pragma omp atomic
+            counts2[labels[i]] += weight1;
+            break;
+          }
+          case 2:
+          {
+            #pragma omp atomic
+            counts3[labels[i]] += weight1;
+            break;
+          }
+          case 3:
+          {
+            #pragma omp atomic
+            counts4[labels[i]] += weight1;
+            break;
+          }
+        }
       }
       /*
       // Handle leftovers.

--- a/src/mlpack/methods/decision_tree/gini_gain.hpp
+++ b/src/mlpack/methods/decision_tree/gini_gain.hpp
@@ -39,7 +39,6 @@ class GiniGain
       return 0.0;
 
     CountType impurity = 0.0;
-    
     #pragma omp parallel for reduction(+:impurity)
     for (size_t i = 0; i < countLength; ++i)
       impurity += counts[i] * (totalCount - counts[i]);
@@ -90,7 +89,7 @@ class GiniGain
 
       // SIMD loop: add counts for four elements simultaneously (if the compiler
       // manages to vectorize the loop).
-      #pragma omp parallel for reduction (+:accWeights)
+      // #pragma omp parallel for reduction (+:accWeights)
       for (size_t i = 3; i < labels.n_elem; i += 4)
       {
         const double weight1 = weights[i - 3];
@@ -101,17 +100,13 @@ class GiniGain
         #pragma omp atomic
         counts[labels[i - 3]] += weight1;
         #pragma omp atomic
-        
         counts2[labels[i - 2]] += weight2;
         #pragma omp atomic
-        
         counts3[labels[i - 1]] += weight3;
         #pragma omp atomic
-        
         counts4[labels[i]] += weight4;
-        //cannot add any counts in reduction as it shows some error.
-        
-        
+        // cannot add any counts in reduction as it shows some error.
+
         accWeights[0] += weight1;
         accWeights[1] += weight2;
         accWeights[2] += weight3;
@@ -168,7 +163,7 @@ class GiniGain
     {
       // SIMD loop: add counts for four elements simultaneously (if the compiler
       // manages to vectorize the loop).
-      //#pragma omp parallel for reduction (+:counts) 
+      // #pragma omp parallel for reduction (+:counts) 
       for (size_t i = 3; i < labels.n_elem; i += 4)
       {
         counts[labels[i - 3]]++;
@@ -195,7 +190,7 @@ class GiniGain
       }
 
       counts += counts2 + counts3 + counts4;
-      //can parallelize
+      // can parallelize
       #pragma omp parallel for reduction(+:impurity)
       for (size_t i = 0; i < numClasses; ++i)
       {

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -55,16 +55,11 @@ class NaiveKernelRule
       // Evaluate the kernel on these two points.
       kernelMatrix(i, j) = kernel.Evaluate(data.unsafe_col(i),
                                            data.unsafe_col(j));
-      kernelMatrix(j-i,i) = kernelMatrix(i, j);
+      kernelMatrix(j-i,i) = kernelMatrix(i, j);   // Copy to the lower triangular part of the matrix.
     }
   }
 
-  // Copy to the lower triangular part of the matrix.
-  /*
-  for (size_t i = 1; i < data.n_cols; ++i)
-    for (size_t j = 0; j < i; ++j)
-      kernelMatrix(i, j) = kernelMatrix(j, i);
-  */
+
 
   // For PCA the data has to be centered, even if the data is centered. But it
   // is not guaranteed that the data, when mapped to the kernel space, is also
@@ -81,9 +76,9 @@ class NaiveKernelRule
 
   // Swap the eigenvalues since they are ordered backwards (we need largest to
   // smallest).
-  omp_size_t varForOpenmp = floor(eigval.n_elem / 2.0);
+  omp_size_t num_eigenvals = floor(eigval.n_elem / 2.0);
   #pragma omp parallel for
-  for (omp_size_t i = 0; i < varForOpenmp ; i++)
+  for (omp_size_t i = 0; i < num_eigenvals ; i++)
     eigval.swap_rows(i, (eigval.n_elem - 1) - i);
 
   // Flip the coefficients to produce the same effect.

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -55,7 +55,7 @@ class NaiveKernelRule
       // Evaluate the kernel on these two points.
       kernelMatrix(i, j) = kernel.Evaluate(data.unsafe_col(i),
                                            data.unsafe_col(j));
-      kernelMatrix(j,i) = kernelMatrix(i, j);
+      kernelMatrix(j, i) = kernelMatrix(i, j);
       // Copy to the lower triangular part of the matrix.
     }
   }
@@ -94,4 +94,3 @@ class NaiveKernelRule
 } // namespace mlpack
 
 #endif
-

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -55,7 +55,8 @@ class NaiveKernelRule
       // Evaluate the kernel on these two points.
       kernelMatrix(i, j) = kernel.Evaluate(data.unsafe_col(i),
                                            data.unsafe_col(j));
-      kernelMatrix(j-i,i) = kernelMatrix(i, j);   // Copy to the lower triangular part of the matrix.
+      kernelMatrix(j,i) = kernelMatrix(i, j);
+      // Copy to the lower triangular part of the matrix.
     }
   }
 

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -47,24 +47,20 @@ class NaiveKernelRule
   // Note that we only need to calculate the upper triangular part of the
   // kernel matrix, since it is symmetric. This helps minimize the number of
   // kernel evaluations.
-  #pragma omp parallel for
-  for (omp_size_t i = 0; i < data.n_cols; ++i)
+  for (size_t i = 0; i < data.n_cols; ++i)
   {
     for (size_t j = i; j < data.n_cols; ++j)
     {
       // Evaluate the kernel on these two points.
       kernelMatrix(i, j) = kernel.Evaluate(data.unsafe_col(i),
                                            data.unsafe_col(j));
-      kernelMatrix(j-i,i) = kernelMatrix(i, j);
     }
   }
 
   // Copy to the lower triangular part of the matrix.
-  /*
   for (size_t i = 1; i < data.n_cols; ++i)
     for (size_t j = 0; j < i; ++j)
       kernelMatrix(i, j) = kernelMatrix(j, i);
-  */
 
   // For PCA the data has to be centered, even if the data is centered. But it
   // is not guaranteed that the data, when mapped to the kernel space, is also
@@ -81,9 +77,7 @@ class NaiveKernelRule
 
   // Swap the eigenvalues since they are ordered backwards (we need largest to
   // smallest).
-  omp_size_t varForOpenmp = floor(eigval.n_elem / 2.0);
-  #pragma omp parallel for
-  for (omp_size_t i = 0; i < varForOpenmp ; i++)
+  for (size_t i = 0; i < floor(eigval.n_elem / 2.0); ++i)
     eigval.swap_rows(i, (eigval.n_elem - 1) - i);
 
   // Flip the coefficients to produce the same effect.
@@ -98,4 +92,3 @@ class NaiveKernelRule
 } // namespace mlpack
 
 #endif
-


### PR DESCRIPTION
Updated NaiveMethod with openmp.

Serial 

```
 Performance counter stats for './a.out':

          5,503.51 msec task-clock                #    1.000 CPUs utilized          
                17      context-switches          #    0.003 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
            14,320      page-faults               #    0.003 M/sec                  
   17,00,99,78,994      cycles                    #    3.091 GHz                    
   34,69,96,64,023      instructions              #    2.04  insn per cycle         
    5,02,09,92,263      branches                  #  912.325 M/sec                  
         80,49,745      branch-misses             #    0.16% of all branches        

       5.504686467 seconds time elapsed


```

Parallel

```
 Performance counter stats for './a.out':

          5,734.69 msec task-clock                #    1.059 CPUs utilized          
                56      context-switches          #    0.010 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
            14,352      page-faults               #    0.003 M/sec                  
   17,40,57,71,386      cycles                    #    3.035 GHz                    
   33,86,87,45,017      instructions              #    1.95  insn per cycle         
    4,90,54,37,375      branches                  #  855.397 M/sec                  
         78,10,430      branch-misses             #    0.16% of all branches        

       5.414346690 seconds time elapsed

```
Speed Up of 6% for 1200 data-samples.

Other hot-spots in the code 
1)arma::eig_sym()
2)Evaluate() as i cannot find source code. 