### PR TITLE
Add Julia binding for linear SVM.

### DIFF
--- a/src/mlpack/methods/linear_svm/CMakeLists.txt
+++ b/src/mlpack/methods/linear_svm/CMakeLists.txt
@@ -19,4 +19,5 @@ set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)
 
 add_cli_executable(linear_svm)
 add_python_binding(linear_svm)
-add_markdown_docs(linear_svm "cli;python" "classification")
+add_julia_binding(linear_svm)
+add_markdown_docs(linear_svm "cli;python;julia" "classification")


### PR DESCRIPTION
Looks like this was just overlooked; I think because the linear SVM binding was merged during the development of the Julia bindings.  This PR will make `mlpack.linear_svm()` available from Julia.