### PR TITLE
Templatize `LSHSearch` to allow sparse matrices

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
   * Add adaptive max pooling and adaptive mean pooling layers (#2195).
 
   * Add `MatType` parameter to `LSHSearch`, allowing sparse matrices to be used
-    for search.
+    for search (#2395).
 
 ### mlpack 3.3.1
 ###### 2020-04-29

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@
 
   * Add adaptive max pooling and adaptive mean pooling layers (#2195).
 
+  * Add `MatType` parameter to `LSHSearch`, allowing sparse matrices to be used
+    for search.
+
 ### mlpack 3.3.1
 ###### 2020-04-29
   * Minor Julia and Python documentation fixes (#2373).

--- a/src/mlpack/methods/lsh/lsh_search.hpp
+++ b/src/mlpack/methods/lsh/lsh_search.hpp
@@ -59,8 +59,12 @@ namespace neighbor {
  * queries.
  *
  * @tparam SortPolicy The sort policy for distances; see NearestNeighborSort.
+ * @tparam MatType Type of matrix to use to store the data.
  */
-template<typename SortPolicy = NearestNeighborSort>
+template<
+    typename SortPolicy = NearestNeighborSort,
+    typename MatType = arma::mat
+>
 class LSHSearch
 {
  public:
@@ -86,7 +90,7 @@ class LSHSearch
    *     value of 0 indicates that there is no limit (so the second hash table
    *     can be arbitrarily large---be careful!).
    */
-  LSHSearch(arma::mat referenceSet,
+  LSHSearch(MatType referenceSet,
             const arma::cube& projections,
             const double hashWidth = 0.0,
             const size_t secondHashSize = 99901,
@@ -114,7 +118,7 @@ class LSHSearch
    *     value of 0 indicates that there is no limit (so the second hash table
    *     can be arbitrarily large---be careful!).
    */
-  LSHSearch(arma::mat referenceSet,
+  LSHSearch(MatType referenceSet,
             const size_t numProj,
             const size_t numTables,
             const double hashWidth = 0.0,
@@ -180,7 +184,7 @@ class LSHSearch
    *     we set numProj = a, numTables = c. b is the reference set
    *     dimensionality.
    */
-  void Train(arma::mat referenceSet,
+  void Train(MatType referenceSet,
              const size_t numProj,
              const size_t numTables,
              const double hashWidth = 0.0,
@@ -209,7 +213,7 @@ class LSHSearch
    * @param T The number of additional probing bins to examine with multiprobe
    *     LSH. If T = 0, classic single-probe LSH is run (default).
    */
-  void Search(const arma::mat& querySet,
+  void Search(const MatType& querySet,
               const size_t k,
               arma::Mat<size_t>& resultingNeighbors,
               arma::mat& distances,
@@ -353,7 +357,7 @@ class LSHSearch
   void BaseCase(const size_t queryIndex,
                 const arma::uvec& referenceIndices,
                 const size_t k,
-                const arma::mat& querySet,
+                const MatType& querySet,
                 arma::Mat<size_t>& neighbors,
                 arma::mat& distances) const;
 
@@ -415,7 +419,7 @@ class LSHSearch
   bool PerturbationValid(const std::vector<bool>& A) const;
 
   //! Reference dataset.
-  arma::mat referenceSet;
+  MatType referenceSet;
 
   //! The number of projections.
   size_t numProj;

--- a/src/mlpack/methods/lsh/lsh_search_impl.hpp
+++ b/src/mlpack/methods/lsh/lsh_search_impl.hpp
@@ -19,9 +19,9 @@ namespace mlpack {
 namespace neighbor {
 
 // Construct the object with random tables
-template<typename SortPolicy>
-LSHSearch<SortPolicy>::
-LSHSearch(arma::mat referenceSet,
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>::
+LSHSearch(MatType referenceSet,
           const size_t numProj,
           const size_t numTables,
           const double hashWidthIn,
@@ -35,14 +35,14 @@ LSHSearch(arma::mat referenceSet,
   distanceEvaluations(0)
 {
   // Pass work to training function.
-  Train(referenceSet, numProj, numTables, hashWidthIn, secondHashSize,
-      bucketSize);
+  Train(std::move(referenceSet), numProj, numTables, hashWidthIn,
+      secondHashSize, bucketSize);
 }
 
 // Construct the object with given tables
-template<typename SortPolicy>
-LSHSearch<SortPolicy>::
-LSHSearch(arma::mat referenceSet,
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>::
+LSHSearch(MatType referenceSet,
           const arma::cube& projections,
           const double hashWidthIn,
           const size_t secondHashSize,
@@ -60,8 +60,8 @@ LSHSearch(arma::mat referenceSet,
 }
 
 // Empty constructor.
-template<typename SortPolicy>
-LSHSearch<SortPolicy>::LSHSearch() :
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>::LSHSearch() :
     numProj(0),
     numTables(0),
     hashWidth(0),
@@ -72,8 +72,8 @@ LSHSearch<SortPolicy>::LSHSearch() :
 }
 
 // Copy constructor.
-template<typename SortPolicy>
-LSHSearch<SortPolicy>::LSHSearch(const LSHSearch& other) :
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>::LSHSearch(const LSHSearch& other) :
     referenceSet(other.referenceSet), // Copy the other set.
     numProj(other.numProj),
     numTables(other.numTables),
@@ -92,8 +92,8 @@ LSHSearch<SortPolicy>::LSHSearch(const LSHSearch& other) :
 }
 
 // Move constructor.
-template<typename SortPolicy>
-LSHSearch<SortPolicy>::LSHSearch(LSHSearch&& other) :
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>::LSHSearch(LSHSearch&& other) :
     referenceSet(std::move(other.referenceSet)),
     numProj(other.numProj),
     numTables(other.numTables),
@@ -118,8 +118,9 @@ LSHSearch<SortPolicy>::LSHSearch(LSHSearch&& other) :
 }
 
 // Copy operator.
-template<typename SortPolicy>
-LSHSearch<SortPolicy>& LSHSearch<SortPolicy>::operator=(const LSHSearch& other)
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>& LSHSearch<SortPolicy, MatType>::operator=(
+    const LSHSearch& other)
 {
   referenceSet = other.referenceSet;
   numProj = other.numProj;
@@ -139,8 +140,9 @@ LSHSearch<SortPolicy>& LSHSearch<SortPolicy>::operator=(const LSHSearch& other)
 }
 
 // Move operator.
-template<typename SortPolicy>
-LSHSearch<SortPolicy>& LSHSearch<SortPolicy>::operator=(LSHSearch&& other)
+template<typename SortPolicy, typename MatType>
+LSHSearch<SortPolicy, MatType>& LSHSearch<SortPolicy, MatType>::operator=(
+    LSHSearch&& other)
 {
   referenceSet = std::move(other.referenceSet);
   numProj = other.numProj;
@@ -168,14 +170,14 @@ LSHSearch<SortPolicy>& LSHSearch<SortPolicy>::operator=(LSHSearch&& other)
 }
 
 // Train on a new reference set.
-template<typename SortPolicy>
-void LSHSearch<SortPolicy>::Train(arma::mat referenceSet,
-                                  const size_t numProj,
-                                  const size_t numTables,
-                                  const double hashWidthIn,
-                                  const size_t secondHashSize,
-                                  const size_t bucketSize,
-                                  const arma::cube &projection)
+template<typename SortPolicy, typename MatType>
+void LSHSearch<SortPolicy, MatType>::Train(MatType referenceSet,
+                                           const size_t numProj,
+                                           const size_t numTables,
+                                           const double hashWidthIn,
+                                           const size_t secondHashSize,
+                                           const size_t bucketSize,
+                                           const arma::cube& projection)
 {
   // Set new reference set.
   this->referenceSet = std::move(referenceSet);
@@ -197,8 +199,8 @@ void LSHSearch<SortPolicy>::Train(arma::mat referenceSet,
       size_t p2 = (size_t) math::RandInt(this->referenceSet.n_cols);
 
       hashWidth += std::sqrt(metric::EuclideanDistance::Evaluate(
-          this->referenceSet.unsafe_col(p1),
-          this->referenceSet.unsafe_col(p2)));
+          this->referenceSet.col(p1),
+          this->referenceSet.col(p2)));
     }
 
     hashWidth /= numSamples;
@@ -349,13 +351,14 @@ void LSHSearch<SortPolicy>::Train(arma::mat referenceSet,
 
 // Base case where the query set is the reference set.  (So, we can't return
 // ourselves as the nearest neighbor.)
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 inline force_inline
-void LSHSearch<SortPolicy>::BaseCase(const size_t queryIndex,
-                                     const arma::uvec& referenceIndices,
-                                     const size_t k,
-                                     arma::Mat<size_t>& neighbors,
-                                     arma::mat& distances) const
+void LSHSearch<SortPolicy, MatType>::BaseCase(
+    const size_t queryIndex,
+    const arma::uvec& referenceIndices,
+    const size_t k,
+    arma::Mat<size_t>& neighbors,
+    arma::mat& distances) const
 {
   // Let's build the list of candidate neighbors for the given query point.
   // It will be initialized with k candidates:
@@ -373,8 +376,8 @@ void LSHSearch<SortPolicy>::BaseCase(const size_t queryIndex,
       continue;
 
     const double distance = metric::EuclideanDistance::Evaluate(
-        referenceSet.unsafe_col(queryIndex),
-        referenceSet.unsafe_col(referenceIndex));
+        referenceSet.col(queryIndex),
+        referenceSet.col(referenceIndex));
 
     Candidate c = std::make_pair(distance, referenceIndex);
     // If this distance is better than the worst candidate, let's insert it.
@@ -394,14 +397,15 @@ void LSHSearch<SortPolicy>::BaseCase(const size_t queryIndex,
 }
 
 // Base case for bichromatic search.
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 inline force_inline
-void LSHSearch<SortPolicy>::BaseCase(const size_t queryIndex,
-                                     const arma::uvec& referenceIndices,
-                                     const size_t k,
-                                     const arma::mat& querySet,
-                                     arma::Mat<size_t>& neighbors,
-                                     arma::mat& distances) const
+void LSHSearch<SortPolicy, MatType>::BaseCase(
+    const size_t queryIndex,
+    const arma::uvec& referenceIndices,
+    const size_t k,
+    const MatType& querySet,
+    arma::Mat<size_t>& neighbors,
+    arma::mat& distances) const
 {
   // Let's build the list of candidate neighbors for the given query point.
   // It will be initialized with k candidates:
@@ -415,8 +419,8 @@ void LSHSearch<SortPolicy>::BaseCase(const size_t queryIndex,
   {
     const size_t referenceIndex = referenceIndices[j];
     const double distance = metric::EuclideanDistance::Evaluate(
-        querySet.unsafe_col(queryIndex),
-        referenceSet.unsafe_col(referenceIndex));
+        querySet.col(queryIndex),
+        referenceSet.col(referenceIndex));
 
     Candidate c = std::make_pair(distance, referenceIndex);
     // If this distance is better than the worst candidate, let's insert it.
@@ -435,9 +439,9 @@ void LSHSearch<SortPolicy>::BaseCase(const size_t queryIndex,
   }
 }
 
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 inline force_inline
-double LSHSearch<SortPolicy>::PerturbationScore(
+double LSHSearch<SortPolicy, MatType>::PerturbationScore(
     const std::vector<bool>& A,
     const arma::vec& scores) const
 {
@@ -448,9 +452,10 @@ double LSHSearch<SortPolicy>::PerturbationScore(
   return score;
 }
 
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 inline force_inline
-bool LSHSearch<SortPolicy>::PerturbationShift(std::vector<bool>& A) const
+bool LSHSearch<SortPolicy, MatType>::PerturbationShift(
+    std::vector<bool>& A) const
 {
   size_t maxPos = 0;
   for (size_t i = 0; i < A.size(); ++i)
@@ -466,9 +471,10 @@ bool LSHSearch<SortPolicy>::PerturbationShift(std::vector<bool>& A) const
   return false; // invalid
 }
 
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 inline force_inline
-bool LSHSearch<SortPolicy>::PerturbationExpand(std::vector<bool>& A) const
+bool LSHSearch<SortPolicy, MatType>::PerturbationExpand(
+    std::vector<bool>& A) const
 {
   // Find the last '1' in A.
   size_t maxPos = 0;
@@ -484,9 +490,9 @@ bool LSHSearch<SortPolicy>::PerturbationExpand(std::vector<bool>& A) const
   return false;
 }
 
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 inline force_inline
-bool LSHSearch<SortPolicy>::PerturbationValid(
+bool LSHSearch<SortPolicy, MatType>::PerturbationValid(
     const std::vector<bool>& A) const
 {
   // Use check to mark dimensions we have seen before in A. If a dimension is
@@ -514,8 +520,8 @@ bool LSHSearch<SortPolicy>::PerturbationValid(
 }
 
 // Compute additional probing bins for a query
-template<typename SortPolicy>
-void LSHSearch<SortPolicy>::GetAdditionalProbingBins(
+template<typename SortPolicy, typename MatType>
+void LSHSearch<SortPolicy, MatType>::GetAdditionalProbingBins(
     const arma::vec& queryCode,
     const arma::vec& queryCodeNotFloored,
     const size_t T,
@@ -696,9 +702,9 @@ void LSHSearch<SortPolicy>::GetAdditionalProbingBins(
   }
 }
 
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 template<typename VecType>
-void LSHSearch<SortPolicy>::ReturnIndicesFromTable(
+void LSHSearch<SortPolicy, MatType>::ReturnIndicesFromTable(
     const VecType& queryPoint,
     arma::uvec& referenceIndices,
     size_t numTablesToSearch,
@@ -849,13 +855,14 @@ void LSHSearch<SortPolicy>::ReturnIndicesFromTable(
 }
 
 // Search for nearest neighbors in a given query set.
-template<typename SortPolicy>
-void LSHSearch<SortPolicy>::Search(const arma::mat& querySet,
-                                   const size_t k,
-                                   arma::Mat<size_t>& resultingNeighbors,
-                                   arma::mat& distances,
-                                   const size_t numTablesToSearch,
-                                   const size_t T)
+template<typename SortPolicy, typename MatType>
+void LSHSearch<SortPolicy, MatType>::Search(
+    const MatType& querySet,
+    const size_t k,
+    arma::Mat<size_t>& resultingNeighbors,
+    arma::mat& distances,
+    const size_t numTablesToSearch,
+    const size_t T)
 {
   // Ensure the dimensionality of the query set is correct.
   if (querySet.n_rows != referenceSet.n_rows)
@@ -938,8 +945,8 @@ void LSHSearch<SortPolicy>::Search(const arma::mat& querySet,
 }
 
 // Search for approximate neighbors of the reference set.
-template<typename SortPolicy>
-void LSHSearch<SortPolicy>::
+template<typename SortPolicy, typename MatType>
+void LSHSearch<SortPolicy, MatType>::
 Search(const size_t k,
        arma::Mat<size_t>& resultingNeighbors,
        arma::mat& distances,
@@ -1003,8 +1010,8 @@ Search(const size_t k,
       std::endl;
 }
 
-template<typename SortPolicy>
-double LSHSearch<SortPolicy>::ComputeRecall(
+template<typename SortPolicy, typename MatType>
+double LSHSearch<SortPolicy, MatType>::ComputeRecall(
     const arma::Mat<size_t>& foundNeighbors,
     const arma::Mat<size_t>& realNeighbors)
 {
@@ -1030,10 +1037,10 @@ double LSHSearch<SortPolicy>::ComputeRecall(
   return ((double) found) / realNeighbors.n_elem;
 }
 
-template<typename SortPolicy>
+template<typename SortPolicy, typename MatType>
 template<typename Archive>
-void LSHSearch<SortPolicy>::serialize(Archive& ar,
-                                      const unsigned int version)
+void LSHSearch<SortPolicy, MatType>::serialize(Archive& ar,
+                                               const unsigned int version)
 {
   ar & BOOST_SERIALIZATION_NVP(referenceSet);
   ar & BOOST_SERIALIZATION_NVP(numProj);

--- a/src/mlpack/tests/lsh_test.cpp
+++ b/src/mlpack/tests/lsh_test.cpp
@@ -925,8 +925,6 @@ BOOST_AUTO_TEST_CASE(MoveOperatorTest)
  */
 BOOST_AUTO_TEST_CASE(SparseLSHTest)
 {
-  mlpack::math::RandomSeed(std::time(NULL));
-
   // kNN and LSH parameters (use LSH default parameters).
   const int k = 5;
   const int numTables = 5;

--- a/src/mlpack/tests/lsh_test.cpp
+++ b/src/mlpack/tests/lsh_test.cpp
@@ -917,4 +917,74 @@ BOOST_AUTO_TEST_CASE(MoveOperatorTest)
   CheckMatrices(distances, distances2);
 }
 
+/**
+ * Run LSH on (identical) dense and sparse data, making sure that we get the
+ * same results.  Note that the sparse data we are using isn't really
+ * sparse---the idea is to test that the class works correctly when the type is
+ * arma::sp_mat.
+ */
+BOOST_AUTO_TEST_CASE(SparseLSHTest)
+{
+  mlpack::math::RandomSeed(std::time(NULL));
+
+  // kNN and LSH parameters (use LSH default parameters).
+  const int k = 5;
+  const int numTables = 5;
+  const int numProj = 2;
+  const double hashWidth = 50.0;
+  const int secondHashSize = 99901;
+  const int bucketSize = 500;
+
+  // Read iris training and testing data as reference and query sets.
+  const string trainSet = "iris_train.csv";
+  const string testSet = "iris_test.csv";
+  arma::mat rdata;
+  arma::mat qdata;
+  data::Load(trainSet, rdata, true);
+  data::Load(testSet, qdata, true);
+
+  // Run on dense data.
+  LSHSearch<> denseLSH(
+      rdata,
+      numProj,
+      numTables,
+      hashWidth,
+      secondHashSize,
+      bucketSize);
+
+  arma::Mat<size_t> denseNeighbors;
+  arma::mat denseDistances;
+  denseLSH.Search(qdata, k, denseNeighbors, denseDistances);
+
+  // Now create and run on sparse data.
+  arma::sp_mat sparseRData(rdata);
+  arma::sp_mat sparseQData(qdata);
+
+  LSHSearch<NearestNeighborSort, arma::sp_mat> sparseLSH(
+      sparseRData,
+      denseLSH.Projections(),
+      hashWidth,
+      secondHashSize,
+      bucketSize);
+
+  arma::Mat<size_t> sparseNeighbors;
+  arma::mat sparseDistances;
+  sparseLSH.Search(sparseQData, k, sparseNeighbors, sparseDistances);
+
+  BOOST_REQUIRE_EQUAL(denseNeighbors.n_rows, sparseNeighbors.n_rows);
+  BOOST_REQUIRE_EQUAL(denseNeighbors.n_cols, sparseNeighbors.n_cols);
+  BOOST_REQUIRE_EQUAL(denseDistances.n_rows, sparseDistances.n_rows);
+  BOOST_REQUIRE_EQUAL(denseDistances.n_cols, sparseDistances.n_cols);
+
+  // Make sure that sparse LSH distances aren't garbage.
+  for (size_t i = 0; i < sparseNeighbors.n_elem; ++i)
+  {
+    BOOST_REQUIRE_GE(sparseNeighbors[i], 0);
+    BOOST_REQUIRE_LT(sparseNeighbors[i], rdata.n_cols);
+    BOOST_REQUIRE_GE(sparseDistances[i], 0.0);
+    BOOST_REQUIRE(!std::isinf(sparseDistances[i]));
+    BOOST_REQUIRE(!std::isnan(sparseDistances[i]));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
I was working on a project that involved nearest neighbor search for a very high dimensional dataset (100k+ dimensions) where the only realistic representation is with an `arma::sp_mat`.  However, `LSHSearch` only took `arma::mat`.  So I refactored it such that the input data can now be an `arma::sp_mat`.

This turns out to be easy and not require any additional refactoring---the first step of LSH is to multiply with a (dense) projection matrix, and then past there everything is dense (but much smaller).

It gets nice results; on a subset of my test data which had size 63k dimensions by 123k points (with 0.006% nonzero elements), the LSH structure took 4.3s to build, and then 24s to compute 12 nearest neighbors.  The approximation level was about ~1.2, which isn't so bad.

I can't compare with a dense version because I can't allocate a 63k x 123k matrix on my system. :)