### PR TITLE
Changes in parameter description for activation functions in ANN module

### DIFF
--- a/src/mlpack/methods/ann/activation_functions/elish_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/elish_function.hpp
@@ -101,7 +101,7 @@ class ElishFunction
   /**
    * Computes the first derivatives of the ELiSH function.
    *
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template<typename InputVecType, typename OutputVecType>

--- a/src/mlpack/methods/ann/activation_functions/hard_sigmoid_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/hard_sigmoid_function.hpp
@@ -78,7 +78,7 @@ class HardSigmoidFunction
   /**
    * Computes the first derivatives of the hard sigmoid function.
    *
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template<typename InputVecType, typename OutputVecType>

--- a/src/mlpack/methods/ann/activation_functions/identity_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/identity_function.hpp
@@ -65,7 +65,7 @@ class IdentityFunction
   /**
    * Computes the first derivatives of the identity function.
    *
-   * @param y Input activations.
+   * @param y Input data/activation.
    * @param x The resulting derivatives.
    */
   template<typename InputVecType, typename OutputVecType>

--- a/src/mlpack/methods/ann/activation_functions/lisht_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/lisht_function.hpp
@@ -79,7 +79,7 @@ class LiSHTFunction
   /**
    * Computes the first derivatives of the LiSHT function.
    * 
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template <typename InputVecType, typename OutputVecType>

--- a/src/mlpack/methods/ann/activation_functions/logistic_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/logistic_function.hpp
@@ -64,7 +64,7 @@ class LogisticFunction
   /**
    * Computes the first derivative of the logistic function.
    *
-   * @param x Input data.
+   * @param x Input activation.
    * @return f'(x)
    */
   static double Deriv(const double y)

--- a/src/mlpack/methods/ann/activation_functions/mish_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/mish_function.hpp
@@ -81,7 +81,7 @@ class MishFunction
   /**
    * Computes the first derivatives of the Mish function.
    * 
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template <typename InputVecType, typename OutputVecType>

--- a/src/mlpack/methods/ann/activation_functions/rectifier_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/rectifier_function.hpp
@@ -96,7 +96,7 @@ class RectifierFunction
   /**
    * Computes the first derivatives of the rectifier function.
    *
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template<typename InputType, typename OutputType>

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -85,7 +85,7 @@ class SoftplusFunction
   /**
    * Computes the first derivatives of the softplus function.
    *
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template<typename InputType, typename OutputType>

--- a/src/mlpack/methods/ann/activation_functions/softsign_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softsign_function.hpp
@@ -78,7 +78,7 @@ class SoftsignFunction
   /**
    * Computes the first derivative of the softsign function.
    *
-   * @param y Input data.
+   * @param y Input activation.
    * @return f'(x)
    */
   static double Deriv(const double y)

--- a/src/mlpack/methods/ann/activation_functions/swish_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/swish_function.hpp
@@ -83,7 +83,7 @@ class SwishFunction
   /**
    * Computes the first derivatives of the swish function.
    *
-   * @param y Input activations.
+   * @param y Input data.
    * @param x The resulting derivatives.
    */
   template<typename InputVecType, typename OutputVecType>

--- a/src/mlpack/methods/ann/activation_functions/tanh_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/tanh_function.hpp
@@ -55,7 +55,7 @@ class TanhFunction
   /**
    * Computes the first derivative of the tanh function.
    *
-   * @param y Input data.
+   * @param y Input activation.
    * @return f'(x)
    */
   static double Deriv(const double y)
@@ -66,7 +66,7 @@ class TanhFunction
   /**
    * Computes the first derivatives of the tanh function.
    *
-   * @param y Input data.
+   * @param y Input activations.
    * @param x The resulting derivatives.
    */
   template<typename InputVecType, typename OutputVecType>


### PR DESCRIPTION
The input parameters of the various activations in ann module have inconsistency in the inputs for calculating derivatives. Some (like tanh) require the **activations** [ i.e. f(x) ] as input while others (like softplus) require the **data** [ i.e. plain x ] as input. 
Since these are different for different activations, having a correct parameter description is necessary, to identify what input (either data or activation) is required for calculating the derivative.

Comments are welcome :)
