### PR TITLE
Temporary solution to issue #2310

### DIFF
--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -41,7 +41,7 @@ FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::FFN(
     numFunctions(0),
     deterministic(true)
 {
-  /* Nothing to do here. */
+  Add<IdentityLayer<>>();
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,


### PR DESCRIPTION
I noticed that if `IdentityLayer<>` is added before all layers then `Convolution<>` layers doesn't cause `Segmentation Fault( core dumped)` when around 64 or more output maps are used. 

So this is a temporary solution to the problem. Since making big models requires huge number of output maps in `Convolution<>` layers, I felt it'll be a useful addition. Also I think it is harmless and won't really cause any real performance drop.

Let me know what you think.