### PR TITLE
Add mat and field support to Split (#2443)

### DIFF
--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -344,6 +344,7 @@ Split(const fieldType& input,
   return std::make_tuple(std::move(trainData),
                          std::move(testData));
 }
+
 } // namespace data
 } // namespace mlpack
 

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -259,8 +259,6 @@ void Split(FieldType& input,
     for (size_t i = 0; i < trainSize; i++)
       trainData[i] = input(0, order(i));
 
-    // Field type has fixed size so we can't use span and assignment
-    // operator.
     for (size_t i = 0; i < trainSize; i++)
       trainLabels(0, i) = inputLabel[i];
   }

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -228,7 +228,7 @@ Split(const arma::Mat<T>& input,
                          std::move(testData));
 }
 
-template <class fieldType,
+template <typename FieldType,
           class = std::enable_if_t<
               arma::is_Col<typename fieldType::object_type>::value ||
               arma::is_Mat_only<typename fieldType::object_type>::value>>

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -230,20 +230,23 @@ Split(const arma::Mat<T>& input,
 
 template <typename FieldType,
           class = std::enable_if_t<
-              arma::is_Col<typename fieldType::object_type>::value ||
-              arma::is_Mat_only<typename fieldType::object_type>::value>>
-void Split(fieldType& input, 
-           fieldType& inputLabel,
-           fieldType& trainData,
-           fieldType& trainLabels,
-           fieldType& testData, 
-           fieldType& testLabels,
+              arma::is_Col<typename FieldType::object_type>::value ||
+              arma::is_Mat_only<typename FieldType::object_type>::value>>
+void Split(FieldType& input, 
+           arma::field<arma::vec>& inputLabel,
+           FieldType& trainData,
+           arma::field<arma::vec>& trainLabels,
+           FieldType& testData, 
+           arma::field<arma::vec>& testLabels,
            const double testRatio, 
            const bool shuffleData = true) 
 {
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
   const size_t trainSize = input.n_cols - testSize;
 
+  trainData.set_size(1, trainSize);
+  testData.set_size(1, testSize);
+  
   arma::uvec order = arma::linspace<arma::uvec>(0, input.n_cols - 1,
       input.n_cols);
   if (shuffleData)
@@ -254,7 +257,7 @@ void Split(fieldType& input,
     trainLabels.set_size(1, trainSize);
 
     for (size_t i = 0; i < trainSize; i++)
-       trainData[i] = input(0, order(i));
+      trainData[i] = input(0, order(i));
 
     // Field type has fixed size so we can't use span and assignment
     // operator.
@@ -273,18 +276,21 @@ void Split(fieldType& input,
   }
 }
 
-template <class fieldType,
+template <class FieldType,
           class = std::enable_if_t<
-              arma::is_Col<typename fieldType::object_type>::value ||
-              arma::is_Mat_only<typename fieldType::object_type>::value>>
-void Split(fieldType& input, 
-           fieldType& trainData,
-           fieldType& testData, 
+              arma::is_Col<typename FieldType::object_type>::value ||
+              arma::is_Mat_only<typename FieldType::object_type>::value>>
+void Split(const FieldType& input, 
+           FieldType& trainData,
+           FieldType& testData, 
            const double testRatio, 
            const bool shuffleData = true) 
 {
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
   const size_t trainSize = input.n_cols - testSize;
+
+  trainData.set_size(1, trainSize);
+  testData.set_size(1, testSize);
 
   arma::uvec order = arma::linspace<arma::uvec>(0, input.n_cols - 1,
       input.n_cols);
@@ -304,20 +310,20 @@ void Split(fieldType& input,
   }
 }
 
-template <class fieldType,
+template <class FieldType,
           class = std::enable_if_t<
-              arma::is_Col<typename fieldType::object_type>::value ||
-              arma::is_Mat_only<typename fieldType::object_type>::value>>
-std::tuple<fieldType, fieldType, fieldType, fieldType>
-Split(fieldType& input, 
-      fieldType& inputLabel,
+              arma::is_Col<typename FieldType::object_type>::value ||
+              arma::is_Mat_only<typename FieldType::object_type>::value>>
+std::tuple<FieldType, FieldType, FieldType, FieldType>
+Split(FieldType& input, 
+      FieldType& inputLabel,
       const double testRatio,
       const bool shuffleData = true)
 {
-  fieldType trainData;
-  fieldType testData;
-  fieldType trainLabel;
-  fieldType testLabel;
+  FieldType trainData;
+  FieldType testData;
+  arma::field<arma::vec> trainLabel;
+  arma::field<arma::vec> testLabel;
 
   Split(input, inputLabel, trainData, testData, trainLabel, testLabel,
     testRatio, shuffleData);
@@ -328,17 +334,17 @@ Split(fieldType& input,
                          std::move(testLabel));
 }
 
-template <class fieldType,
+template <class FieldType,
           class = std::enable_if_t<
-              arma::is_Col<typename fieldType::object_type>::value ||
-              arma::is_Mat_only<typename fieldType::object_type>::value>>
-std::tuple<fieldType, fieldType>
-Split(const fieldType& input,
+              arma::is_Col<typename FieldType::object_type>::value ||
+              arma::is_Mat_only<typename FieldType::object_type>::value>>
+std::tuple<FieldType, FieldType>
+Split(const FieldType& input,
       const double testRatio,
       const bool shuffleData = true)
 {
-  fieldType trainData;
-  fieldType testData;
+  FieldType trainData;
+  FieldType testData;
   Split(input, trainData, testData, testRatio, shuffleData);
 
   return std::make_tuple(std::move(trainData),

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -48,7 +48,7 @@ namespace data {
  *       sample is visited in linear order. (Default true.)
  */
 template <typename T, class LabelType,
-          class = std::enable_if_t<arma::is_Row<LabelType>::value ||
+          typename = std::enable_if_t<arma::is_Row<LabelType>::value ||
                            arma::is_Mat_only<LabelType>::value>>
 void Split(const arma::Mat<T>& input,
            const LabelType& inputLabel,
@@ -174,7 +174,7 @@ void Split(const arma::Mat<T>& input,
  *      (arma::Mat<T>), trainLabel (arma::Row<U>), and testLabel (arma::Row<U>).
  */
 template <typename T, class LabelType,
-          class = std::enable_if_t<arma::is_Row<LabelType>::value ||
+          typename = std::enable_if_t<arma::is_Row<LabelType>::value ||
                            arma::is_Mat_only<LabelType>::value>>
 std::tuple<arma::Mat<T>, arma::Mat<T>, LabelType, LabelType>
 Split(const arma::Mat<T>& input,
@@ -229,7 +229,7 @@ Split(const arma::Mat<T>& input,
 }
 
 template <typename FieldType,
-          class = std::enable_if_t<
+          typename = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
               arma::is_Mat_only<typename FieldType::object_type>::value>>
 void Split(FieldType& input, 

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -264,13 +264,13 @@ template <typename FieldType,
           typename = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
               arma::is_Mat_only<typename FieldType::object_type>::value>>
-void Split(FieldType& input, 
+void Split(FieldType& input,
            arma::field<arma::vec>& inputLabel,
            FieldType& trainData,
            arma::field<arma::vec>& trainLabels,
-           FieldType& testData, 
+           FieldType& testData,
            arma::field<arma::vec>& testLabels,
-           const double testRatio, 
+           const double testRatio,
            const bool shuffleData = true) 
 {
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
@@ -278,7 +278,7 @@ void Split(FieldType& input,
 
   trainData.set_size(1, trainSize);
   testData.set_size(1, testSize);
-  
+
   arma::uvec order = arma::linspace<arma::uvec>(0, input.n_cols - 1,
       input.n_cols);
   if (shuffleData)
@@ -299,7 +299,7 @@ void Split(FieldType& input,
   {
     for (size_t i = trainSize; i < input.n_cols - 1; i++)
      testData[i - trainSize] = input(0, order(i));
-    
+
     testLabels.set_size(1, testSize);
     for (size_t i = trainSize; i < input.n_cols; i++)
       testLabels(0, i - trainSize) = inputLabel[i];
@@ -335,11 +335,11 @@ template <class FieldType,
           class = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
               arma::is_Mat_only<typename FieldType::object_type>::value>>
-void Split(const FieldType& input, 
+void Split(const FieldType& input,
            FieldType& trainData,
-           FieldType& testData, 
-           const double testRatio, 
-           const bool shuffleData = true) 
+           FieldType& testData,
+           const double testRatio,
+           const bool shuffleData = true)
 {
   const size_t testSize = static_cast<size_t>(input.n_cols * testRatio);
   const size_t trainSize = input.n_cols - testSize;
@@ -361,7 +361,7 @@ void Split(const FieldType& input,
   if (testSize <= input.n_cols)
   {
     for (size_t i = trainSize; i < input.n_cols - 1; i++)
-       testData[i - trainSize] = input(0,order(i));
+       testData[i - trainSize] = input(0, order(i));
   }
 }
 
@@ -394,7 +394,7 @@ template <class FieldType,
               arma::is_Col<typename FieldType::object_type>::value ||
               arma::is_Mat_only<typename FieldType::object_type>::value>>
 std::tuple<FieldType, FieldType, FieldType, FieldType>
-Split(FieldType& input, 
+Split(FieldType& input,
       arma::field<arma::vec>& inputLabel,
       const double testRatio,
       const bool shuffleData = true)

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -265,7 +265,7 @@ void Split(fieldType& input,
   if (testSize <= input.n_cols)
   {
     for (size_t i = trainSize; i < input.n_cols - 1; i++)
-       testData[i - trainSize] = input(0,order(i));
+     testData[i - trainSize] = input(0, order(i));
     
     testLabels.set_size(1, testSize);
     for (size_t i = trainSize; i < input.n_cols; i++)

--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -228,6 +228,38 @@ Split(const arma::Mat<T>& input,
                          std::move(testData));
 }
 
+/**
+ * Given an input dataset and labels, split into a training set and test set.
+ * Example usage below.  This overload places the split dataset into the four
+ * output parameters given (trainData, testData, trainLabel, and testLabel).
+ * 
+ * NOTE: Here FieldType could be arma::field<arma::mat> or arma::field<arma::vec>
+ *
+ * @code
+ * arma::field<arma::mat> input = loadData();
+ * arma::field<arma::vec> label = loadLabel();
+ * arma::field<arma::mat> trainData;
+ * arma::field<arma::mat> testData;
+ * arma::field<arma::vec> trainLabel;
+ * arma::field<arma::vec> testLabel;
+ * math::RandomSeed(100); // Set the seed if you like.
+ *
+ * // Split the dataset into a training and test set, with 30% of the data being
+ * // held out for the test set.
+ * Split(input, label, trainData,
+ *                testData, trainLabel, testLabel, 0.3);
+ * @endcode
+ *
+ * @param input Input dataset to split.
+ * @param inputLabel Input labels to split.
+ * @param trainData FieldType to store training data into.
+ * @param testData FieldType test data into.
+ * @param trainLabel Field vector to store training labels into.
+ * @param testLabel Field vector to store test labels into.
+ * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
+ * @param shuffleData If true, the sample order is shuffled; otherwise, each
+ *       sample is visited in linear order. (Default true.)
+ */
 template <typename FieldType,
           typename = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
@@ -274,6 +306,31 @@ void Split(FieldType& input,
   }
 }
 
+/**
+ * Given an input dataset, split into a training set and test set.
+ * Example usage below. This overload places the split dataset into the two
+ * output parameters given (trainData, testData).
+ * 
+ * NOTE: Here FieldType could be arma::field<arma::mat> or arma::field<arma::vec>
+ *
+ * @code
+ * arma::field<arma::mat> input = loadData();
+ * arma::field<arma::mat> trainData;
+ * arma::field<arma::mat> testData;
+ * math::RandomSeed(100); // Set the seed if you like.
+ *
+ * // Split the dataset into a training and test set, with 30% of the data being
+ * // held out for the test set.
+ * Split(input, trainData, testData, 0.3);
+ * @endcode
+ *
+ * @param input Input dataset to split.
+ * @param trainData FieldType to store training data into.
+ * @param testData FieldType test data into.
+ * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
+ * @param shuffleData If true, the sample order is shuffled; otherwise, each
+ *       sample is visited in linear order. (Default true).
+ */
 template <class FieldType,
           class = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
@@ -308,13 +365,37 @@ void Split(const FieldType& input,
   }
 }
 
+/**
+ * Given an input dataset and labels, split into a training set and test set.
+ * Example usage below.  This overload returns the split dataset as a std::tuple
+ * with four elements: an FieldType containing the training data, an
+ * FieldType containing the test data, an arma::field<arma::vec> containing the
+ * training labels, and an arma::field<arma::vec> containing the test labels.
+ * 
+ * NOTE: Here FieldType could be arma::field<arma::mat> or arma::field<arma::vec>
+ *
+ * @code
+ * arma::field<arma::mat> input = loadData();
+ * arma::field<arma::vec> label = loadLabel();
+ * auto splitResult = Split(input, label, 0.2);
+ * @endcode
+ *
+ * @param input Input dataset to split.
+ * @param inputLabel Input labels to split.
+ * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
+ * @param shuffleData If true, the sample order is shuffled; otherwise, each
+ *       sample is visited in linear order. (Default true).
+ * @return std::tuple containing trainData (FieldType), testData
+ *      (FieldType), trainLabel (arma::field<arma::vec>), and 
+ *                   testLabel (arma::field<arma::vec>).
+ */
 template <class FieldType,
           class = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
               arma::is_Mat_only<typename FieldType::object_type>::value>>
 std::tuple<FieldType, FieldType, FieldType, FieldType>
 Split(FieldType& input, 
-      FieldType& inputLabel,
+      arma::field<arma::vec>& inputLabel,
       const double testRatio,
       const bool shuffleData = true)
 {
@@ -332,6 +413,26 @@ Split(FieldType& input,
                          std::move(testLabel));
 }
 
+/**
+ * Given an input dataset, split into a training set and test set.
+ * Example usage below.  This overload returns the split dataset as a std::tuple
+ * with two elements: an FieldType containing the training data and an
+ * FieldType containing the test data.
+ * 
+ * NOTE: Here FieldType could be arma::field<arma::mat> or arma::field<arma::vec>
+ *
+ * @code
+ * arma::field<arma::mat> input = loadData();
+ * auto splitResult = Split(input, 0.2);
+ * @endcode
+ *
+ * @param input Input dataset to split.
+ * @param testRatio Percentage of dataset to use for test set (between 0 and 1).
+ * @param shuffleData If true, the sample order is shuffled; otherwise, each
+ *       sample is visited in linear order. (Default true).
+ * @return std::tuple containing trainData (FieldType)
+ *      and testData (FieldType).
+ */
 template <class FieldType,
           class = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(SplitDataResultField)
   BOOST_REQUIRE_EQUAL(std::get<0>(value).n_cols, 1); // Train data.
   BOOST_REQUIRE_EQUAL(std::get<1>(value).n_cols, 1); // Test data.
 
-  field<mat> concat = arma::join_rows(std::get<0>(value)(0), std::get<1>(value)(0));
+  field<mat> concat = {std::get<0>(value)(0), std::get<1>(value)(0)};
   // Order matters here.
   CheckFields(input, concat);
 }

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -123,6 +123,29 @@ BOOST_AUTO_TEST_CASE(SplitDataResultMat)
   CheckMatrices(input, concat);
 }
 
+BOOST_AUTO_TEST_CASE(SplitDataResultField)
+{
+  field<mat> input(1, 2);
+
+  mat matA(2, 10);
+  mat matB(2, 10);
+
+  size_t count = 0; // Counter for unique sequential values.
+  matA.imbue([&count]() { return ++count; });
+  matB.imbue([&count]() { return ++count; });
+
+  input(0, 0) = matA;
+  input(0, 1) = matB;
+
+  const auto value = Split(input, 0.5, false);
+  BOOST_REQUIRE_EQUAL(std::get<0>(value).n_cols, 1); // Train data.
+  BOOST_REQUIRE_EQUAL(std::get<1>(value).n_cols, 1); // Test data.
+
+  field<mat> concat = arma::join_rows(std::get<0>(value)(0), std::get<1>(value)(0));
+  // Order matters here.
+  CheckFields(input, concat);
+}
+
 BOOST_AUTO_TEST_CASE(ZeroRatioSplitData)
 {
   mat input(2, 10);

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -48,19 +48,22 @@ inline void CheckMatrices(const arma::Mat<size_t>& a,
     BOOST_REQUIRE_EQUAL(a[i], b[i]);
 }
 
-template <class fieldType,
+template <typename FieldType,
           class = std::enable_if_t<
-              arma::is_Col<typename fieldType::object_type>::value ||
-              arma::is_Mat_only<typename fieldType::object_type>::value>>
-// Check the values of two unsigned matrices.
-inline void CheckFields(const fieldType& a,
-                          const fieldType& b)
+              arma::is_Col<typename FieldType::object_type>::value ||
+              arma::is_Mat_only<typename FieldType::object_type>::value>>
+// Check the values of two field types
+inline void CheckFields(const FieldType& a,
+                          const FieldType& b)
 {
   BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
   BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);
 
-  for (size_t i = 0; i < a.n_elem; ++i)
-    BOOST_REQUIRE_EQUAL(a[i], b[i]);
+  for (size_t i = 0; i < a.n_elem; ++i) {
+    for (size_t j = 0; j < a[i].n_elem; ++j) {
+      BOOST_REQUIRE_EQUAL(a(0, i).at(j), b(0, i).at(j));
+    }
+  }
 }
 
 // Check the values of two cubes.

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -48,6 +48,21 @@ inline void CheckMatrices(const arma::Mat<size_t>& a,
     BOOST_REQUIRE_EQUAL(a[i], b[i]);
 }
 
+template <class fieldType,
+          class = std::enable_if_t<
+              arma::is_Col<typename fieldType::object_type>::value ||
+              arma::is_Mat_only<typename fieldType::object_type>::value>>
+// Check the values of two unsigned matrices.
+inline void CheckFields(const fieldType& a,
+                          const fieldType& b)
+{
+  BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
+  BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);
+
+  for (size_t i = 0; i < a.n_elem; ++i)
+    BOOST_REQUIRE_EQUAL(a[i], b[i]);
+}
+
 // Check the values of two cubes.
 inline void CheckMatrices(const arma::cube& a,
                           const arma::cube& b,

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -60,7 +60,7 @@ inline void CheckFields(const FieldType& a,
   BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
   BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);
 
-  for (size_t i = 0; i< a.n_slices; ++i)
+  for (size_t i = 0; i < a.n_slices; ++i)
     CheckMatrices(a(i), b(i));
 }
 

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -50,7 +50,7 @@ inline void CheckMatrices(const arma::Mat<size_t>& a,
 }
 
 template <typename FieldType,
-          class = std::enable_if_t<
+          typename = std::enable_if_t<
               arma::is_Col<typename FieldType::object_type>::value ||
               arma::is_Mat_only<typename FieldType::object_type>::value>>
 // Check the values of two field types

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -37,7 +37,6 @@ inline void CheckMatrices(const arma::mat& a,
   }
 }
 
-
 // Check the values of two unsigned matrices.
 inline void CheckMatrices(const arma::Mat<size_t>& a,
                           const arma::Mat<size_t>& b)

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -37,6 +37,7 @@ inline void CheckMatrices(const arma::mat& a,
   }
 }
 
+
 // Check the values of two unsigned matrices.
 inline void CheckMatrices(const arma::Mat<size_t>& a,
                           const arma::Mat<size_t>& b)
@@ -59,11 +60,8 @@ inline void CheckFields(const FieldType& a,
   BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
   BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);
 
-  for (size_t i = 0; i < a.n_elem; ++i) {
-    for (size_t j = 0; j < a[i].n_elem; ++j) {
-      BOOST_REQUIRE_EQUAL(a(0, i).at(j), b(0, i).at(j));
-    }
-  }
+  for (size_t i = 0; i< a.n_slices; ++i)
+    CheckMatrices(a(i), b(i));
 }
 
 // Check the values of two cubes.

--- a/src/mlpack/tests/test_tools.hpp
+++ b/src/mlpack/tests/test_tools.hpp
@@ -54,7 +54,7 @@ template <typename FieldType,
               arma::is_Mat_only<typename FieldType::object_type>::value>>
 // Check the values of two field types
 inline void CheckFields(const FieldType& a,
-                          const FieldType& b)
+                        const FieldType& b)
 {
   BOOST_REQUIRE_EQUAL(a.n_rows, b.n_rows);
   BOOST_REQUIRE_EQUAL(a.n_cols, b.n_cols);


### PR DESCRIPTION
This should generalize for both matrix and row type. Tackles #2443 

Here are its drawbacks:
1) Template substitution errors could be very common, ```labelType``` could take in any type even int!, user can put in any type of input type and not know the exact error (because labelType accepts them all) 
2) I could write separate code for mat and field, but that'd lots of wasted code for just a few lines difference (atleast in matrix case). 

Thoughts? @kartikdutt18  @zoq 
p.s. yet to add field case.
