### PR TITLE
Bug Fix : Check correctness of shape in Transposed Conv. layer only when output width and height aren't zero.

### DIFF
--- a/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
@@ -161,10 +161,11 @@ TransposedConvolution<
 
   // Check if the output height and width are possible given the other
   // parameters of the layer.
-  if (outputWidth != strideWidth * (inputWidth - 1) +
+  if (outputWidth != 0 && outputHeight != 0 &&
+      (outputWidth != strideWidth * (inputWidth - 1) +
       aW + kernelWidth - totalPadWidth ||
       outputHeight != strideHeight * (inputHeight - 1) +
-      aH + kernelHeight - totalPadHeight)
+      aH + kernelHeight - totalPadHeight))
   {
     Log::Fatal << "The output width / output height is not possible given "
                << "the other parameters of the layer." << std::endl;

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3715,4 +3715,28 @@ BOOST_AUTO_TEST_CASE(AdaptiveMeanPoolingTestCase)
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 1.5);
 }
 
+BOOST_AUTO_TEST_CASE(VAEModelTest)
+{
+  Sequential<>* decoder = new Sequential<>();
+
+    decoder->Add<Linear<>>(20, 10 * 10 * 24);
+    decoder->Add<LeakyReLU<>>();
+
+    decoder->Add<TransposedConvolution<>>(
+        24,  // Number of input activation maps.
+        16,  // Number of output activation maps.
+        5,   // Filter width.
+        5,   // Filter height.
+        1,   // Stride along width.
+        1,   // Stride along height.
+        0,   // Padding width.
+        0,   // Padding height.
+        10,  // Input width.
+        10); // Input height.
+
+    decoder->Add<LeakyReLU<>>();
+    decoder->Add<TransposedConvolution<>>(16, 1, 15, 15,
+        1, 1, 1, 1, 14, 14);
+}
+
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3715,28 +3715,16 @@ BOOST_AUTO_TEST_CASE(AdaptiveMeanPoolingTestCase)
   BOOST_REQUIRE_EQUAL(arma::accu(delta), 1.5);
 }
 
-BOOST_AUTO_TEST_CASE(VAEModelTest)
+BOOST_AUTO_TEST_CASE(TransposedConvolutionalLayerOptionalParameterTest)
 {
   Sequential<>* decoder = new Sequential<>();
 
-    decoder->Add<Linear<>>(20, 10 * 10 * 24);
-    decoder->Add<LeakyReLU<>>();
+  // Check if we can create an object without specifying output.
+  BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(24, 16,
+      5, 5, 1, 1, 0, 0, 10, 10), std::runtime_error);
 
-    decoder->Add<TransposedConvolution<>>(
-        24,  // Number of input activation maps.
-        16,  // Number of output activation maps.
-        5,   // Filter width.
-        5,   // Filter height.
-        1,   // Stride along width.
-        1,   // Stride along height.
-        0,   // Padding width.
-        0,   // Padding height.
-        10,  // Input width.
-        10); // Input height.
-
-    decoder->Add<LeakyReLU<>>();
-    decoder->Add<TransposedConvolution<>>(16, 1, 15, 15,
-        1, 1, 1, 1, 14, 14);
+    BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(16, 1,
+        15, 15, 1, 1, 1, 1, 14, 14), std::runtime_error);
 
     delete decoder;
 }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3721,10 +3721,10 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionalLayerOptionalParameterTest)
 
   // Check if we can create an object without specifying output.
   BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(24, 16,
-      5, 5, 1, 1, 0, 0, 10, 10), std::runtime_error);
+      5, 5, 1, 1, 0, 0, 10, 10));
 
     BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(16, 1,
-        15, 15, 1, 1, 1, 1, 14, 14), std::runtime_error);
+        15, 15, 1, 1, 1, 1, 14, 14));
 
     delete decoder;
 }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3737,6 +3737,8 @@ BOOST_AUTO_TEST_CASE(VAEModelTest)
     decoder->Add<LeakyReLU<>>();
     decoder->Add<TransposedConvolution<>>(16, 1, 15, 15,
         1, 1, 1, 1, 14, 14);
+
+    delete decoder;
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -3723,8 +3723,8 @@ BOOST_AUTO_TEST_CASE(TransposedConvolutionalLayerOptionalParameterTest)
   BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(24, 16,
       5, 5, 1, 1, 0, 0, 10, 10));
 
-    BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(16, 1,
-        15, 15, 1, 1, 1, 1, 14, 14));
+  BOOST_REQUIRE_NO_THROW(decoder->Add<TransposedConvolution<>>(16, 1,
+      15, 15, 1, 1, 1, 1, 14, 14));
 
     delete decoder;
 }


### PR DESCRIPTION
Transposed convolution should check for correctness only when output width / height is specified.
In #1493, A check was added in this layer which went on subsequent modifications in further layers. However the drawback of such a check is that if user doesn't pass outputW or outputH to the layer the layer will always give fatal. That means we will always have to specify outputW, outputH. I have added a check to ensure both of them aren't zero.
CC: @zoq