### PR TITLE
Fix LogisticRegression parameter size 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -56,7 +56,7 @@
   * Add LiSHT activation function (#2182).
 
   * Add Valid and Same Padding for Transposed Convolution layer (#2163).
-  
+
   * Add CELU activation function (#2191)
 
   * Add Log-Hyperbolic-Cosine Loss function (#2207)
@@ -78,6 +78,9 @@
   * Add Cosine Embedding Loss Function (#2209).
 
   * Add Margin Ranking Loss Function (#2264).
+
+  * Bugfix for incorrect parameter vector sizes in logistic regression and
+    softmax regression (#2359).
 
 ### mlpack 3.2.2
 ###### 2019-11-26

--- a/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
@@ -25,7 +25,6 @@ LogisticRegression<MatType>::LogisticRegression(
     const MatType& predictors,
     const arma::Row<size_t>& responses,
     const double lambda) :
-    parameters(arma::rowvec(predictors.n_rows + 1, arma::fill::zeros)),
     lambda(lambda)
 {
   Train(predictors, responses);
@@ -60,7 +59,6 @@ LogisticRegression<MatType>::LogisticRegression(
     const arma::Row<size_t>& responses,
     OptimizerType& optimizer,
     const double lambda) :
-    parameters(arma::rowvec(predictors.n_rows + 1, arma::fill::zeros)),
     lambda(lambda)
 {
   Train(predictors, responses, optimizer);
@@ -85,9 +83,11 @@ double LogisticRegression<MatType>::Train(
     OptimizerType& optimizer,
     CallbackTypes&&... callbacks)
 {
-  LogisticRegressionFunction<MatType> errorFunction(predictors,
-                                                    responses,
-                                                    lambda);
+  LogisticRegressionFunction<MatType> errorFunction(predictors, responses,
+      lambda);
+
+  // Set size of parameters vector according to the input data received.
+  parameters = arma::rowvec(predictors.n_rows + 1, arma::fill::zeros);
   errorFunction.InitialPoint() = parameters;
 
   Timer::Start("logistic_regression_optimization");

--- a/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
@@ -65,7 +65,7 @@ double SoftmaxRegression::Train(const arma::mat& data,
 {
   SoftmaxRegressionFunction regressor(data, labels, numClasses, lambda,
                                       fitIntercept);
-  if (parameters.is_empty())
+  if (parameters.n_elem != regressor.GetInitialPoint().n_elem)
     parameters = regressor.GetInitialPoint();
 
   // Train the model.
@@ -88,7 +88,7 @@ double SoftmaxRegression::Train(const arma::mat& data,
 {
   SoftmaxRegressionFunction regressor(data, labels, numClasses, lambda,
                                       fitIntercept);
-  if (parameters.is_empty())
+  if (parameters.n_elem != regressor.GetInitialPoint().n_elem)
     parameters = regressor.GetInitialPoint();
 
   // Train the model.

--- a/src/mlpack/tests/logistic_regression_test.cpp
+++ b/src/mlpack/tests/logistic_regression_test.cpp
@@ -1002,4 +1002,25 @@ BOOST_AUTO_TEST_CASE(LogisticRegressionTrainReturnObjective)
   BOOST_REQUIRE_EQUAL(std::isfinite(objVal), true);
 }
 
+/**
+ * Test that construction *then* training works fine.  Thanks @Trento89 for the
+ * test case (see #2358).
+ */
+BOOST_AUTO_TEST_CASE(ConstructionThenTraining)
+{
+  arma::mat myMatrix;
+
+  // Four points, three dimensions.
+  myMatrix << 0.555950 << 0.274690 << 0.540605 << 0.798938 << arma::endr
+           << 0.948014 << 0.973234 << 0.216504 << 0.883152 << arma::endr
+           << 0.023787 << 0.675382 << 0.231751 << 0.450332 << arma::endr;
+
+  arma::Row<size_t> myTargets("1 0 1 0");
+
+  regression::LogisticRegression<> lr;
+
+  // Make sure that training doesn't crash with invalid parameter sizes.
+  BOOST_REQUIRE_NO_THROW(lr.Train(myMatrix, myTargets));
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
This PR fixes #2358.  I actually had it ready a few hours ago but then life happened to me and I hadn't clicked the 'create pull request' button yet. :)

Basically, what I found was that when a `LogisticRegression` object is created, it sets a `parameters` vector that is used for the initial point during training.  However, if the object is created and then `Train()` is called with a parameter vector of a different size, then training will fail!

So, this PR fixes that by ensuring that the parameters vector used for training is the same size as expected by the model.  I also found a similar bug in `SoftmaxRegression`.

I've added the original test case to the test cases for logistic regression, too. :)

Thanks to @trento89 for finding the issue! :+1: