### PR TITLE
Fix Initialisation in Simple DQN and Duelling DQN.

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/q_networks/dueling_dqn.hpp
+++ b/src/mlpack/methods/reinforcement_learning/q_networks/dueling_dqn.hpp
@@ -80,8 +80,7 @@ class DuelingDQN
              const int h1,
              const int h2,
              const int outputDim,
-             const bool isNoisy = false):
-      completeNetwork(EmptyLoss<>(), GaussianInitialization(0, 0.001)),
+             const bool isNoisy = false) :
       isNoisy(isNoisy)
   {
     featureNetwork = new Sequential<>();

--- a/src/mlpack/methods/reinforcement_learning/q_networks/simple_dqn.hpp
+++ b/src/mlpack/methods/reinforcement_learning/q_networks/simple_dqn.hpp
@@ -50,8 +50,7 @@ class SimpleDQN
             const int h1,
             const int h2,
             const int outputDim,
-            const bool isNoisy = false):
-      network(MeanSquaredError<>(), GaussianInitialization(0, 0.001)),
+            const bool isNoisy = false) :
       isNoisy(isNoisy)
   {
     network.Add(new Linear<>(inputDim, h1));

--- a/src/mlpack/tests/q_learning_test.cpp
+++ b/src/mlpack/tests/q_learning_test.cpp
@@ -59,7 +59,7 @@ bool testAgent(AgentType& agent,
       continue;
     else
       returnList.erase(returnList.begin());
-    
+
     double averageReturn = std::accumulate(returnList.begin(),
         returnList.end(), 0.0) / returnList.size();
 


### PR DESCRIPTION
Hey everyone,
This PR removes initialization of network in Simple DQN and Duelling DQN. The reason behind it is that the `Complete Network Type` template parameter specifies the type of network however The initialization of network model in the class has fixed OutputLayerType and InitializationType. Other than this, initialization is also needed here. C++ will internally handle the initialization.
We can merge this #2475, that has all style fixes.
Kindly let me know if I missed something.
Thanks.