### PR TITLE
Add Copy, Move Constructors and Copy, Move Operators for LARS class.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,11 +11,9 @@
   * Pass CMAKE_CXX_FLAGS (compilation options) correctly to Python build
     (#2367).
 
-<<<<<<< HEAD
   * Expose ensmallen Callbacks for sparseautoencoder (#2198).
-=======
+
   * Bugfix for LARS class causing invalid read (#2374).
->>>>>>> ca72bc21b... Updated copy and move constructors to check if matGram points to internally held matrix, Updated History.md
 
 ### mlpack 3.3.0
 ###### 2020-04-07

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,11 @@
   * Pass CMAKE_CXX_FLAGS (compilation options) correctly to Python build
     (#2367).
 
+<<<<<<< HEAD
   * Expose ensmallen Callbacks for sparseautoencoder (#2198).
+=======
+  * Bugfix for LARS class causing invalid read (#2374).
+>>>>>>> ca72bc21b... Updated copy and move constructors to check if matGram points to internally held matrix, Updated History.md
 
 ### mlpack 3.3.0
 ###### 2020-04-07

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -109,9 +109,6 @@ LARS::LARS(LARS&& other) :
 {
   // Clean the other object to prevent to objects pointing
   // at the memory location.
-  if (other.matGram)
-    delete other.matGram;
-
   other.matGram = new arma::mat(other.matGramInternal);
   other.lambda1 = 0.0;
   other.lambda2 = 0.0;
@@ -122,10 +119,6 @@ LARS& LARS::operator=(const LARS& other)
 {
   if (&other == this)
     return *this;
-
-  // Clean the memory first.
-  if (matGram)
-    delete matGram;
 
   matGramInternal = other.matGramInternal;
   matGram = &matGramInternal;
@@ -151,10 +144,6 @@ LARS& LARS::operator=(LARS&& other)
   if (&other == this)
     return *this;
 
-  // Clean the memory first.
-  if (matGram)
-    delete matGram;
-
   matGramInternal = std::move(other.matGramInternal);
   matGram = other.matGram;
   matUtriCholFactor = std::move(other.matUtriCholFactor);
@@ -173,9 +162,6 @@ LARS& LARS::operator=(LARS&& other)
 
   // Clean the other object to prevent to objects pointing
   // at the memory location.
-  if (other.matGram)
-    delete other.matGram;
-
   other.matGram = new arma::mat(other.matGramInternal);
   other.lambda1 = 0.0;
   other.lambda2 = 0.0;

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -71,7 +71,8 @@ LARS::LARS(const arma::mat& data,
 // Copy Constructor.
 LARS::LARS(const LARS& other) :
     matGramInternal(other.matGramInternal),
-    matGram(&matGramInternal),
+    matGram(other.matGram != &other.matGramInternal ?
+        other.matGram : &matGramInternal),
     matUtriCholFactor(other.matUtriCholFactor),
     useCholesky(other.useCholesky),
     lasso(other.lasso),
@@ -92,7 +93,8 @@ LARS::LARS(const LARS& other) :
 // Move constructor.
 LARS::LARS(LARS&& other) :
     matGramInternal(std::move(other.matGramInternal)),
-    matGram(other.matGram),
+    matGram(other.matGram != &other.matGramInternal ?
+        other.matGram : &matGramInternal),
     matUtriCholFactor(std::move(other.matUtriCholFactor)),
     useCholesky(other.useCholesky),
     lasso(other.lasso),
@@ -107,11 +109,7 @@ LARS::LARS(LARS&& other) :
     ignoreSet(std::move(other.ignoreSet)),
     isIgnored(std::move(other.isIgnored))
 {
-  // Clean the other object to prevent to objects pointing
-  // at the memory location.
-  other.matGram = new arma::mat(other.matGramInternal);
-  other.lambda1 = 0.0;
-  other.lambda2 = 0.0;
+  // Nothing to do here.
 }
 
 // Copy operator.
@@ -121,7 +119,8 @@ LARS& LARS::operator=(const LARS& other)
     return *this;
 
   matGramInternal = other.matGramInternal;
-  matGram = &matGramInternal;
+  matGram = other.matGram != &other.matGramInternal ?
+      other.matGram : &matGramInternal;
   matUtriCholFactor = other.matUtriCholFactor;
   useCholesky = other.useCholesky;
   lasso = other.lasso;
@@ -145,7 +144,8 @@ LARS& LARS::operator=(LARS&& other)
     return *this;
 
   matGramInternal = std::move(other.matGramInternal);
-  matGram = other.matGram;
+  matGram = other.matGram != &other.matGramInternal ?
+      other.matGram : &matGramInternal;
   matUtriCholFactor = std::move(other.matUtriCholFactor);
   useCholesky = other.useCholesky;
   lasso = other.lasso;
@@ -159,12 +159,6 @@ LARS& LARS::operator=(LARS&& other)
   isActive = std::move(other.isActive);
   ignoreSet = std::move(other.ignoreSet);
   isIgnored = std::move(other.isIgnored);
-
-  // Clean the other object to prevent to objects pointing
-  // at the memory location.
-  other.matGram = new arma::mat(other.matGramInternal);
-  other.lambda1 = 0.0;
-  other.lambda2 = 0.0;
   return *this;
 }
 

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -68,6 +68,120 @@ LARS::LARS(const arma::mat& data,
   Train(data, responses, transposeData);
 }
 
+// Copy Constructor.
+LARS::LARS(const LARS& other) :
+    matGramInternal(other.matGramInternal),
+    matGram(&matGramInternal),
+    matUtriCholFactor(other.matUtriCholFactor),
+    useCholesky(other.useCholesky),
+    lasso(other.lasso),
+    lambda1(other.lambda1),
+    lambda2(other.lambda2),
+    elasticNet(other.elasticNet),
+    tolerance(other.tolerance),
+    betaPath(other.betaPath),
+    lambdaPath(other.lambdaPath),
+    activeSet(other.activeSet),
+    isActive(other.isActive),
+    ignoreSet(other.ignoreSet),
+    isIgnored(other.isIgnored)
+{
+  // Nothing to do here.
+}
+
+// Move constructor.
+LARS::LARS(LARS&& other) :
+    matGramInternal(std::move(other.matGramInternal)),
+    matGram(other.matGram),
+    matUtriCholFactor(std::move(other.matUtriCholFactor)),
+    useCholesky(other.useCholesky),
+    lasso(other.lasso),
+    lambda1(other.lambda1),
+    lambda2(other.lambda2),
+    elasticNet(other.elasticNet),
+    tolerance(other.tolerance),
+    betaPath(std::move(other.betaPath)),
+    lambdaPath(std::move(other.lambdaPath)),
+    activeSet(std::move(other.activeSet)),
+    isActive(std::move(other.isActive)),
+    ignoreSet(std::move(other.ignoreSet)),
+    isIgnored(std::move(other.isIgnored))
+{
+  // Clean the other object to prevent to objects pointing
+  // at the memory location.
+  if (other.matGram)
+    delete other.matGram;
+
+  other.matGram = new arma::mat(other.matGramInternal);
+  other.lambda1 = 0.0;
+  other.lambda2 = 0.0;
+}
+
+// Copy operator.
+LARS& LARS::operator=(const LARS& other)
+{
+  if (&other == this)
+    return *this;
+
+  // Clean the memory first.
+  if (matGram)
+    delete matGram;
+
+  matGramInternal = other.matGramInternal;
+  matGram = &matGramInternal;
+  matUtriCholFactor = other.matUtriCholFactor;
+  useCholesky = other.useCholesky;
+  lasso = other.lasso;
+  lambda1 = other.lambda1;
+  lambda2 = other.lambda2;
+  elasticNet = other.elasticNet;
+  tolerance = other.tolerance;
+  betaPath = other.betaPath;
+  lambdaPath = other.lambdaPath;
+  activeSet = other.activeSet;
+  isActive = other.isActive;
+  ignoreSet = other.ignoreSet;
+  isIgnored = other.isIgnored;
+  return *this;
+}
+
+// Move Operator.
+LARS& LARS::operator=(LARS&& other)
+{
+  if (&other == this)
+    return *this;
+
+  // Clean the memory first.
+  if (matGram)
+    delete matGram;
+
+  matGramInternal = std::move(other.matGramInternal);
+  matGram = other.matGram;
+  matUtriCholFactor = std::move(other.matUtriCholFactor);
+  useCholesky = other.useCholesky;
+  lasso = other.lasso;
+  lambda1 = other.lambda1;
+  lambda2 = other.lambda2;
+  elasticNet = other.elasticNet;
+  tolerance = other.tolerance;
+  betaPath = std::move(other.betaPath);
+  lambdaPath = std::move(other.lambdaPath);
+  activeSet = std::move(other.activeSet);
+  isActive = std::move(other.isActive);
+  ignoreSet = std::move(other.ignoreSet);
+  isIgnored = std::move(other.isIgnored);
+
+  // Clean the other object to prevent to objects pointing
+  // at the memory location.
+  if (other.matGram)
+    delete other.matGram;
+
+  other.matGram = new arma::mat(other.matGramInternal);
+  other.lambda1 = 0.0;
+  other.lambda2 = 0.0;
+  return *this;
+}
+
 double LARS::Train(const arma::mat& matX,
                    const arma::rowvec& y,
                    arma::vec& beta,

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -189,14 +189,14 @@ class LARS
    *
    * @param other LARS object to copy.
    */
-  LARS &operator=(const LARS& other);
+  LARS& operator=(const LARS& other);
 
   /**
    * Take ownership of the given LARS object.
    *
    * @param other LARS object to take ownership of.
    */
-  LARS &operator=(LARS&& other);
+  LARS& operator=(LARS&& other);
 
   /**
    * Run LARS.  The input matrix (like all mlpack matrices) should be

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -171,6 +171,34 @@ class LARS
        const double tolerance = 1e-16);
 
   /**
+   * Construct the LARS object by copying the given LARS object.
+   *
+   * @param other LARS object to copy.
+   */
+  LARS(const LARS& other);
+
+  /**
+   * Construct the LARS object by taking ownership of the given LARS object.
+   *
+   * @param other LARS object to take ownership of.
+   */
+  LARS(LARS&& other);
+
+  /**
+   * Copy the given LARS object.
+   *
+   * @param other LARS object to copy.
+   */
+  LARS &operator=(const LARS& other);
+
+  /**
+   * Take ownership of the given LARS object.
+   *
+   * @param other LARS object to take ownership of.
+   */
+  LARS &operator=(LARS&& other);
+
+  /**
    * Run LARS.  The input matrix (like all mlpack matrices) should be
    * column-major -- each column is an observation and each row is a dimension.
    * However, because LARS is more efficient on a row-major matrix, this method

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -421,35 +421,45 @@ BOOST_AUTO_TEST_CASE(LARSTestComputeError)
   BOOST_REQUIRE_EQUAL(cost == train1, true);
 }
 
+/**
+ * Simple test for LARS copy constructor.
+ */
 BOOST_AUTO_TEST_CASE(LARSCopyConstructorTest)
 {
   arma::mat features, Y;
   arma::rowvec targets;
+
+  // Load training input and predictions for testing.
   data::Load("lars_dependent_x.csv", features);
   data::Load("lars_dependent_y.csv", Y);
   targets = Y.row(0);
+
+  // Check if the copy is accessible even after deleting the pointer to the
+  // object.
   mlpack::regression::LARS* glm1 = new mlpack::regression::LARS(false, .1, .1);
   arma::rowvec predictions, predictionsFromCopiedModel;
   std::vector<mlpack::regression::LARS> models;
   glm1->Train(features, targets);
   glm1->Predict(features, predictions);
-  models.emplace_back(*glm1);
+  models.emplace_back(*glm1); // Call the copy constructor.
   delete glm1; // Free LARS internal memory.
   models[0].Predict(features, predictionsFromCopiedModel);
+  // The output of both models should be the same.
   CheckMatrices(predictions, predictionsFromCopiedModel);
   // Check if we can train the model again.
   BOOST_REQUIRE_NO_THROW(models[0].Train(features, targets));
 
-  // Check for object.
+  // Check if we can train the copied model.
   mlpack::regression::LARS glm2(false, 0.1, 0.1);
-  models.emplace_back(glm2);
+  models.emplace_back(glm2); // Call the copy constructor.
   BOOST_REQUIRE_NO_THROW(glm2.Train(features, targets));
   BOOST_REQUIRE_NO_THROW(models[1].Train(features, targets));
 
-  // Check assignment operator.
+  // Create a copy using assignment operator.
   mlpack::regression::LARS glm3 = glm2;
   models[1].Predict(features, predictions);
   glm3.Predict(features, predictionsFromCopiedModel);
+  // The output of both models should be the same.
   CheckMatrices(predictions, predictionsFromCopiedModel);
 }
 


### PR DESCRIPTION
Aims to close #2372.
Changes made :

- Add Copy Constructor and Move Constructor.

- Add Copy and Move Assignment Operator.

- Add Tests for assignment and copy constructors. Test were adapted from the one mentioned in #2372.

One thing that requires a close look : Clean up of other object in move Constructor.

Other points:
1. A few other methods also lack this function so they might also fail. I will probably test them and add them maybe in another PR so that we can at least close #2372. That way it will be easy to review as well as easier for me to make changes in other layers as well.

Thanks a lot!