### PR TITLE
Allow using only `--input_model` with `mlpack_lsh`

### DIFF
--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -124,8 +124,8 @@ static void mlpackMain()
       "no results will be saved");
   if (CLI::HasParam("k"))
   {
-    RequireAtLeastOnePassed({ "query", "reference" }, true, "must pass set to "
-        "search");
+    RequireAtLeastOnePassed({ "query", "reference", "input_model" }, true,
+        "must pass set to search");
   }
 
   if (CLI::HasParam("input_model") && CLI::HasParam("k") &&
@@ -167,7 +167,7 @@ static void mlpackMain()
         numTables << " tables (L) with default hash width." << endl;
   else
     Log::Info << "Using LSH with " << numProj << " projections (K) and " <<
-        numTables << " tables (L) with hash width(r): " << hashWidth << endl;
+        numTables << " tables (L) with hash width (r): " << hashWidth << endl;
 
   LSHSearch<>* allkann;
   if (CLI::HasParam("reference"))


### PR DESCRIPTION
I was working with `mlpack_lsh` on a project and I wanted to use it like this (from Julia):

```julia
_, _, model = mlpack.lsh(reference=dataset, ...)
```

and then later on in my code, I wanted to do search on only the reference dataset.  (This should be done by leaving `query` unspecified but specifying `input_model`.)

```julia
distances, neighbors, _ = mlpack.lsh(input_model=model, k=5)
```

However, this issues an error---claiming that search can't be done unless `reference` or `query` is specified.  But this isn't true; even the LSH code itself will work correctly if `input_model` is specified (then it takes the reference dataset from the input model as the query set).  So, I've just corrected the error checking.