### PR TITLE
Use HDF 1.10 API instead of 1.08.

### DIFF
--- a/src/mlpack/core/arma_extend/arma_extend.hpp
+++ b/src/mlpack/core/arma_extend/arma_extend.hpp
@@ -39,8 +39,7 @@
 // Force definition of old HDF5 API.  Thanks to Mike Roberts for helping find
 // this workaround.
 #if !defined(H5_USE_110_API)
-  #undef H5_USE_18_API
-  #define H5_USE_18_API
+  #define H5_USE_110_API
 #endif
 
 // Include everything we'll need for serialize().


### PR DESCRIPTION
This is a based on a [suggestion](https://github.com/mlpack/mlpack/commit/682d25f69b14b159a2ff44393aaa638f3a14588d#commitcomment-38061822).  Thanks @conradsnicta! :+1: