### PR TITLE
Fix ARFF loader to be case sensitive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,8 @@
 
   * Replace boost program_options dependency with CLI11 (#2459).
 
-  * Additional functionality for the ARFF loader (#2486).
+  * Additional functionality for the ARFF loader (#2486); use case sensitive
+    categories (#2516).
 
 ### mlpack 3.3.2
 ###### 2020-06-18

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -1171,7 +1171,7 @@ BOOST_AUTO_TEST_CASE(NormalizeLabelTest)
 class TestInner
 {
  public:
-  TestInner(char c, string s) : c(c), s(s) { }
+  TestInner(char c, const string& s) : c(c), s(s) { }
 
   template<typename Archive>
   void serialize(Archive& ar, const unsigned int /* version */)

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -2179,6 +2179,44 @@ BOOST_AUTO_TEST_CASE(CaseTest)
 }
 
 /**
+ * Ensure that a failure happens if we set a category to use capital letters but
+ * it receives them in lowercase.
+ */
+BOOST_AUTO_TEST_CASE(CategoryCaseTest)
+{
+  fstream f;
+  f.open("test.arff", fstream::out);
+  f << "@relation    \t test" << endl;
+  f << endl;
+  f << endl;
+  f << "@attribute @@@@flfl {A, B, C, D}" << endl;
+  f << endl;
+  f << "% comment" << endl;
+  f << "@attribute \"hello world\" string" << endl;
+  f << "@attribute 12345 integer" << endl;
+  f << "@attribute real real" << endl;
+  f << "@attribute \"blah blah blah     \t \" numeric % comment" << endl;
+  f << "% comment" << endl;
+  f << "@data" << endl;
+  f << "A, one, 3, 4.5, 6" << endl;
+  f << "B, two, 4, 5.5, 7 % comment" << endl;
+  f << "c, \"three five, six\", 5, 6.5, 8" << endl;
+  f.close();
+
+  arma::mat dataset;
+  data::DatasetInfo info;
+
+  // Make sure to parse with fatal errors (that's what the `true` parameter
+  // means).
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(data::Load("test.arff", dataset, info, true),
+      std::runtime_error);
+  Log::Fatal.ignoreInput = false;
+
+  remove("test.arff");
+}
+
+/**
  * Test that a CSV with the wrong number of columns fails.
  */
 BOOST_AUTO_TEST_CASE(MalformedCSVTest)


### PR DESCRIPTION
In the process of fixing #2478, I misunderstood the ARFF spec:

> Values of string and nominal attributes are case sensitive
https://www.cs.waikato.ac.nz/~ml/weka/arff.html

So, as a result, I didn't actually fix the problem in #2486, since the loader I had was case-insensitive, leading to the issue that @pesoke reported as a follow-up.

These changes force case-sensitivity in the ARFF loader when a dimension has a categorical type with specified categories, like this:

```
@attribute dimension_name {A, B, C, D}
```

instead of computing categories after they have been converted to lowercase, this computes categories as they are specified in the ARFF file exactly.

Then, while parsing, if a dimension is categorical and the categories were specified as in the example above, then if that dimension takes a value *outside* of what was specified in the category list, an error is thrown and parsing fails.

I also added a test to ensure that parsing fails in the expected way when this happens.