### PR TITLE
Remove Python 2.7 build from OS X.

### DIFF
--- a/.ci/ci.yaml
+++ b/.ci/ci.yaml
@@ -43,9 +43,6 @@ jobs:
       Plain:
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF'
         python.version: '2.7'
-      Python27:
-        python.version: '2.7'
-        CMakeArgs: '-DDEBUG=OFF -DPROFILE=OFF'
       Python37:
         python.version: '3.7'
         CMakeArgs: '-DDEBUG=OFF -DPROFILE=OFF'


### PR DESCRIPTION
This removes the Python 2.7 CI build from Azure Pipelines.

I think that this is a reasonable thing to do, since we keep having trouble with it (due to Homebrew versions, pip versioning issues, and so forth), and since Python 2.7 is EOL anyway.  I think that it will save us time to just remove the build altogether from Azure Pipelines, instead of continually trying to debug it.

Happy to consider other ideas too, I just wanted to propose this as a low-effort possibility.