### PR TITLE
Allow Julia CMake configuration to handle spaces in directories

### DIFF
--- a/src/mlpack/bindings/julia/CMakeLists.txt
+++ b/src/mlpack/bindings/julia/CMakeLists.txt
@@ -148,7 +148,7 @@ if (BUILD_JULIA_BINDINGS)
       ${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.h
       ${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.cpp
       COMMAND ${CMAKE_COMMAND}
-          -DPROGRAM_NAME="${name}"
+          -DPROGRAM_NAME=${name}
           -DPROGRAM_MAIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}_main.cpp
           -DJULIA_H_IN=${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.h.in
           -DJULIA_H_OUT=${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.h
@@ -218,7 +218,7 @@ if (BUILD_JULIA_BINDINGS)
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/bin/")
   add_custom_command(TARGET generate_jl_${name} POST_BUILD
       COMMAND ${CMAKE_COMMAND}
-          -DGENERATE_BINDING_PROGRAM="${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/bin/generate_jl_${name}"
+          -DGENERATE_BINDING_PROGRAM=${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/bin/generate_jl_${name}
           -DBINDING_OUTPUT_FILE=${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/src/${name}.jl
           -P ${CMAKE_SOURCE_DIR}/CMake/GenerateBinding.cmake)
 

--- a/src/mlpack/bindings/julia/CMakeLists.txt
+++ b/src/mlpack/bindings/julia/CMakeLists.txt
@@ -21,7 +21,7 @@ if (BUILD_JULIA_BINDINGS)
     find_package(Julia 0.7.0)
     if (NOT JULIA_FOUND)
       unset(BUILD_JULIA_BINDINGS CACHE)
-      message(FATAL_ERROR "Could not Build Julia Bindings")
+      message(FATAL_ERROR "Julia not found; cannot build Julia bindings!")
     endif()
   else ()
     find_package(Julia 0.7.0)
@@ -149,11 +149,11 @@ if (BUILD_JULIA_BINDINGS)
       ${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.cpp
       COMMAND ${CMAKE_COMMAND}
           -DPROGRAM_NAME="${name}"
-          -DPROGRAM_MAIN_FILE="${CMAKE_CURRENT_SOURCE_DIR}/${name}_main.cpp"
-          -DJULIA_H_IN="${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.h.in"
-          -DJULIA_H_OUT="${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.h"
-          -DJULIA_CPP_IN="${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.cpp.in"
-          -DJULIA_CPP_OUT="${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.cpp"
+          -DPROGRAM_MAIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}_main.cpp
+          -DJULIA_H_IN=${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.h.in
+          -DJULIA_H_OUT=${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.h
+          -DJULIA_CPP_IN=${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.cpp.in
+          -DJULIA_CPP_OUT=${CMAKE_BINARY_DIR}/src/mlpack/bindings/julia/mlpack/build/julia_${name}.cpp
           -P ${CMAKE_SOURCE_DIR}/CMake/julia/ConfigureJuliaHCPP.cmake
       DEPENDS ${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.h.in
               ${CMAKE_SOURCE_DIR}/src/mlpack/bindings/julia/julia_method.cpp.in


### PR DESCRIPTION
This fixes the error reported by @zoq from the build farm:

http://ci.mlpack.org/job/pull-requests%20mlpack%20memory/5261/console

This is caused because CMake is not properly passing filenames with spaces in them to the `COMMAND` CMake command.

@Yashwants19 I think this problem also exists with the Go CMake configuration; basically, I made sure to just strip any `"` around arguments when calling `cmake(COMMAND ...)`.