### PR TITLE
Clarify comment---Serialize() is long gone.

### DIFF
--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -925,17 +925,14 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * Note that the first parameter of this model is the type (the class name) of
- * the model to be loaded.  This model type must have a Serialize() function; a
+ * the model to be loaded.  This model type must have a serialize() function; a
  * compilation error (a very long and complex one) will result if the model type
  * does not have the following function:
  *
  * @code
  * template<typename Archive>
- * void Serialize(Archive& ar, const unsigned int version);
+ * void serialize(Archive& ar, const unsigned int version);
  * @endcode
- *
- * This is the boost::serialization serialize() function, just with a capital s
- * for Serialize() (see src/mlpack/core/data/serialization_shim.hpp).
  *
  * @param TYPE Type of the model to be loaded.
  * @param ID Name of the parameter.
@@ -959,17 +956,14 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
  * @endcode
  *
  * Note that the first parameter of this model is the type (the class name) of
- * the model to be loaded.  This model type must have a Serialize() function; a
+ * the model to be loaded.  This model type must have a serialize() function; a
  * compilation error (a very long and complex one) will result if the model type
  * does not have the following function:
  *
  * @code
  * template<typename Archive>
- * void Serialize(Archive& ar, const unsigned int version);
+ * void serialize(Archive& ar, const unsigned int version);
  * @endcode
- *
- * This is the boost::serialization serialize() function, just with a capital s
- * for Serialize() (see src/mlpack/core/data/serialization_shim.hpp).
  *
  * @param TYPE Type of the model to be loaded.
  * @param ID Name of the parameter.


### PR DESCRIPTION
This is just a fix to some out-of-date documentation.  A long time ago I strangely thought it was a good idea to put massive amounts of effort into a metaprogramming shim that allowed us to have `Serialize()` functions that matched the capitalization style of the mlpack style guide, instead of just using the boost::serialization `serialize()`.  Later, after the surfacing of numerous bugs I realized the entire thing was a bad idea to begin with and removed that entire shim (although it was pretty cool to write!).

This PR just fixes that I apparently forgot to update when I made that change.