### PR TITLE
Pass CXXFLAGS correctly to Python build

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
   * Add L1 Loss function (#2203).
 
+  * Pass CMAKE_CXX_FLAGS (compilation options) correctly to Python build.
+
 ### mlpack 3.3.0
 ###### 2020-04-07
   * Templated return type of `Forward function` of loss functions (#2339).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,8 @@
 
   * Add L1 Loss function (#2203).
 
-  * Pass CMAKE_CXX_FLAGS (compilation options) correctly to Python build.
+  * Pass CMAKE_CXX_FLAGS (compilation options) correctly to Python build
+    (#2367).
 
 ### mlpack 3.3.0
 ###### 2020-04-07

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -134,6 +134,7 @@ if (BUILDING_PYTHON_BINDINGS)
           -D OpenMP_CXX_FLAGS="${OpenMP_CXX_FLAGS}"
           -D DISABLE_CFLAGS="${DISABLE_CFLAGS}"
           -D CYTHON_INCLUDE_DIRECTORIES="${CYTHON_INCLUDE_DIRECTORIES}"
+          -D CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
           -D OUTPUT_DIR=${CMAKE_BINARY_DIR}
           -P "${CMAKE_SOURCE_DIR}/src/mlpack/bindings/python/ConfigureSetup.cmake"
       BYPRODUCTS "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py"


### PR DESCRIPTION
While packaging mlpack 3.3.0 for Fedora, I found that the CXXFLAGS used for compilation of mlpack (and set via `CMAKE_CXX_FLAGS`) weren't actually being used by Cython when compiling the Python bindings.  After some digging I realized why: `CMAKE_CXX_FLAGS` is not actually set to the project's `CMAKE_CXX_FLAGS` when the `ConfigureSetup.cmake` script is called to turn `setup.py.in` to `setup.py`.  That means the `cxx_flags` variable in `setup.py.in`, which is set like this:

```python
  cxx_flags = '${CMAKE_CXX_FLAGS}'.strip()
```

was actually being set to the empty string.

This PR fixes that by explicitly setting `CMAKE_CXX_FLAGS` as a CMake variable when calling `ConfigureSetup.cmake`.