### PR TITLE
Remove unnecessary Log::Fatal `ignoreInput` settings

### DIFF
--- a/src/mlpack/core/tree/cellbound_impl.hpp
+++ b/src/mlpack/core/tree/cellbound_impl.hpp
@@ -87,10 +87,10 @@ inline CellBound<
     ElemType>& CellBound<MetricType, ElemType>::operator=(
     const CellBound<MetricType, ElemType>& other)
 {
- if (this == &other)
-    return *this;  
+  if (this == &other)
+    return *this;
 
- if (dim != other.Dim())
+  if (dim != other.Dim())
   {
     // Reallocation is necessary.
     delete[] bounds;

--- a/src/mlpack/tests/cli_test.cpp
+++ b/src/mlpack/tests/cli_test.cpp
@@ -188,9 +188,7 @@ BOOST_AUTO_TEST_CASE(TestVectorOption)
   argv[3] = "2";
   argv[4] = "4";
 
-  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-  Log::Fatal.ignoreInput = false;
 
   BOOST_REQUIRE(CLI::HasParam("test_vec"));
 
@@ -221,9 +219,7 @@ BOOST_AUTO_TEST_CASE(TestVectorOption2)
   argv[5] = "--test2_vec";
   argv[6] = "4";
 
-//  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-//  Log::Fatal.ignoreInput = false;
 
   BOOST_REQUIRE(CLI::HasParam("test2_vec"));
 
@@ -250,9 +246,7 @@ BOOST_AUTO_TEST_CASE(InputColVectorParamTest)
   int argc = 3;
 
   // The const-cast is a little hacky but should be fine...
-  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-  Log::Fatal.ignoreInput = false;
 
   // The --vector parameter should exist.
   BOOST_REQUIRE(CLI::HasParam("vector"));
@@ -287,9 +281,7 @@ BOOST_AUTO_TEST_CASE(InputUnsignedColVectorParamTest)
   int argc = 3;
 
   // The const-cast is a little hacky but should be fine...
-  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-  Log::Fatal.ignoreInput = false;
 
   // The --vector parameter should exist.
   BOOST_REQUIRE(CLI::HasParam("vector"));
@@ -324,9 +316,7 @@ BOOST_AUTO_TEST_CASE(InputRowVectorParamTest)
   int argc = 3;
 
   // The const-cast is a little hacky but should be fine...
-  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-  Log::Fatal.ignoreInput = false;
 
   // The --vector parameter should exist.
   BOOST_REQUIRE(CLI::HasParam("row"));
@@ -361,9 +351,7 @@ BOOST_AUTO_TEST_CASE(InputUnsignedRowVectorParamTest)
   int argc = 3;
 
   // The const-cast is a little hacky but should be fine...
-  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-  Log::Fatal.ignoreInput = false;
 
   // The --vector parameter should exist.
   BOOST_REQUIRE(CLI::HasParam("row"));
@@ -587,9 +575,7 @@ BOOST_AUTO_TEST_CASE(InputMatrixParamTest)
   int argc = 3;
 
   // The const-cast is a little hacky but should be fine...
-  Log::Fatal.ignoreInput = true;
   ParseCommandLine(argc, const_cast<char**>(argv));
-  Log::Fatal.ignoreInput = false;
 
   // The --matrix parameter should exist.
   BOOST_REQUIRE(CLI::HasParam("matrix"));


### PR DESCRIPTION
I found in `CLITest` that we have several places where we call `Log::Fatal.ignoreInput = true` and it's unnecessary.  We should only need to do that to prevent a bunch of output right before we expect something to throw an exception.  But in these cases, we expect parsing to succeed, and so there should be no problem with leaving `ignoreInput` to its default value of `false`.