### PR TITLE
correction in backward function of log softmax layer

### DIFF
--- a/src/mlpack/methods/ann/layer/log_softmax.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax.hpp
@@ -61,7 +61,7 @@ class LogSoftMax
    * @param g The calculated gradient.
    */
   template<typename eT>
-  void Backward(const arma::Mat<eT>& input,
+  void Backward(const arma::Mat<eT>& /* input */,
                 const arma::Mat<eT>& gy,
                 arma::Mat<eT>& g);
 
@@ -75,6 +75,11 @@ class LogSoftMax
   //! Modify the delta.
   InputDataType& Delta() { return delta; }
 
+  //! Get the value of deterministic.
+  InputDataType& Deterministic() const { return deterministic; }
+  //! Modify the value of deterministic.
+  InputDataType& Deterministic() { return deterministic; }
+
   /**
    * Serialize the layer.
    */
@@ -87,6 +92,12 @@ class LogSoftMax
 
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! If false, output of forward pass saved for derivative calculation.
+  bool deterministic;
+
+  //! Buffer for output of forward pass if non-deterministic.
+  arma::Mat<typename InputDataType::elem_type> y;
 }; // class LogSoftmax
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
@@ -19,7 +19,7 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-LogSoftMax<InputDataType, OutputDataType>::LogSoftMax()
+LogSoftMax<InputDataType, OutputDataType>::LogSoftMax() : deterministic(0)
 {
   // Nothing to do here.
 }
@@ -59,16 +59,21 @@ void LogSoftMax<InputDataType, OutputDataType>::Forward(
 
   maxInput.each_row() += arma::log(arma::sum(output));
   output = input - maxInput;
+
+  if (!deterministic)
+  {
+    y = output;
+  }
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void LogSoftMax<InputDataType, OutputDataType>::Backward(
-    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& /* input */,
     const arma::Mat<eT>& gy,
     arma::Mat<eT>& g)
 {
-  g = arma::exp(input) + gy;
+  g = gy - arma::exp(y);
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1498,7 +1498,23 @@ BOOST_AUTO_TEST_CASE(SimpleLogSoftmaxLayerTest)
   error(1, 0) = -1;
   module.Backward(input, error, delta);
   BOOST_REQUIRE_SMALL(arma::accu(arma::abs(
-      arma::mat("1.6487; 0.6487") - delta)), 1e-3);
+      arma::mat("-0.5; -1.5") - delta)), 1e-3);
+}
+
+/**
+ * Jacobian LogSoftMax module test.
+ */
+BOOST_AUTO_TEST_CASE(JacobianLogSoftMaxLayerTest)
+{
+  for (size_t i = 0; i < 5; ++i)
+  {
+    const size_t inputSize = math::RandInt(2, 100);
+    LogSoftMax<> module;
+
+    arma::mat input(inputSize, 1);
+    const double error = JacobianTest(module, input);
+    BOOST_CHECK_LE(error, 1e-04);
+  }
 }
 
 /*


### PR DESCRIPTION
Hi everyone,
The backward function in the LogSoftmax layer seems to have some error as neither it satisfies mathematical equation nor it passes Jacobian Test (i.e. producing large error). The deduction for derivative of LogSoftmax function is:
<p align="center">
<img src="https://user-images.githubusercontent.com/35535378/78896738-94e1eb80-7a8e-11ea-889a-bafb28bf4bd1.png" width="40%" height="40%">
</p>
...but the current implementation is:

https://github.com/mlpack/mlpack/blob/fded9ee333bfbac179e9826bdfe4a3b093ef67f2/src/mlpack/methods/ann/layer/log_softmax_impl.hpp#L64-L72

which doesn't look like the correct equation.
The error in the Jacobian Test for the new backward function is around 9.5e-05, but the error in Jacobian Test for the current backward function is around 0.98. 