### PR TITLE
Fix data in sample ML app to be column-major.

### DIFF
--- a/doc/guide/sample_ml_app.hpp
+++ b/doc/guide/sample_ml_app.hpp
@@ -94,7 +94,7 @@ copy "mlpack/tests/data/german.csv" and paste into a new "data" folder in your p
 mat dataset;
 bool loaded = mlpack::data::Load("data/german.csv", dataset);
 if (!loaded)
-	return -1;
+  return -1;
 @endcode
 
 Then we need to extract the labels from the last dimension of the dataset and remove the
@@ -121,7 +121,7 @@ const size_t numTrees = 10;
 RandomForest<GiniGain, RandomDimensionSelect> rf;
 
 rf = RandomForest<GiniGain, RandomDimensionSelect>(dataset, labels,
-	numClasses, numTrees, minimumLeafSize);
+    numClasses, numTrees, minimumLeafSize);
 @endcode
 
 Now that the training is completed, we quickly compute the training accuracy:
@@ -143,7 +143,7 @@ to assess the quality of the trained model.
 @code
 const size_t k = 10;
 KFoldCV<RandomForest<GiniGain, RandomDimensionSelect>, Accuracy> cv(k, 
-	dataset, labels, numClasses);
+    dataset, labels, numClasses);
 double cvAcc = cv.Evaluate(numTrees, minimumLeafSize);
 cout << "\nKFoldCV Accuracy: " << cvAcc;
 @endcode
@@ -188,12 +188,16 @@ Finally, the ultimate goal is to classify a new sample using the previously trai
 Random Forest classifier provides both predictions and probabilities, we obtain both.
 
 @code
-mat sample("2 12 2 13 1 2 2 1 3 24 3 1 1 1 1 1 0 1 0 1 0 0 0");
+// Create a test sample containing only one point.  Because Armadillo is
+// column-major, this matrix has one column (one point) and the number of rows
+// is equal to the dimensionality of the point (23).
+mat sample("2; 12; 2; 13; 1; 2; 2; 1; 3; 24; 3; 1; 1; 1; 1; 1; 0; 1; 0; 1;"
+    " 0; 0; 0");
 mat probabilities;
 rf.Classify(sample, predictions, probabilities);
 u64 result = predictions.at(0);
 cout << "\nClassification result: " << result << " , Probabilities: " <<
-		probabilities.at(0) << "/" << probabilities.at(1);
+    probabilities.at(0) << "/" << probabilities.at(1);
 @endcode
 
 @section sample_app_conclussion Final thoughts


### PR DESCRIPTION
This comes out of #2538.  There is a bug in the example program: the `sample` point to `Classify()` is specified incorrectly; it is intended that it should be one point that is 23 dimensions, but it's specified in such a way that it results in a matrix with one row and 23 columns (but what we need is 23 rows and one column).

This PR fixes that issue and clarifies in the example code that mlpack is column-major.