### PR TITLE
Linking RL tutorial

### DIFF
--- a/doc/tutorials/tutorials.txt
+++ b/doc/tutorials/tutorials.txt
@@ -48,6 +48,7 @@ progress to complex, extensible uses.
  - \ref cftutorial
  - \ref akfntutorial
  - \ref anntutorial
+ - \ref rltutorial
 
 @section adv_tut Advanced Tutorials
 


### PR DESCRIPTION
Noticed the RL tutorial isn't linked on our site, this should fix it I think