### PR TITLE
Removing r-value reference from RBM

### DIFF
--- a/src/mlpack/methods/ann/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm.hpp
@@ -27,11 +27,13 @@ namespace ann /** Artificial Neural Network. */ {
  * machines, with the restriction that the neurons must form a bipartite graph.
  *
  * @tparam InitializationRuleType Rule used to initialize the network.
+ * @tparam InputType The type of matrix to be used as input type.
  * @tparam DataType The type of matrix to be used.
  * @tparam PolicyType The RBM variant to be used (BinaryRBM or SpikeSlabRBM).
  */
 template<
   typename InitializationRuleType,
+  typename InputType = arma::mat,
   typename DataType = arma::mat,
   typename PolicyType = BinaryRBM
 >
@@ -118,7 +120,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, double>::type
-  FreeEnergy(arma::Mat<ElemType>&& input);
+  FreeEnergy(const arma::Mat<ElemType>& input);
 
   /**
    * This function calculates the free energy of the SpikeSlabRBM.
@@ -133,7 +135,7 @@ class RBM
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value,
       double>::type
-  FreeEnergy(arma::Mat<ElemType>&& input);
+  FreeEnergy(const arma::Mat<ElemType>& input);
 
   /**
    * Calculates the gradient of the RBM network on the provided input.
@@ -143,7 +145,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-  Phase(DataType&& input, DataType&& gradient);
+  Phase(const InputType& input, DataType& gradient);
 
   /**
    * Calculates the gradient of the RBM network on the provided input.
@@ -153,7 +155,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  Phase(DataType&& input, DataType&& gradient);
+  Phase(const InputType& input, DataType& gradient);
 
   /**
    * This function samples the hidden layer given the visible layer using
@@ -164,7 +166,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-  SampleHidden(arma::Mat<ElemType>&& input, arma::Mat<ElemType>&& output);
+  SampleHidden(const arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
    * This function samples the slab outputs from the Normal distribution with
@@ -178,7 +180,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  SampleHidden(arma::Mat<ElemType>&& input, arma::Mat<ElemType>&& output);
+  SampleHidden(const arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
    * This function samples the visible layer given the hidden layer using
@@ -189,7 +191,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-  SampleVisible(arma::Mat<ElemType>&& input, arma::Mat<ElemType>&& output);
+  SampleVisible(arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
    * Sample Hidden function samples the slab outputs from the Normal
@@ -203,7 +205,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  SampleVisible(arma::Mat<ElemType>&& input, arma::Mat<ElemType>&& output);
+  SampleVisible(arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
    * The function calculates the mean for the visible layer.
@@ -213,7 +215,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-  VisibleMean(DataType&& input, DataType&& output);
+  VisibleMean(InputType& input, DataType& output);
 
   /**
    * The function calculates the mean of the Normal distribution of P(v|s, h).
@@ -225,7 +227,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  VisibleMean(DataType&& input, DataType&& output);
+  VisibleMean(InputType& input, DataType& output);
 
   /**
    * The function calculates the mean for the hidden layer.
@@ -235,7 +237,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-  HiddenMean(DataType&& input, DataType&& output);
+  HiddenMean(const InputType& input, DataType& output);
 
   /**
    * The function calculates the mean of the Normal distribution of P(s|v, h).
@@ -249,7 +251,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  HiddenMean(DataType&& input, DataType&& output);
+  HiddenMean(const InputType& input, DataType& output);
 
   /**
    * The function calculates the mean of the distribution P(h|v),
@@ -261,7 +263,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  SpikeMean(DataType&& visible, DataType&& spikeMean);
+  SpikeMean(const InputType& visible, DataType& spikeMean);
 
   /**
    * The function samples the spike function using Bernoulli distribution.
@@ -270,7 +272,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  SampleSpike(DataType&& spikeMean, DataType&& spike);
+  SampleSpike(InputType& spikeMean, DataType& spike);
 
   /**
    * The function calculates the mean of Normal distribution of P(s|v, h),
@@ -283,7 +285,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  SlabMean(DataType&& visible, DataType&& spike, DataType&& slabMean);
+  SlabMean(const DataType& visible, DataType& spike, DataType& slabMean);
 
   /**
    * The function samples from the Normal distribution of P(s|v, h),
@@ -297,7 +299,7 @@ class RBM
    */
   template<typename Policy = PolicyType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-  SampleSlab(DataType&& slabMean, DataType&& slab);
+  SampleSlab(InputType& slabMean, DataType& slab);
 
   /**
    * This function does the k-step Gibbs Sampling.
@@ -306,8 +308,8 @@ class RBM
    * @param output Used for storing the negative sample.
    * @param steps Number of Gibbs Sampling steps taken.
    */
-  void Gibbs(arma::Mat<ElemType>&& input,
-             arma::Mat<ElemType>&& output,
+  void Gibbs(const arma::Mat<ElemType>& input,
+             arma::Mat<ElemType>& output,
              const size_t steps = SIZE_MAX);
 
   /**

--- a/src/mlpack/methods/ann/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm.hpp
@@ -27,7 +27,6 @@ namespace ann /** Artificial Neural Network. */ {
  * machines, with the restriction that the neurons must form a bipartite graph.
  *
  * @tparam InitializationRuleType Rule used to initialize the network.
- * @tparam InputType The type of matrix to be used as input type.
  * @tparam DataType The type of matrix to be used.
  * @tparam PolicyType The RBM variant to be used (BinaryRBM or SpikeSlabRBM).
  */

--- a/src/mlpack/methods/ann/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm.hpp
@@ -33,7 +33,6 @@ namespace ann /** Artificial Neural Network. */ {
  */
 template<
   typename InitializationRuleType,
-  typename InputType = arma::mat,
   typename DataType = arma::mat,
   typename PolicyType = BinaryRBM
 >
@@ -72,12 +71,12 @@ class RBM
       const bool persistence = false);
 
   // Reset the network.
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
   Reset();
 
   // Reset the network.
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   Reset();
 
@@ -118,7 +117,7 @@ class RBM
    *
    * @param input The visible neurons.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, double>::type
   FreeEnergy(const arma::Mat<ElemType>& input);
 
@@ -132,7 +131,7 @@ class RBM
    *
    * @param input The visible layer neurons.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value,
       double>::type
   FreeEnergy(const arma::Mat<ElemType>& input);
@@ -143,7 +142,7 @@ class RBM
    * @param input The provided input data.
    * @param gradient Stores the gradient of the RBM network.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
   Phase(const InputType& input, DataType& gradient);
 
@@ -153,7 +152,7 @@ class RBM
    * @param input The provided input data.
    * @param gradient Stores the gradient of the RBM network.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   Phase(const InputType& input, DataType& gradient);
 
@@ -164,7 +163,7 @@ class RBM
    * @param input Visible layer input.
    * @param output The sampled hidden layer.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
   SampleHidden(const arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
@@ -178,7 +177,7 @@ class RBM
    * @param input Consists of both visible and spike variables.
    * @param output Sampled slab neurons.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   SampleHidden(const arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
@@ -189,7 +188,7 @@ class RBM
    * @param input Hidden layer of the network.
    * @param output The sampled visible layer.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
   SampleVisible(arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
@@ -203,7 +202,7 @@ class RBM
    * @param input Hidden layer of the network.
    * @param output The sampled visible layer.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   SampleVisible(arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
@@ -213,7 +212,7 @@ class RBM
    * @param input Hidden neurons from the hidden layer of the network.
    * @param output Visible neuron activations.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
   VisibleMean(InputType& input, DataType& output);
 
@@ -225,7 +224,7 @@ class RBM
    * @param input Consists of both the spike and slab variables.
    * @param output Mean of the of the Normal distribution.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   VisibleMean(InputType& input, DataType& output);
 
@@ -235,7 +234,7 @@ class RBM
    * @param input Visible neurons.
    * @param output Hidden neuron activations.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
   HiddenMean(const InputType& input, DataType& output);
 
@@ -249,7 +248,7 @@ class RBM
    * @param input Visible layer neurons.
    * @param output Consists of both the spike samples and slab samples.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   HiddenMean(const InputType& input, DataType& output);
 
@@ -261,7 +260,7 @@ class RBM
    * @param visible The visible layer neurons.
    * @param spikeMean Indicates P(h|v).
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   SpikeMean(const InputType& visible, DataType& spikeMean);
 
@@ -270,7 +269,7 @@ class RBM
    * @param spikeMean Indicates P(h|v).
    * @param spike Sampled binary spike variables.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   SampleSpike(InputType& spikeMean, DataType& spike);
 
@@ -283,7 +282,7 @@ class RBM
    * @param spike The spike variables from hidden layer.
    * @param slabMean The mean of the Normal distribution of slab neurons.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   SlabMean(const DataType& visible, DataType& spike, DataType& slabMean);
 
@@ -297,7 +296,7 @@ class RBM
    * @param slabMean Mean of the Normal distribution of the slab neurons.
    * @param slab Sampled slab variable from the Normal distribution.
    */
-  template<typename Policy = PolicyType>
+  template<typename Policy = PolicyType, typename InputType = DataType>
   typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
   SampleSlab(InputType& slabMean, DataType& slab);
 

--- a/src/mlpack/methods/ann/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm_impl.hpp
@@ -21,11 +21,10 @@ namespace ann /** Artificial neural networks. */ {
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::RBM(
+RBM<InitializationRuleType, DataType, PolicyType>::RBM(
     arma::Mat<ElemType> predictors,
     InitializationRuleType initializeRule,
     const size_t visibleSize,
@@ -56,13 +55,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::RBM(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::Reset()
+RBM<InitializationRuleType, DataType, PolicyType>::Reset()
 {
   size_t shape = (visibleSize * hiddenSize) + visibleSize + hiddenSize;
 
@@ -90,12 +88,11 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::Reset()
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
 template<typename OptimizerType, typename... CallbackType>
-double RBM<InitializationRuleType, InputType, DataType, PolicyType>::Train(
+double RBM<InitializationRuleType, DataType, PolicyType>::Train(
     OptimizerType& optimizer, CallbackType&&... callbacks)
 {
   if (!reset)
@@ -108,13 +105,12 @@ double RBM<InitializationRuleType, InputType, DataType, PolicyType>::Train(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, double>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::FreeEnergy(
+RBM<InitializationRuleType, DataType, PolicyType>::FreeEnergy(
     const arma::Mat<ElemType>& input)
 {
   preActivation = (weight.slice(0) * input);
@@ -125,13 +121,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::FreeEnergy(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::Phase(
+RBM<InitializationRuleType, DataType, PolicyType>::Phase(
     const InputType& input,
     DataType& gradient)
 {
@@ -147,11 +142,10 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::Phase(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-double RBM<InitializationRuleType, InputType, DataType, PolicyType>::Evaluate(
+double RBM<InitializationRuleType, DataType, PolicyType>::Evaluate(
     const arma::Mat<ElemType>& /* parameters*/,
     const size_t i,
     const size_t batchSize)
@@ -164,13 +158,12 @@ double RBM<InitializationRuleType, InputType, DataType, PolicyType>::Evaluate(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleHidden(
+RBM<InitializationRuleType, DataType, PolicyType>::SampleHidden(
     const arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
 {
@@ -184,13 +177,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleHidden(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleVisible(
+RBM<InitializationRuleType, DataType, PolicyType>::SampleVisible(
     arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
 {
@@ -204,13 +196,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleVisible(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::VisibleMean(
+RBM<InitializationRuleType, DataType, PolicyType>::VisibleMean(
     InputType& input,
     DataType& output)
 {
@@ -221,13 +212,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::VisibleMean(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::HiddenMean(
+RBM<InitializationRuleType, DataType, PolicyType>::HiddenMean(
     const InputType& input,
     DataType& output)
 {
@@ -238,11 +228,10 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::HiddenMean(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-void RBM<InitializationRuleType, InputType, DataType, PolicyType>::Gibbs(
+void RBM<InitializationRuleType, DataType, PolicyType>::Gibbs(
     const arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output,
     const size_t steps)
@@ -273,11 +262,10 @@ void RBM<InitializationRuleType, InputType, DataType, PolicyType>::Gibbs(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-void RBM<InitializationRuleType, InputType, DataType, PolicyType>::Gradient(
+void RBM<InitializationRuleType, DataType, PolicyType>::Gradient(
     const arma::Mat<ElemType>& /*parameters*/,
     const size_t i,
     arma::Mat<ElemType>& gradient,
@@ -303,11 +291,10 @@ void RBM<InitializationRuleType, InputType, DataType, PolicyType>::Gradient(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-void RBM<InitializationRuleType, InputType, DataType, PolicyType>::Shuffle()
+void RBM<InitializationRuleType, DataType, PolicyType>::Shuffle()
 {
   predictors = predictors.cols(arma::shuffle(arma::linspace<arma::uvec>(0,
       predictors.n_cols - 1, predictors.n_cols)));
@@ -315,12 +302,11 @@ void RBM<InitializationRuleType, InputType, DataType, PolicyType>::Shuffle()
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
 template<typename Archive>
-void RBM<InitializationRuleType, InputType, DataType, PolicyType>::serialize(
+void RBM<InitializationRuleType, DataType, PolicyType>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
   ar & BOOST_SERIALIZATION_NVP(parameter);

--- a/src/mlpack/methods/ann/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/rbm_impl.hpp
@@ -210,7 +210,8 @@ template<
 >
 template<typename Policy>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::VisibleMean(InputType& input,
+RBM<InitializationRuleType, InputType, DataType, PolicyType>::VisibleMean(
+    InputType& input,
     DataType& output)
 {
   output = weight.slice(0).t() * input;
@@ -226,7 +227,8 @@ template<
 >
 template<typename Policy>
 typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::HiddenMean(const InputType& input,
+RBM<InitializationRuleType, InputType, DataType, PolicyType>::HiddenMean(
+    const InputType& input,
     DataType& output)
 {
   output = weight.slice(0) * input;

--- a/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
@@ -70,7 +70,7 @@ template<
 template<typename Policy>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, double>::type
 RBM<InitializationRuleType, InputType, DataType, PolicyType>::FreeEnergy(
-   const arma::Mat<ElemType>& input)
+    const arma::Mat<ElemType>& input)
 {
   ElemType freeEnergy = 0.5 * visiblePenalty(0) * arma::dot(input, input);
 

--- a/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
@@ -22,13 +22,12 @@ namespace ann {
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::Reset()
+RBM<InitializationRuleType, DataType, PolicyType>::Reset()
 {
   size_t shape = (visibleSize * hiddenSize * poolSize) + visibleSize +
       hiddenSize;
@@ -63,13 +62,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::Reset()
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, double>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::FreeEnergy(
+RBM<InitializationRuleType, DataType, PolicyType>::FreeEnergy(
     const arma::Mat<ElemType>& input)
 {
   ElemType freeEnergy = 0.5 * visiblePenalty(0) * arma::dot(input, input);
@@ -89,13 +87,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::FreeEnergy(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::Phase(
+RBM<InitializationRuleType, DataType, PolicyType>::Phase(
     const InputType& input,
     DataType& gradient)
 {
@@ -126,13 +123,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::Phase(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleHidden(
+RBM<InitializationRuleType, DataType, PolicyType>::SampleHidden(
     const arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
 {
@@ -150,13 +146,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleHidden(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleVisible(
+RBM<InitializationRuleType, DataType, PolicyType>::SampleVisible(
     arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
 {
@@ -189,13 +184,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleVisible(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::VisibleMean(
+RBM<InitializationRuleType, DataType, PolicyType>::VisibleMean(
     InputType& input,
     DataType& output)
 {
@@ -215,13 +209,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::VisibleMean(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::HiddenMean(
+RBM<InitializationRuleType, DataType, PolicyType>::HiddenMean(
     const InputType& input,
     DataType& output)
 {
@@ -238,13 +231,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::HiddenMean(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SpikeMean(
+RBM<InitializationRuleType, DataType, PolicyType>::SpikeMean(
     const InputType& visible,
     DataType& spikeMean)
 {
@@ -258,13 +250,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SpikeMean(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleSpike(
+RBM<InitializationRuleType, DataType, PolicyType>::SampleSpike(
     InputType& spikeMean,
     DataType& spike)
 {
@@ -276,13 +267,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleSpike(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SlabMean(
+RBM<InitializationRuleType, DataType, PolicyType>::SlabMean(
     const DataType& visible,
     DataType& spike,
     DataType& slabMean)
@@ -296,13 +286,12 @@ RBM<InitializationRuleType, InputType, DataType, PolicyType>::SlabMean(
 
 template<
   typename InitializationRuleType,
-  typename InputType,
   typename DataType,
   typename PolicyType
 >
-template<typename Policy>
+template<typename Policy, typename InputType>
 typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
-RBM<InitializationRuleType, InputType, DataType, PolicyType>::SampleSlab(
+RBM<InitializationRuleType, DataType, PolicyType>::SampleSlab(
     InputType& slabMean,
     DataType& slab)
 {

--- a/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
@@ -102,9 +102,6 @@ RBM<InitializationRuleType, DataType, PolicyType>::Phase(
   DataType spikeBiasGrad = DataType(gradient.memptr() + weightGrad.n_elem,
       hiddenSize, 1, false, false);
 
-  DataType visiblePenaltyGrad = DataType(gradient.memptr() +
-      weightGrad.n_elem + spikeBiasGrad.n_elem, 1, 1, false, false);
-
   SpikeMean(input, spikeMean);
   SampleSpike(spikeMean, spikeSamples);
   SlabMean(input, spikeSamples, slabMean);
@@ -116,9 +113,9 @@ RBM<InitializationRuleType, DataType, PolicyType>::Phase(
   }
 
   spikeBiasGrad = spikeMean;
-
-  visiblePenaltyGrad = -0.5 * arma::dot(input, input)
-      / std::pow(input.n_cols, 2);
+  // Setting visiblePenaltyGrad.
+  gradient.row(weightGrad.n_elem + spikeBiasGrad.n_elem) = -0.5 * arma::dot(
+                                    input, input) / std::pow(input.n_cols, 2);
 }
 
 template<

--- a/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
+++ b/src/mlpack/methods/ann/rbm/spike_slab_rbm_impl.hpp
@@ -115,7 +115,7 @@ RBM<InitializationRuleType, DataType, PolicyType>::Phase(
   spikeBiasGrad = spikeMean;
   // Setting visiblePenaltyGrad.
   gradient.row(weightGrad.n_elem + spikeBiasGrad.n_elem) = -0.5 * arma::dot(
-                                    input, input) / std::pow(input.n_cols, 2);
+       input, input) / std::pow(input.n_cols, 2);
 }
 
 template<

--- a/src/mlpack/tests/rbm_network_test.cpp
+++ b/src/mlpack/tests/rbm_network_test.cpp
@@ -169,9 +169,9 @@ BOOST_AUTO_TEST_CASE(ssRBMClassificationTest)
   YRbm.zeros();
   double slabPenalty = 8;
 
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> modelssRBM(
-      trainData, gaussian, trainData.n_rows, hiddenLayerSize, batchSize, 1,
-      1, poolSize, slabPenalty, radius);
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> modelssRBM(trainData,
+      gaussian, trainData.n_rows, hiddenLayerSize, batchSize, 1, 1, poolSize,
+      slabPenalty, radius);
 
   size_t numRBMIterations = trainData.n_cols * numEpoches;
   numRBMIterations /= batchSize;
@@ -220,9 +220,8 @@ void BuildVanillaNetwork(MatType& trainData,
 {
   MatType output;
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, MatType, BinaryRBM> model(
-      trainData, gaussian, trainData.n_rows, hiddenLayerSize,
-      1, 1, 1, 2, 8, 1, true);
+  RBM<GaussianInitialization, MatType, BinaryRBM> model(trainData, gaussian,
+      trainData.n_rows, hiddenLayerSize, 1, 1, 1, 2, 8, 1, true);
 
   model.Reset();
   // Set the parameters from a learned RBM Sklearn random state 23.

--- a/src/mlpack/tests/rbm_network_test.cpp
+++ b/src/mlpack/tests/rbm_network_test.cpp
@@ -88,14 +88,14 @@ BOOST_AUTO_TEST_CASE(BinaryRBMClassificationTest)
 
   for (size_t i = 0; i < trainData.n_cols; ++i)
   {
-    model.HiddenMean(std::move(trainData.col(i)), std::move(output));
+    model.HiddenMean(trainData.col(i), output);
     XRbm.col(i) = output;
   }
 
   for (size_t i = 0; i < testData.n_cols; ++i)
   {
-    model.HiddenMean(std::move(testData.col(i)),
-      std::move(output));
+    model.HiddenMean(testData.col(i),
+      output);
     YRbm.col(i) = output;
   }
   const size_t numClasses = 10; // Number of classes.
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(ssRBMClassificationTest)
   YRbm.zeros();
   double slabPenalty = 8;
 
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> modelssRBM(trainData,
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> modelssRBM(trainData,
       gaussian, trainData.n_rows, hiddenLayerSize, batchSize, 1, 1, poolSize,
       slabPenalty, radius);
 
@@ -189,15 +189,15 @@ BOOST_AUTO_TEST_CASE(ssRBMClassificationTest)
 
   for (size_t i = 0; i < trainData.n_cols; ++i)
   {
-    modelssRBM.HiddenMean(std::move(trainData.col(i)),
-        std::move(output));
+    modelssRBM.HiddenMean(trainData.col(i),
+        output);
     XRbm.col(i) = output;
   }
 
   for (size_t i = 0; i < testData.n_cols; ++i)
   {
-    modelssRBM.HiddenMean(std::move(testData.col(i)),
-      std::move(output));
+    modelssRBM.HiddenMean(testData.col(i),
+      output);
     YRbm.col(i) = output;
   }
   const size_t numClasses = 10; // Number of classes.
@@ -223,7 +223,7 @@ void BuildVanillaNetwork(MatType& trainData,
 {
   MatType output;
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, MatType, BinaryRBM> model(trainData, gaussian,
+  RBM<GaussianInitialization, MatType, MatType, BinaryRBM> model(trainData, gaussian,
       trainData.n_rows, hiddenLayerSize, 1, 1, 1, 2, 8, 1, true);
 
   model.Reset();
@@ -238,7 +238,7 @@ void BuildVanillaNetwork(MatType& trainData,
   arma::vec calculatedFreeEnergy(4, arma::fill::zeros);
   for (size_t i = 0; i < trainData.n_cols; ++i)
   {
-    calculatedFreeEnergy(i) = model.FreeEnergy(std::move(trainData.col(i)));
+    calculatedFreeEnergy(i) = model.FreeEnergy(trainData.col(i));
   }
 
   for (size_t i = 0; i < freeEnergy.n_elem; ++i)

--- a/src/mlpack/tests/rbm_network_test.cpp
+++ b/src/mlpack/tests/rbm_network_test.cpp
@@ -170,9 +170,9 @@ BOOST_AUTO_TEST_CASE(ssRBMClassificationTest)
   YRbm.zeros();
   double slabPenalty = 8;
 
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> modelssRBM(trainData,
-      gaussian, trainData.n_rows, hiddenLayerSize, batchSize, 1, 1, poolSize,
-      slabPenalty, radius);
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> modelssRBM(
+      trainData, gaussian, trainData.n_rows, hiddenLayerSize, batchSize, 1,
+      1, poolSize, slabPenalty, radius);
 
   size_t numRBMIterations = trainData.n_cols * numEpoches;
   numRBMIterations /= batchSize;
@@ -223,8 +223,9 @@ void BuildVanillaNetwork(MatType& trainData,
 {
   MatType output;
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, MatType, MatType, BinaryRBM> model(trainData, gaussian,
-      trainData.n_rows, hiddenLayerSize, 1, 1, 1, 2, 8, 1, true);
+  RBM<GaussianInitialization, MatType, MatType, BinaryRBM> model(
+      trainData, gaussian, trainData.n_rows, hiddenLayerSize,
+      1, 1, 1, 2, 8, 1, true);
 
   model.Reset();
   // Set the parameters from a learned RBM Sklearn random state 23.

--- a/src/mlpack/tests/rbm_network_test.cpp
+++ b/src/mlpack/tests/rbm_network_test.cpp
@@ -94,8 +94,7 @@ BOOST_AUTO_TEST_CASE(BinaryRBMClassificationTest)
 
   for (size_t i = 0; i < testData.n_cols; ++i)
   {
-    model.HiddenMean(testData.col(i),
-      output);
+    model.HiddenMean(testData.col(i), output);
     YRbm.col(i) = output;
   }
   const size_t numClasses = 10; // Number of classes.
@@ -170,7 +169,7 @@ BOOST_AUTO_TEST_CASE(ssRBMClassificationTest)
   YRbm.zeros();
   double slabPenalty = 8;
 
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> modelssRBM(
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> modelssRBM(
       trainData, gaussian, trainData.n_rows, hiddenLayerSize, batchSize, 1,
       1, poolSize, slabPenalty, radius);
 
@@ -189,15 +188,13 @@ BOOST_AUTO_TEST_CASE(ssRBMClassificationTest)
 
   for (size_t i = 0; i < trainData.n_cols; ++i)
   {
-    modelssRBM.HiddenMean(trainData.col(i),
-        output);
+    modelssRBM.HiddenMean(trainData.col(i), output);
     XRbm.col(i) = output;
   }
 
   for (size_t i = 0; i < testData.n_cols; ++i)
   {
-    modelssRBM.HiddenMean(testData.col(i),
-      output);
+    modelssRBM.HiddenMean(testData.col(i), output);
     YRbm.col(i) = output;
   }
   const size_t numClasses = 10; // Number of classes.
@@ -223,7 +220,7 @@ void BuildVanillaNetwork(MatType& trainData,
 {
   MatType output;
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, MatType, MatType, BinaryRBM> model(
+  RBM<GaussianInitialization, MatType, BinaryRBM> model(
       trainData, gaussian, trainData.n_rows, hiddenLayerSize,
       1, 1, 1, 2, 8, 1, true);
 

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -1578,9 +1578,9 @@ BOOST_AUTO_TEST_CASE(ssRBMTest)
   RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmText(data,
       gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
       radius, true);
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmBinary(data,
-      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
-      radius, true);
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmBinary(
+      data, gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize,
+      slabPenalty, radius, true);
   Rbm.Reset();
   Rbm.VisiblePenalty().fill(15);
   Rbm.SpikeBias().ones();

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -1569,18 +1569,18 @@ BOOST_AUTO_TEST_CASE(ssRBMTest)
   size_t poolSize = 1;
 
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> Rbm(data, gaussian,
-      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
-      true);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmXml(data, gaussian,
-      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
-      true);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmText(data, gaussian,
-      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
-      true);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmBinary(data, gaussian,
-      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
-      true);
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> Rbm(data,
+      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
+      radius, true);
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmXml(data,
+      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
+      radius, true);
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmText(data,
+      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
+      radius, true);
+  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmBinary(data,
+      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
+      radius, true);
   Rbm.Reset();
   Rbm.VisiblePenalty().fill(15);
   Rbm.SpikeBias().ones();

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -1569,18 +1569,18 @@ BOOST_AUTO_TEST_CASE(ssRBMTest)
   size_t poolSize = 1;
 
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> Rbm(data,
-      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
-      radius, true);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmXml(data,
-      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
-      radius, true);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmText(data,
-      gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
-      radius, true);
-  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmBinary(
-      data, gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize,
-      slabPenalty, radius, true);
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> Rbm(data, gaussian,
+      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
+      true);
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmXml(data, gaussian,
+      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
+      true);
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmText(data, gaussian,
+      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
+      true);
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmBinary(data, gaussian,
+      data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty, radius,
+      true);
   Rbm.Reset();
   Rbm.VisiblePenalty().fill(15);
   Rbm.SpikeBias().ones();

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -1569,16 +1569,16 @@ BOOST_AUTO_TEST_CASE(ssRBMTest)
   size_t poolSize = 1;
 
   GaussianInitialization gaussian(0, 0.1);
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> Rbm(data,
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> Rbm(data,
       gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
       radius, true);
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmXml(data,
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmXml(data,
       gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
       radius, true);
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmText(data,
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmText(data,
       gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize, slabPenalty,
       radius, true);
-  RBM<GaussianInitialization, arma::mat, arma::mat, SpikeSlabRBM> RbmBinary(
+  RBM<GaussianInitialization, arma::mat, SpikeSlabRBM> RbmBinary(
       data, gaussian, data.n_rows, hiddenLayerSize, 1, 1, 1, poolSize,
       slabPenalty, radius, true);
   Rbm.Reset();


### PR DESCRIPTION
Trying to remove remove r-value reference from RBM module to maintain the code.