### PR TITLE
Add Silhouette Score and Pairwise Distance

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,6 +39,8 @@
 
   * Add `RBF` layer in ann module to make `RBFN` architecture (#2261).
 
+  * Add Silhoutte Score metric and Pairwise Distances (#2406).
+
 ### mlpack 3.3.1
 ###### 2020-04-29
   * Minor Julia and Python documentation fixes (#2373).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-### mlpack 3.3.3
+### mlpack ?.?.?
 ###### ????-??-??
   * Add Silhoutte Score metric and Pairwise Distances (#2406).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
-### mlpack ?.?.?
+### mlpack 3.3.3
 ###### ????-??-??
+  * Add Silhoutte Score metric and Pairwise Distances (#2406).
 
 ### mlpack 3.3.2
 ###### 2020-06-18
@@ -38,8 +39,6 @@
     the `QDAFN` algorithm (#2448).
 
   * Add `RBF` layer in ann module to make `RBFN` architecture (#2261).
-
-  * Add Silhoutte Score metric and Pairwise Distances (#2406).
 
 ### mlpack 3.3.1
 ###### 2020-04-29

--- a/src/mlpack/core/cv/metrics/facilities.hpp
+++ b/src/mlpack/core/cv/metrics/facilities.hpp
@@ -1,6 +1,7 @@
 /**
  * @file core/cv/metrics/facilities.hpp
  * @author Kirill Mishchenko
+ * @author Khizir Siddiqui
  *
  * Functionality that is used more than in one metric.
  *
@@ -13,6 +14,7 @@
 #define MLPACK_CORE_CV_METRICS_FACILITIES_HPP
 
 #include <mlpack/core.hpp>
+#include <mlpack/core/metrics/lmetric.hpp>
 
 namespace mlpack {
 namespace cv {
@@ -38,6 +40,29 @@ void AssertSizes(const DataType& data,
         << std::endl;
     throw std::invalid_argument(oss.str());
   }
+}
+
+/**
+  * Pairwise distance of the given data.
+  *
+  * @param data Column-major matrix.
+  * @param metric Distance metric to be used.
+  */
+template<typename DataType, typename Metric>
+DataType PairwiseDistances(const DataType& data,
+                           const Metric& metric)
+{
+  DataType distances = DataType(data.n_cols, data.n_cols, arma::fill::none);
+  for (size_t i = 0; i < data.n_cols; i++)
+  {
+    for (size_t j = 0; j < i; j++)
+    {
+      distances(i, j) = metric.Evaluate(data.col(i), data.col(j));
+      distances(j, i) = distances(i, j);
+    }
+  }
+  distances.diag().zeros();
+  return distances;
 }
 
 } // namespace cv

--- a/src/mlpack/core/cv/metrics/silhouette_score.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score.hpp
@@ -18,35 +18,78 @@ namespace mlpack {
 namespace cv {
 
 /**
+ * The Silhouette Score is a metric of performance for clustering
+ * that represents the quality of clusters made as a result.
+ * It provides an indication of goodness of fit and therefore a measure of how
+ * well unseen samples are likely to be predicted by the model, considering
+ * the inter-cluster and intra-cluster dissimilarities.
+ * Silhoutte Score is dependent on the metric used to calculate the
+ * dissimilarities. The best possible score is @f$ s(i) = 1.0 @f$.
+ * Smaller values of Silhouette Score indicate poor clustering.
+ *  Negative values would occur when a wrong label was put on the element.
+ *  Values near zero indicate overlapping clusters.
+ * For an element i @f$ a(i) $@f is within cluster average dissimilarity
+ * and @f$ b(i) $@f is minimum of average dissimilarity from other clusters.
+ * the Silhouette Score @f$ s(i) $@f of a Sample is calculated by
+ * @f{eqnarray*}{
+ * s(i)  &=& \frac{b(i) - a(i)}{max\{b(i), a(i)\}}
+ * @f}
  * 
- * //////////==============TODO=======================\\\\\\\\\\
- * 
+ * The Overall Silhouette Score is the mean of individual silhoutte scores.
  */
 class SilhouetteScore
 {
  public:
   /**
-   * Run classification and calculate accuracy.
+   * Find the overall silhouette score.
    *
-   * @param data Column-major data containing test items.
-   * @param labels Ground truth (correct) labels for the test items.
+   * @param X Column-major data used for clustering.
+   * @param labels Labels assigned to data by clustering.
+   * @param metric Metric to be used to calculate dissimilarity.
+   * @return (double) silhouette score.
    */
   template<typename DataType, typename Metric>
   static double Overall(const DataType& X,
-                                     const arma::Row<size_t>& labels,
-                                     const Metric& metric);
+                        const arma::Row<size_t>& labels,
+                        const Metric& metric);
 
-  template<typename DataType, typename Metric>
+  /**
+   * Find the individual silhouette scores for precomputted dissimilarites.
+   *
+   * @param distances Square matrix containing distances between data points.
+   * @param labels Labels assigned to data by clustering.
+   * @return (arma::rowvec) element-wise silhouette score.
+   */
+  template<typename DataType>
   static arma::rowvec SamplesScore(const DataType& distances,
-                                     const arma::Row<size_t>& labels,
-                                     const Metric& metric);
+                                   const arma::Row<size_t>& labels);
 
+  /**
+   * Find silhouette score of all individual elements.
+   * (Distance not precomputed).
+   * 
+   * @param X Column-major data used for clustering.
+   * @param labels Labels assigned to data by clustering.
+   * @param metric Metric to be used to calculate dissimilarity.
+   * @return (arma::rowvec) element-wise silhouette score.
+   */
   template<typename DataType, typename Metric>
-  static double DistanceFromCluster(const arma::rowvec& distances,
-                                          const arma::Row<size_t>& labels,
-                                          const size_t& label,
-                                          const Metric& metric,
-                                          const bool& sameCluster = 0);
+  static arma::rowvec SamplesScore(const DataType& X,
+                                   const arma::Row<size_t>& labels,
+                                   const Metric& metric);
+
+  /**
+   * Find mean distance of element from a given cluster.
+   * 
+   * @param distances colvec containing distances from other elements.
+   * @param labels Labels assigned to data by clustering.
+   * @param label label of the target cluster.
+   * @return (double) distance from the cluster.
+   */
+  static double MeanDistanceFromCluster(const arma::colvec& distances,
+                                        const arma::Row<size_t>& labels,
+                                        const size_t& label,
+                                        const bool& sameCluster = false);
 
   /**
    * Information for hyper-parameter tuning code. It indicates that we want

--- a/src/mlpack/core/cv/metrics/silhouette_score.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score.hpp
@@ -28,13 +28,13 @@ namespace cv {
  * Smaller values of Silhouette Score indicate poor clustering.
  *  Negative values would occur when a wrong label was put on the element.
  *  Values near zero indicate overlapping clusters.
- * For an element i @f$ a(i) $@f is within cluster average dissimilarity
- * and @f$ b(i) $@f is minimum of average dissimilarity from other clusters.
- * the Silhouette Score @f$ s(i) $@f of a Sample is calculated by
+ * For an element i @f$ a(i) @f$ is within cluster average dissimilarity
+ * and @f$ b(i) @f$ is minimum of average dissimilarity from other clusters.
+ * the Silhouette Score @f$ s(i) @f$ of a Sample is calculated by
  * @f{eqnarray*}{
  * s(i)  &=& \frac{b(i) - a(i)}{max\{b(i), a(i)\}}
  * @f}
- * 
+ *
  * The Overall Silhouette Score is the mean of individual silhoutte scores.
  */
 class SilhouetteScore
@@ -67,7 +67,7 @@ class SilhouetteScore
   /**
    * Find silhouette score of all individual elements.
    * (Distance not precomputed).
-   * 
+   *
    * @param X Column-major data used for clustering.
    * @param labels Labels assigned to data by clustering.
    * @param metric Metric to be used to calculate dissimilarity.
@@ -80,7 +80,7 @@ class SilhouetteScore
 
   /**
    * Find mean distance of element from a given cluster.
-   * 
+   *
    * @param distances colvec containing distances from other elements.
    * @param labels Labels assigned to data by clustering.
    * @param label label of the target cluster.

--- a/src/mlpack/core/cv/metrics/silhouette_score.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score.hpp
@@ -84,6 +84,7 @@ class SilhouetteScore
    * @param distances colvec containing distances from other elements.
    * @param labels Labels assigned to data by clustering.
    * @param label label of the target cluster.
+   * @param sameCluster true if calculating mean distance from same cluster.
    * @return (double) distance from the cluster.
    */
   static double MeanDistanceFromCluster(const arma::colvec& distances,

--- a/src/mlpack/core/cv/metrics/silhouette_score.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score.hpp
@@ -1,0 +1,64 @@
+/**
+ * @file silhouette_score.hpp
+ * @author Khizir Siddiqui
+ *
+ * The Silhouette metric.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_SILHOUETTE_SCORE_HPP
+#define MLPACK_CORE_CV_METRICS_SILHOUETTE_SCORE_HPP
+
+#include <mlpack/core.hpp>
+
+namespace mlpack {
+namespace cv {
+
+/**
+ * 
+ * //////////==============TODO=======================\\\\\\\\\\
+ * 
+ */
+class SilhouetteScore
+{
+ public:
+  /**
+   * Run classification and calculate accuracy.
+   *
+   * @param data Column-major data containing test items.
+   * @param labels Ground truth (correct) labels for the test items.
+   */
+  template<typename DataType, typename Metric>
+  static double Overall(const DataType& X,
+                                     const arma::Row<size_t>& labels,
+                                     const Metric& metric);
+
+  template<typename DataType, typename Metric>
+  static arma::rowvec SamplesScore(const DataType& distances,
+                                     const arma::Row<size_t>& labels,
+                                     const Metric& metric);
+
+  template<typename DataType, typename Metric>
+  static double DistanceFromCluster(const arma::rowvec& distances,
+                                          const arma::Row<size_t>& labels,
+                                          const size_t& label,
+                                          const Metric& metric,
+                                          const bool& sameCluster = 0);
+
+  /**
+   * Information for hyper-parameter tuning code. It indicates that we want
+   * to maximize the metric.
+   */
+  static const bool NeedsMinimization = false;
+};
+
+} // namespace cv
+} // namespace mlpack
+
+// Include implementation.
+#include "silhouette_score_impl.hpp"
+
+#endif

--- a/src/mlpack/core/cv/metrics/silhouette_score_impl.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score_impl.hpp
@@ -40,22 +40,19 @@ arma::rowvec SilhouetteScore::SamplesScore(const DataType& distances,
   for (size_t i = 0; i < distances.n_rows; i++)
   {
     double interClusterDistance = DBL_MAX, intraClusterDistance = 0;
-    double minInterClusterDistance = DBL_MAX;    
+    double minInterClusterDistance = DBL_MAX;
     for (size_t j = 0; j < clusterLabels.n_elem; j++)
     {
       size_t clusterLabel = labels(clusterLabels(j));
       if (labels(i) != clusterLabel) {
         interClusterDistance = MeanDistanceFromCluster(
-          distances.col(i), labels, clusterLabel, false
-        );
+          distances.col(i), labels, clusterLabel, false);
         if (interClusterDistance < minInterClusterDistance) {
           minInterClusterDistance = interClusterDistance;
         }
-      }
-      else {
+      } else {
         intraClusterDistance = MeanDistanceFromCluster(
-          distances.col(i), labels, clusterLabel, true
-        );
+          distances.col(i), labels, clusterLabel, true);
         if (intraClusterDistance == 0) {
           // s(i) = 0, no more calculation needed.
           break;
@@ -65,10 +62,10 @@ arma::rowvec SilhouetteScore::SamplesScore(const DataType& distances,
     if (intraClusterDistance == 0) {
       // i is the only element in the cluster.
       sampleScores(i) = 0.0;
-    }
-    else {
+    } else {
       sampleScores(i) = minInterClusterDistance - intraClusterDistance;
-      sampleScores(i) /= std::max(intraClusterDistance, minInterClusterDistance);
+      sampleScores(i) /= std::max(
+        intraClusterDistance, minInterClusterDistance);
     }
   }
   return sampleScores;
@@ -98,9 +95,7 @@ double SilhouetteScore::MeanDistanceFromCluster(const arma::colvec& distances,
   {
     // Return 0 if subject element is the only element in cluster.
     return 0.0;
-  }
-  else
-  {
+  } else {
     double distance = arma::accu(distances.elem(sameClusterIndices));
     distance /= (numSameCluster - sameCluster);
     return distance;

--- a/src/mlpack/core/cv/metrics/silhouette_score_impl.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score_impl.hpp
@@ -1,0 +1,96 @@
+/**
+ * @file silhouette_score_impl.hpp
+ * @author Khizir Siddiqui
+ *
+ * The implementation of the class SilhouetteScore.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_SILHOUETTE_SCORE_IMPL_HPP
+#define MLPACK_CORE_CV_METRICS_SILHOUETTE_SCORE_IMPL_HPP
+
+#include <mlpack/core/cv/metrics/facilities.hpp>
+
+namespace mlpack {
+namespace cv {
+
+template<typename DataType, typename Metric>
+double SilhouetteScore::Overall(const DataType& X,
+                                const arma::Row<size_t>& labels,
+                                const Metric& metric)
+{
+  AssertSizes(data, labels, "SilhouetteScore::Overall()");
+  DataType distances = PairwiseDistances(X, metric);
+  return arma::mean(SamplesScore(distances, labels, metric));
+}
+
+template<typename DataType, typename Metric>
+arma::rowvec SilhouetteScore::SamplesScore(const DataType& distances,
+                                const arma::Row<size_t>& labels,
+                                const Metric& metric)
+{
+  AssertSizes(data, labels, "SilhouetteScore::SamplesScore()");
+
+  // Stores the silhouette scores of individual samples
+  arma::rowvec sampleScores(distances.n_rows);
+  // Finds one index per cluster.
+  arma::ucolvec clusterLabels = arma::find_unique(labels);
+  double interClusterDistance, intraClusterDistance;
+  double minIntraClusterDistance = DBL_MAX;
+  for (size_t i = 0; i < distances.n_rows; i++)
+  {
+    for (size_t j = 0; j < clusterLabels; j++)
+    {
+      if (labels(i) != clusterLabels(i) {
+        intraClusterDistance = DistanceFromCluster(
+          distances.col(i), labels, clusterLabels(i), metric, false
+        );
+        if (intraClusterDistance < minIntraClusterDistance) {
+          minIntraClusterDistance = intraClusterDistance;
+        }
+      }
+      else {
+        interClusterDistance = DistanceFromCluster(
+          distances.col(i), labels, clusterLabels(i), metric, true
+        );
+      }
+    }
+    sampleScores(i) = minIntraClusterDistance - interClusterDistance;
+    sampleScores(i) /= std::max(intraClusterDistance, minIntraClusterDistance);
+  }
+  
+  return sampleScores;
+}
+
+template<typename DataType, typename Metric>
+double SilhouetteScore::DistanceFromCluster(const arma::rowvec& distances,
+                                                  const arma::Row<size_t>& labels,
+                                                  const size_t& elemLabel,
+                                                  const Metric& metric,
+                                                  const bool& sameCluster)
+{
+  AssertSizes(distances, labels, "SilhouetteScore::DistanceFromCluster()");
+
+  // Find indices of elements with same label as subject element.
+  arma::uvec sameClusterIndices = arma::find(labels == elemLabel);
+  size_t numSameCluster = sameClusterIndices.n_elem;
+  if (sameCluster == true && numSameCluster == 1)
+  {
+    // Return 0 if subject element is the only element in cluster.
+    return 0.0;
+  }
+  else
+  {
+    double distance = arma::accu(distances.elem(sameClusterIndices));
+    distance /= (numSameCluster - sameCluster);
+    return distance;
+  }
+}
+
+} // namespace cv
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/core/cv/metrics/silhouette_score_impl.hpp
+++ b/src/mlpack/core/cv/metrics/silhouette_score_impl.hpp
@@ -32,7 +32,7 @@ arma::rowvec SilhouetteScore::SamplesScore(const DataType& distances,
 {
   AssertSizes(distances, labels, "SilhouetteScore::SamplesScore()");
 
-  // Stores the silhouette scores of individual samples
+  // Stores the silhouette scores of individual samples.
   arma::rowvec sampleScores(distances.n_rows);
   // Finds one index per cluster.
   arma::ucolvec clusterLabels = arma::find_unique(labels, false);

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(mlpack_test
   drusilla_select_test.cpp
   emst_test.cpp
   fastmks_test.cpp
+  facilities_test.cpp
   feedforward_network_test.cpp
   gan_test.cpp
   gmm_test.cpp

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -18,6 +18,7 @@
 #include <mlpack/core/cv/metrics/precision.hpp>
 #include <mlpack/core/cv/metrics/recall.hpp>
 #include <mlpack/core/cv/metrics/r2_score.hpp>
+#include <mlpack/core/cv/metrics/silhouette_score.hpp>
 #include <mlpack/core/cv/simple_cv.hpp>
 #include <mlpack/core/cv/k_fold_cv.hpp>
 #include <mlpack/methods/ann/ffn.hpp>
@@ -717,6 +718,21 @@ BOOST_AUTO_TEST_CASE(KFoldCVWithDTTestUnevenBinsWeighted)
   // This is a very loose tolerance, but we expect about the same as we would
   // from an individual decision tree training.
   BOOST_REQUIRE_GT(accuracy, 0.7);
+}
+
+/**
+ * Test Silhouette Score
+ */
+BOOST_AUTO_TEST_CASE(SilhouetteScoreTest)
+{
+  arma::mat X;
+  X << 0 << 1 << 1 << 0 << 0 << arma::endr
+    << 0 << 1 << 2 << 0 << 0 << arma::endr
+    << 1 << 1 << 3 << 2 << 0 << arma::endr;
+  arma::Row<size_t> labels = {0, 1, 2, 0, 0};
+  metric::EuclideanDistance metric;
+  double silhouetteScore = SilhouetteScore::Overall(X, labels, metric);
+  BOOST_REQUIRE_CLOSE(silhouetteScore, 0.1121684822489150, 1e-5);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/facilities_test.cpp
+++ b/src/mlpack/tests/facilities_test.cpp
@@ -45,13 +45,15 @@ BOOST_AUTO_TEST_CASE(AssertSizesTest)
  */
 BOOST_AUTO_TEST_CASE(PairwiseDistanceTest)
 {
-  arma::mat X(2, 2, arma::fill::ones);
-  X(0, 0) = 0;
+  arma::mat X;
+  X << 0 << 1 << 1 << 0 << 0 << arma::endr
+    << 0 << 1 << 2 << 0 << 0 << arma::endr
+    << 1 << 1 << 3 << 2 << 0 << arma::endr;
   metric::EuclideanDistance metric;
   arma::mat dist = PairwiseDistances(X, metric);
-
   BOOST_REQUIRE_EQUAL(dist(0, 0), 0);
-  BOOST_REQUIRE_EQUAL(dist(1, 0), 1);
+  BOOST_REQUIRE_CLOSE(dist(1, 0), 1.41421, 1e-3);
+  BOOST_REQUIRE_EQUAL(dist(2, 0), 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/facilities_test.cpp
+++ b/src/mlpack/tests/facilities_test.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file facilities_test.cpp
+ * @author Khizir Siddiqui
+ *
+ * Test file for facilities in metrics.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#include <mlpack/core.hpp>
+#include <mlpack/core/cv/metrics/facilities.hpp>
+#include <mlpack/core/metrics/lmetric.hpp>
+#include <mlpack/core/data/load.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include "test_tools.hpp"
+
+using namespace mlpack;
+using namespace mlpack::cv;
+
+BOOST_AUTO_TEST_SUITE(FacilitiesTest);
+
+
+/**
+ * The unequal sizes for data and labels show throw an error.
+ */
+BOOST_AUTO_TEST_CASE(AssertSizesTest)
+{
+  // Load the dataset.
+  arma::mat dataset;
+  data::Load("iris_train.csv", dataset);
+  // Load the labels.
+  arma::Row<size_t> labels;
+  data::Load("iris_test_labels.csv", labels);
+
+  BOOST_REQUIRE_THROW(AssertSizes(dataset, labels, "test"), std::invalid_argument);
+}
+
+
+/**
+ * Pairwise distances.
+ */
+BOOST_AUTO_TEST_CASE(PairwiseDistanceTest)
+{
+  arma::mat X(2, 2, arma::fill::ones);
+  X(0, 0) = 0;
+  metric::EuclideanDistance metric;
+  arma::mat dist = PairwiseDistances(X, metric);
+
+  BOOST_REQUIRE_EQUAL(dist(0, 0), 0);
+  BOOST_REQUIRE_EQUAL(dist(1, 0), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/facilities_test.cpp
+++ b/src/mlpack/tests/facilities_test.cpp
@@ -36,7 +36,8 @@ BOOST_AUTO_TEST_CASE(AssertSizesTest)
   arma::Row<size_t> labels;
   data::Load("iris_test_labels.csv", labels);
 
-  BOOST_REQUIRE_THROW(AssertSizes(dataset, labels, "test"), std::invalid_argument);
+  BOOST_REQUIRE_THROW(
+    AssertSizes(dataset, labels, "test"), std::invalid_argument);
 }
 
 


### PR DESCRIPTION
Silhouette Score is a widely used metric for clustering algorithms, I thought it be nice to have it here.
 - Add Pairwise Distance (and test)
 - Add Silhouette Score (and test)
 - Add test for AssertSizes (already implemented, added test)