### PR TITLE
Migrate bayesian_linear_regression related test from boost to catch2

### DIFF
--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -4,7 +4,6 @@ add_executable(mlpack_test
   async_learning_test.cpp
   augmented_rnns_tasks_test.cpp
   binarize_test.cpp
-  bayesian_linear_regression_test.cpp
   callback_test.cpp
   cf_test.cpp
   cli_binding_test.cpp
@@ -94,7 +93,6 @@ add_executable(mlpack_test
   union_find_test.cpp
   vantage_point_tree_test.cpp
   wgan_test.cpp
-  main_tests/bayesian_linear_regression_test.cpp
   main_tests/cf_test.cpp
   main_tests/dbscan_test.cpp
   main_tests/det_test.cpp
@@ -146,6 +144,7 @@ add_executable(mlpack_catch_test
   ann_test_tools.hpp
   ann_visitor_test.cpp
   armadillo_svd_test.cpp
+  bayesian_linear_regression_test.cpp
   bias_svd_test.cpp
   block_krylov_svd_test.cpp
   convolutional_network_test.cpp
@@ -170,6 +169,7 @@ add_executable(mlpack_catch_test
   test_catch_tools.hpp
   main_tests/adaboost_test.cpp
   main_tests/approx_kfn_test.cpp
+  main_tests/bayesian_linear_regression_test.cpp
   main_tests/decision_stump_test.cpp
   main_tests/decision_tree_test.cpp
   main_tests/image_converter_test.cpp

--- a/src/mlpack/tests/bayesian_linear_regression_test.cpp
+++ b/src/mlpack/tests/bayesian_linear_regression_test.cpp
@@ -14,12 +14,10 @@
 #include <mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp>
 #include <mlpack/methods/linear_regression/linear_regression.hpp>
 
-#include <boost/test/unit_test.hpp>
+#include "catch.hpp"
 
 using namespace mlpack::regression;
 using namespace mlpack::data;
-
-BOOST_AUTO_TEST_SUITE(BayesianLinearRegressionTest);
 
 void GenerateProblem(arma::mat& matX,
                      arma::rowvec& y,
@@ -35,7 +33,8 @@ void GenerateProblem(arma::mat& matX,
 
 // Ensure that predictions are close enough to the target
 // for a free noise dataset.
-BOOST_AUTO_TEST_CASE(BayesianLinearRegressionRegressionTest)
+TEST_CASE("BayesianLinearRegressionRegressionTest",
+          "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y, predictions;
@@ -49,14 +48,14 @@ BOOST_AUTO_TEST_CASE(BayesianLinearRegressionRegressionTest)
 
   // Check the predictions are close enough to the targets in a free noise case.
   for (size_t i = 0; i < y.size(); i++)
-    BOOST_REQUIRE_CLOSE(predictions[i], y[i], 1e-6);
+    REQUIRE(predictions[i] == Approx(y[i]).epsilon(1e-8));
 
   // Check that the estimated variance is zero.
-  BOOST_REQUIRE_SMALL(estimator.Variance(), 1e-6);
+  REQUIRE(estimator.Variance() == Approx(0.0).margin(1e-5));
 }
 
 // Verify centerData and scaleData equal false do not affect the solution.
-BOOST_AUTO_TEST_CASE(TestCenter0ScaleData0)
+TEST_CASE("TestCenter0ScaleData0", "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y;
@@ -69,17 +68,17 @@ BOOST_AUTO_TEST_CASE(TestCenter0ScaleData0)
   estimator.Train(matX, y);
 
   // Check dataOffset is empty.
-  BOOST_REQUIRE(estimator.DataOffset().n_elem == 0);
+  REQUIRE(estimator.DataOffset().n_elem == 0);
 
   // To be neutral responseOffset must be 0.
-  BOOST_REQUIRE(estimator.ResponsesOffset() == 0);
+  REQUIRE(estimator.ResponsesOffset() == 0);
 
   // Check dataScale is empty.
-  BOOST_REQUIRE(estimator.DataScale().n_elem == 0);
+  REQUIRE(estimator.DataScale().n_elem == 0);
 }
 
 // Verify that centering and normalization are correct.
-BOOST_AUTO_TEST_CASE(TestCenterDataTrueScaleDataTrue)
+TEST_CASE("TestCenterDataTrueScaleDataTrue", "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y;
@@ -93,14 +92,16 @@ BOOST_AUTO_TEST_CASE(TestCenterDataTrueScaleDataTrue)
   arma::colvec xStd = arma::stddev(matX, 0, 1);
   double yMean = arma::mean(y);
 
-  BOOST_REQUIRE_SMALL((double) abs(sum(estimator.DataOffset() - xMean)), 1e-6);
-  BOOST_REQUIRE_SMALL((double) abs(sum(estimator.DataScale() - xStd)), 1e-6);
-  BOOST_REQUIRE_CLOSE(estimator.ResponsesOffset(), yMean, 1e-6);
+  REQUIRE((double) abs(sum(estimator.DataOffset() - xMean)) ==
+      Approx(0.0).margin(1e-6));
+  REQUIRE((double) abs(sum(estimator.DataScale() - xStd)) ==
+      Approx(0.0).margin(1e-6));
+  REQUIRE(estimator.ResponsesOffset() == Approx(yMean).epsilon(1e-8));
 }
 
 // Make sure a model with center ans scale option set is different than a model
 // without it set.
-BOOST_AUTO_TEST_CASE(OptionsMakeModelDifferent)
+TEST_CASE("OptionsMakeModelDifferent", "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y;
@@ -115,13 +116,13 @@ BOOST_AUTO_TEST_CASE(OptionsMakeModelDifferent)
   blrCS.Train(matX, y);
 
   for (size_t i = 0; i < nDims; ++i)
-    BOOST_REQUIRE((blr.Omega()(i) != blrC.Omega()(i)) &&
-                  (blr.Omega()(i) != blrCS.Omega()(i)) &&
-                  (blrC.Omega()(i) != blrCS.Omega()(i)));
+    REQUIRE(((blr.Omega()(i) != blrC.Omega()(i)) &&
+             (blr.Omega()(i) != blrCS.Omega()(i)) &&
+             (blrC.Omega()(i) != blrCS.Omega()(i))));
 }
 
 // Check that Train() does not fail with two colinear vectors.
-BOOST_AUTO_TEST_CASE(SingularMatix)
+TEST_CASE("SingularMatix", "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y;
@@ -136,7 +137,7 @@ BOOST_AUTO_TEST_CASE(SingularMatix)
 
 // Check that std are well computed/coherent. At least higher than the
 // estimated predictive variance.
-BOOST_AUTO_TEST_CASE(PredictiveUncertainties)
+TEST_CASE("PredictiveUncertainties", "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y;
@@ -151,14 +152,14 @@ BOOST_AUTO_TEST_CASE(PredictiveUncertainties)
   const double estStd = sqrt(estimator.Variance());
 
   for (size_t i = 0; i < matX.n_cols; i++)
-    BOOST_REQUIRE_GT(std[i], estStd);
+    REQUIRE(std[i] > estStd);
 
   // Check that the estimated variance is close to 1.
-  BOOST_REQUIRE_CLOSE(estStd, 1, 30);
+  REQUIRE(estStd == Approx(1).epsilon(0.3));
 }
 
 // Check the solution is equal to the classical ridge.
-BOOST_AUTO_TEST_CASE(EqualtoRidge)
+TEST_CASE("EqualtoRidge", "[BayesianLinearRegressionTest]")
 {
   arma::mat matX;
   arma::rowvec y, blrPred, ridgePred;
@@ -182,13 +183,11 @@ BOOST_AUTO_TEST_CASE(EqualtoRidge)
 
     // Check the predictions are close enough between ridge and our blr.
     for (size_t i = 0; i < y.size(); ++i)
-      BOOST_REQUIRE_CLOSE(blrPred[i], ridgePred[i], 1);
+      REQUIRE(blrPred[i] == Approx(ridgePred[i]).epsilon(1));
 
     // Exit once a test case has completed.
     break;
   }
 
-  BOOST_REQUIRE_LT(trial, 3);
+  REQUIRE(trial < 3);
 }
-
-BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/bayesian_linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/bayesian_linear_regression_test.cpp
@@ -19,8 +19,8 @@ static const std::string testName = "BayesianLinearRegression";
 #include "test_helper.hpp"
 #include <mlpack/methods/bayesian_linear_regression/bayesian_linear_regression_main.cpp>
 
-#include <boost/test/unit_test.hpp>
-#include "../test_tools.hpp"
+#include "../test_catch_tools.hpp"
+#include "../catch.hpp"
 
 using namespace mlpack;
 
@@ -41,12 +41,12 @@ struct BRTestFixture
   }
 };
 
-BOOST_FIXTURE_TEST_SUITE(BayesianLinearRegressionMainTest, BRTestFixture);
-
 /**
  * Check the center and scale options.
  */
-BOOST_AUTO_TEST_CASE(BRCenter0Scale0)
+TEST_CASE_METHOD(BRTestFixture,
+                 "BRCenter0Scale0",
+                 "[BayesianLinearRegressionMainTest][BindingTests]")
 {
   int n = 50, m = 4;
   arma::mat matX = arma::randu<arma::mat>(m, n);
@@ -62,14 +62,16 @@ BOOST_AUTO_TEST_CASE(BRCenter0Scale0)
   BayesianLinearRegression* estimator =
       IO::GetParam<BayesianLinearRegression*>("output_model");
 
-  BOOST_REQUIRE(estimator->DataOffset().n_elem == 0);
-  BOOST_REQUIRE(estimator->DataScale().n_elem == 0);
+  REQUIRE(estimator->DataOffset().n_elem == 0);
+  REQUIRE(estimator->DataScale().n_elem == 0);
 }
 
 /**
  * Check predictions of saved model and in code model are equal.
  */
-BOOST_AUTO_TEST_CASE(BayesianLinearRegressionSavedEqualCode)
+TEST_CASE_METHOD(BRTestFixture,
+                 "BayesianLinearRegressionSavedEqualCode",
+                 "[BayesianLinearRegressionMainTest][BindingTests]")
 {
   int n = 10, m = 4;
   arma::mat matX = arma::randu<arma::mat>(m, n);
@@ -106,7 +108,9 @@ BOOST_AUTO_TEST_CASE(BayesianLinearRegressionSavedEqualCode)
  * Check a crash happens if neither input or input_model are specified.
  * Check a crash happens if both input and input_model are specified.
  */
-BOOST_AUTO_TEST_CASE(CheckParamsPassed)
+TEST_CASE_METHOD(BRTestFixture,
+                 "CheckParamsPassed",
+                 "[BayesianLinearRegressionMainTest][BindingTests]")
 {
   int n = 10, m = 4;
   arma::mat matX = arma::randu<arma::mat>(m, n);
@@ -124,7 +128,9 @@ BOOST_AUTO_TEST_CASE(CheckParamsPassed)
   // is specified.
   SetInputParam("responses", std::move(y));
 
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = true;
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
 
   // Continue only with input passed.
   SetInputParam("input", std::move(matX));
@@ -137,7 +143,7 @@ BOOST_AUTO_TEST_CASE(CheckParamsPassed)
                 IO::GetParam<BayesianLinearRegression*>("output_model"));
   SetInputParam("test", std::move(matXtest));
 
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = true;
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
 }
-
-BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
#2523 