### PR TITLE
Extract the correct number of neighbors for QDAFN.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,9 @@
   * Fix `no_intercept` and probability computation for linear SVM bindings
     (#2419).
 
+  * Fix incorrect neighbors for `k > 1` searches in `approx_kfn` binding, for
+    the `QDAFN` algorithm (#2448).
+
 ### mlpack 3.3.1
 ###### 2020-04-29
   * Minor Julia and Python documentation fixes (#2373).

--- a/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
+++ b/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
@@ -55,6 +55,10 @@ PROGRAM_INFO("Approximate furthest neighbor search",
     "specify the number of neighbors to search for with " +
     PRINT_PARAM_STRING("k") + "."
     "\n\n"
+    "Note that for 'qdafn' in lower dimensions, " +
+    PRINT_PARAM_STRING("num_projections") + " may need to be set to a high "
+    "value in order to return results for each query point."
+    "\n\n"
     "If no query set is specified, the reference set will be used as the "
     "query set.  The " + PRINT_PARAM_STRING("output_model") + " output "
     "parameter may be used to store the built model, and an input model may be "

--- a/src/mlpack/methods/approx_kfn/qdafn_impl.hpp
+++ b/src/mlpack/methods/approx_kfn/qdafn_impl.hpp
@@ -139,12 +139,7 @@ void QDAFN<MatType>::Search(const MatType& querySet,
       const double dist = mlpack::metric::EuclideanDistance::Evaluate(
           querySet.col(q), candidateSet[p.second].col(tableIndex));
 
-      // Is this neighbor good enough to insert into the results?
-      if (dist > resultsQueue.top().first)
-      {
-        resultsQueue.pop();
-        resultsQueue.push(std::make_pair(dist, sIndices(tableIndex, p.second)));
-      }
+      resultsQueue.push(std::make_pair(dist, sIndices(tableIndex, p.second)));
 
       // Now (line 14) get the next element and insert into the queue.  Do this
       // by adjusting the previous value.  Don't insert anything if we are at
@@ -159,12 +154,27 @@ void QDAFN<MatType>::Search(const MatType& querySet,
       }
     }
 
-    // Extract the results.
-    for (size_t j = 1; j <= k; ++j)
+    // Extract the results and deduplicate.
+    size_t extracted = 1;
+    neighbors(0, q) = resultsQueue.top().second;
+    distances(0, q) = resultsQueue.top().first;
+    resultsQueue.pop();
+
+    while (!resultsQueue.empty())
     {
-      neighbors(k - j, q) = resultsQueue.top().second;
-      distances(k - j, q) = resultsQueue.top().first;
+      if (extracted == k)
+        break;
+
+      std::pair<double, size_t> result = resultsQueue.top();
       resultsQueue.pop();
+
+      // Avoid inserting any duplicates.
+      if (neighbors(extracted - 1, q) != result.second)
+      {
+        neighbors(extracted, q) = resultsQueue.top().second;
+        distances(extracted, q) = resultsQueue.top().first;
+        ++extracted;
+      }
     }
   }
 }

--- a/src/mlpack/methods/approx_kfn/qdafn_impl.hpp
+++ b/src/mlpack/methods/approx_kfn/qdafn_impl.hpp
@@ -154,7 +154,7 @@ void QDAFN<MatType>::Search(const MatType& querySet,
       }
     }
 
-    // Extract the results and deduplicate.
+    // Extract the results and deduplicate them.
     size_t extracted = 1;
     neighbors(0, q) = resultsQueue.top().second;
     distances(0, q) = resultsQueue.top().first;

--- a/src/mlpack/tests/qdafn_test.cpp
+++ b/src/mlpack/tests/qdafn_test.cpp
@@ -108,6 +108,43 @@ BOOST_AUTO_TEST_CASE(QDAFNUniformSet)
 }
 
 /**
+ * Make sure that more than one valid neighbor is returned when k > 1.
+ */
+BOOST_AUTO_TEST_CASE(QDAFNMultipleNeighbors)
+{
+  arma::mat uniformSet = arma::randu<arma::mat>(25, 1000);
+
+  QDAFN<> qdafn(uniformSet, 10, 30);
+
+  // Get the actual neighbors.
+  KFN kfn(uniformSet);
+  arma::Mat<size_t> trueNeighbors;
+  arma::mat trueDistances;
+
+  kfn.Search(999, trueNeighbors, trueDistances);
+
+  arma::Mat<size_t> qdafnNeighbors;
+  arma::mat qdafnDistances;
+
+  qdafn.Search(uniformSet, 3, qdafnNeighbors, qdafnDistances);
+
+  BOOST_REQUIRE_EQUAL(qdafnNeighbors.n_rows, 3);
+  BOOST_REQUIRE_EQUAL(qdafnNeighbors.n_cols, 1000);
+  BOOST_REQUIRE_EQUAL(qdafnDistances.n_rows, 3);
+  BOOST_REQUIRE_EQUAL(qdafnDistances.n_cols, 1000);
+
+  // We expect to find a neighbor for each point.
+  for (size_t i = 0; i < 999; ++i)
+  {
+    BOOST_REQUIRE_LT(qdafnNeighbors(0, i), 1000);
+    BOOST_REQUIRE_LT(qdafnNeighbors(1, i), 1000);
+    BOOST_REQUIRE_LT(qdafnNeighbors(2, i), 1000);
+    BOOST_REQUIRE_NE(qdafnNeighbors(0, i), qdafnNeighbors(1, i));
+    BOOST_REQUIRE_NE(qdafnNeighbors(0, i), qdafnNeighbors(2, i));
+  }
+}
+
+/**
  * Test re-training method.
  */
 BOOST_AUTO_TEST_CASE(RetrainTest)


### PR DESCRIPTION
While binding mlpack into my company's product, I found that `mlpack_approx_kfn` does not work correctly when searching with `k > 1`. Specifically, all neighbors returned except the last one have distance `-1` and invalid neighbor indices.

I discovered that this bug existed because of an apparent failure in thinking on my part that caused the results to be sorted backwards in the priority queue that collects candidates. When I fixed that, I also had to handle the situation where points could be added to the priority queue multiple times; so I added some deduplication code.

This situation existed in part because it turns out the tests I wrote only test with `k = 1`. So I added some tests that test for greater values of `k` too. :)