### PR TITLE
Fix type in mlpack_krann binding

### DIFF
--- a/src/mlpack/methods/rann/krann_main.cpp
+++ b/src/mlpack/methods/rann/krann_main.cpp
@@ -203,7 +203,7 @@ static void mlpackMain()
     rann = CLI::GetParam<RANNModel*>("input_model");
 
     Log::Info << "Using rank-approximate kNN model from '"
-        << CLI::GetPrintableParam<RANNModel>("input_model") << "' (trained on "
+        << CLI::GetPrintableParam<RANNModel*>("input_model") << "' (trained on "
         << rann->Dataset().n_rows << "x" << rann->Dataset().n_cols
         << " dataset)." << endl;
 


### PR DESCRIPTION
This is a simple one---`GetPrintableParam` was being called with the wrong type, resulting in errors like

```
[FATAL] Attempted to access parameter --input_model as type N6mlpack8neighbor7RAModelINS0_9NearestNSEEE, but its true type is PN6mlpack8neighbor7RAModelINS0_9NearestNSEEE!
```

But... these don't show up in the test suite, because... there is no test for the krann binding!  I guess I closed #1152 too early. :)  I'll open another issue for that.