### PR TITLE
Alternate Homebrew HDF5 fix

### DIFF
--- a/src/mlpack/core/arma_extend/arma_extend.hpp
+++ b/src/mlpack/core/arma_extend/arma_extend.hpp
@@ -36,6 +36,13 @@
     #endif
 #endif
 
+// Force definition of old HDF5 API.  Thanks to Mike Roberts for helping find
+// this workaround.
+#if !defined(H5_USE_110_API)
+  #undef H5_USE_18_API
+  #define H5_USE_18_API
+#endif
+
 // Include everything we'll need for serialize().
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/nvp.hpp>


### PR DESCRIPTION
This is based on the findings in https://github.com/Homebrew/homebrew-core/issues/52003 and Conrad's workaround in https://gitlab.com/conradsnicta/armadillo-code/-/commit/0166bc036c5c6754402f60b0b2ffeb0914ea2939.

In essence, the breakages in the OS X builds are caused by HDF5 updating from 1.10 to 1.12 and this is a reverse-incompatible change (!).  So this replicates Conrad's fix for new versions of Armadillo, which is to force the HDF5 1.8 API.  We do the same here, since it will still be needed for older versions of Armadillo.

See also #2320 and related issues.

Let's see if it builds successfully...