### PR TITLE
Don't use masterblaster.mlpack.org anymore in CI steps

### DIFF
--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -29,7 +29,7 @@ steps:
 - bash: |
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
 
-    curl -O http://masterblaster.mlpack.org:5005/armadillo-8.400.0.tar.gz -o armadillo-8.400.0.tar.gz
+    curl -O http://www.ratml.org/misc/armadillo-8.400.0.tar.gz -o armadillo-8.400.0.tar.gz
     tar -xzvf armadillo-8.400.0.tar.gz
 
     cd armadillo-8.400.0/ && cmake $(CMakeGenerator) \


### PR DESCRIPTION
I rehosted armadillo-8.400.0.tar.gz somewhere else, so this should fix the Windows builds.