### PR TITLE
Addition of Normal Distribution to ANN module

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,8 @@
 
 ### mlpack 3.3.0
 ###### 2020-04-07
+  * Added `Normal Distribution` to `ann/dists` (#2382).
+
   * Templated return type of `Forward function` of loss functions (#2339).
 
   * Added `R2 Score` regression metric (#2323).

--- a/src/mlpack/methods/.vscode/settings.json
+++ b/src/mlpack/methods/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "*.txt": "cpp",
-        "armadillo": "cpp"
-    }
-}

--- a/src/mlpack/methods/.vscode/settings.json
+++ b/src/mlpack/methods/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "*.txt": "cpp",
+        "armadillo": "cpp"
+    }
+}

--- a/src/mlpack/methods/ann/dists/CMakeLists.txt
+++ b/src/mlpack/methods/ann/dists/CMakeLists.txt
@@ -3,6 +3,8 @@
 set(SOURCES
   bernoulli_distribution.hpp
   bernoulli_distribution_impl.hpp
+  normal_distribution.hpp
+  normal_distribution_impl.hpp
 )
 
 # Add directory name to sources.

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -1,0 +1,132 @@
+/**
+ * @file normal_distribution.hpp
+ * @author xiaohong ji
+ *
+ * Definition of the Normal distribution class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_DISTRIBUTIONS_NORMAL_DISTRIBUTION_HPP
+#define MLPACK_METHODS_ANN_DISTRIBUTIONS_NORMAL_DISTRIBUTION_HPP
+
+#include <mlpack/prereqs.hpp>
+#include "../activation_functions/logistic_function.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * Multiple independent Bernoulli distributions.
+ *
+ * Bernoulli distribution is the discrete probability distribution of a random
+ * variable which takes the value 1 with probability p and the value 0 with
+ * probability q = 1 - p.
+ * In this implementation, the p values of the distributions are given by the
+ * param matrix.
+ *
+ */
+class NormalDistribution
+{
+ private:
+  //! Mean of the distribution.
+  arma::vec mean;
+  //! Variance of the distribution.
+  arma::vec sigma;
+
+  // pi
+  static const constexpr double pi = 3.14159265358979323846264338327950288;
+
+ public:
+  /**
+   * Default constructor, which creates a Normal distribution with zero
+   * dimension.
+   */
+  NormalDistribution();
+
+  /**
+   * Create a Normal distribution with the given mean and sigma.
+   */
+  NormalDistribution(const arma::vec& mean, const arma::vec& sigma);
+
+  /**
+   * Return the probabilities of the given matrix of observations.
+   *
+   * @param observation The observation matrix.
+   */
+  arma::vec Probability(const arma::vec& observation) const
+  {
+    return arma::exp(LogProbability(observation));
+  }
+
+  /**
+   * Return the log probabilities of the given matrix of observations.
+   *
+   * @param observation The observation matrix.
+   */
+  arma::vec LogProbability(const arma::vec& observation) const;
+
+  /**
+   * Calculates the normal probability density function for each
+   * data point (column) in the given matrix.
+   *
+   * @param x List of observations.
+   * @param probabilities Output probabilities for each input observation.
+   */
+  void Probability(const arma::vec& x, arma::vec& probabilities) const
+  {
+    probabilities = Probability(x);
+  }
+
+  /**
+   * Return a randomly generated observation according to the probability
+   * distribution defined by this object.
+   *
+   * @return Random observation from this Normal distribution.
+   */
+  arma::vec Sample() const;
+
+  /**
+   * Return the mean.
+   */
+  const arma::vec& Mean() const { return mean; }
+
+  /**
+   * Return a modifiable copy of the mean.
+   */
+  arma::vec& Mean() { return mean; }
+
+  /**
+   * Return the variance.
+   */
+  const arma::vec& Sigma() const { return sigma; }
+
+  /**
+   * Return a modifiable copy of the variance.
+   */
+  arma::vec& Variance() { return sigma; }
+
+  //! Return the dimensionality of this distribution.
+  size_t Dimensionality() const { return mean.n_elem; }
+
+  /**
+   * Serialize the distribution.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */)
+  {
+    // We just need to serialize each of the members.
+    ar & BOOST_SERIALIZATION_NVP(mean);
+    ar & BOOST_SERIALIZATION_NVP(sigma);
+  }
+}; // class NormalDistribution
+
+} // namespace ann
+} // namespace mlpack
+
+// Include implementation.
+#include "normal_distribution_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -24,6 +24,9 @@ namespace ann /** Artificial Neural Network. */ {
  *
  * Normal distribution is a function which accepts a mean and a standard deviation
  * term and creates a probablity distribution out of it.
+ * 
+ * @tparam DataType Type of the input data. (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
  */
 template <typename DataType = arma::mat>
 class NormalDistribution

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -69,6 +69,17 @@ class NormalDistribution
   arma::vec LogProbability(const arma::vec& observation) const;
 
   /**
+   * Stores the gradient of the probabilities of the observations
+   * with respect to mean and standard deviation.
+   *
+   * @param observation The observation matrix.
+   * @param dmu The gradient with respect to mean.
+   * @param dsigma The gradient with respect to standard deviation.
+   */
+  void ProbBackward(const arma::vec& observation, arma::vec& dmu,
+arma::vec& dsigma) const;
+
+  /**
    * Calculates the normal probability density function for each
    * data point (column) in the given matrix.
    *
@@ -78,6 +89,18 @@ class NormalDistribution
   void Probability(const arma::vec& x, arma::vec& probabilities) const
   {
     probabilities = Probability(x);
+  }
+
+  /**
+    * Calculates the log of normal probability density function for each
+    * data point (column) in the given matrix.
+    *
+    * @param x List of observations.
+    * @param log probabilities Output probabilities for each input observation.
+    */
+  void LogProbability(const arma::vec& x, arma::vec& probabilities) const
+  {
+    probabilities = LogProbability(x);
   }
 
   /**

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -69,7 +69,7 @@ class NormalDistribution
    *
    * @param observation The observation matrix.
    * @param dmu The gradient with respect to mean.
-   * @param dsigma The gradient with respect to standard deviation.
+   * @param dsigma The gradient with respect to the standard deviation.
    */
   void ProbBackward(const DataType& observation,
                     DataType& dmu,
@@ -79,7 +79,7 @@ class NormalDistribution
    * Calculates the normal probability density function for each
    * data point (column) in the given matrix.
    *
-   * @param x List of observations.
+   * @param x The observation matrix.
    * @param probabilities Output probabilities for each input observation.
    */
   void Probability(const DataType& x, DataType& probabilities) const
@@ -91,8 +91,8 @@ class NormalDistribution
     * Calculates the log of normal probability density function for each
     * data point (column) in the given matrix.
     *
-    * @param x List of observations.
-    * @param log probabilities Output probabilities for each input observation.
+    * @param x The observation matrix.
+    * @param probabilities Output log probabilities for each input observation.
     */
   void LogProbability(const DataType& x, DataType& probabilities) const
   {
@@ -126,7 +126,7 @@ class NormalDistribution
    * Serialize the distribution.
    */
   template<typename Archive>
-  void serialize(Archive& ar, const unsigned int /* version */)
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   //! Mean of the distribution.

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -25,6 +25,7 @@ namespace ann /** Artificial Neural Network. */ {
  * Normal distribution is a function which accepts a mean and a standard deviation
  * term and creates a probablity distribution out of it.
  */
+template <typename DataType = arma::mat>
 class NormalDistribution
 {
  public:
@@ -40,14 +41,14 @@ class NormalDistribution
    * @param mean The mean of the normal distribution.
    * @param sigma The standard deviation of the normal distribution.
    */
-  NormalDistribution(const arma::vec& mean, const arma::vec& sigma);
+  NormalDistribution(const DataType& mean, const DataType& sigma);
 
   /**
    * Return the probabilities of the given matrix of observations.
    *
    * @param observation The observation matrix.
    */
-  arma::vec Probability(const arma::vec& observation) const
+  DataType Probability(const DataType& observation) const
   {
     return arma::exp(LogProbability(observation));
   }
@@ -57,7 +58,7 @@ class NormalDistribution
    *
    * @param observation The observation matrix.
    */
-  arma::vec LogProbability(const arma::vec& observation) const;
+  DataType LogProbability(const DataType& observation) const;
 
   /**
    * Stores the gradient of the probabilities of the observations
@@ -67,9 +68,9 @@ class NormalDistribution
    * @param dmu The gradient with respect to mean.
    * @param dsigma The gradient with respect to standard deviation.
    */
-  void ProbBackward(const arma::vec& observation,
-                    arma::vec& dmu,
-                    arma::vec& dsigma) const;
+  void ProbBackward(const DataType& observation,
+                    DataType& dmu,
+                    DataType& dsigma) const;
 
   /**
    * Calculates the normal probability density function for each
@@ -78,7 +79,7 @@ class NormalDistribution
    * @param x List of observations.
    * @param probabilities Output probabilities for each input observation.
    */
-  void Probability(const arma::vec& x, arma::vec& probabilities) const
+  void Probability(const DataType& x, DataType& probabilities) const
   {
     probabilities = Probability(x);
   }
@@ -90,7 +91,7 @@ class NormalDistribution
     * @param x List of observations.
     * @param log probabilities Output probabilities for each input observation.
     */
-  void LogProbability(const arma::vec& x, arma::vec& probabilities) const
+  void LogProbability(const DataType& x, DataType& probabilities) const
   {
     probabilities = LogProbability(x);
   }
@@ -101,27 +102,27 @@ class NormalDistribution
    *
    * @return Random observation from this Normal distribution.
    */
-  arma::vec Sample() const;
+  DataType Sample() const;
 
   /**
    * Return the mean.
    */
-  const arma::vec& Mean() const { return mean; }
+  const DataType& Mean() const { return mean; }
 
   /**
    * Return a modifiable copy of the mean.
    */
-  arma::vec& Mean() { return mean; }
+  DataType& Mean() { return mean; }
 
   /**
    * Return the standard deviation.
    */
-  const arma::vec& Sigma() const { return sigma; }
+  const DataType& StandardDeviation() const { return sigma; }
 
   /**
    * Return a modifiable copy of the standard deviation.
    */
-  arma::vec& StandardDeviation() { return sigma; }
+  DataType& StandardDeviation() { return sigma; }
 
   //! Return the dimensionality of this distribution.
   size_t Dimensionality() const { return mean.n_elem; }
@@ -139,10 +140,10 @@ class NormalDistribution
 
  private:
   //! Mean of the distribution.
-  arma::vec mean;
+  DataType mean;
 
   //! Standard deviation of the distribution.
-  arma::vec sigma;
+  DataType sigma;
 }; // class NormalDistribution
 
 } // namespace ann

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -19,14 +19,10 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 /**
- * Multiple independent Bernoulli distributions.
+ * Implementation of the Normal Distribution function.
  *
- * Bernoulli distribution is the discrete probability distribution of a random
- * variable which takes the value 1 with probability p and the value 0 with
- * probability q = 1 - p.
- * In this implementation, the p values of the distributions are given by the
- * param matrix.
- *
+ * Normal distribution is a function which accepts a mean and a standard deviation
+ * term and creates a probablity distribution out of it.
  */
 class NormalDistribution
 {

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -104,24 +104,16 @@ class NormalDistribution
    */
   DataType Sample() const;
 
-  /**
-   * Return the mean.
-   */
+  //! Get the mean.
   const DataType& Mean() const { return mean; }
 
-  /**
-   * Return a modifiable copy of the mean.
-   */
+  //! Modify the mean.
   DataType& Mean() { return mean; }
 
-  /**
-   * Return the standard deviation.
-   */
+  //! Get the standard deviation.
   const DataType& StandardDeviation() const { return sigma; }
 
-  /**
-   * Return a modifiable copy of the standard deviation.
-   */
+  //! Modify the standard deviation.
   DataType& StandardDeviation() { return sigma; }
 
   //! Return the dimensionality of this distribution.
@@ -132,11 +124,6 @@ class NormalDistribution
    */
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */)
-  {
-    // We just need to serialize each of the members.
-    ar & BOOST_SERIALIZATION_NVP(mean);
-    ar & BOOST_SERIALIZATION_NVP(sigma);
-  }
 
  private:
   //! Mean of the distribution.

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -33,7 +33,7 @@ class NormalDistribution
  private:
   //! Mean of the distribution.
   arma::vec mean;
-  //! Variance of the distribution.
+  //! Standard deviation of the distribution.
   arma::vec sigma;
 
   // pi
@@ -99,14 +99,14 @@ class NormalDistribution
   arma::vec& Mean() { return mean; }
 
   /**
-   * Return the variance.
+   * Return the standard deviation.
    */
   const arma::vec& Sigma() const { return sigma; }
 
   /**
-   * Return a modifiable copy of the variance.
+   * Return a modifiable copy of the standard deviation.
    */
-  arma::vec& Variance() { return sigma; }
+  arma::vec& StandardDeviation() { return sigma; }
 
   //! Return the dimensionality of this distribution.
   size_t Dimensionality() const { return mean.n_elem; }

--- a/src/mlpack/methods/ann/dists/normal_distribution.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution.hpp
@@ -1,6 +1,7 @@
 /**
  * @file normal_distribution.hpp
  * @author xiaohong ji
+ * @author Nishant Kumar
  *
  * Definition of the Normal distribution class.
  *
@@ -26,15 +27,6 @@ namespace ann /** Artificial Neural Network. */ {
  */
 class NormalDistribution
 {
- private:
-  //! Mean of the distribution.
-  arma::vec mean;
-  //! Standard deviation of the distribution.
-  arma::vec sigma;
-
-  // pi
-  static const constexpr double pi = 3.14159265358979323846264338327950288;
-
  public:
   /**
    * Default constructor, which creates a Normal distribution with zero
@@ -44,6 +36,9 @@ class NormalDistribution
 
   /**
    * Create a Normal distribution with the given mean and sigma.
+   *
+   * @param mean The mean of the normal distribution.
+   * @param sigma The standard deviation of the normal distribution.
    */
   NormalDistribution(const arma::vec& mean, const arma::vec& sigma);
 
@@ -72,8 +67,9 @@ class NormalDistribution
    * @param dmu The gradient with respect to mean.
    * @param dsigma The gradient with respect to standard deviation.
    */
-  void ProbBackward(const arma::vec& observation, arma::vec& dmu,
-arma::vec& dsigma) const;
+  void ProbBackward(const arma::vec& observation,
+                    arma::vec& dmu,
+                    arma::vec& dsigma) const;
 
   /**
    * Calculates the normal probability density function for each
@@ -140,6 +136,13 @@ arma::vec& dsigma) const;
     ar & BOOST_SERIALIZATION_NVP(mean);
     ar & BOOST_SERIALIZATION_NVP(sigma);
   }
+
+ private:
+  //! Mean of the distribution.
+  arma::vec mean;
+
+  //! Standard deviation of the distribution.
+  arma::vec sigma;
 }; // class NormalDistribution
 
 } // namespace ann

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -19,37 +19,42 @@
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
-NormalDistribution::NormalDistribution()
+template<typename DataType>
+NormalDistribution<DataType>::NormalDistribution()
 {
   // Nothing to do here.
 }
 
-NormalDistribution::NormalDistribution(
-    const arma::vec& mean,
-    const arma::vec& sigma) :
+template<typename DataType>
+NormalDistribution<DataType>::NormalDistribution(
+    const DataType& mean,
+    const DataType& sigma) :
     mean(mean),
     sigma(sigma)
 {
 }
 
-arma::vec NormalDistribution::Sample() const
+template<typename DataType>
+DataType NormalDistribution<DataType>::Sample() const
 {
-  return sigma * arma::randn<arma::vec>(mean.n_elem) + mean;
+  return sigma * arma::randn<DataType>(mean.n_elem) + mean;
 }
 
-arma::vec NormalDistribution::LogProbability(
-    const arma::vec& observation) const
+template<typename DataType>
+DataType NormalDistribution<DataType>::LogProbability(
+    const DataType& observation) const
 {
-  const arma::vec variance = arma::square(sigma);
-  arma::vec v1 = arma::log(sigma) + std::log(std::sqrt(2 * M_PI));
-  arma::vec v2 = arma::square(observation - mean) / (2 * variance);
+  const DataType variance = arma::square(sigma);
+  DataType v1 = arma::log(sigma) + std::log(std::sqrt(2 * M_PI));
+  DataType v2 = arma::square(observation - mean) / (2 * variance);
   return  (-v1 - v2);
 }
 
-void NormalDistribution::ProbBackward(
-    const arma::vec& observation,
-    arma::vec& dmu,
-    arma::vec& dsigma) const
+template<typename DataType>
+void NormalDistribution<DataType>::ProbBackward(
+    const DataType& observation,
+    DataType& dmu,
+    DataType& dsigma) const
 {
   dmu = (observation - mean) / (arma::square(sigma)) % Probability(observation);
   dsigma = (- 1.0 / sigma +

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -40,8 +40,8 @@ arma::vec NormalDistribution::LogProbability(
     const arma::vec& observation) const
 {
   const arma::vec variance = arma::square(sigma);
-  arma::vec v1 = sigma + std::log(std::sqrt(2 * pi));
-  arma::vec v2 = arma::square(observation - sigma) / (2 * variance);
+  arma::vec v1 = arma::log(sigma) + std::log(std::sqrt(2 * pi));
+  arma::vec v2 = arma::square(observation - mu) / (2 * variance);
   return  (-v1 - v2);
 }
 

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -1,0 +1,51 @@
+/**
+ * @file normal_distribution_impl.hpp
+ * @author xiaohong ji
+ *
+ * Implementation of the Normal distribution class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_DISTRIBUTIONS_NORMAL_DISTRIBUTION_IMPL_HPP
+#define MLPACK_METHODS_ANN_DISTRIBUTIONS_NORMAL_DISTRIBUTION_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "normal_distribution.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+NormalDistribution::NormalDistribution()
+{
+  // Nothing to do here.
+}
+
+NormalDistribution::NormalDistribution(
+    const arma::vec& mean,
+    const arma::vec& sigma) :
+    mean(mean),
+    sigma(sigma)
+{
+}
+
+arma::vec NormalDistribution::Sample() const
+{
+  return sigma * arma::randn<arma::vec>(mean.n_elem) + mean;
+}
+
+arma::vec NormalDistribution::LogProbability(
+    const arma::vec& observation) const
+{
+  const arma::vec variance = arma::square(sigma);
+  arma::vec v1 = sigma + std::log(std::sqrt(2 * pi));
+  arma::vec v2 = arma::square(observation - sigma) / (2 * variance);
+  return  (-v1 - v2);
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -1,6 +1,7 @@
 /**
  * @file normal_distribution_impl.hpp
  * @author xiaohong ji
+ * @author Nishant Kumar
  *
  * Implementation of the Normal distribution class.
  *
@@ -40,7 +41,7 @@ arma::vec NormalDistribution::LogProbability(
     const arma::vec& observation) const
 {
   const arma::vec variance = arma::square(sigma);
-  arma::vec v1 = arma::log(sigma) + std::log(std::sqrt(2 * pi));
+  arma::vec v1 = arma::log(sigma) + std::log(std::sqrt(2 * M_PI));
   arma::vec v2 = arma::square(observation - mean) / (2 * variance);
   return  (-v1 - v2);
 }

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -62,6 +62,15 @@ void NormalDistribution<DataType>::ProbBackward(
             % Probability(observation);
 }
 
+template<typename DataType>
+template<typename Archive>
+void NormalDistribution<DataType>::serialize(Archive& ar,
+                                             const unsigned int /* version */)
+{
+  ar & BOOST_SERIALIZATION_NVP(mean);
+  ar & BOOST_SERIALIZATION_NVP(sigma);
+}
+
 } // namespace ann
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -50,10 +50,10 @@ void NormalDistribution::ProbBackward(
     arma::vec& dmu,
     arma::vec& dsigma) const
 {
-    dmu = (observation - mean) / (arma::square(sigma)) % Probability(observation);
-    dsigma = (- 1.0 / sigma +
-              (arma::square(observation - mean) / arma::pow(sigma, 3)))
-              % Probability(observation);
+  dmu = (observation - mean) / (arma::square(sigma)) % Probability(observation);
+  dsigma = (- 1.0 / sigma +
+            (arma::square(observation - mean) / arma::pow(sigma, 3)))
+            % Probability(observation);
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -3,7 +3,7 @@
  * @author xiaohong ji
  * @author Nishant Kumar
  *
- * Implementation of the Normal distribution class.
+ * Implementation of the Normal Distribution class.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -32,6 +32,7 @@ NormalDistribution<DataType>::NormalDistribution(
     mean(mean),
     sigma(sigma)
 {
+  // Nothing to do here.
 }
 
 template<typename DataType>
@@ -44,9 +45,9 @@ template<typename DataType>
 DataType NormalDistribution<DataType>::LogProbability(
     const DataType& observation) const
 {
-  const DataType variance = arma::square(sigma);
-  DataType v1 = arma::log(sigma) + std::log(std::sqrt(2 * M_PI));
-  DataType v2 = arma::square(observation - mean) / (2 * variance);
+  const DataType v1 = arma::log(sigma) + std::log(std::sqrt(2 * M_PI));
+  const DataType v2 = arma::square(observation - mean) /
+                      (2 * arma::square(sigma));
   return  (-v1 - v2);
 }
 

--- a/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
+++ b/src/mlpack/methods/ann/dists/normal_distribution_impl.hpp
@@ -41,8 +41,19 @@ arma::vec NormalDistribution::LogProbability(
 {
   const arma::vec variance = arma::square(sigma);
   arma::vec v1 = arma::log(sigma) + std::log(std::sqrt(2 * pi));
-  arma::vec v2 = arma::square(observation - mu) / (2 * variance);
+  arma::vec v2 = arma::square(observation - mean) / (2 * variance);
   return  (-v1 - v2);
+}
+
+void NormalDistribution::ProbBackward(
+    const arma::vec& observation,
+    arma::vec& dmu,
+    arma::vec& dsigma) const
+{
+    dmu = (observation - mean) / (arma::square(sigma)) % Probability(observation);
+    dsigma = (- 1.0 / sigma +
+              (arma::square(observation - mean) / arma::pow(sigma, 3)))
+              % Probability(observation);
 }
 
 } // namespace ann

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(NormalDistributionTest)
   arma::vec prob;
   normalDist.LogProbability(x, prob);
 
-  // testing output of log probablity for some random mu, sigma and x.
+  // Testing output of log probability for some random mu, sigma and x.
   BOOST_REQUIRE_CLOSE(prob[0], 1.2586464, 1e-3);
   BOOST_REQUIRE_CLOSE(prob[1], 0.8751131, 1e-3);
   BOOST_REQUIRE_CLOSE(prob[2], -0.30579138, 1e-3);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(NormalDistributionTest)
   arma::vec dmu, dsigma;
   normalDist.ProbBackward(x, dmu, dsigma);
 
-  // testing output of dmu and dsigma for some random mu, sigma and x.
+  // Testing output of dmu and dsigma for some random mu, sigma and x.
   BOOST_REQUIRE_CLOSE(dmu[0], -17.603287, 1e-3);
   BOOST_REQUIRE_CLOSE(dsigma[0], -26.40487, 1e-3);
   BOOST_REQUIRE_CLOSE(dmu[1], -19.827663, 1e-3);

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -12,6 +12,7 @@
 #include <mlpack/core.hpp>
 
 #include <mlpack/methods/ann/dists/bernoulli_distribution.hpp>
+#include <mlpack/methods/ann/dists/normal_distribution.hpp>
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -125,6 +126,42 @@ BOOST_AUTO_TEST_CASE(JacobianBernoulliDistributionLogisticTest)
     BOOST_REQUIRE_LE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))),
         3e-5);
   }
+}
+
+/**
+ * Normal Distribution module test.
+ */
+BOOST_AUTO_TEST_CASE(NormalDistributionTest)
+{
+  arma::vec mu = {1.1, 1.2, 1.5, 1.7};
+  arma::vec sigma = {0.1, 0.11, 0.5, 0.23};
+
+  ann::NormalDistribution normalDist =
+    ann::NormalDistribution(mu, sigma);
+
+  arma::vec x = {1.05, 1.1, 1.7, 2.5};
+
+  arma::vec prob;
+  normalDist.LogProbability(x, prob);
+  
+  // testing output of log probablity for some random mu, sigma and x.
+  BOOST_REQUIRE_CLOSE(prob[0], 1.2586464, 1e-3);
+  BOOST_REQUIRE_CLOSE(prob[1], 0.8751131, 1e-3);
+  BOOST_REQUIRE_CLOSE(prob[2], -0.30579138, 1e-3);
+  BOOST_REQUIRE_CLOSE(prob[3], -5.498411, 1e-3);
+
+  arma::vec dmu, dsigma;
+  normalDist.ProbBackward(x, dmu, dsigma);
+
+  // testing output of dmu and dsigma for some random mu, sigma and x.
+  BOOST_REQUIRE_CLOSE(dmu[0], -17.603287, 1e-3);
+  BOOST_REQUIRE_CLOSE(dsigma[0], -26.40487, 1e-3);
+  BOOST_REQUIRE_CLOSE(dmu[1], -19.827663, 1e-3);
+  BOOST_REQUIRE_CLOSE(dsigma[1], -3.7852707, 1e-3);
+  BOOST_REQUIRE_CLOSE(dmu[2], 0.5892323, 1e-3);
+  BOOST_REQUIRE_CLOSE(dsigma[2], -1.2373875, 1e-3);
+  BOOST_REQUIRE_CLOSE(dmu[3], 0.061901994, 1e-3);
+  BOOST_REQUIRE_CLOSE(dsigma[3], 0.19751444, 1e-3);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(NormalDistributionTest)
 
   arma::vec prob;
   normalDist.LogProbability(x, prob);
-  
+
   // testing output of log probablity for some random mu, sigma and x.
   BOOST_REQUIRE_CLOSE(prob[0], 1.2586464, 1e-3);
   BOOST_REQUIRE_CLOSE(prob[1], 0.8751131, 1e-3);

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(NormalDistributionTest)
 }
 
 /**
- * Jacobian Normal distribution module test for mean.
+ * Jacobian Normal Distribution module test for mean.
  */
 BOOST_AUTO_TEST_CASE(JacobianNormalDistributionMeanTest)
 {
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(JacobianNormalDistributionMeanTest)
 }
 
 /**
- * Jacobian Normal distribution module test for standard deviation.
+ * Jacobian Normal Distribution module test for standard deviation.
  */
 BOOST_AUTO_TEST_CASE(JacobianNormalDistributionStandardDeviationTest)
 {


### PR DESCRIPTION
Hey!
The implementation of Normal Distribution in https://github.com/mlpack/mlpack/pull/1912 had a small bug in the `LogProbablity()` function. Also, the backward pass and tests for the class was not present. 
This is an attempt to complete the work, as normal distribution is of use in many places, especially for continuous action space environments in RL module.
For the tests, I have taken 4 random values of `mean`, `sigma` and `x` to produce corresponding LogProbabilites and gradients, and compared it with pytorch's implementation.
I use this snippet to get the `prob`, `dmu` and `dsigma`.
```python
mu = torch.tensor(1.1, requires_grad = True)
std = torch.tensor(0.1, requires_grad = True)
n = Normal(mu, std)
action_tensor = torch.tensor(1.05, requires_grad = False)
log_prob = n.log_prob(action_tensor)
ratio = torch.exp(log_prob)

print(log_prob.data.numpy())
ratio.backward()
print('gradients of mu and sigma: ', mu.grad.data.numpy(), std.grad.data.numpy())

```
Please have a look and share your thoughts :)