### PR TITLE
Check the Static ci job.

### DIFF
--- a/src/mlpack/methods/amf/termination_policies/incomplete_incremental_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/incomplete_incremental_termination.hpp
@@ -17,7 +17,7 @@
 namespace mlpack {
 namespace amf {
 
-/**
+/** trigger the static ci job
  * This class acts as a wrapper for basic termination policies to be used by
  * SVDIncompleteIncrementalLearning. This class calls the wrapped class functions
  * after every n calls to main class functions where n is the number of rows.


### PR DESCRIPTION
This is just a check if the static ci job works as expected, in this case it should fail because not all members of a class are initialized inside the constructor.