### PR TITLE
Fix ModelType Julia Documentation.

### DIFF
--- a/src/mlpack/bindings/julia/print_doc.hpp
+++ b/src/mlpack/bindings/julia/print_doc.hpp
@@ -24,7 +24,8 @@ void PrintDoc(util::ParamData& d, const void* /* input */, void* output)
 
   std::ostringstream& oss = *((std::ostringstream*) output);
 
-  oss << "`" << juliaName << "::" << GetJuliaType<T>(d) << "`: " << d.desc;
+  oss << "`" << juliaName << "::" << GetJuliaType<typename std::remove_pointer
+      <T>::type>(d) << "`: " << d.desc;
 
   // Print a default, if possible.  Defaults aren't printed for matrix or model
   // parameters.


### PR DESCRIPTION
Hi @rcurtin, I think so we are not printing model type correctly [here](https://github.com/mlpack/mlpack.jl/blob/ab0a526f5936aa8829becd32dd3f5143c80532ac/src/adaboost.jl#L104). It is printing `unknow_` and not `AdaBoostModel` in Julia documentation. I have tried to resolve this issue in the PR.

Thank You.