### PR TITLE
Fix version of Julia in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ following Python packages are installed:
       numpy
       pandas >= 0.15.0
 
-If you would like to build the Julia bindings, make sure that Julia >= 3.2.2 is
+If you would like to build the Julia bindings, make sure that Julia >= 1.3.0 is
 installed.
 
 If the STB library headers are available, image loading support will be


### PR DESCRIPTION
Oops---thanks @zoq for pointing this out.  The README said that the minimum version of Julia is 3.2.2, but that's not true---the minimum version required for Julia should be 1.3.0.