### PR TITLE
Fix linear SVM binding bugs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,10 +12,13 @@
 
   * Add `MatType` parameter to `LSHSearch`, allowing sparse matrices to be used
     for search (#2395).
-    
+
   * Documentation fixes to resolve Doxygen warnings and issues (#2400).
-  
+
   * Add Load and Save of Sparse Matrix (#2344).
+
+  * Fix `no_intercept` and probability computation for linear SVM bindings
+    (#2419).
 
 ### mlpack 3.3.1
 ###### 2020-04-29

--- a/src/mlpack/methods/linear_svm/linear_svm_impl.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_impl.hpp
@@ -184,7 +184,7 @@ void LinearSVM<MatType>::Classify(
   if (fitIntercept)
   {
     scores = parameters.rows(0, parameters.n_rows - 2).t() * data
-        + arma::repmat(parameters.row(data.n_rows - 1).t(), 1,
+        + arma::repmat(parameters.row(parameters.n_rows - 1).t(), 1,
         data.n_cols);
   }
   else

--- a/src/mlpack/methods/linear_svm/linear_svm_main.cpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_main.cpp
@@ -172,7 +172,7 @@ static void mlpackMain()
   const double delta = CLI::GetParam<double>("delta");
   const string optimizerType = CLI::GetParam<string>("optimizer");
   const double tolerance = CLI::GetParam<double>("tolerance");
-  const bool intercept = CLI::HasParam("no_intercept");
+  const bool intercept = !CLI::HasParam("no_intercept");
   const size_t epochs = (size_t) CLI::GetParam<int>("epochs");
   const size_t maxIterations = (size_t) CLI::GetParam<int>("max_iterations");
 


### PR DESCRIPTION
While trying to integrate `linear_svm()` into my company's software, I found two bugs; one simple, one rather subtle:

 1. `no_intercept` is backwards---you have to specify `no_intercept` to get an intercept.  This PR corrects the behavior. :)
 2. The intercept was not properly being added in the call to `Classify()`.  Specifically, we were using `data.n_rows - 1` to get the index of the intercept in `parameters`---but if there is an intercept, then `data` has one fewer row than `parameters`!  So we should use `parameters.n_rows - 1` instead.