### PR TITLE
Serialization Fix for some ANN layers.

### DIFF
--- a/src/mlpack/methods/ann/layer/concat_performance_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concat_performance_impl.hpp
@@ -102,9 +102,9 @@ void ConcatPerformance<
     OutputLayerType,
     InputDataType,
     OutputDataType
->::serialize(Archive& /* ar */, const unsigned int /* version */)
+>::serialize(Archive& ar, const unsigned int /* version */)
 {
-  // Nothing to do here.
+  ar & BOOST_SERIALIZATION_NVP(inSize);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/reinforce_normal.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal.hpp
@@ -87,7 +87,7 @@ class ReinforceNormal
    * Serialize the layer
    */
   template<typename Archive>
-  void serialize(Archive& /* ar */, const unsigned int /* version */);
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Standard deviation used during the forward and backward pass.

--- a/src/mlpack/methods/ann/layer/reinforce_normal_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reinforce_normal_impl.hpp
@@ -63,9 +63,9 @@ void ReinforceNormal<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void ReinforceNormal<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */, const unsigned int /* version */)
+    Archive& ar, const unsigned int /* version */)
 {
-  // Nothing to do here.
+  ar & BOOST_SERIALIZATION_NVP(stdev);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
@@ -63,10 +63,11 @@ void HuberLoss<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void HuberLoss<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const unsigned int /* version */)
 {
-  // Nothing to do here.
+  ar & BOOST_SERIALIZATION_NVP(delta);
+  ar & BOOST_SERIALIZATION_NVP(mean);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
@@ -62,10 +62,10 @@ void KLDivergence<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void KLDivergence<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const unsigned int /* version */)
 {
-  // Nothing to do here.
+  ar & BOOST_SERIALIZATION_NVP(takeMean);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
@@ -47,10 +47,10 @@ void LogCoshLoss<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void LogCoshLoss<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const unsigned int /* version */)
 {
-  // Nothing to do here.
+  ar & BOOST_SERIALIZATION_NVP(a);
 }
 
 } // namespace ann


### PR DESCRIPTION
Hi everyone, I noticed some parameters weren't serialized in some layers while I was going through concat layer. So I took a look at other layers as well and added serialization for them as well. This is an attempt to fix the same. I would love to hear your thoughts regarding this.
Hopefully last Bugfix before the release.
Thanks.