### PR TITLE
corrections to handle vector types in Armadillo 9.870

### DIFF
--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -82,7 +82,8 @@ struct IsVector<arma::subview_row<eT> >
 };
 
 
-#if ( (ARMA_VERSION_MAJOR >= 10) || ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)) )
+#if ((ARMA_VERSION_MAJOR >= 10) || \
+    ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)))
 
   // Armadillo 9.869+ has SpSubview_col and SpSubview_row
 

--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -81,14 +81,33 @@ struct IsVector<arma::subview_row<eT> >
   const static bool value = true;
 };
 
-// I'm not so sure about this one.  An SpSubview object can be a row or column,
-// but it can also be a matrix subview.
 
-// template<>
-template<typename eT>
-struct IsVector<arma::SpSubview<eT> >
-{
-  const static bool value = true;
-};
+#if ( (ARMA_VERSION_MAJOR >= 10) || ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)) )
+
+  // Armadillo 9.869+ has SpSubview_col and SpSubview_row
+
+  template<typename eT>
+  struct IsVector<arma::SpSubview_col<eT> >
+  {
+    const static bool value = true;
+  };
+
+  template<typename eT>
+  struct IsVector<arma::SpSubview_row<eT> >
+  {
+    const static bool value = true;
+  };
+
+#else
+
+  // fallback for older Armadillo versions
+
+  template<typename eT>
+  struct IsVector<arma::SpSubview<eT> >
+  {
+    const static bool value = true;
+  };
+
+#endif
 
 #endif


### PR DESCRIPTION
This patch corrects handling of Armadillo vector types by `IsVector`.
Without this patch, mlpack will not compile with Armadillo 9.870 (and development version 9.869).

Armadillo 9.870 has extended handling of sparse submatrix views. In addition to `arma::SpSubview`, it now has `arma::SpSubview_col` and `arma::SpSubview_row`.  The latter two types are vector types, so `IsVector` needs to be adjusted accordingly.