### PR TITLE
Add IoU metric for bounding boxes.

### DIFF
--- a/src/mlpack/core/metrics/CMakeLists.txt
+++ b/src/mlpack/core/metrics/CMakeLists.txt
@@ -3,6 +3,8 @@
 set(SOURCES
   ip_metric.hpp
   ip_metric_impl.hpp
+  iou_metric.hpp
+  iou_metric_impl.hpp
   lmetric.hpp
   lmetric_impl.hpp
   mahalanobis_distance.hpp

--- a/src/mlpack/core/metrics/iou_metric.hpp
+++ b/src/mlpack/core/metrics/iou_metric.hpp
@@ -35,7 +35,7 @@ namespace metric {
  *                        in the formate x0, y0, x1, y1. Else the bounding box is
  *                        represented as x0, y0, h, w.
  */
-template<bool useCoordinates = false>
+template<bool UseCoordinates = false>
 class IoU
 {
  public:
@@ -59,14 +59,11 @@ class IoU
   static typename VecTypeA::elem_type Evaluate(const VecTypeA& a,
                                                const VecTypeB& b);
 
-  static const bool UseCoordinates = useCoordinates;
+  static const bool useCoordinates = UseCoordinates;
 
   //! Serialize the metric.
   template<typename Archive>
-  void serialize(Archive& /* ar */, const unsigned int /* version */)
-  {
-    // Nothing to do here.
-  }
+  void serialize(Archive& ar, const unsigned int /* version */);
 }; // class IoU
 
 } // namespace metric

--- a/src/mlpack/core/metrics/iou_metric.hpp
+++ b/src/mlpack/core/metrics/iou_metric.hpp
@@ -1,0 +1,78 @@
+/**
+ * @file iou_metric.hpp
+ * @author Kartik Dutt
+ *
+ * Definition of Intersection Over Union metric. It is defined as intersection
+ * of given bounding-boxes / masks divided by their union. Useful metric for
+ * object detection.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_METRICS_IOU_HPP
+#define MLPACK_CORE_METRICS_IOU_HPP
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace metric {
+
+/**
+ * Definition of Intersection over Union metric.
+ *
+ * For bounding box representation there are two common representation
+ * either as coordinates i.e. each value in vector represents a
+ * coordinate in the format x0, y0, x1, y1 where x0, y0 represent the
+ * lower left coordinate and x1, y1, represent upper right coordinate.
+ * 
+ * Second representation follows the following representation : x0, y0, h, w.
+ * Where x0 and y0 are bottom left bounding box coordinates and h, w are
+ * height and width of the bounding box.
+ *
+ * @tparam useCoordinates Toggles between the two representation of bounding box.
+ *                        If true, each value in vector represents a coordinate 
+ *                        in the formate x0, y0, x1, y1. Else the bounding box is
+ *                        represented as x0, y0, h, w.
+ */
+template<bool useCoordinates = false>
+class IoU
+{
+ public:
+  //! Default constructor required to satisfy the Metric policy.
+  IoU()
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Computes the Intersection over Union metric between of two
+   * bounding boxes having pattern bx, by, h, w.
+   *
+   * @tparam VecTypeA Type of first vector.
+   * @tparam VecTypeB Type of second vector.
+   * @param a First vector.
+   * @param b Second vector.
+   * @return IoU of vectors a and b.
+   */
+  template<typename VecTypeA, typename VecTypeB>
+  static typename VecTypeA::elem_type Evaluate(const VecTypeA& a,
+                                               const VecTypeB& b);
+
+  static const bool UseCoordinates = useCoordinates;
+
+  //! Serialize the metric.
+  template<typename Archive>
+  void serialize(Archive& /* ar */, const unsigned int /* version */)
+  {
+    // Nothing to do here.
+  }
+}; // class IoU
+
+} // namespace metric
+} // namespace mlpack
+
+// Include implementation.
+#include "iou_metric_impl.hpp"
+
+#endif

--- a/src/mlpack/core/metrics/iou_metric_impl.hpp
+++ b/src/mlpack/core/metrics/iou_metric_impl.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file iou_metric_impl.hpp
+ * @author Kartik Dutt
+ *
+ * Implementation of Intersection Over Union metric.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_METRICS_IOU_IMPL_HPP
+#define MLPACK_CORE_METRICS_IOU_IMPL_HPP
+
+// In case it hasn't been included.
+#include "iou_metric.hpp"
+
+namespace mlpack {
+namespace metric {
+
+template<bool useCoordinates>
+template <typename VecTypeA, typename VecTypeB>
+typename VecTypeA::elem_type IoU<useCoordinates>::Evaluate(
+    const VecTypeA& a,
+    const VecTypeB& b)
+{
+  Log::Assert(a.n_elem == b.n_elem && a.n_elem == 4, "Incorrect \
+      shape for bounding boxes. They must contain 4 elements either be \
+      (x0, y0, x1, y1) or (x0, y0, h, w). Refer to the documentation \
+      for more information.");
+
+  // Bounding boxes represented as (x0, y0, x1, y1).
+  if (useCoordinates)
+  {
+    typename VecTypeA::elem_type interSectionArea = std::max(0.0,
+        std::min(a(2), b(2)) - std::max(a(0), b(0)) + 1) * std::max(0.0,
+        std::min(a(3), b(3)) - std::max(a(1), b(1)) + 1);
+
+    // Union of Area can be calculated using the following equation
+    // A union B = A + B - A intersection B.
+    return interSectionArea / (1.0 * ((a(2) - a(0) + 1) * (a(3) - a(1) + 1) +
+        (b(2) - b(0) + 1) * (b(3) - b(1) + 1) - interSectionArea));
+  }
+
+  // Bounding boxes represented as (x0, y0, h, w).
+  typename VecTypeA::elem_type interSectionArea = std::max(0.0,
+      std::min(a(0) + a(2), b(0) + b(2)) - std::max(a(0), b(0)) + 1)
+      * std::max(0.0, std::min(a(1) + a(3), b(1) + b(3)) - std::max(a(1),
+      b(1)) + 1);
+
+  return interSectionArea / (1.0 * ((a(2) + 1) * (a(3) + 1) + (b(2) + 1) *
+      (b(3) + 1) - interSectionArea));
+}
+
+} // namespace metric
+} // namespace mlpack
+#endif

--- a/src/mlpack/core/metrics/lmetric.hpp
+++ b/src/mlpack/core/metrics/lmetric.hpp
@@ -3,7 +3,7 @@
  * @author Ryan Curtin
  *
  * Generalized L-metric, allowing both squared distances to be returned as well
- * as non-squared distances.  The squared distances are faster to compute.
+ * as non-squared distances. The squared distances are faster to compute.
  *
  * This also gives several convenience typedefs for commonly used L-metrics.
  *

--- a/src/mlpack/tests/metric_test.cpp
+++ b/src/mlpack/tests/metric_test.cpp
@@ -11,6 +11,7 @@
 #include <mlpack/core.hpp>
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <boost/test/unit_test.hpp>
+#include <mlpack/core/metrics/iou_metric.hpp>
 #include "test_tools.hpp"
 
 using namespace std;
@@ -18,6 +19,9 @@ using namespace mlpack::metric;
 
 BOOST_AUTO_TEST_SUITE(LMetricTest);
 
+/**
+ * Simple test for L-1 metric.
+ */
 BOOST_AUTO_TEST_CASE(L1MetricTest)
 {
   arma::vec a1(5);
@@ -41,6 +45,9 @@ BOOST_AUTO_TEST_CASE(L1MetricTest)
                       lMetric.Evaluate(a2, b2), 1e-5);
 }
 
+/**
+ * Simple test for L-2 metric.
+ */
 BOOST_AUTO_TEST_CASE(L2MetricTest)
 {
   arma::vec a1(5);
@@ -64,6 +71,9 @@ BOOST_AUTO_TEST_CASE(L2MetricTest)
                       lMetric.Evaluate(a2, b2), 1e-5);
 }
 
+/**
+ * Simple test for L-Infinity metric.
+ */
 BOOST_AUTO_TEST_CASE(LINFMetricTest)
 {
   arma::vec a1(5);
@@ -85,6 +95,18 @@ BOOST_AUTO_TEST_CASE(LINFMetricTest)
 
   BOOST_REQUIRE_CLOSE((double) arma::as_scalar(arma::max(arma::abs(a2 - b2))),
                       lMetric.Evaluate(a2, b2), 1e-5);
+}
+
+/**
+ * Simple test for IoU metric.
+ */
+BOOST_AUTO_TEST_CASE(IoUMetricTest)
+{
+  arma::vec bbox1(4), bbox2(4);
+  bbox1.zeros();
+  bbox2.zeros();
+
+  BOOST_REQUIRE_CLOSE(1.0, IoU<>::Evaluate(bbox1, bbox2), 1e-3);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/metric_test.cpp
+++ b/src/mlpack/tests/metric_test.cpp
@@ -1,7 +1,7 @@
 /**
  * @file metric_test.cpp
  *
- * Unit tests for the 'LMetric' class.
+ * Unit tests for the various metrics.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -103,10 +103,34 @@ BOOST_AUTO_TEST_CASE(LINFMetricTest)
 BOOST_AUTO_TEST_CASE(IoUMetricTest)
 {
   arma::vec bbox1(4), bbox2(4);
-  bbox1.zeros();
-  bbox2.zeros();
+  bbox1 << 1 << 2 << 100 << 200;
+  bbox2 << 1 << 2 << 100 << 200;
+  // IoU of same bounding boxes equals 1.0.
+  BOOST_REQUIRE_CLOSE(1.0, IoU<>::Evaluate(bbox1, bbox2), 1e-4);
 
-  BOOST_REQUIRE_CLOSE(1.0, IoU<>::Evaluate(bbox1, bbox2), 1e-3);
+  // Use coordinate system to represent bounding boxes.
+  // Bounding boxes represent {x0, y0, x1, y1}.
+  bbox1 << 39 << 63 << 203 << 112;
+  bbox2 << 54 << 66 << 198 << 114;
+  // Value calculated using Python interpreter.
+  BOOST_REQUIRE_CLOSE(IoU<true>::Evaluate(bbox1, bbox2), 0.7980093, 1e-4);
+
+  bbox1 << 31 << 69 << 201 << 125;
+  bbox2 << 18 << 63 << 235 << 135;
+  // Value calculated using Python interpreter.
+  BOOST_REQUIRE_CLOSE(IoU<true>::Evaluate(bbox1, bbox2), 0.612479577, 1e-4);
+
+  // Use hieght - width representation of bounding boxes.
+  // Bounding boxes represent {x0, y0, h, w}.
+  bbox1 << 49 << 75 << 154 << 50;
+  bbox2 << 42 << 78 << 144 << 48;
+  // Value calculated using Python interpreter.
+  BOOST_REQUIRE_CLOSE(IoU<>::Evaluate(bbox1, bbox2), 0.7898879, 1e-4);
+
+  bbox1 << 35 << 51 << 161 << 59;
+  bbox2 << 36 << 60 << 144 << 48;
+  // Value calculated using Python interpreter.
+  BOOST_REQUIRE_CLOSE(IoU<>::Evaluate(bbox1, bbox2), 0.7309670, 1e-4);
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Hey everyone,
This PR aims to add IoU metric to this repo. I need to add more detailed tests for it. Also some metrics such ip_metric don't have tests in `metric_tests.cpp`. Did I miss something?

Also, This metric is for bounding boxes which I would need for NMS and object detection algorithm. I do plan on opening another PR to add mIoU to take as input a matrix where each pixel is label. That is more useful for segmentation so I have left that for now.

Files changed:
- metrics/CMakeLists.txt
- metrics/iou_metric.hpp
- metrics/iou_metric_impl.hpp
- tests/metric_tests.cpp

Changes made :
- Added IoU metric (only for bounding boxes).
- Added a simple test. (will add more soon).

Let me know if I missed something. 
Thanks a ton! 
Regards.