### PR TITLE
Change parameter description in BatchNorm layer to make it more clear.

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -62,7 +62,7 @@ class BatchNorm
   /**
    * Create the BatchNorm layer object for a specified number of input units.
    *
-   * @param size The number of input units.
+   * @param size The number of input units / channels.
    * @param eps The epsilon added to variance to ensure numerical stability.
    */
   BatchNorm(const size_t size, const double eps = 1e-8);

--- a/src/mlpack/methods/ann/layer/virtual_batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/virtual_batch_norm.hpp
@@ -54,7 +54,7 @@ class VirtualBatchNorm
    *
    * @param referenceBatch The data from which the normalization
    *        statistics are computed.
-   * @param size The number of input units.
+   * @param size The number of input units / channels.
    * @param eps The epsilon added to variance to ensure numerical stability.
    */
   template<typename eT>


### PR DESCRIPTION
Hey everyone,
I have changed the parameter description for the batch norm layer a bit. From parameter description it wasn't clear to me what units mean, hence added the word 'channels' which is more commonly used. Kindly let me know what you think.
Regards.