### PR TITLE
Quick Saturday fixes

### DIFF
--- a/doc/guide/julia_quickstart.hpp
+++ b/doc/guide/julia_quickstart.hpp
@@ -54,8 +54,7 @@ df = CSV.read(ZlibInflateInputStream(open(download(
 labels = df[!, :label][:]
 dataset = select!(df, Not(:label))
 
-# Split the dataset using mlpack.  The output comes back as a dictionary,
-# which we'll unpack for clarity of code.
+# Split the dataset using mlpack.
 test, test_labels, train, train_labels = mlpack.preprocess_split(
     input=dataset,
     input_labels=labels,

--- a/src/mlpack/methods/lsh/lsh_search.hpp
+++ b/src/mlpack/methods/lsh/lsh_search.hpp
@@ -276,7 +276,7 @@ class LSHSearch
   size_t& DistanceEvaluations() { return distanceEvaluations; }
 
   //! Return the reference dataset.
-  const arma::mat& ReferenceSet() const { return referenceSet; }
+  const MatType& ReferenceSet() const { return referenceSet; }
 
   //! Get the number of projections.
   size_t NumProjections() const { return projections.n_slices; }


### PR DESCRIPTION
Two things I noticed while poking around today:

 1. The Julia quickstart documentation is wrong.  It doesn't return `Dict`s, so I fixed the inaccurate sentence (by removing it).

 2. In #2395 it looks like I forgot to return the correct type in the `ReferenceSet()` function.  This didn't trigger a build failure because the function was never called in the tests when `MatType` *wasn't* `arma::mat`.