### PR TITLE
ftp.fau.de - faulty RAID controller

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ environment:
   boost_serialization-vc140.1.60.0.0/lib/native/address-model-64/lib/*.*"
   BOOST_UNIT_TEST : "C:/projects/mlpack/\
   boost_unit_test_framework-vc140.1.60.0.0/lib/native/address-model-64/lib/*.*"
-  ARMADILLO_DOWNLOAD : "http://ftp.fau.de/macports/distfiles/armadillo/armadillo-8.400.0.tar.xz"
+  ARMADILLO_DOWNLOAD : "https://data.kurg.org/armadillo-8.400.0.tar.xz"
   ARMADILLO_LIBRARY : "C:/projects/mlpack/armadillo-8.400.0/\
   build/Debug/armadillo.lib"
   BLAS_LIBRARY : "%APPVEYOR_BUILD_FOLDER%/OpenBLAS.0.2.14.1/lib/native/lib/x64/\

--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -40,7 +40,7 @@ steps:
     fi
 
     # Install armadillo.
-    curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
+    curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
     cmake . && make && sudo make install && cd ..
   displayName: 'Install Build Dependencies'
 


### PR DESCRIPTION
The source (https://ftp.fau.de/) we use to download armadillo has a faulty RAID controller:

"The machine has a faulty RAID controller. Until a replacement part arrives, bad performance and crashes are to be expected. Mirrors will NOT be updated for now. Sorry for the inconvenience."

so switch to another source for now to fix the Linux build jobs.