### PR TITLE
Forward function update for softplus_function.hpp

### DIFF
--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -52,20 +52,9 @@ class SoftplusFunction
   static double Fn(const double x)
   {
     const double val = std::log(1 + std::exp(x));
-    if (x < DBL_MAX)
-    {
-      if (x > -DBL_MAX)
-      {
-        if (std::isfinite(val))
-          return val;
-        else
-          return x;
-      }
-      else
-        return 0;
-    }
-    else
-      return 1.0;
+    if (std::isfinite(val))
+      return val;
+    return x;
   }
 
   /**
@@ -115,15 +104,9 @@ class SoftplusFunction
   static double Inv(const double y)
   {
     const double val = std::log(std::exp(y) - 1);
-    if (y > 0)
-    {
-      if (std::isfinite(val))
-        return val;
-      else
-        return y;
-    }
-    else
-      return 0;
+    if (std::isfinite(val))
+      return val;
+    return y;
   }
 
   /**

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -53,13 +53,17 @@ class SoftplusFunction
   {
     const double val = std::log(1 + std::exp(x));
     if (x < DBL_MAX)
-      if(x > -DBL_MAX)
+    {
+      if (x > -DBL_MAX)
+      {
         if (std::isfinite(val))
           return val;
         else
           return x;
+      }
       else
         return 0;
+    }
     else
       return 1.0;
   }
@@ -111,11 +115,13 @@ class SoftplusFunction
   static double Inv(const double y)
   {
     const double val = std::log(std::exp(y) - 1);
-    if(y > 0)
+    if (y > 0)
+    {
       if (std::isfinite(val))
         return val;
       else
         return y;
+    }
     else
       return 0;
   }

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -54,7 +54,7 @@ class SoftplusFunction
     const double val = std::log(1 + std::exp(x));
     if (x < DBL_MAX)
       return x > -DBL_MAX ? (std::isnan(val) || std::isinf(val) ? x : val)
-                          : 0;
+          : 0;
     return 1.0;
   }
 
@@ -104,7 +104,9 @@ class SoftplusFunction
    */
   static double Inv(const double y)
   {
-    return y > 0 ? arma::trunc_log(arma::trunc_exp(y) - 1) : 0;
+    const double val = std::log(std::exp(y) - 1);
+    return y > 0 ? (std::isnan(val) || std::isinf(val) ? y : val)
+        : 0;
   }
 
   /**

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -54,7 +54,7 @@ class SoftplusFunction
   {
     if (x > threshold)
       return x;
-    else 
+    else
       return std::log(1 + std::exp(x));
   }
 

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -47,11 +47,12 @@ class SoftplusFunction
    * Computes the softplus function.
    *
    * @param x Input data.
+   * @param threshold The threshold value above which softplus behaves linear.
    * @return f(x).
    */
-  static double Fn(const double x)
+  static double Fn(const double x, const double threshold = 40.0)
   {
-    if (x > 20.0)
+    if (x > threshold)
       return x;
     else 
       return std::log(1 + std::exp(x));
@@ -62,14 +63,16 @@ class SoftplusFunction
    *
    * @param x Input data.
    * @param y The resulting output activation.
+   * @param threshold The threshold value above which softplus behaves linear.
    */
   template<typename InputType, typename OutputType>
-  static void Fn(const InputType& x, OutputType& y)
+  static void Fn(const InputType& x, OutputType& y,
+                  const double threshold = 40.0)
   {
     y.set_size(arma::size(x));
 
     for (size_t i = 0; i < x.n_elem; i++)
-      y(i) = Fn(x(i));
+      y(i) = Fn(x(i), threshold);
   }
 
   /**

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -53,9 +53,15 @@ class SoftplusFunction
   {
     const double val = std::log(1 + std::exp(x));
     if (x < DBL_MAX)
-      return x > -DBL_MAX ? (std::isnan(val) || std::isinf(val) ? x : val)
-          : 0;
-    return 1.0;
+      if(x > -DBL_MAX)
+        if (std::isfinite(val))
+          return val;
+        else
+          return x;
+      else
+        return 0;
+    else
+      return 1.0;
   }
 
   /**
@@ -105,8 +111,13 @@ class SoftplusFunction
   static double Inv(const double y)
   {
     const double val = std::log(std::exp(y) - 1);
-    return y > 0 ? (std::isnan(val) || std::isinf(val) ? y : val)
-        : 0;
+    if(y > 0)
+      if (std::isfinite(val))
+        return val;
+      else
+        return y;
+    else
+      return 0;
   }
 
   /**

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -51,9 +51,10 @@ class SoftplusFunction
    */
   static double Fn(const double x)
   {
-    if (x < DBL_MAX)
-      return x > -DBL_MAX ? std::log(1 + std::exp(x)) : 0;
-    return 1.0;
+    if (x > 20.0)
+      return x;
+    else 
+      return std::log(1 + std::exp(x));
   }
 
   /**

--- a/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/softplus_function.hpp
@@ -47,15 +47,15 @@ class SoftplusFunction
    * Computes the softplus function.
    *
    * @param x Input data.
-   * @param threshold The threshold value above which softplus behaves linear.
    * @return f(x).
    */
-  static double Fn(const double x, const double threshold = 40.0)
+  static double Fn(const double x)
   {
-    if (x > threshold)
-      return x;
-    else
-      return std::log(1 + std::exp(x));
+    const double val = std::log(1 + std::exp(x));
+    if (x < DBL_MAX)
+      return x > -DBL_MAX ? (std::isnan(val) || std::isinf(val) ? x : val)
+                          : 0;
+    return 1.0;
   }
 
   /**
@@ -63,16 +63,14 @@ class SoftplusFunction
    *
    * @param x Input data.
    * @param y The resulting output activation.
-   * @param threshold The threshold value above which softplus behaves linear.
    */
   template<typename InputType, typename OutputType>
-  static void Fn(const InputType& x, OutputType& y,
-                  const double threshold = 40.0)
+  static void Fn(const InputType& x, OutputType& y)
   {
     y.set_size(arma::size(x));
 
     for (size_t i = 0; i < x.n_elem; i++)
-      y(i) = Fn(x(i), threshold);
+      y(i) = Fn(x(i));
   }
 
   /**

--- a/src/mlpack/tests/activation_functions_test.cpp
+++ b/src/mlpack/tests/activation_functions_test.cpp
@@ -683,13 +683,15 @@ BOOST_AUTO_TEST_CASE(ELUFunctionTest)
  */
 BOOST_AUTO_TEST_CASE(SoftplusFunctionTest)
 {
+  const arma::colvec activationData("-2 3.2 4.5 -100.2 1 -1 2 0 1000 10000");
+
   const arma::colvec desiredActivations("0.12692801 3.23995333 4.51104774 \
                                          0 1.31326168 0.31326168 2.12692801 \
-                                         0.69314718");
+                                         0.69314718 1000 10000");
 
   const arma::colvec desiredDerivatives("0.53168946 0.96231041 0.98913245 \
                                          0.5 0.78805844 0.57768119 0.89349302\
-                                         0.66666666");
+                                         0.66666666 1 1");
 
   CheckActivationCorrect<SoftplusFunction>(activationData, desiredActivations);
   CheckDerivativeCorrect<SoftplusFunction>(desiredActivations,


### PR DESCRIPTION
Hey!
While working on https://github.com/mlpack/mlpack/pull/1912, after training for a few iterations, I noticed that every parameter would turn `null`! Turns out that it was because the `Fn` function for `softplus_function` has a small error.

Since softplus turns close to linear for high input values, we can just return x instead of `log(1 + exp(x))`. Because as x goes higher (around 700), `exp(700)` turns infinity, causing null errors in further calculations.
Further, I find `20` to be an acceptable threshold as done [here](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/activation.py#L662). 

Let me know your thoughts :)