### PR TITLE
Changes in the Pendulum-v0 implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
-  * Updated terminal state for Pendulum environment (#2354).
+  * Updated terminal state and fixed bugs for Pendulum environment (#2354, #2369).
 
   * Added `EliSH` activation function (#2323).
 

--- a/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
@@ -94,8 +94,6 @@ class Pendulum
    * @param maxAngularVelocity Maximum angular velocity.
    * @param maxTorque Maximum torque.
    * @param dt The differential value.
-   * @param angleThreshold The region about the upright position where the
-   *    state is considered terminal.
    * @param doneReward The reward recieved by the agent on success.
    * @param maxSteps The number of steps after which the episode
    *    terminates. If the value is 0, there is no limit (Default: 200 steps). 
@@ -103,13 +101,11 @@ class Pendulum
   Pendulum(const double maxAngularVelocity = 8,
            const double maxTorque = 2.0,
            const double dt = 0.05,
-           const double angleThreshold = M_PI / 12,
            const double doneReward = 0.0,
            const size_t maxSteps = 200) :
       maxAngularVelocity(maxAngularVelocity),
       maxTorque(maxTorque),
       dt(dt),
-      angleThreshold(angleThreshold),
       doneReward(doneReward),
       maxSteps(maxSteps),
       stepsPerformed(0)
@@ -191,7 +187,7 @@ class Pendulum
   State InitialSample()
   {
     State state;
-    state.Theta() = math::Random(-M_PI + angleThreshold, M_PI - angleThreshold);
+    state.Theta() = math::Random(-M_PI, M_PI);
     state.AngularVelocity() = math::Random(-1.0, 1.0);
     stepsPerformed = 0;
     return state;
@@ -245,9 +241,6 @@ class Pendulum
 
   //! Locally-stored dt.
   double dt;
-
-  //! Locally-stored angle threshold.
-  double angleThreshold;
 
   //! Locally-stored done reward.
   double doneReward;

--- a/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
@@ -151,15 +151,6 @@ class Pendulum
     nextState.AngularVelocity() = math::ClampRange(newAngularVelocity,
         -maxAngularVelocity, maxAngularVelocity);
 
-    // Check if the episode has terminated
-    bool done = IsTerminal(nextState);
-
-    // Do not reward the agent if time ran out.
-    if (done && maxSteps != 0 && stepsPerformed >= maxSteps)
-      return 0;
-    else if (done)
-      return doneReward;
-
     // Return the reward of taking the action in current state.
     // The reward is simply the negative of cost incurred for the action.
     return -costs;

--- a/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
@@ -149,11 +149,11 @@ class Pendulum
 
     // Calculate new state values and assign to the next state.
     double newAngularVelocity = angularVelocity + (-3.0 * gravity / (2 *
-        length) * std::sin(theta + M_PI) + 3.0 / std::pow(mass * length, 2) *
+        length) * std::sin(theta + M_PI) + 3.0 / (mass * std::pow(length, 2)) *
         torque) * dt;
+    nextState.Theta() = theta + newAngularVelocity * dt;
     nextState.AngularVelocity() = math::ClampRange(newAngularVelocity,
         -maxAngularVelocity, maxAngularVelocity);
-    nextState.Theta() = theta + newAngularVelocity * dt;
 
     // Check if the episode has terminated
     bool done = IsTerminal(nextState);

--- a/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
@@ -205,7 +205,10 @@ class Pendulum
   double AngleNormalize(double theta) const
   {
     // Scale angle within [-pi, pi).
-    return double(fmod(theta + M_PI, 2 * M_PI) - M_PI);
+    double x = fmod(theta + M_PI, 2 * M_PI);
+    if (x < 0)
+      x += 2 * M_PI;
+    return x - M_PI;
   }
 
   /**

--- a/src/mlpack/tests/rl_components_test.cpp
+++ b/src/mlpack/tests/rl_components_test.cpp
@@ -38,25 +38,25 @@ BOOST_AUTO_TEST_SUITE(RLComponentsTest)
 BOOST_AUTO_TEST_CASE(SimplePendulumTest)
 {
   Pendulum task = Pendulum();
-  task.MaxSteps() = 5;
+  task.MaxSteps() = 20;
 
   Pendulum::State state = task.InitialSample();
   Pendulum::Action action;
   action.action[0] = math::Random(-2.0, 2.0);
-  double reward = task.Sample(state, action);
-
-  // The reward is always negative. Check if not lower than lowest possible.
-  BOOST_REQUIRE(reward >= -(pow(M_PI, 2) + 6.404));
+  double reward;
 
   BOOST_REQUIRE(!task.IsTerminal(state));
 
   while (!task.IsTerminal(state))
-    task.Sample(state, action, state);
+    reward = task.Sample(state, action, state);
+
+  // The reward is always negative. Check if not lower than lowest possible.
+  BOOST_REQUIRE(reward >= -(pow(M_PI, 2) + 6.404));
 
   // Check if the number of steps performed is less or equal as the maximum
   // allowed, since we use a random action there is no guarantee that we will
   // reach the maximum number of steps.
-  BOOST_REQUIRE_LE(task.StepsPerformed(), 5);
+  BOOST_REQUIRE_LE(task.StepsPerformed(), 20);
 
   // The action is simply the torque. Check if dimension is 1.
   BOOST_REQUIRE_EQUAL(1, action.size);

--- a/src/mlpack/tests/rl_components_test.cpp
+++ b/src/mlpack/tests/rl_components_test.cpp
@@ -43,15 +43,18 @@ BOOST_AUTO_TEST_CASE(SimplePendulumTest)
   Pendulum::State state = task.InitialSample();
   Pendulum::Action action;
   action.action[0] = math::Random(-2.0, 2.0);
-  double reward;
+  double reward, minReward = 0.0;
 
   BOOST_REQUIRE(!task.IsTerminal(state));
 
   while (!task.IsTerminal(state))
+  {
     reward = task.Sample(state, action, state);
+    minReward = std::min(reward, minReward);
+  }
 
   // The reward is always negative. Check if not lower than lowest possible.
-  BOOST_REQUIRE(reward >= -(pow(M_PI, 2) + 6.404));
+  BOOST_REQUIRE(minReward >= -(pow(M_PI, 2) + 6.404));
 
   // Check if the number of steps performed is less or equal as the maximum
   // allowed, since we use a random action there is no guarantee that we will


### PR DESCRIPTION
While working with the Pendulum environment, I noticed that it has some bugs which need to be removed:
1) `AngleNormalize` [here](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp#L205) is used to normalize the angle between -PI to PI just like [here](https://github.com/openai/gym/blob/master/gym/envs/classic_control/pendulum.py#L92). However the current implementation uses `fmod()` which is not the same as `%` used in python for cases of negative numbers. Thus the changes have been made accordingly.
2) The correct reward function [here](https://github.com/openai/gym/blob/master/gym/envs/classic_control/pendulum.py#L44) uses `m*l**2` which means `m*(l^2)` and not `(m*l)^2`.
3) As said [here](https://github.com/openai/gym/wiki/Pendulum-v0#starting-state) and [here](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp#L186), the `Theta` should be initialized between [-PI, PI].
4) Since  `angleThreshold` is no longer used anywhere, it is removed. (It was used in the isTerminal function earlier). 
5) A more accurate implementation of Pendulum environment should not require the return of any special "terminal state reward" or `doneReward`, as no such condition is provided [here](https://github.com/openai/gym/blob/master/gym/envs/classic_control/pendulum.py#L32).

Sorry for not noticing the changes in the previous PR related to pendulum. Any comments and suggestions are welcome :)