### PR TITLE
Fix documentation for incremental logistic regression

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,8 @@
     version of linear regression where the regularization parameter is
     automatically tuned (#2030).
 
+  * Fix incremental training of logistic regression models (#2560).
+
 ### mlpack 3.3.2
 ###### 2020-06-18
   * Added Noisy DQN to q_networks (#2446).

--- a/src/mlpack/methods/logistic_regression/logistic_regression.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression.hpp
@@ -140,12 +140,9 @@ class LogisticRegression
    * Using this overload allows configuring the instantiated optimizer before
    * training is performed.
    *
-   * Note that the initial point of the optimizer
-   * (optimizer.Function().GetInitialPoint()) will be used as the initial point
-   * of the optimization, overwriting any existing trained model.  If you don't
-   * want to overwrite the existing model, set
-   * optimizer.Function().GetInitialPoint() to the current parameters vector,
-   * accessible via Parameters().
+   * This will use the existing model parameters as a starting point for the
+   * optimization.  If this is not what you want, then you should access the
+   * parameters vector directly with Parameters() and modify it as desired.
    *
    * @tparam OptimizerType Type of optimizer to use to train the model.
    * @tparam CallbackTypes Types of Callback Functions.

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function.hpp
@@ -41,24 +41,6 @@ class LogisticRegressionFunction
                              const arma::Row<size_t>& responses,
                              const double lambda = 0);
 
-  /**
-   * Creates the LogisticRegressionFunction with initialPoint.
-   *
-   * @param predictors The matrix of data points.
-   * @param responses The measured data for each point in predictors.
-   * @param initialPoint Point from which to start the optimization.
-   * @param lambda Regularization constant for ridge regression.
-   */
-  LogisticRegressionFunction(const MatType& predictors,
-                             const arma::Row<size_t>& responses,
-                             const arma::vec& initialPoint,
-                             const double lambda = 0);
-
-  //! Return the initial point for the optimization.
-  const arma::mat& InitialPoint() const { return initialPoint; }
-  //! Modify the initial point for the optimization.
-  arma::mat& InitialPoint() { return initialPoint; }
-
   //! Return the regularization parameter (lambda).
   const double& Lambda() const { return lambda; }
   //! Modify the regularization parameter (lambda).
@@ -170,9 +152,6 @@ class LogisticRegressionFunction
                               GradType& gradient,
                               const size_t batchSize = 1) const;
 
-  //! Return the initial point for the optimization.
-  const arma::mat& GetInitialPoint() const { return initialPoint; }
-
   //! Return the number of separable functions (the number of predictor points).
   size_t NumFunctions() const { return predictors.n_cols; }
 
@@ -180,8 +159,6 @@ class LogisticRegressionFunction
   size_t NumFeatures() const { return predictors.n_rows + 1; }
 
  private:
-  //! The initial point, from which to start the optimization.
-  arma::mat initialPoint;
   //! The matrix of data points (predictors).  This is an alias until shuffling
   //! is done.
   MatType predictors;

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
@@ -31,8 +31,6 @@ LogisticRegressionFunction<MatType>::LogisticRegressionFunction(
         false)),
     lambda(lambda)
 {
-  initialPoint = arma::rowvec(predictors.n_rows + 1, arma::fill::zeros);
-
   // Sanity check.
   if (responses.n_elem != predictors.n_cols)
   {
@@ -41,25 +39,6 @@ LogisticRegressionFunction<MatType>::LogisticRegressionFunction(
         << "responses vector has " << responses.n_elem << " elements (should be"
         << " " << predictors.n_cols << ")!" << std::endl;
   }
-}
-
-template<typename MatType>
-LogisticRegressionFunction<MatType>::LogisticRegressionFunction(
-    const MatType& predictors,
-    const arma::Row<size_t>& responses,
-    const arma::vec& initialPoint,
-    const double lambda) :
-    initialPoint(initialPoint),
-    // We promise to be well-behaved... the elements won't be modified.
-    predictors(math::MakeAlias(const_cast<MatType&>(predictors), false)),
-    responses(math::MakeAlias(const_cast<arma::Row<size_t>&>(responses),
-        false)),
-    lambda(lambda)
-{
-  // To check if initialPoint is compatible with predictors.
-  if (initialPoint.n_rows != (predictors.n_rows + 1) ||
-      initialPoint.n_cols != 1)
-    this->initialPoint = arma::rowvec(predictors.n_rows + 1, arma::fill::zeros);
 }
 
 /**

--- a/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
@@ -89,7 +89,6 @@ double LogisticRegression<MatType>::Train(
   // Set size of parameters vector according to the input data received.
   if (parameters.n_elem != predictors.n_rows + 1)
     parameters = arma::rowvec(predictors.n_rows + 1, arma::fill::zeros);
-  errorFunction.InitialPoint() = parameters;
 
   Timer::Start("logistic_regression_optimization");
   const double out = optimizer.Optimize(errorFunction, parameters,

--- a/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_impl.hpp
@@ -87,7 +87,8 @@ double LogisticRegression<MatType>::Train(
       lambda);
 
   // Set size of parameters vector according to the input data received.
-  parameters = arma::rowvec(predictors.n_rows + 1, arma::fill::zeros);
+  if (parameters.n_elem != predictors.n_rows + 1)
+    parameters = arma::rowvec(predictors.n_rows + 1, arma::fill::zeros);
   errorFunction.InitialPoint() = parameters;
 
   Timer::Start("logistic_regression_optimization");

--- a/src/mlpack/tests/logistic_regression_test.cpp
+++ b/src/mlpack/tests/logistic_regression_test.cpp
@@ -1023,4 +1023,38 @@ BOOST_AUTO_TEST_CASE(ConstructionThenTraining)
   BOOST_REQUIRE_NO_THROW(lr.Train(myMatrix, myTargets));
 }
 
+/**
+ * Make sure that incremental training works.
+ */
+BOOST_AUTO_TEST_CASE(IncrementalTraining)
+{
+  // Generate a two-Gaussian dataset.
+  GaussianDistribution g1(arma::vec("1.0 1.0 1.0"), arma::eye<arma::mat>(3, 3));
+  GaussianDistribution g2(arma::vec("9.0 9.0 9.0"), arma::eye<arma::mat>(3, 3));
+
+  arma::mat data(3, 1000);
+  arma::Row<size_t> responses(1000);
+  for (size_t i = 0; i < 500; ++i)
+  {
+    data.col(i) = g1.Random();
+    responses[i] = 0;
+  }
+  for (size_t i = 500; i < 1000; ++i)
+  {
+    data.col(i) = g2.Random();
+    responses[i] = 1;
+  }
+
+  // Now train a logistic regression object on it.
+  LogisticRegression<> lr(data.n_rows, 0.5);
+  for (size_t epoch = 0; epoch < 10; ++epoch)
+    for (size_t i = 0; i < data.n_cols; ++i)
+      lr.Train<ens::StandardSGD>(data, responses);
+
+  // Ensure that the error is close to zero.
+  const double acc = lr.ComputeAccuracy(data, responses);
+
+  BOOST_REQUIRE_CLOSE(acc, 100.0, 3.0); // 3% error tolerance.
+}
+
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
`ak` in the chat channel pointed out that incremental logistic regression via successive calls to `Train()` don't seem to work as the documentation suggests.  When I looked into the code, it does seem like there is a bug.  So this PR changes the behavior of `Train()` to only reset the parameters vector when it is of a different size.  It also corrects some slightly inaccurate documentation.