### PR TITLE
Remove -Wreorder warning in  LARS.

### DIFF
--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -77,8 +77,8 @@ LARS::LARS(const LARS& other) :
     useCholesky(other.useCholesky),
     lasso(other.lasso),
     lambda1(other.lambda1),
-    lambda2(other.lambda2),
     elasticNet(other.elasticNet),
+    lambda2(other.lambda2),
     tolerance(other.tolerance),
     betaPath(other.betaPath),
     lambdaPath(other.lambdaPath),
@@ -99,8 +99,8 @@ LARS::LARS(LARS&& other) :
     useCholesky(other.useCholesky),
     lasso(other.lasso),
     lambda1(other.lambda1),
-    lambda2(other.lambda2),
     elasticNet(other.elasticNet),
+    lambda2(other.lambda2),
     tolerance(other.tolerance),
     betaPath(std::move(other.betaPath)),
     lambdaPath(std::move(other.lambdaPath)),
@@ -125,8 +125,8 @@ LARS& LARS::operator=(const LARS& other)
   useCholesky = other.useCholesky;
   lasso = other.lasso;
   lambda1 = other.lambda1;
-  lambda2 = other.lambda2;
   elasticNet = other.elasticNet;
+  lambda2 = other.lambda2;
   tolerance = other.tolerance;
   betaPath = other.betaPath;
   lambdaPath = other.lambdaPath;
@@ -150,8 +150,8 @@ LARS& LARS::operator=(LARS&& other)
   useCholesky = other.useCholesky;
   lasso = other.lasso;
   lambda1 = other.lambda1;
-  lambda2 = other.lambda2;
   elasticNet = other.elasticNet;
+  lambda2 = other.lambda2;
   tolerance = other.tolerance;
   betaPath = std::move(other.betaPath);
   lambdaPath = std::move(other.lambdaPath);


### PR DESCRIPTION
Hi everyone,
Just removing some warnings while building mlpack. Unfortunately I missed them in my PR as they didn't showed up locally.
Thanks.