### PR TITLE
Update to soversion libmlpack.so.3.3

### DIFF
--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(mlpack ${MLPACK_LIBRARIES})
 
 set_target_properties(mlpack
   PROPERTIES
-  VERSION 3.2
+  VERSION 3.3
   SOVERSION 3
 )
 


### PR DESCRIPTION
This actually should have happened earlier, when we released mlpack 3.3.0!

Basically the change here is that we should be building, e.g., `libmlpack.so.3.3` not `libmlpack.so.3.2` since the version is now 3.3.x.

I edited the release preparation guide to account for this:
https://github.com/mlpack/mlpack/wiki/ReleasePreparationGuide

During the next release I'll incorporate this into the scripts (and hopefully it will never be a problem again!).