### PR TITLE
fixed a typo that the caused incorrect configuration of the cmake

### DIFF
--- a/CMake/mlpack-config.cmake.in
+++ b/CMake/mlpack-config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake)
 
 set_and_check(MLPACK_INCLUDE_DIRS "@PACKAGE_MLPACK_INCS_DIR@")
 


### PR DESCRIPTION
This fixes [the same bug](https://github.com/mlpack/ensmallen/commit/1aa9e2e991c140aed3c15d871890f9ce756e0197) that appeared in Ensmallen. I noticed this but I couldn't reproduce it correctly especially when the installation was done via Homebrew, but after Ensmallen's fix, I investigated it, and it's working as expected now.