### PR TITLE
Memory leak and invalid use fixes

### DIFF
--- a/src/mlpack/core/arma_extend/Cube_extra_meat.hpp
+++ b/src/mlpack/core/arma_extend/Cube_extra_meat.hpp
@@ -19,6 +19,9 @@ void Cube<eT>::serialize(Archive& ar, const unsigned int /* version */)
   // mem_state will always be 0 on load, so we don't need to save it.
   if (Archive::is_loading::value)
   {
+    // Clean any mat pointers.
+    delete_mat();
+
     // Don't free if local memory is being used.
     if (mem_state == 0 && mem != NULL && old_n_elem > arma_config::mat_prealloc)
     {

--- a/src/mlpack/core/data/scaler_methods/zca_whitening.hpp
+++ b/src/mlpack/core/data/scaler_methods/zca_whitening.hpp
@@ -52,10 +52,7 @@ class ZCAWhitening
    *
    * @param eps Regularization parameter.
    */
-  ZCAWhitening(double eps = 0.00005)
-  {
-    pca = new data::PCAWhitening(eps);
-  }
+  ZCAWhitening(double eps = 0.00005) : pca(eps) { }
 
   /**
    * Function to fit features, to find out the min max and scale.
@@ -65,7 +62,7 @@ class ZCAWhitening
   template<typename MatType>
   void Fit(const MatType& input)
   {
-    pca->Fit(input);
+    pca.Fit(input);
   }
 
   /**
@@ -77,8 +74,8 @@ class ZCAWhitening
   template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
-    pca->Transform(input, output);
-    output = pca->EigenVectors() * output;
+    pca.Transform(input, output);
+    output = pca.EigenVectors() * output;
   }
 
   /**
@@ -90,19 +87,19 @@ class ZCAWhitening
   template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
-    output = inv(pca->EigenVectors()) * arma::diagmat(arma::sqrt(
-        pca->EigenValues())) * inv(pca->EigenVectors().t()) * input;
-    output = (output.each_col() + pca->ItemMean());
+    output = inv(pca.EigenVectors()) * arma::diagmat(arma::sqrt(
+        pca.EigenValues())) * inv(pca.EigenVectors().t()) * input;
+    output = (output.each_col() + pca.ItemMean());
   }
 
   //! Get the mean row vector.
-  const arma::vec& ItemMean() const { return pca->ItemMean(); }
+  const arma::vec& ItemMean() const { return pca.ItemMean(); }
   //! Get the eigenvalues vector.
-  const arma::vec& EigenValues() const { return pca->EigenValues(); }
+  const arma::vec& EigenValues() const { return pca.EigenValues(); }
   //! Get the eigenvector.
-  const arma::mat& EigenVectors() const { return pca->EigenVectors(); }
+  const arma::mat& EigenVectors() const { return pca.EigenVectors(); }
   //! Get the regularization parameter.
-  double Epsilon() const { return pca->Epsilon(); }
+  double Epsilon() const { return pca.Epsilon(); }
 
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */)
@@ -112,7 +109,7 @@ class ZCAWhitening
 
  private:
   // A pointer to PcaWhitening Class.
-  PCAWhitening* pca;
+  PCAWhitening pca;
 }; // class ZCAWhitening
 
 } // namespace data

--- a/src/mlpack/core/metrics/ip_metric_impl.hpp
+++ b/src/mlpack/core/metrics/ip_metric_impl.hpp
@@ -49,7 +49,7 @@ IPMetric<KernelType>::~IPMetric()
 
 template<typename KernelType>
 IPMetric<KernelType>::IPMetric(const IPMetric& other) :
-  kernel(other.kernel),
+  kernel(!other.kernelOwner ? other.kernel : new KernelType(*other.kernel)),
   kernelOwner(other.kernelOwner)
 {
   // Nothing to do.
@@ -90,7 +90,11 @@ void IPMetric<KernelType>::serialize(Archive& ar,
   // If we're loading, we need to allocate space for the kernel, and we will own
   // the kernel.
   if (Archive::is_loading::value)
+  {
+    if (kernelOwner)
+      delete kernel;
     kernelOwner = true;
+  }
 
   ar & BOOST_SERIALIZATION_NVP(kernel);
 }

--- a/src/mlpack/core/tree/hollow_ball_bound_impl.hpp
+++ b/src/mlpack/core/tree/hollow_ball_bound_impl.hpp
@@ -80,6 +80,9 @@ template<typename TMetricType, typename ElemType>
 HollowBallBound<TMetricType, ElemType>& HollowBallBound<TMetricType, ElemType>::
 operator=(const HollowBallBound& other)
 {
+  if (ownsMetric)
+    delete metric;
+
   radii = other.radii;
   center = other.center;
   hollowCenter = other.hollowCenter;

--- a/src/mlpack/methods/ann/brnn.hpp
+++ b/src/mlpack/methods/ann/brnn.hpp
@@ -73,9 +73,11 @@ class BRNN
   BRNN(const size_t rho,
        const bool single = false,
        OutputLayerType outputLayer = OutputLayerType(),
-       MergeLayerType mergeLayer = MergeLayerType(),
-       MergeOutputType mergeOutput = MergeOutputType(),
+       MergeLayerType* mergeLayer = new MergeLayerType(),
+       MergeOutputType* mergeOutput = new MergeOutputType(),
        InitializationRuleType initializeRule = InitializationRuleType());
+
+  ~BRNN();
 
   /**
    * Check if the optimizer has MaxIterations() parameter, if it does

--- a/src/mlpack/methods/ann/brnn_impl.hpp
+++ b/src/mlpack/methods/ann/brnn_impl.hpp
@@ -39,13 +39,13 @@ BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     const size_t rho,
     const bool single,
     OutputLayerType outputLayer,
-    MergeLayerType mergeLayer,
-    MergeOutputType mergeOutput,
+    MergeLayerType* mergeLayer,
+    MergeOutputType* mergeOutput,
     InitializationRuleType initializeRule) :
     rho(rho),
     outputLayer(std::move(outputLayer)),
-    mergeLayer(new MergeLayerType(mergeLayer)),
-    mergeOutput(new MergeOutputType(mergeOutput)),
+    mergeLayer(mergeLayer),
+    mergeOutput(mergeOutput),
     initializeRule(std::move(initializeRule)),
     inputSize(0),
     outputSize(0),
@@ -58,6 +58,22 @@ BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     backwardRNN(rho, single, outputLayer, initializeRule)
 {
   /* Nothing to do here. */
+}
+
+template<typename OutputLayerType, typename MergeLayerType,
+         typename MergeOutputType, typename InitializationRuleType,
+         typename... CustomLayers>
+BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
+    InitializationRuleType, CustomLayers...>::~BRNN()
+{
+  // Remove mergeLayer from the forward and backward RNNs so it doesn't get
+  // deleted.  This assumes that mergeLayer is the last layer!
+  forwardRNN.network.pop_back();
+  backwardRNN.network.pop_back();
+
+  // Clean up layers that we allocated.
+  boost::apply_visitor(DeleteVisitor(), mergeLayer);
+  boost::apply_visitor(DeleteVisitor(), mergeOutput);
 }
 
 template<typename OutputLayerType, typename MergeLayerType,
@@ -230,7 +246,7 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
       boost::apply_visitor(LoadOutputParameterVisitor(results2),
           backwardRNN.network.back());
 
-      boost::apply_visitor(ForwardVisitor(std::move(input),
+      boost::apply_visitor(ForwardVisitor(input,
           boost::apply_visitor(outputParameterVisitor, mergeLayer)),
           mergeLayer);
       boost::apply_visitor(ForwardVisitor(
@@ -318,15 +334,15 @@ double BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     boost::apply_visitor(LoadOutputParameterVisitor(results2),
         backwardRNN.network.back());
 
-    boost::apply_visitor(ForwardVisitor(std::move(input),
+    boost::apply_visitor(ForwardVisitor(input,
         boost::apply_visitor(outputParameterVisitor, mergeLayer)),
         mergeLayer);
     boost::apply_visitor(ForwardVisitor(
         boost::apply_visitor(outputParameterVisitor, mergeLayer),
         boost::apply_visitor(outputParameterVisitor, mergeOutput)),
         mergeOutput);
-    performance += outputLayer.Forward(std::move(
-        boost::apply_visitor(outputParameterVisitor, mergeOutput)),
+    performance += outputLayer.Forward(
+        boost::apply_visitor(outputParameterVisitor, mergeOutput),
         arma::mat(responses.slice(responseSeq).colptr(begin),
         responses.n_rows, batchSize, false, true));
   }
@@ -634,6 +650,8 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
 {
   if (!reset)
   {
+    // TODO: what if we call ResetParameters() multiple times?  Do we have to
+    // remove any existing mergeLayer?
     boost::apply_visitor(AddVisitor<CustomLayers...>(
         forwardRNN.network.back()), mergeLayer);
     boost::apply_visitor(AddVisitor<CustomLayers...>(
@@ -707,6 +725,8 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
   ar & BOOST_SERIALIZATION_NVP(parameter);
   ar & BOOST_SERIALIZATION_NVP(backwardRNN);
   ar & BOOST_SERIALIZATION_NVP(forwardRNN);
+
+  // TODO: are there more parameters to be serialized?
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/brnn_impl.hpp
+++ b/src/mlpack/methods/ann/brnn_impl.hpp
@@ -66,8 +66,9 @@ template<typename OutputLayerType, typename MergeLayerType,
 BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     InitializationRuleType, CustomLayers...>::~BRNN()
 {
-  // Remove mergeLayer from the forward and backward RNNs so it doesn't get
-  // deleted.  This assumes that mergeLayer is the last layer!
+  // Remove the last layers from the forward and backward RNNs, as they are held
+  // in mergeLayer.  So, when we use DeleteVisitor with mergeLayer, those two
+  // layers will be properly (and not doubly) freed.
   forwardRNN.network.pop_back();
   backwardRNN.network.pop_back();
 

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -96,7 +96,8 @@ typename std::enable_if<
       !HasMaxIterations<OptimizerType, size_t&(OptimizerType::*)()>
       ::value, void>::type
 FFN<OutputLayerType, InitializationRuleType, CustomLayers...>::
-WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const
+WarnMessageMaxIterations(OptimizerType& /* optimizer */, size_t /* samples */)
+    const
 {
   return;
 }

--- a/src/mlpack/methods/ann/layer/add_merge.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge.hpp
@@ -50,6 +50,15 @@ class AddMerge
    */
   AddMerge(const bool model = false, const bool run = true);
 
+  /**
+   * Create the AddMerge object using the specified parameters.
+   *
+   * @param model Expose all the network modules.
+   * @param run Call the Forward/Backward method before the output is merged.
+   * @param ownsLayers Delete the layers when this is deallocated.
+   */
+  AddMerge(const bool model, const bool run, const bool ownsLayers);
+
   //! Destructor to release allocated memory.
   ~AddMerge();
 
@@ -184,8 +193,9 @@ class AddMerge
   //! before merging the output.
   bool run;
 
-  //! We need this to know whether we should delete the layer in the destructor.
-  bool ownsLayer;
+  //! We need this to know whether we should delete the internally-held layers
+  //! in the destructor.
+  bool ownsLayers;
 
   //! Locally-stored network modules.
   std::vector<LayerTypes<CustomLayers...> > network;

--- a/src/mlpack/methods/ann/layer/add_merge.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge.hpp
@@ -231,6 +231,24 @@ class AddMerge
 } // namespace ann
 } // namespace mlpack
 
+//! Set the serialization version of the AddMerge class.
+namespace boost {
+namespace serialization {
+
+template<
+    typename InputDataType,
+    typename OutputDataType,
+    typename... CustomLayers
+>
+struct version<mlpack::ann::AddMerge<
+    InputDataType, OutputDataType, CustomLayers...>>
+{
+  BOOST_STATIC_CONSTANT(int, value = 1);
+}
+
+} // namespace serialization
+} // namespace boost
+
 // Include implementation.
 #include "add_merge_impl.hpp"
 

--- a/src/mlpack/methods/ann/layer/add_merge.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge.hpp
@@ -244,7 +244,7 @@ struct version<mlpack::ann::AddMerge<
     InputDataType, OutputDataType, CustomLayers...>>
 {
   BOOST_STATIC_CONSTANT(int, value = 1);
-}
+};
 
 } // namespace serialization
 } // namespace boost

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -150,7 +150,7 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 template<typename Archive>
 void AddMerge<InputDataType, OutputDataType, CustomLayers...>::serialize(
-    Archive& ar, const unsigned int /* version */)
+    Archive& ar, const unsigned int version)
 {
   // Be sure to clear other layers before loading.
   if (Archive::is_loading::value)

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -27,7 +27,16 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 AddMerge<InputDataType, OutputDataType, CustomLayers...>::AddMerge(
     const bool model, const bool run) :
-    model(model), run(run), ownsLayer(!model)
+    model(model), run(run), ownsLayers(!model)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType,
+         typename... CustomLayers>
+AddMerge<InputDataType, OutputDataType, CustomLayers...>::AddMerge(
+    const bool model, const bool run, const bool ownsLayers) :
+    model(model), run(run), ownsLayers(ownsLayers)
 {
   // Nothing to do here.
 }
@@ -36,7 +45,7 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 AddMerge<InputDataType, OutputDataType, CustomLayers...>::~AddMerge()
 {
-  if (ownsLayer)
+  if (!model && ownsLayers)
   {
     std::for_each(network.begin(), network.end(),
         boost::apply_visitor(deleteVisitor));
@@ -150,7 +159,7 @@ void AddMerge<InputDataType, OutputDataType, CustomLayers...>::serialize(
   ar & BOOST_SERIALIZATION_NVP(network);
   ar & BOOST_SERIALIZATION_NVP(model);
   ar & BOOST_SERIALIZATION_NVP(run);
-  ar & BOOST_SERIALIZATION_NVP(ownsLayer);
+  ar & BOOST_SERIALIZATION_NVP(ownsLayers);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -159,7 +159,15 @@ void AddMerge<InputDataType, OutputDataType, CustomLayers...>::serialize(
   ar & BOOST_SERIALIZATION_NVP(network);
   ar & BOOST_SERIALIZATION_NVP(model);
   ar & BOOST_SERIALIZATION_NVP(run);
-  ar & BOOST_SERIALIZATION_NVP(ownsLayers);
+
+  if (version >= 1)
+  {
+    ar & BOOST_SERIALIZATION_NVP(ownsLayers);
+  }
+  else if (Archive::is_loading::value)
+  {
+    ownsLayers = !model;
+  }
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/add_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge_impl.hpp
@@ -161,13 +161,9 @@ void AddMerge<InputDataType, OutputDataType, CustomLayers...>::serialize(
   ar & BOOST_SERIALIZATION_NVP(run);
 
   if (version >= 1)
-  {
     ar & BOOST_SERIALIZATION_NVP(ownsLayers);
-  }
   else if (Archive::is_loading::value)
-  {
     ownsLayers = !model;
-  }
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/atrous_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution.hpp
@@ -365,9 +365,6 @@ class AtrousConvolution
   //! Locally-stored transformed output parameter.
   arma::cube outputTemp;
 
-  //! Locally-stored transformed input parameter.
-  arma::cube inputTemp;
-
   //! Locally-stored transformed padded input parameter.
   arma::cube inputPaddedTemp;
 

--- a/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
@@ -187,7 +187,7 @@ void AtrousConvolution<
 >::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
+  arma::cube inputTemp(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (padding.PadWLeft() != 0 || padding.PadWRight() != 0 ||
@@ -271,9 +271,9 @@ void AtrousConvolution<
   arma::cube mappedError(((arma::Mat<eT>&) gy).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 
-  g.set_size(inputTemp.n_rows * inputTemp.n_cols * inSize, batchSize);
-  gTemp = arma::Cube<eT>(g.memptr(), inputTemp.n_rows,
-      inputTemp.n_cols, inputTemp.n_slices, false, false);
+  g.set_size(inputWidth * inputHeight * inSize, batchSize);
+  gTemp = arma::Cube<eT>(g.memptr(), inputWidth, inputHeight,
+      inSize * batchSize, false, false);
   gTemp.zeros();
 
   for (size_t outMap = 0, outMapIdx = 0, batchCount = 0; outMap <
@@ -325,12 +325,14 @@ void AtrousConvolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& input,
     const arma::Mat<eT>& error,
     arma::Mat<eT>& gradient)
 {
   arma::cube mappedError(((arma::Mat<eT>&) error).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
+  arma::cube inputTemp(const_cast<arma::Mat<eT>&>(input).memptr(),
+      inputWidth, inputHeight, inSize * batchSize, false, false);
 
   gradient.set_size(weights.n_elem, 1);
   gradientTemp = arma::Cube<eT>(gradient.memptr(), weight.n_rows,

--- a/src/mlpack/methods/ann/layer/concat_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_impl.hpp
@@ -90,9 +90,12 @@ template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
 Concat<InputDataType, OutputDataType, CustomLayers...>::~Concat()
 {
-  // Clear memory.
-  std::for_each(network.begin(), network.end(),
-      boost::apply_visitor(deleteVisitor));
+  if (!model)
+  {
+    // Clear memory.
+    std::for_each(network.begin(), network.end(),
+        boost::apply_visitor(deleteVisitor));
+  }
 }
 
 template<typename InputDataType, typename OutputDataType,

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -362,9 +362,6 @@ class Convolution
   //! Locally-stored transformed output parameter.
   arma::cube outputTemp;
 
-  //! Locally-stored transformed input parameter.
-  arma::cube inputTemp;
-
   //! Locally-stored transformed padded input parameter.
   arma::cube inputPaddedTemp;
 

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -178,7 +178,7 @@ void Convolution<
 >::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
+  arma::cube inputTemp(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0)
@@ -258,9 +258,9 @@ void Convolution<
   arma::cube mappedError(((arma::Mat<eT>&) gy).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
 
-  g.set_size(inputTemp.n_rows * inputTemp.n_cols * inSize, batchSize);
-  gTemp = arma::Cube<eT>(g.memptr(), inputTemp.n_rows,
-      inputTemp.n_cols, inputTemp.n_slices, false, false);
+  g.set_size(inputWidth * inputHeight * inSize, batchSize);
+  gTemp = arma::Cube<eT>(g.memptr(), inputWidth, inputHeight,
+      inSize * batchSize, false, false);
   gTemp.zeros();
 
   for (size_t outMap = 0, outMapIdx = 0, batchCount = 0; outMap <
@@ -308,12 +308,14 @@ void Convolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& input,
     const arma::Mat<eT>& error,
     arma::Mat<eT>& gradient)
 {
   arma::cube mappedError(((arma::Mat<eT>&) error).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
+  arma::cube inputTemp(((arma::Mat<eT>&) input).memptr(), inputWidth,
+      inputHeight, inSize * batchSize, false, false);
 
   gradient.set_size(weights.n_elem, 1);
   gradientTemp = arma::Cube<eT>(gradient.memptr(), weight.n_rows,

--- a/src/mlpack/methods/ann/layer/dropconnect.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect.hpp
@@ -78,14 +78,12 @@ class DropConnect
               const size_t outSize,
               const double ratio = 0.5);
 
-  ~DropConnect();
-
   /**
-  * Ordinary feed forward pass of the DropConnect layer.
-  *
-  * @param input Input data used for evaluating the specified function.
-  * @param output Resulting output activation.
-  */
+   * Ordinary feed forward pass of the DropConnect layer.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param output Resulting output activation.
+   */
   template<typename eT>
   void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
 

--- a/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect_impl.hpp
@@ -48,12 +48,6 @@ DropConnect<InputDataType, OutputDataType>::DropConnect(
   network.push_back(baseLayer);
 }
 
-template <typename InputDataType, typename OutputDataType>
-DropConnect<InputDataType, OutputDataType>::~DropConnect()
-{
-  boost::apply_visitor(DeleteVisitor(), baseLayer);
-}
-
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void DropConnect<InputDataType, OutputDataType>::Forward(

--- a/src/mlpack/methods/ann/layer/gru.hpp
+++ b/src/mlpack/methods/ann/layer/gru.hpp
@@ -73,11 +73,6 @@ class GRU
       const size_t rho = std::numeric_limits<size_t>::max());
 
   /**
-   * Delete the GRU and the layers it holds.
-   */
-  ~GRU();
-
-  /**
    * Ordinary feed forward pass of a neural network, evaluating the function
    * f(x) by propagating the activity forward through f.
    *

--- a/src/mlpack/methods/ann/layer/gru_impl.hpp
+++ b/src/mlpack/methods/ann/layer/gru_impl.hpp
@@ -77,17 +77,6 @@ GRU<InputDataType, OutputDataType>::GRU(
 }
 
 template<typename InputDataType, typename OutputDataType>
-GRU<InputDataType, OutputDataType>::~GRU()
-{
-  boost::apply_visitor(deleteVisitor, input2GateModule);
-  boost::apply_visitor(deleteVisitor, output2GateModule);
-  boost::apply_visitor(deleteVisitor, outputHidden2GateModule);
-  boost::apply_visitor(deleteVisitor, inputGateModule);
-  boost::apply_visitor(deleteVisitor, forgetGateModule);
-  boost::apply_visitor(deleteVisitor, hiddenStateModule);
-}
-
-template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void GRU<InputDataType, OutputDataType>::Forward(
     const arma::Mat<eT>& input, arma::Mat<eT>& output)

--- a/src/mlpack/methods/ann/layer/highway.hpp
+++ b/src/mlpack/methods/ann/layer/highway.hpp
@@ -75,11 +75,6 @@ class Highway
   ~Highway();
 
   /**
-   * Destroy all the modules added to the Highway object.
-   */
-  void DeleteModules();
-
-  /**
    * Reset the layer parameter.
    */
   void Reset();
@@ -126,14 +121,22 @@ class Highway
    * @param args The layer parameter.
    */
   template <class LayerType, class... Args>
-  void Add(Args... args) { network.push_back(new LayerType(args...)); }
+  void Add(Args... args)
+  {
+    network.push_back(new LayerType(args...));
+    networkOwnerships.push_back(true);
+  }
 
   /**
    * Add a new module to the model.
    *
    * @param layer The Layer to be added to the model.
    */
-  void Add(LayerTypes<CustomLayers...> layer) { network.push_back(layer); }
+  void Add(LayerTypes<CustomLayers...> layer)
+  {
+    network.push_back(layer);
+    networkOwnerships.push_back(false);
+  }
 
   //! Return the modules of the model.
   std::vector<LayerTypes<CustomLayers...> >& Model()
@@ -189,6 +192,9 @@ class Highway
 
   //! Locally-stored network modules.
   std::vector<LayerTypes<CustomLayers...> > network;
+
+  //! The list of network modules we are responsible for.
+  std::vector<bool> networkOwnerships;
 
   //! Locally-stored empty list of modules.
   std::vector<LayerTypes<CustomLayers...> > empty;

--- a/src/mlpack/methods/ann/layer/highway_impl.hpp
+++ b/src/mlpack/methods/ann/layer/highway_impl.hpp
@@ -57,23 +57,10 @@ Highway<InputDataType, OutputDataType, CustomLayers...>::~Highway()
 {
   if (!model)
   {
-    for (LayerTypes<CustomLayers...>& layer : network)
+    for (size_t i = 0; i < network.size(); ++i)
     {
-      boost::apply_visitor(deleteVisitor, layer);
-    }
-  }
-}
-
-template<typename InputDataType, typename OutputDataType,
-         typename... CustomLayers>
-void Highway<
-    InputDataType, OutputDataType, CustomLayers...>::DeleteModules()
-{
-  if (model)
-  {
-    for (LayerTypes<CustomLayers...>& layer : network)
-    {
-      boost::apply_visitor(deleteVisitor, layer);
+      if (networkOwnerships[i])
+        boost::apply_visitor(deleteVisitor, network[i]);
     }
   }
 }

--- a/src/mlpack/methods/ann/layer/recurrent.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent.hpp
@@ -50,9 +50,6 @@ class Recurrent
    */
   Recurrent();
 
-  //! Destructor to release allocated memory.
-  ~Recurrent();
-
   //! Copy constructor.
   Recurrent(const Recurrent&);
 

--- a/src/mlpack/methods/ann/layer/recurrent_impl.hpp
+++ b/src/mlpack/methods/ann/layer/recurrent_impl.hpp
@@ -37,19 +37,6 @@ Recurrent<InputDataType, OutputDataType, CustomLayers...>::Recurrent() :
   // Nothing to do.
 }
 
-template<typename InputDataType, typename OutputDataType,
-         typename... CustomLayers>
-Recurrent<InputDataType, OutputDataType, CustomLayers...>::~Recurrent()
-{
-  if (ownsLayer)
-  {
-    boost::apply_visitor(DeleteVisitor(), recurrentModule);
-    boost::apply_visitor(DeleteVisitor(), initialModule);
-    boost::apply_visitor(DeleteVisitor(), startModule);
-    network.clear();
-  }
-}
-
 template <typename InputDataType, typename OutputDataType,
           typename... CustomLayers>
 template<
@@ -76,8 +63,8 @@ Recurrent<InputDataType, OutputDataType, CustomLayers...>::Recurrent(
     ownsLayer(true)
 {
   initialModule = new Sequential<>();
-  mergeModule = new AddMerge<>(false, false);
-  recurrentModule = new Sequential<>(false);
+  mergeModule = new AddMerge<>(false, false, false);
+  recurrentModule = new Sequential<>(false, false);
 
   boost::apply_visitor(AddVisitor<CustomLayers...>(inputModule),
                        initialModule);
@@ -116,8 +103,8 @@ Recurrent<InputDataType, OutputDataType, CustomLayers...>::Recurrent(
   feedbackModule = boost::apply_visitor(copyVisitor, network.feedbackModule);
   transferModule = boost::apply_visitor(copyVisitor, network.transferModule);
   initialModule = new Sequential<>();
-  mergeModule = new AddMerge<>(false, false);
-  recurrentModule = new Sequential<>(false);
+  mergeModule = new AddMerge<>(false, false, false);
+  recurrentModule = new Sequential<>(false, false);
 
   boost::apply_visitor(AddVisitor<CustomLayers...>(inputModule),
                        initialModule);
@@ -292,8 +279,8 @@ void Recurrent<InputDataType, OutputDataType, CustomLayers...>::serialize(
   if (Archive::is_loading::value)
   {
     initialModule = new Sequential<>();
-    mergeModule = new AddMerge<>(false, false);
-    recurrentModule = new Sequential<>(false);
+    mergeModule = new AddMerge<>(false, false, false);
+    recurrentModule = new Sequential<>(false, false);
 
     boost::apply_visitor(AddVisitor<CustomLayers...>(inputModule),
                          initialModule);

--- a/src/mlpack/methods/ann/layer/sequential.hpp
+++ b/src/mlpack/methods/ann/layer/sequential.hpp
@@ -264,7 +264,7 @@ struct version<mlpack::ann::Sequential<
     InputDataType, OutputDataType, Residual, CustomLayers...>>
 {
   BOOST_STATIC_CONSTANT(int, value = 1);
-}
+};
 
 } // namespace serialization
 } // namespace boost

--- a/src/mlpack/methods/ann/layer/sequential.hpp
+++ b/src/mlpack/methods/ann/layer/sequential.hpp
@@ -78,6 +78,15 @@ class Sequential
    */
   Sequential(const bool model = true);
 
+  /**
+   * Create the Sequential object using the specified parameters.
+   *
+   * @param model Expose all the network modules.
+   * @param ownsLayers If true, then this module will delete its layers when
+   *      deallocated.
+   */
+  Sequential(const bool model, const bool ownsLayers);
+
   //! Destroy the Sequential object.
   ~Sequential();
 
@@ -131,11 +140,6 @@ class Sequential
    * @param layer The Layer to be added to the model.
    */
   void Add(LayerTypes<CustomLayers...> layer) { network.push_back(layer); }
-
-  /*
-   * Destroy all the modules added to the Sequential object.
-   */
-  void DeleteModules();
 
   //! Return the model modules.
   std::vector<LayerTypes<CustomLayers...> >& Model()
@@ -227,6 +231,9 @@ class Sequential
 
   //! The input height.
   size_t height;
+
+  //! Whether we are responsible for deleting the layers held in this module.
+  bool ownsLayers;
 }; // class Sequential
 
 /*
@@ -242,6 +249,25 @@ using Residual = Sequential<
 
 } // namespace ann
 } // namespace mlpack
+
+//! Set the serialization version of the Sequential class.
+namespace boost {
+namespace serialization {
+
+template <
+    typename InputDataType,
+    typename OutputDataType,
+    bool Residual,
+    typename... CustomLayers
+>
+struct version<mlpack::ann::Sequential<
+    InputDataType, OutputDataType, Residual, CustomLayers...>>
+{
+  BOOST_STATIC_CONSTANT(int, value = 1);
+}
+
+} // namespace serialization
+} // namespace boost
 
 // Include implementation.
 #include "sequential_impl.hpp"

--- a/src/mlpack/methods/ann/layer/sequential_impl.hpp
+++ b/src/mlpack/methods/ann/layer/sequential_impl.hpp
@@ -27,9 +27,18 @@ namespace ann /** Artificial Neural Network. */ {
 
 template <typename InputDataType, typename OutputDataType, bool Residual,
           typename... CustomLayers>
-Sequential<
-    InputDataType, OutputDataType, Residual, CustomLayers...>::Sequential(
-        const bool model) : model(model), reset(false), width(0), height(0)
+Sequential<InputDataType, OutputDataType, Residual, CustomLayers...>::
+Sequential(const bool model) :
+    model(model), reset(false), width(0), height(0), ownsLayers(!model)
+{
+  // Nothing to do here.
+}
+
+template <typename InputDataType, typename OutputDataType, bool Residual,
+          typename... CustomLayers>
+Sequential<InputDataType, OutputDataType, Residual, CustomLayers...>::
+Sequential(const bool model, const bool ownsLayers) :
+    model(model), reset(false), width(0), height(0), ownsLayers(ownsLayers)
 {
   // Nothing to do here.
 }
@@ -39,7 +48,7 @@ template <typename InputDataType, typename OutputDataType, bool Residual,
 Sequential<
     InputDataType, OutputDataType, Residual, CustomLayers...>::~Sequential()
 {
-  if (!model)
+  if (!model && ownsLayers)
   {
     for (LayerTypes<CustomLayers...>& layer : network)
       boost::apply_visitor(deleteVisitor, layer);
@@ -175,26 +184,12 @@ Gradient(const arma::Mat<eT>& input,
       boost::apply_visitor(deltaVisitor, network[1])), network.front());
 }
 
-template <typename InputDataType, typename OutputDataType, bool Residual,
-          typename... CustomLayers>
-void Sequential<
-    InputDataType, OutputDataType, Residual, CustomLayers...>::DeleteModules()
-{
-  if (model == true)
-  {
-    for (LayerTypes<CustomLayers...>& layer : network)
-    {
-      boost::apply_visitor(deleteVisitor, layer);
-    }
-  }
-}
-
 template<typename InputDataType, typename OutputDataType, bool Residual,
          typename... CustomLayers>
 template<typename Archive>
 void Sequential<
     InputDataType, OutputDataType, Residual, CustomLayers...>::serialize(
-        Archive& ar, const unsigned int /* version */)
+        Archive& ar, const unsigned int version)
 {
   // If loading, delete the old layers.
   if (Archive::is_loading::value)
@@ -207,6 +202,15 @@ void Sequential<
 
   ar & BOOST_SERIALIZATION_NVP(model);
   ar & BOOST_SERIALIZATION_NVP(network);
+
+  if (version >= 1)
+  {
+    ar & BOOST_SERIALIZATION_NVP(ownsLayers);
+  }
+  else if (Archive::is_loading::value)
+  {
+    ownsLayers = !model;
+  }
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/sequential_impl.hpp
+++ b/src/mlpack/methods/ann/layer/sequential_impl.hpp
@@ -204,13 +204,9 @@ void Sequential<
   ar & BOOST_SERIALIZATION_NVP(network);
 
   if (version >= 1)
-  {
     ar & BOOST_SERIALIZATION_NVP(ownsLayers);
-  }
   else if (Archive::is_loading::value)
-  {
     ownsLayers = !model;
-  }
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/transposed_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/transposed_convolution.hpp
@@ -429,9 +429,6 @@ class TransposedConvolution
   //! Locally-stored transformed output parameter.
   arma::cube outputTemp;
 
-  //! Locally-stored transformed input parameter.
-  arma::cube inputTemp;
-
   //! Locally-stored transformed padded input parameter.
   arma::cube inputPaddedTemp;
 

--- a/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
@@ -210,7 +210,7 @@ void TransposedConvolution<
 >::Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
   batchSize = input.n_cols;
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
+  arma::cube inputTemp(const_cast<arma::Mat<eT>&>(input).memptr(),
       inputWidth, inputHeight, inSize * batchSize, false, false);
 
   if (strideWidth > 1 || strideHeight > 1)
@@ -330,9 +330,9 @@ void TransposedConvolution<
           mappedErrorPadded.slice(i));
     }
   }
-  g.set_size(inputTemp.n_rows * inputTemp.n_cols * inSize, batchSize);
-  gTemp = arma::Cube<eT>(g.memptr(), inputTemp.n_rows,
-      inputTemp.n_cols, inputTemp.n_slices, false, false);
+  g.set_size(inputWidth * inputHeight * inSize, batchSize);
+  gTemp = arma::Cube<eT>(g.memptr(), inputWidth, inputHeight, inSize *
+      batchSize, false, false);
 
   gTemp.zeros();
 
@@ -381,12 +381,14 @@ void TransposedConvolution<
     InputDataType,
     OutputDataType
 >::Gradient(
-    const arma::Mat<eT>& /* input */,
+    const arma::Mat<eT>& input,
     const arma::Mat<eT>& error,
     arma::Mat<eT>& gradient)
 {
   arma::Cube<eT> mappedError(((arma::Mat<eT>&) error).memptr(), outputWidth,
       outputHeight, outSize * batchSize, false, false);
+  arma::cube inputTemp(const_cast<arma::Mat<eT>&>(input).memptr(),
+      inputWidth, inputHeight, inSize * batchSize, false, false);
 
   gradient.set_size(weights.n_elem, 1);
   gradientTemp = arma::Cube<eT>(gradient.memptr(), weight.n_rows,

--- a/src/mlpack/methods/ann/visitor/delete_visitor.hpp
+++ b/src/mlpack/methods/ann/visitor/delete_visitor.hpp
@@ -27,9 +27,17 @@ namespace ann {
 class DeleteVisitor : public boost::static_visitor<void>
 {
  public:
-  //! Execute the destructor.
+  //! Execute the destructor if the layer does not hold layers internally.
   template<typename LayerType>
-  void operator()(LayerType* layer) const;
+  typename std::enable_if<
+      !HasModelCheck<LayerType>::value, void>::type
+  operator()(LayerType* layer) const;
+
+  //! Execute the destructor if the layer does hold layers internally.
+  template<typename LayerType>
+  typename std::enable_if<
+      HasModelCheck<LayerType>::value, void>::type
+  operator()(LayerType* layer) const;
 
   void operator()(MoreTypes layer) const;
 };

--- a/src/mlpack/methods/ann/visitor/delete_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/delete_visitor_impl.hpp
@@ -20,10 +20,28 @@ namespace ann {
 
 //! DeleteVisitor visitor class.
 template<typename LayerType>
-inline void DeleteVisitor::operator()(LayerType* layer) const
+inline typename std::enable_if<
+    !HasModelCheck<LayerType>::value, void>::type
+DeleteVisitor::operator()(LayerType* layer) const
 {
   if (layer)
     delete layer;
+}
+
+template<typename LayerType>
+inline typename std::enable_if<
+    HasModelCheck<LayerType>::value, void>::type
+DeleteVisitor::operator()(LayerType* layer) const
+{
+  if (layer)
+  {
+    for (size_t i = 0; i < layer->Model().size(); ++i)
+    {
+      boost::apply_visitor(DeleteVisitor(), layer->Model()[i]);
+    }
+
+    delete layer;
+  }
 }
 
 inline void DeleteVisitor::operator()(MoreTypes layer) const

--- a/src/mlpack/methods/ann/visitor/delete_visitor_impl.hpp
+++ b/src/mlpack/methods/ann/visitor/delete_visitor_impl.hpp
@@ -36,9 +36,7 @@ DeleteVisitor::operator()(LayerType* layer) const
   if (layer)
   {
     for (size_t i = 0; i < layer->Model().size(); ++i)
-    {
       boost::apply_visitor(DeleteVisitor(), layer->Model()[i]);
-    }
 
     delete layer;
   }

--- a/src/mlpack/methods/cf/cf_main.cpp
+++ b/src/mlpack/methods/cf/cf_main.cpp
@@ -223,14 +223,14 @@ void ComputeRecommendations(CFModel* cf,
                             const size_t numRecs,
                             arma::Mat<size_t>& recommendations)
 {
-  //  Verifying the Interpolation algorithms
+  // Verify the Interpolation algorithms.
   RequireParamInSet<string>("interpolation", { "average",
       "regression", "similarity" }, true, "unknown interpolation algorithm");
 
-  //  Taking Interpolation Alternatives
+  // Taking Interpolation Alternatives
   const string interpolationAlgorithm = CLI::GetParam<string>("interpolation");
 
-  //  Determining the Interpolation Algorithm
+  // Determining the Interpolation Algorithm
   if (interpolationAlgorithm == "average")
   {
     ComputeRecommendations<NeighborSearchType, AverageInterpolation>
@@ -382,6 +382,11 @@ void PerformAction(arma::mat& dataset,
                    const double minResidue)
 {
   const size_t neighborhood = (size_t) CLI::GetParam<int>("neighborhood");
+
+  // Make sure the normalization strategy is valid.
+  RequireParamInSet<string>("normalization", { "overall_mean", "item_mean",
+      "user_mean", "z_score", "none" }, true, "unknown normalization type");
+
   CFModel* c = new CFModel();
 
   const string normalizationType = CLI::GetParam<string>("normalization");
@@ -390,7 +395,16 @@ void PerformAction(arma::mat& dataset,
       maxIterations, minResidue, CLI::HasParam("iteration_only_termination"),
       normalizationType);
 
-  PerformAction(c);
+  try
+  {
+    PerformAction(c);
+  }
+  catch (std::exception& e)
+  {
+    // Clean the memory before throwing completely.
+    delete c;
+    throw;
+  }
 }
 
 void AssembleFactorizerType(const std::string& algorithm,

--- a/src/mlpack/methods/fastmks/fastmks_main.cpp
+++ b/src/mlpack/methods/fastmks/fastmks_main.cpp
@@ -128,6 +128,12 @@ static void mlpackMain()
         "number of maximum kernels must be greater than 0");
   }
 
+  if (CLI::HasParam("base"))
+  {
+    RequireParamValue<double>("base", [](double x) { return x > 1.0; }, true,
+        "base must be greater than or equal to 1!");
+  }
+
   // Naive mode overrides single mode.
   ReportIgnoredParam({{ "naive", true }}, "single");
 
@@ -223,12 +229,32 @@ static void mlpackMain()
       Log::Info << "Loaded query data (" << queryData.n_rows << " x "
           << queryData.n_cols << ")." << endl;
 
-      model->Search(queryData, (size_t) CLI::GetParam<int>("k"), indices,
-          kernels, base);
+      try
+      {
+        model->Search(queryData, (size_t) CLI::GetParam<int>("k"), indices,
+            kernels, base);
+      }
+      catch (std::invalid_argument& e)
+      {
+        // Delete the memory, if needed.
+        if (CLI::HasParam("reference"))
+          delete model;
+        throw;
+      }
     }
     else
     {
-      model->Search((size_t) CLI::GetParam<int>("k"), indices, kernels);
+      try
+      {
+        model->Search((size_t) CLI::GetParam<int>("k"), indices, kernels);
+      }
+      catch (std::invalid_argument& e)
+      {
+        // Delete the memory, if needed.
+        if (CLI::HasParam("reference"))
+          delete model;
+        throw e;
+      }
     }
 
     // Save output.

--- a/src/mlpack/methods/gmm/gmm_train_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_train_main.cpp
@@ -188,10 +188,6 @@ static void mlpackMain()
           << " model (given with " << PRINT_PARAM_STRING("input_model")
           << " has dimensionality " << gmm->Dimensionality() << "!" << endl;
   }
-  else
-  {
-    gmm = new GMM(size_t(gaussians), dataPoints.n_rows);
-  }
 
   // Gather parameters for EMFit object.
   const size_t maxIterations = (size_t) CLI::GetParam<int>("max_iterations");
@@ -211,6 +207,11 @@ static void mlpackMain()
     RequireParamValue<double>("percentage", [](double x) {
         return x > 0.0 && x <= 1.0; }, true, "percentage to sample must be "
         "be greater than 0.0 and less than or equal to 1.0");
+
+    // Initialize the GMM if needed.  (We didn't do this earlier, because
+    // RequireParamValue() would leak the memory if the check failed.)
+    if (!CLI::HasParam("input_model"))
+      gmm = new GMM(size_t(gaussians), dataPoints.n_rows);
 
     const int samplings = CLI::GetParam<int>("samplings");
     const double percentage = CLI::GetParam<double>("percentage");
@@ -274,6 +275,10 @@ static void mlpackMain()
   }
   else
   {
+    // Initialize the GMM if needed.
+    if (!CLI::HasParam("input_model"))
+      gmm = new GMM(size_t(gaussians), dataPoints.n_rows);
+
     // Depending on the value of forcePositive and diagonalCovariance, we have
     // to use different types.
     if (diagonalCovariance)

--- a/src/mlpack/methods/hmm/hmm_train_main.cpp
+++ b/src/mlpack/methods/hmm/hmm_train_main.cpp
@@ -515,16 +515,26 @@ static void mlpackMain()
   if (CLI::HasParam("input_model"))
   {
     hmm = CLI::GetParam<HMMModel*>("input_model");
+
+    hmm->PerformAction<Train, vector<mat>>(&trainSeq);
   }
   else
   {
     // We need to initialize the model.
     hmm = new HMMModel(typeId);
-    hmm->PerformAction<Init, vector<mat>>(&trainSeq);
-  }
 
-  // Train the model.
-  hmm->PerformAction<Train, vector<mat>>(&trainSeq);
+    // Catch any exceptions so that we can clean the model if needed.
+    try
+    {
+      hmm->PerformAction<Init, vector<mat>>(&trainSeq);
+      hmm->PerformAction<Train, vector<mat>>(&trainSeq);
+    }
+    catch (std::exception& e)
+    {
+      delete hmm;
+      throw;
+    }
+  }
 
   // If necessary, save the output.
   CLI::GetParam<HMMModel*>("output_model") = hmm;

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
@@ -121,6 +121,8 @@ class HoeffdingTree
    * @param dimensionMappings Mappings from dimension indices to positions in
    *      numeric and categorical split vectors.  If left NULL, a new one will
    *      be created.
+   * @param copyDatasetInfo If true, then a copy of the datasetInfo will be
+   *      made.
    */
   HoeffdingTree(const data::DatasetInfo& datasetInfo,
                 const size_t numClasses,
@@ -133,7 +135,8 @@ class HoeffdingTree
                 const NumericSplitType<FitnessFunction>& numericSplitIn =
                     NumericSplitType<FitnessFunction>(0),
                 std::unordered_map<size_t, std::pair<size_t, size_t>>*
-                    dimensionMappings = NULL);
+                    dimensionMappings = NULL,
+                const bool copyDatasetInfo = true);
 
   /**
    * Construct a Hoeffding tree with no data and no information.  Be sure to

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_impl.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_impl.hpp
@@ -96,7 +96,8 @@ HoeffdingTree<
                      categoricalSplitIn,
                  const NumericSplitType<FitnessFunction>& numericSplitIn,
                  std::unordered_map<size_t, std::pair<size_t, size_t>>*
-                     dimensionMappingsIn) :
+                     dimensionMappingsIn,
+                 const bool copyDatasetInfo) :
     dimensionMappings((dimensionMappingsIn != NULL) ? dimensionMappingsIn :
         new std::unordered_map<size_t, std::pair<size_t, size_t>>()),
     ownsMappings(dimensionMappingsIn == NULL),
@@ -105,8 +106,9 @@ HoeffdingTree<
     maxSamples((maxSamples == 0) ? size_t(-1) : maxSamples),
     checkInterval(checkInterval),
     minSamples(minSamples),
-    datasetInfo(new data::DatasetInfo(datasetInfo)),
-    ownsInfo(true),
+    datasetInfo(copyDatasetInfo ? new data::DatasetInfo(datasetInfo) :
+        &datasetInfo),
+    ownsInfo(copyDatasetInfo),
     successProbability(successProbability),
     splitDimension(size_t(-1)),
     majorityClass(0),
@@ -208,7 +210,18 @@ HoeffdingTree<FitnessFunction, NumericSplitType, CategoricalSplitType>::
 {
   // Copy each of the children.
   for (size_t i = 0; i < other.children.size(); ++i)
+  {
     children.push_back(new HoeffdingTree(*other.children[i]));
+
+    // Delete copied datasetInfo and dimension mappings.
+    delete children[i]->datasetInfo;
+    children[i]->datasetInfo = this->datasetInfo;
+    children[i]->ownsInfo = false;
+
+    delete children[i]->dimensionMappings;
+    children[i]->dimensionMappings = this->dimensionMappings;
+    children[i]->ownsMappings = false;
+  }
 }
 
 template<typename FitnessFunction,
@@ -744,7 +757,7 @@ void HoeffdingTree<
       children.push_back(new HoeffdingTree(*datasetInfo, numClasses,
           successProbability, maxSamples, checkInterval, minSamples,
           CategoricalSplitType<FitnessFunction>(0, numClasses),
-          numericSplits[0], dimensionMappings));
+          numericSplits[0], dimensionMappings, false));
     }
     else if (numericSplits.size() == 0)
     {
@@ -752,14 +765,14 @@ void HoeffdingTree<
       children.push_back(new HoeffdingTree(*datasetInfo, numClasses,
           successProbability, maxSamples, checkInterval, minSamples,
           categoricalSplits[0], NumericSplitType<FitnessFunction>(numClasses),
-          dimensionMappings));
+          dimensionMappings, false));
     }
     else
     {
       // Pass both splits that we already have.
       children.push_back(new HoeffdingTree(*datasetInfo, numClasses,
           successProbability, maxSamples, checkInterval, minSamples,
-          categoricalSplits[0], numericSplits[0], dimensionMappings));
+          categoricalSplits[0], numericSplits[0], dimensionMappings, false));
     }
 
     children[i]->MajorityClass() = childMajorities[i];
@@ -874,7 +887,8 @@ void HoeffdingTree<
       {
         // The child doesn't actually own its own DatasetInfo.  We do.  The same
         // applies for the dimension mappings.
-        children[i]->ownsInfo = false;
+        if (children[i]->datasetInfo == datasetInfo)
+          children[i]->ownsInfo = false;
         children[i]->ownsMappings = false;
       }
 

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.cpp
@@ -135,6 +135,12 @@ void HoeffdingTreeModel::BuildModel(
     const size_t bins,
     const size_t observationsBeforeBinning)
 {
+  // Clean memory, if needed.
+  delete giniHoeffdingTree;
+  delete giniBinaryTree;
+  delete infoHoeffdingTree;
+  delete infoBinaryTree;
+
   // Depending on the type, create the tree.
   switch (type)
   {

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.hpp
@@ -188,30 +188,18 @@ class HoeffdingTreeModel
     data::DatasetInfo info;
     if (type == GINI_HOEFFDING)
     {
-      // Create fake tree to load into if needed.
-      if (Archive::is_loading::value)
-        giniHoeffdingTree = new GiniHoeffdingTreeType(info, 1, 1);
       ar & BOOST_SERIALIZATION_NVP(giniHoeffdingTree);
     }
     else if (type == GINI_BINARY)
     {
-      // Create fake tree to load into if needed.
-      if (Archive::is_loading::value)
-        giniBinaryTree = new GiniBinaryTreeType(info, 1, 1);
       ar & BOOST_SERIALIZATION_NVP(giniBinaryTree);
     }
     else if (type == INFO_HOEFFDING)
     {
-      // Create fake tree to load into if needed.
-      if (Archive::is_loading::value)
-        infoHoeffdingTree = new InfoHoeffdingTreeType(info, 1, 1);
       ar & BOOST_SERIALIZATION_NVP(infoHoeffdingTree);
     }
     else if (type == INFO_BINARY)
     {
-      // Create fake tree to load into if needed.
-      if (Archive::is_loading::value)
-        infoBinaryTree = new InfoBinaryTreeType(info, 1, 1);
       ar & BOOST_SERIALIZATION_NVP(infoBinaryTree);
     }
   }

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.hpp
@@ -187,21 +187,13 @@ class HoeffdingTreeModel
     // Fake dataset info may be needed to create fake trees.
     data::DatasetInfo info;
     if (type == GINI_HOEFFDING)
-    {
       ar & BOOST_SERIALIZATION_NVP(giniHoeffdingTree);
-    }
     else if (type == GINI_BINARY)
-    {
       ar & BOOST_SERIALIZATION_NVP(giniBinaryTree);
-    }
     else if (type == INFO_HOEFFDING)
-    {
       ar & BOOST_SERIALIZATION_NVP(infoHoeffdingTree);
-    }
     else if (type == INFO_BINARY)
-    {
       ar & BOOST_SERIALIZATION_NVP(infoBinaryTree);
-    }
   }
 
  private:

--- a/src/mlpack/methods/kde/kde_impl.hpp
+++ b/src/mlpack/methods/kde/kde_impl.hpp
@@ -336,7 +336,16 @@ Evaluate(MatType querySet, arma::vec& estimations)
     std::vector<size_t> oldFromNewQueries;
     Tree* queryTree = BuildTree<Tree>(std::move(querySet), oldFromNewQueries);
     Timer::Stop("building_query_tree");
-    this->Evaluate(queryTree, oldFromNewQueries, estimations);
+    try
+    {
+      this->Evaluate(queryTree, oldFromNewQueries, estimations);
+    }
+    catch (std::exception& e)
+    {
+      // Make sure we delete the query tree.
+      delete queryTree;
+      throw;
+    }
     delete queryTree;
   }
   else if (mode == SINGLE_TREE_MODE)

--- a/src/mlpack/methods/kde/kde_main.cpp
+++ b/src/mlpack/methods/kde/kde_main.cpp
@@ -314,6 +314,5 @@ static void mlpackMain()
     CLI::GetParam<arma::vec>("predictions") = std::move(estimations);
 
   // Save model.
-  if (CLI::HasParam("output_model"))
-    CLI::GetParam<KDEModel*>("output_model") = kde;
+  CLI::GetParam<KDEModel*>("output_model") = kde;
 }

--- a/src/mlpack/methods/linear_svm/linear_svm_main.cpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_main.cpp
@@ -312,6 +312,13 @@ static void mlpackMain()
     model->svm.NumClasses() = numClasses;
     model->svm.FitIntercept() = intercept;
 
+    if (numClasses <= 1)
+    {
+      if (!CLI::HasParam("input_model"))
+        delete model;
+      throw std::invalid_argument("Given input data has only 1 class!");
+    }
+
     if (optimizerType == "lbfgs")
     {
       ens::L_BFGS lbfgsOpt;
@@ -369,6 +376,9 @@ static void mlpackMain()
     // Checking the dimensionality of the test data.
     if (testSet.n_rows != trainingDimensionality)
     {
+      // Clean memory if needed.
+      if (!CLI::HasParam("input_model"))
+        delete model;
       Log::Fatal << "Test data dimensionality (" << testSet.n_rows << ") must "
           << "be the same as the dimensionality of the training data ("
           << trainingDimensionality << ")!" << endl;
@@ -398,6 +408,8 @@ static void mlpackMain()
 
       if (testSet.n_cols != testLabels.n_elem)
       {
+        if (!CLI::HasParam("input_model"))
+          delete model;
         Log::Fatal << "Test data given with " << PRINT_PARAM_STRING("test")
             << " has " << testSet.n_cols << " points, but labels in "
             << PRINT_PARAM_STRING("test_labels") << " have "

--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -220,8 +220,11 @@ static void mlpackMain()
     if (trueNeighbors.n_rows != neighbors.n_rows ||
         trueNeighbors.n_cols != neighbors.n_cols)
     {
-        Log::Fatal << "The true neighbors file must have the same number of "
-            << "values as the set of neighbors being queried!" << endl;
+      // Delete the model if needed.
+      if (CLI::HasParam("reference"))
+        delete allkann;
+      Log::Fatal << "The true neighbors file must have the same number of "
+          << "values as the set of neighbors being queried!" << endl;
     }
 
     Log::Info << "Using true neighbor indices from '"

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -188,14 +188,14 @@ static void mlpackMain()
 
   if (CLI::HasParam("reference"))
   {
-    kfn = new KFNModel();
-
     // Get all the parameters.
     RequireParamInSet<string>("tree_type", { "kd", "cover", "r", "r-star",
         "ball", "x", "hilbert-r", "r-plus", "r-plus-plus", "vp", "rp", "max-rp",
         "ub", "oct" }, true, "unknown tree type");
     const string treeType = CLI::GetParam<string>("tree_type");
     const bool randomBasis = CLI::HasParam("random_basis");
+
+    kfn = new KFNModel();
 
     KFNModel::TreeTypes tree = KFNModel::KD_TREE;
     if (treeType == "kd")
@@ -274,8 +274,12 @@ static void mlpackMain()
           << queryData.n_rows << "x" << queryData.n_cols << ")." << endl;
       if (queryData.n_rows != kfn->Dataset().n_rows)
       {
+        // Clean memory if needed.
+        const size_t dimensions = kfn->Dataset().n_rows;
+        if (CLI::HasParam("reference"))
+          delete kfn;
         Log::Fatal << "Query has invalid dimensions (" << queryData.n_rows <<
-            "); should be " << kfn->Dataset().n_rows << "!" << endl;
+            "); should be " << dimensions << "!" << endl;
       }
     }
 
@@ -284,18 +288,26 @@ static void mlpackMain()
     // we only test the upper bound.
     if (k > kfn->Dataset().n_cols)
     {
+      // Clean memory if needed.
+      const size_t referencePoints = kfn->Dataset().n_cols;
+      if (CLI::HasParam("reference"))
+        delete kfn;
       Log::Fatal << "Invalid k: " << k << "; must be greater than 0 and less "
           << "than or equal to the number of reference points ("
-          << kfn->Dataset().n_cols << ")." << endl;
+          << referencePoints << ")." << endl;
     }
 
     // Sanity check on k value: must not be equal to the number of reference
     // points when query data has not been provided.
     if (!CLI::HasParam("query") && k == kfn->Dataset().n_cols)
     {
+      // Clean memory if needed.
+      const size_t referencePoints = kfn->Dataset().n_cols;
+      if (CLI::HasParam("reference"))
+        delete kfn;
       Log::Fatal << "Invalid k: " << k << "; must be less than the number of "
-          << "reference points (" << kfn->Dataset().n_cols << ") "
-          << "if query data has not been provided." << endl;
+          << "reference points (" << referencePoints << ") if query data has "
+          << "not been provided." << endl;
     }
 
     // Now run the search.
@@ -321,8 +333,13 @@ static void mlpackMain()
 
       if (trueDistances.n_rows != distances.n_rows ||
           trueDistances.n_cols != distances.n_cols)
+      {
+        // Clean memory if needed.
+        if (CLI::HasParam("reference"))
+          delete kfn;
         Log::Fatal << "The true distances file must have the same number of "
             << "values than the set of distances being queried!" << endl;
+      }
 
       Log::Info << "Effective error: " << KFN::EffectiveError(distances,
           trueDistances) << endl;
@@ -341,8 +358,13 @@ static void mlpackMain()
 
       if (trueNeighbors.n_rows != neighbors.n_rows ||
           trueNeighbors.n_cols != neighbors.n_cols)
+      {
+        // Clean memory if needed.
+        if (CLI::HasParam("reference"))
+          delete kfn;
         Log::Fatal << "The true neighbors file must have the same number of "
             << "values than the set of neighbors being queried!" << endl;
+      }
 
       Log::Info << "Recall: " << KFN::Recall(neighbors, trueNeighbors) << endl;
     }

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -200,8 +200,6 @@ static void mlpackMain()
 
   if (CLI::HasParam("reference"))
   {
-    knn = new KNNModel();
-
     // Get all the parameters.
     const string treeType = CLI::GetParam<string>("tree_type");
     const bool randomBasis = CLI::HasParam("random_basis");
@@ -210,6 +208,9 @@ static void mlpackMain()
     RequireParamInSet<string>("tree_type", { "kd", "cover", "r", "r-star",
         "ball", "x", "hilbert-r", "r-plus", "r-plus-plus", "spill", "vp", "rp",
         "max-rp", "ub", "oct" }, true, "unknown tree type");
+
+    knn = new KNNModel();
+
     if (treeType == "kd")
       tree = KNNModel::KD_TREE;
     else if (treeType == "cover")
@@ -292,8 +293,12 @@ static void mlpackMain()
           << queryData.n_rows << "x" << queryData.n_cols << ")." << endl;
       if (queryData.n_rows != knn->Dataset().n_rows)
       {
+        // Clean memory if needed before crashing.
+        const size_t dimensions = knn->Dataset().n_rows;
+        if (CLI::HasParam("reference"))
+          delete knn;
         Log::Fatal << "Query has invalid dimensions(" << queryData.n_rows <<
-            "); should be " << knn->Dataset().n_rows << "!" << endl;
+            "); should be " << dimensions << "!" << endl;
       }
     }
 
@@ -302,18 +307,26 @@ static void mlpackMain()
     // we only test the upper bound.
     if (k > knn->Dataset().n_cols)
     {
+      // Clean memory if needed before crashing.
+      const size_t referencePoints = knn->Dataset().n_cols;
+      if (CLI::HasParam("reference"))
+        delete knn;
       Log::Fatal << "Invalid k: " << k << "; must be greater than 0 and less "
           << "than or equal to the number of reference points ("
-          << knn->Dataset().n_cols << ")." << endl;
+          << referencePoints << ")." << endl;
     }
 
     // Sanity check on k value: must not be equal to the number of reference
     // points when query data has not been provided.
     if (!CLI::HasParam("query") && k == knn->Dataset().n_cols)
     {
+      // Clean memory if needed before crashing.
+      const size_t referencePoints = knn->Dataset().n_cols;
+      if (CLI::HasParam("reference"))
+        delete knn;
       Log::Fatal << "Invalid k: " << k << "; must be less than the number of "
-          << "reference points (" << knn->Dataset().n_cols << ") "
-          << "if query data has not been provided." << endl;
+          << "reference points (" << referencePoints << ") if query data has "
+          << "not been provided." << endl;
     }
 
     // Now run the search.
@@ -339,8 +352,12 @@ static void mlpackMain()
 
       if (trueDistances.n_rows != distances.n_rows ||
           trueDistances.n_cols != distances.n_cols)
+      {
+        if (CLI::HasParam("reference"))
+          delete knn;
         Log::Fatal << "The true distances file must have the same number of "
             << "values than the set of distances being queried!" << endl;
+      }
 
       Log::Info << "Effective error: " << KNN::EffectiveError(distances,
           trueDistances) << endl;
@@ -359,8 +376,12 @@ static void mlpackMain()
 
       if (trueNeighbors.n_rows != neighbors.n_rows ||
           trueNeighbors.n_cols != neighbors.n_cols)
+      {
+        if (CLI::HasParam("reference"))
+          delete knn;
         Log::Fatal << "The true neighbors file must have the same number of "
             << "values than the set of neighbors being queried!" << endl;
+      }
 
       Log::Info << "Recall: " << KNN::Recall(neighbors, trueNeighbors) << endl;
     }

--- a/src/mlpack/methods/preprocess/preprocess_scale_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_scale_main.cpp
@@ -188,6 +188,6 @@ static void mlpackMain()
   if (CLI::HasParam("output"))
     CLI::GetParam<arma::mat>("output") = std::move(output);
   Timer::Stop("feature_scaling");
-  if (CLI::HasParam("output_model"))
-    CLI::GetParam<ScalingModel*>("output_model") = m;
+
+  CLI::GetParam<ScalingModel*>("output_model") = m;
 }

--- a/src/mlpack/methods/range_search/range_search_main.cpp
+++ b/src/mlpack/methods/range_search/range_search_main.cpp
@@ -155,14 +155,14 @@ static void mlpackMain()
   const bool singleMode = CLI::HasParam("single_mode");
   if (CLI::HasParam("reference"))
   {
-    rs = new RSModel();
-
     // Get all the parameters.
     const string treeType = CLI::GetParam<string>("tree_type");
     RequireParamInSet<string>("tree_type", { "kd", "cover", "r", "r-star",
         "ball", "x", "hilbert-r", "r-plus", "r-plus-plus", "vp", "rp", "max-rp",
         "ub", "oct" }, true, "unknown tree type");
     const bool randomBasis = CLI::HasParam("random_basis");
+
+    rs = new RSModel();
 
     RSModel::TreeTypes tree = RSModel::KD_TREE;
     if (treeType == "kd")

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1148,7 +1148,9 @@ BOOST_AUTO_TEST_CASE(GradientGRULayerTest)
  */
 BOOST_AUTO_TEST_CASE(ForwardGRULayerTest)
 {
-  GRU<> gru(3, 3, 5);
+  // This will make it easier to clean memory later.
+  GRU<>* gruAlloc = new GRU<>(3, 3, 5);
+  GRU<>& gru = *gruAlloc;
 
   // Initialize the weights to all ones.
   NetworkInitialization<ConstInitialization>
@@ -1194,6 +1196,9 @@ BOOST_AUTO_TEST_CASE(ForwardGRULayerTest)
   expectedOutput = z_t % expectedOutput + (arma::ones(3, 1) - z_t) % o_t;
 
   BOOST_REQUIRE_LE(arma::as_scalar(arma::trans(output) * expectedOutput), 1e-2);
+
+  LayerTypes<> layer(gruAlloc);
+  boost::apply_visitor(DeleteVisitor(), layer);
 }
 
 /**
@@ -2633,7 +2638,6 @@ BOOST_AUTO_TEST_CASE(GradientHighwayLayerTest)
 
     ~GradientFunction()
     {
-      highway->DeleteModules();
       delete model;
     }
 
@@ -2685,7 +2689,6 @@ BOOST_AUTO_TEST_CASE(GradientSequentialLayerTest)
 
     ~GradientFunction()
     {
-      sequential->DeleteModules();
       delete model;
     }
 

--- a/src/mlpack/tests/ann_visitor_test.cpp
+++ b/src/mlpack/tests/ann_visitor_test.cpp
@@ -51,6 +51,8 @@ BOOST_AUTO_TEST_CASE(BiasSetVisitorTest)
   boost::apply_visitor(ForwardVisitor(input, output), linear);
 
   BOOST_REQUIRE_EQUAL(arma::accu(output), 55);
+
+  boost::apply_visitor(DeleteVisitor(), linear);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(HighwayNetworkTest)
   Highway<>* highway = new Highway<>(10, true);
   highway->Add<Linear<> >(10, 10);
   highway->Add<SigmoidLayer<> >();
-  model.Add(highway);
+  model.Add(highway); // This takes ownership of the memory.
   model.Add<Linear<> >(10, 2);
   model.Add<LogSoftMax<> >();
   TestNetwork<>(model, dataset, labels, dataset, labels, 10, 0.2);

--- a/src/mlpack/tests/main_tests/fastmks_test.cpp
+++ b/src/mlpack/tests/main_tests/fastmks_test.cpp
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(FastMKSBaseTest)
   SetInputParam("base", 0.0); // Invalid.
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::invalid_argument);
+  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
@@ -464,6 +464,9 @@ BOOST_AUTO_TEST_CASE(FastMKSKernelTest)
     CLI::GetSingleton().Parameters()["reference"].wasPassed = false;
     CLI::GetSingleton().Parameters()["query"].wasPassed = false;
     CLI::GetSingleton().Parameters()["kernel"].wasPassed = false;
+
+    if (i != nofkerneltypes - 1)
+      bindings::tests::CleanMemory();
   }
 }
 

--- a/src/mlpack/tests/main_tests/gmm_train_test.cpp
+++ b/src/mlpack/tests/main_tests/gmm_train_test.cpp
@@ -249,6 +249,8 @@ BOOST_AUTO_TEST_CASE(GmmTrainNoiseTest)
   GMM* gmm1 = CLI::GetParam<GMM*>("output_model");
 
   BOOST_REQUIRE(CheckDifferent(gmm, gmm1));
+
+  delete gmm;
 }
 
 // Ensure that Trials affects the final result.
@@ -273,7 +275,7 @@ BOOST_AUTO_TEST_CASE(GmmTrainTrialsTest)
 
     mlpackMain();
 
-    GMM* gmm = std::move(CLI::GetParam<GMM*>("output_model"));
+    GMM* gmm = CLI::GetParam<GMM*>("output_model");
 
     ResetGmmTrainSetting();
 
@@ -290,10 +292,12 @@ BOOST_AUTO_TEST_CASE(GmmTrainTrialsTest)
     GMM* gmm1 = CLI::GetParam<GMM*>("output_model");
 
     success = CheckDifferent(gmm, gmm1);
+
+    delete gmm;
+
     if (success)
       break;
 
-    delete gmm;
     bindings::tests::CleanMemory();
   }
 
@@ -332,6 +336,8 @@ BOOST_AUTO_TEST_CASE(GmmTrainDiffMaxIterationsTest)
   GMM* gmm1 = CLI::GetParam<GMM*>("output_model");
 
   BOOST_REQUIRE(CheckDifferent(gmm, gmm1));
+
+  delete gmm;
 }
 
 // Ensure that the maximum number of k-means iterations affects the result.
@@ -375,10 +381,13 @@ BOOST_AUTO_TEST_CASE(GmmTrainDiffKmeansMaxIterationsTest)
     ResetGmmTrainSetting();
 
     success = CheckDifferent(gmm, gmm1);
+
+    delete gmm;
+    delete gmm1;
+
     if (success)
       break;
 
-    delete gmm;
     bindings::tests::CleanMemory();
   }
 
@@ -419,6 +428,8 @@ BOOST_AUTO_TEST_CASE(GmmTrainPercentageTest)
   GMM* gmm1 = CLI::GetParam<GMM*>("output_model");
 
   BOOST_REQUIRE(CheckDifferent(gmm, gmm1));
+
+  delete gmm;
 }
 
 // Ensure that Sampling affects the final result when refined_start is true.
@@ -455,6 +466,8 @@ BOOST_AUTO_TEST_CASE(GmmTrainSamplingsTest)
   GMM* gmm1 = CLI::GetParam<GMM*>("output_model");
 
   BOOST_REQUIRE(CheckDifferent(gmm, gmm1));
+
+  delete gmm;
 }
 
 // Ensure that tolerance affects the final result.
@@ -487,6 +500,8 @@ BOOST_AUTO_TEST_CASE(GmmTrainToleranceTest)
   GMM* gmm1 = CLI::GetParam<GMM*>("output_model");
 
   BOOST_REQUIRE(CheckDifferent(gmm, gmm1));
+
+  delete gmm;
 }
 
 // Ensure that saved model can be used again.

--- a/src/mlpack/tests/main_tests/kde_test.cpp
+++ b/src/mlpack/tests/main_tests/kde_test.cpp
@@ -30,14 +30,15 @@ struct KDETestFixture
  public:
   KDETestFixture()
   {
-      // Cache in the options for this program.
-      CLI::RestoreSettings(testName);
+    // Cache in the options for this program.
+    CLI::RestoreSettings(testName);
   }
 
   ~KDETestFixture()
   {
-      // Clear the settings.
-      CLI::ClearSettings();
+    // Clear the settings.
+    bindings::tests::CleanMemory();
+    CLI::ClearSettings();
   }
 };
 
@@ -544,6 +545,8 @@ BOOST_AUTO_TEST_CASE(KDEMainMonteCarloFlag)
   // Compute estimations 1.
   mlpackMain();
   estimations1 = std::move(CLI::GetParam<arma::vec>("predictions"));
+
+  delete CLI::GetParam<KDEModel*>("output_model");
 
   // Compute estimations 2.
   SetInputParam("reference", reference);

--- a/src/mlpack/tests/main_tests/knn_test.cpp
+++ b/src/mlpack/tests/main_tests/knn_test.cpp
@@ -683,6 +683,7 @@ BOOST_AUTO_TEST_CASE(KNNDifferentLeafSizes)
   BOOST_CHECK_EQUAL(output_model->LeafSize(), (int) 1);
   BOOST_CHECK_EQUAL(CLI::GetParam<KNNModel*>("output_model")->LeafSize(),
     (int) 10);
-  }
+  delete output_model;
+}
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/linear_svm_test.cpp
+++ b/src/mlpack/tests/main_tests/linear_svm_test.cpp
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(LinearSVMNonNegativeEpochsTest)
 }
 
 /**
- * Ensuring that number classes must not be zero.
+ * Ensuring that number classes must not be one.
  */
 BOOST_AUTO_TEST_CASE(LinearSVMZeroNumberOfClassesTest)
 {
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE(LinearSVMZeroNumberOfClassesTest)
   SetInputParam("training", std::move(trainData));
   SetInputParam("labels", std::move(trainLabels));
 
-  // Number of classes for optimizer is zero.
+  // Number of classes for optimizer is only one.
   // It should throw a invalid_argument error.
   Log::Fatal.ignoreInput = true;
   BOOST_REQUIRE_THROW(mlpackMain(), std::invalid_argument);

--- a/src/mlpack/tests/main_tests/preprocess_scale_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_scale_test.cpp
@@ -57,16 +57,18 @@ BOOST_AUTO_TEST_CASE(TwoScalerTest)
   SetInputParam("scaler_method", method);
 
   mlpackMain();
-  arma::mat max_abs_scaler_output = CLI::GetParam<arma::mat>("output");
+  arma::mat maxAbsScalerOutput = CLI::GetParam<arma::mat>("output");
+
+  bindings::tests::CleanMemory();
 
   method = "standard_scaler";
   SetInputParam("input", dataset);
   SetInputParam("scaler_method", std::move(method));
 
   mlpackMain();
-  arma::mat standard_scaler_output = CLI::GetParam<arma::mat>("output");
+  arma::mat standardScalerOutput = CLI::GetParam<arma::mat>("output");
 
-  CheckMatricesNotEqual(standard_scaler_output, max_abs_scaler_output);
+  CheckMatricesNotEqual(standardScalerOutput, maxAbsScalerOutput);
 }
 
 /**
@@ -82,6 +84,8 @@ BOOST_AUTO_TEST_CASE(TwoOptionTest)
 
   mlpackMain();
   arma::mat output = CLI::GetParam<arma::mat>("output");
+
+  bindings::tests::CleanMemory();
 
   SetInputParam("input", dataset);
   SetInputParam("scaler_method", std::move(method));
@@ -106,6 +110,8 @@ BOOST_AUTO_TEST_CASE(UnrelatedOptionTest)
 
   mlpackMain();
   arma::mat scaled = CLI::GetParam<arma::mat>("output");
+
+  bindings::tests::CleanMemory();
 
   SetInputParam("input", dataset);
   SetInputParam("scaler_method", std::move(method));
@@ -176,6 +182,8 @@ BOOST_AUTO_TEST_CASE(EpsilonTest)
 
   mlpackMain();
   arma::mat scaled = CLI::GetParam<arma::mat>("output");
+
+  bindings::tests::CleanMemory();
 
   SetInputParam("scaler_method", std::move(method));
   SetInputParam("input", dataset);

--- a/src/mlpack/tests/main_tests/range_search_test.cpp
+++ b/src/mlpack/tests/main_tests/range_search_test.cpp
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(ModelCheck)
   neighbors = ReadData<size_t>(neighborsFile);
   distances = ReadData<double>(distanceFile);
 
-  RSModel* outputModel = move(CLI::GetParam<RSModel*>("output_model"));
+  RSModel* outputModel = CLI::GetParam<RSModel*>("output_model");
   CLI::GetSingleton().Parameters()["reference"].wasPassed = false;
 
   SetInputParam("input_model", outputModel);
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(ModelCheck)
   CheckMatrices(distances, distancetemp);
 
   BOOST_REQUIRE_EQUAL(ModelToString(outputModel),
-                   ModelToString(CLI::GetParam<RSModel*>("output_model")));
+                      ModelToString(CLI::GetParam<RSModel*>("output_model")));
 
   remove(neighborsFile.c_str());
   remove(distanceFile.c_str());
@@ -351,7 +351,12 @@ BOOST_AUTO_TEST_CASE(LeafValueTesting)
 
     BOOST_REQUIRE_NE(ModelToString(outputModel1),
                      ModelToString(CLI::GetParam<RSModel*>("output_model")));
+
+    if (i != leafSizes.size() - 1)
+      delete CLI::GetParam<RSModel*>("output_model");
   }
+
+  delete outputModel1;
 
   remove(neighborsFile.c_str());
   remove(distanceFile.c_str());
@@ -419,7 +424,12 @@ BOOST_AUTO_TEST_CASE(TreeTypeTesting)
     CheckMatrices(distances, distancestemp);
     BOOST_REQUIRE_NE(ModelToString(outputModel1),
                      ModelToString(CLI::GetParam<RSModel*>("output_model")));
+
+    if (i != trees.size() - 1)
+      delete CLI::GetParam<RSModel*>("output_model");
   }
+
+  delete outputModel1;
 
   remove(neighborsFile.c_str());
   remove(distanceFile.c_str());
@@ -462,6 +472,8 @@ BOOST_AUTO_TEST_CASE(RandomBasisTesting)
 
   BOOST_REQUIRE_NE(ModelToString(outputModel),
                    ModelToString(CLI::GetParam<RSModel*>("output_model")));
+
+  delete outputModel;
 
   remove(neighborsFile.c_str());
   remove(distanceFile.c_str());
@@ -515,6 +527,8 @@ BOOST_AUTO_TEST_CASE(NaiveModeTest)
   BOOST_REQUIRE_NE(ModelToString(outputModel),
                    ModelToString(CLI::GetParam<RSModel*>("output_model")));
 
+  delete outputModel;
+
   remove(neighborsFile.c_str());
   remove(distanceFile.c_str());
 }
@@ -565,6 +579,8 @@ BOOST_AUTO_TEST_CASE(SingleModeTest)
   CheckMatrices(distances, distancestemp);
   BOOST_REQUIRE_NE(ModelToString(outputModel),
                    ModelToString(CLI::GetParam<RSModel*>("output_model")));
+
+  delete outputModel;
 
   remove(neighborsFile.c_str());
   remove(distanceFile.c_str());

--- a/src/mlpack/tests/recurrent_network_test.cpp
+++ b/src/mlpack/tests/recurrent_network_test.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(SequenceClassificationBRNNTest)
     BOOST_TEST_CHECKPOINT("Training over");
     arma::cube prediction;
     model.Predict(input, prediction);
-    BOOST_TEST_CHECKPOINT("Predicion over");
+    BOOST_TEST_CHECKPOINT("Prediction over");
 
     size_t error = 0;
     for (size_t i = 0; i < prediction.n_cols; ++i)
@@ -825,7 +825,7 @@ void DistractedSequenceRecallTestNetwork(
         inputTemp = arma::cube(trainInput.at(0, j).memptr(), inputSize, 1,
             trainInput.at(0, j).n_elem / inputSize, false, true);
         labelsTemp = arma::cube(trainLabels.at(0, j).memptr(), outputSize, 1,
-            trainInput.at(0, j).n_elem / outputSize, false, true);
+            trainLabels.at(0, j).n_elem / outputSize, false, true);
 
         model.Train(inputTemp, labelsTemp, opt);
       }

--- a/src/mlpack/tests/tree_test.cpp
+++ b/src/mlpack/tests/tree_test.cpp
@@ -2129,12 +2129,15 @@ BOOST_AUTO_TEST_CASE(BinarySpaceTreeCopyConstructor)
   TreeType b(data);
   b.Begin() = 10;
   b.Count() = 50;
+
   b.Left() = new TreeType(data);
   b.Left()->Begin() = 10;
   b.Left()->Count() = 30;
+  b.Left()->Parent() = &b;
   b.Right() = new TreeType(data);
   b.Right()->Begin() = 40;
   b.Right()->Count() = 20;
+  b.Right()->Parent() = &b;
 
   // Copy the tree.
   TreeType c(b);
@@ -2159,6 +2162,11 @@ BOOST_AUTO_TEST_CASE(BinarySpaceTreeCopyConstructor)
   BOOST_REQUIRE_EQUAL(b.Right()->Left(), c.Right()->Left());
   BOOST_REQUIRE_EQUAL(b.Right()->Right(), (TreeType*) NULL);
   BOOST_REQUIRE_EQUAL(b.Right()->Right(), c.Right()->Right());
+
+  // Clean memory (we built the tree by hand, so this is what we have to do
+  // since the destructor won't free the children's datasets).
+  delete &b.Left()->Dataset();
+  delete &b.Right()->Dataset();
 }
 
 //! Count the number of leaves under this node.


### PR DESCRIPTION
Inspired by #2314, #2310, #2300, and others, I built mlpack with `-fsanitize=address` and ran `mlpack_test`.  The results were... noisy.  But I took some time and I fixed everything (except for one, detailed later).

 * All of the ANN layers are properly freed now; it took a while to get this write, and `DeleteVisitor` will now delete internally-held layers when the layer has a `Model()` method.  This may solve some issues people were having.

 * CNN layers don't make an alias of the input from `Forward()` anymore.  This should fix #2146 .

 * Test code properly frees things that it allocates.  There were some tricky places where deallocation had been overlooked.

 * Bindings handle exceptions properly and deallocate any allocated memory when an exception is thrown.  It makes the code a bit uglier, but it's safer.

There is one bug I didn't solve, which surfaces in the reinforcement learning code, in `q_learning_impl.hpp`:

```
     // Update target network
     if (totalSteps % config.TargetNetworkSyncInterval() == 0)
      targetNetwork = learningNetwork;
```

This code actually copies an `FFN`, and each individual layer will require a copy constructor to fix that memory leak.  That's the same issue as in #2314, and anyway, that isn't solved here.  But everything else in the tests is.

I do think it's important that we merge this before a release, otherwise we'll probably get lots of segfault and invalid memory access reports. :)