### PR TITLE
Instance Norm.

### DIFF
--- a/src/mlpack/methods/ann/layer/CMakeLists.txt
+++ b/src/mlpack/methods/ann/layer/CMakeLists.txt
@@ -46,6 +46,8 @@ set(SOURCES
   hard_tanh_impl.hpp
   highway.hpp
   highway_impl.hpp
+  instance_norm.hpp
+  instance_norm_impl.hpp
   join.hpp
   join_impl.hpp
   layer.hpp

--- a/src/mlpack/methods/ann/layer/instance_norm.hpp
+++ b/src/mlpack/methods/ann/layer/instance_norm.hpp
@@ -1,0 +1,209 @@
+/**
+ * @file methods/ann/layer/instance_norm.hpp
+ * @author Anjishnu Mukherjee
+ *
+ * Definition of the Instance Normalization layer class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LAYER_INSTANCENORM_HPP
+#define MLPACK_METHODS_ANN_LAYER_INSTANCENORM_HPP
+
+#include <mlpack/prereqs.hpp>
+#include "layer_types.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * Declaration of the Instance Normalization layer class. The layer transforms
+ * the input data into zero mean and unit variance and then scales and shifts
+ * the data by parameters, gamma and beta respectively. These parameters are
+ * learnt by the network. The mean and standard-deviation are calculated
+ * per-dimension separately for each object in a mini-batch.
+ *
+ * If deterministic is false (training), the mean and variance are calculated
+ * and the data is normalized. If it is set to true (testing) then
+ * the mean and variance accrued over the training set is used.
+ *
+ * For more information, refer to the following paper,
+ *
+ * @code
+ * @article{Ulyanov17,
+ *   author    = {Dmitry Ulyanov, Andrea Vedaldi and
+ *                Victor Lempitsky},
+ *   title     = {Instance Normalization:
+ *                The Missing Ingredient for Fast Stylization},
+ *   year      = {2017},
+ *   url       = {https://arxiv.org/abs/1607.08022}
+ * }
+ * @endcode
+ *
+ * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template <
+  typename InputDataType = arma::mat,
+  typename OutputDataType = arma::mat
+>
+class InstanceNorm
+{
+ public:
+  //! Create the InstanceNorm object.
+  InstanceNorm();
+
+  /**
+   * Create the InstanceNorm layer object with the specified parameters.
+   *
+   * @param size The number of input units / channels.
+   * @param eps The epsilon added to variance to ensure numerical stability.
+   * @param average Boolean to determine whether cumulative average is used for
+   *                updating the parameters or momentum is used.
+   * @param momentum Parameter used to to update the running mean and variance.
+   */
+  InstanceNorm(const size_t size,
+              const double eps = 1e-5,
+              const bool average = true,
+              const double momentum = 0.1);
+
+  /**
+   * Forward pass of the Instance Normalization layer. Transforms the input data
+   * into zero mean and unit variance, scales the data by a factor gamma and
+   * shifts it by beta.
+   *
+   * @param input Input data for the layer
+   * @param output Resulting output activations.
+   */
+  template<typename eT>
+  void Forward(const arma::Mat<eT>& input, arma::Mat<eT>& output);
+
+  /**
+   * Backward pass through the layer.
+   *
+   * @param input The input activations
+   * @param gy The backpropagated error.
+   * @param g The calculated gradient.
+   */
+  template<typename eT>
+  void Backward(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& gy,
+                arma::Mat<eT>& g);
+
+  /**
+   * Calculate the gradient using the output delta and the input activations.
+   *
+   * @param input The input activations
+   * @param error The calculated error
+   * @param gradient The calculated gradient.
+   */
+  template<typename eT>
+  void Gradient(const arma::Mat<eT>& input,
+                const arma::Mat<eT>& error,
+                arma::Mat<eT>& gradient);
+
+  //! Get the parameters.
+  OutputDataType const& Parameters() const { return batchNorm.Parameters(); }
+  //! Modify the parameters.
+  OutputDataType& Parameters() { return batchNorm.Parameters(); }
+
+  //! Get the output parameter.
+  OutputDataType const& OutputParameter() const
+  { return batchNorm.OutputParameter(); }
+
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return batchNorm.OutputParameter(); }
+
+  //! Get the delta.
+  OutputDataType const& Delta() const { return batchNorm.Delta(); }
+  //! Modify the delta.
+  OutputDataType& Delta() { return batchNorm.Delta(); }
+
+  //! Get the gradient.
+  OutputDataType const& Gradient() const { return batchNorm.Gradient(); }
+  //! Modify the gradient.
+  OutputDataType& Gradient() { return batchNorm.Gradient(); }
+
+  //! Get the value of deterministic parameter.
+  bool Deterministic() const { return deterministic; }
+  //! Modify the value of deterministic parameter.
+  bool& Deterministic() { return deterministic; }
+
+  //! Get the mean over the training data.
+  OutputDataType const& TrainingMean() const { return runningMean; }
+  //! Modify the mean over the training data.
+  OutputDataType& TrainingMean() { return runningMean; }
+
+  //! Get the variance over the training data.
+  OutputDataType const& TrainingVariance() const { return runningVariance; }
+  //! Modify the variance over the training data.
+  OutputDataType& TrainingVariance() { return runningVariance; }
+
+  //! Get the number of input units / channels.
+  size_t InputSize() const { return size; }
+
+  //! Get the epsilon value.
+  double Epsilon() const { return eps; }
+
+  //! Get the momentum value.
+  double Momentum() const { return momentum; }
+
+  //! Get the average parameter.
+  bool Average() const { return average; }
+
+  /**
+   * Serialize the layer
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int version);
+
+ private:
+   //! Locally stored BatchNorm Object.
+  BatchNorm<InputDataType, OutputDataType> batchNorm;
+
+  //! Locally-stored reset parameter used to initialize the layer once.
+  bool reset;
+
+  //! Number of input rows.
+  size_t shapeA;
+
+  //! Number of input columns.
+  size_t shapeB;
+
+  //! Locally-stored number of input units.
+  size_t size;
+
+  //! Locally-stored epsilon value.
+  double eps;
+
+  //! If true use average else use momentum for computing running mean
+  //! and variance
+  bool average;
+
+  //! Locally-stored value for momentum.
+  double momentum;
+
+  /**
+   * If true then mean and variance over the training set will be considered
+   * instead of being calculated over the batch.
+   */
+  bool deterministic;
+
+  //! Locally-stored mean object.
+  OutputDataType runningMean;
+
+  //! Locally-stored variance object.
+  OutputDataType runningVariance;
+}; // class InstanceNorm
+
+} // namespace ann
+} // namespace mlpack
+
+// Include the implementation.
+#include "instance_norm_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/layer/instance_norm.hpp
+++ b/src/mlpack/methods/ann/layer/instance_norm.hpp
@@ -67,9 +67,9 @@ class InstanceNorm
    * @param momentum Parameter used to to update the running mean and variance.
    */
   InstanceNorm(const size_t size,
-              const double eps = 1e-5,
-              const bool average = true,
-              const double momentum = 0.1);
+               const double eps = 1e-5,
+               const bool average = true,
+               const double momentum = 0.1);
 
   /**
    * Forward pass of the Instance Normalization layer. Transforms the input data

--- a/src/mlpack/methods/ann/layer/instance_norm.hpp
+++ b/src/mlpack/methods/ann/layer/instance_norm.hpp
@@ -162,7 +162,7 @@ class InstanceNorm
   void serialize(Archive& ar, const unsigned int version);
 
  private:
-   //! Locally stored BatchNorm Object.
+  //! Locally stored BatchNorm Object.
   BatchNorm<InputDataType, OutputDataType> batchNorm;
 
   //! Locally-stored reset parameter used to initialize the layer once.

--- a/src/mlpack/methods/ann/layer/instance_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/instance_norm_impl.hpp
@@ -56,7 +56,7 @@ void InstanceNorm<InputDataType, OutputDataType>::Forward(
   // Instance Norm with (N, C, H, W) is same as Batch Norm with (1, N*C, H, W),
   // where N is the batchSize, C is the number of channels, H and W are the
   // height and width of each image respectively.
-  if(!reset)
+  if (!reset)
   {
     shapeA = input.n_rows;
     shapeB = input.n_cols;

--- a/src/mlpack/methods/ann/layer/instance_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/instance_norm_impl.hpp
@@ -1,0 +1,141 @@
+/**
+ * @file methods/ann/layer/instance_norm_impl.hpp
+ * @author Anjishnu Mukherjee
+ *
+ * Implementation of the Instance Normalization Layer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_LAYER_INSTANCENORM_IMPL_HPP
+#define MLPACK_METHODS_ANN_LAYER_INSTANCENORM_IMPL_HPP
+
+// In case it is not included.
+#include "instance_norm.hpp"
+
+namespace mlpack {
+namespace ann { /** Artificial Neural Network. */
+
+template<typename InputDataType, typename OutputDataType>
+InstanceNorm<InputDataType, OutputDataType>::InstanceNorm() :
+    size(0),
+    eps(1e-8),
+    average(true),
+    momentum(0.0),
+    deterministic(false),
+    reset(false)
+{
+  // Nothing to do here.
+}
+
+template <typename InputDataType, typename OutputDataType>
+InstanceNorm<InputDataType, OutputDataType>::InstanceNorm(
+    const size_t size,
+    const double eps,
+    const bool average,
+    const double momentum) :
+    size(size),
+    eps(eps),
+    average(average),
+    momentum(momentum),
+    deterministic(false),
+    reset(false)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void InstanceNorm<InputDataType, OutputDataType>::Forward(
+    const arma::Mat<eT>& input,
+    arma::Mat<eT>& output)
+{
+  // Instance Norm with (N, C, H, W) is same as Batch Norm with (1, N*C, H, W),
+  // where N is the batchSize, C is the number of channels, H and W are the
+  // height and width of each image respectively.
+  if(!reset)
+  {
+    shapeA = input.n_rows;
+    shapeB = input.n_cols;
+    batchNorm = ann::BatchNorm<> (size*input.n_cols, eps, average, momentum);
+    batchNorm.Reset();
+    runningMean.zeros(size, 1);
+    runningVariance.ones(size, 1);
+    runningVariance = batchNorm.TrainingVariance();
+    reset = true;
+  }
+
+  if(deterministic)
+    batchNorm.Deterministic() = true;
+
+  arma::mat inputCopy(const_cast<arma::Mat<eT>&>(input).memptr(), shapeA*shapeB,
+        1, false, false);
+  batchNorm.Forward(inputCopy, output);
+  output.reshape(shapeA, shapeB);
+  arma::mat runningTemp = arma::zeros(size, 1);
+  runningMean = batchNorm.TrainingMean();
+  runningMean.reshape(size, shapeB);
+  runningTemp = arma::mean(runningMean, 1);
+  runningMean.set_size(size, 1);
+  runningMean = runningTemp;
+  runningVariance = batchNorm.TrainingVariance();
+  runningVariance.reshape(size, shapeB);
+  runningTemp = arma::mean(runningVariance, 1);
+  runningVariance.set_size(size, 1);
+  runningVariance = runningTemp;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void InstanceNorm<InputDataType, OutputDataType>::Backward(
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& gy,
+    arma::Mat<eT>& g)
+{
+  arma::mat inputCopy(const_cast<arma::Mat<eT>&>(input).memptr(), shapeA*shapeB,
+      1, false, false);
+  arma::mat gyCopy(const_cast<arma::Mat<eT>&>(gy).memptr(), shapeA*shapeB,
+      1, false, false);
+  batchNorm.Backward(inputCopy, gyCopy, g);
+  g.reshape(shapeA, shapeB);
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename eT>
+void InstanceNorm<InputDataType, OutputDataType>::Gradient(
+    const arma::Mat<eT>& input,
+    const arma::Mat<eT>& error,
+    arma::Mat<eT>& gradient)
+{
+  arma::mat errorCopy(const_cast<arma::Mat<eT>&>(error).memptr(), shapeA*shapeB,
+      1, false, false);
+  batchNorm.Gradient(input, errorCopy, gradient);
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void InstanceNorm<InputDataType, OutputDataType>::serialize(
+    Archive& ar, const unsigned int version)
+{
+  ar & BOOST_SERIALIZATION_NVP(size);
+  ar & BOOST_SERIALIZATION_NVP(eps);
+  ar & BOOST_SERIALIZATION_NVP(average);
+  ar & BOOST_SERIALIZATION_NVP(momentum);
+  ar & BOOST_SERIALIZATION_NVP(deterministic);
+  ar & BOOST_SERIALIZATION_NVP(runningMean);
+  ar & BOOST_SERIALIZATION_NVP(runningVariance);
+  ar & BOOST_SERIALIZATION_NVP(reset);
+  ar & BOOST_SERIALIZATION_NVP(shapeA);
+  ar & BOOST_SERIALIZATION_NVP(shapeB);
+
+  if (version > 0)
+    ar & BOOST_SERIALIZATION_NVP(batchNorm);
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/layer/instance_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/instance_norm_impl.hpp
@@ -68,7 +68,7 @@ void InstanceNorm<InputDataType, OutputDataType>::Forward(
     reset = true;
   }
 
-  if(deterministic)
+  if (deterministic)
     batchNorm.Deterministic() = true;
 
   arma::mat inputCopy(const_cast<arma::Mat<eT>&>(input).memptr(), shapeA*shapeB,

--- a/src/mlpack/methods/ann/layer/layer.hpp
+++ b/src/mlpack/methods/ann/layer/layer.hpp
@@ -38,6 +38,7 @@
 #include "hard_tanh.hpp"
 #include "hardshrink.hpp"
 #include "highway.hpp"
+#include "instance_norm.hpp"
 #include "join.hpp"
 #include "layer_norm.hpp"
 #include "layer_types.hpp"

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -19,6 +19,7 @@
 #include <mlpack/methods/ann/layer/alpha_dropout.hpp>
 #include <mlpack/methods/ann/layer/base_layer.hpp>
 #include <mlpack/methods/ann/layer/batch_norm.hpp>
+#include <mlpack/methods/ann/layer/instance_norm.hpp>
 #include <mlpack/methods/ann/layer/bilinear_interpolation.hpp>
 #include <mlpack/methods/ann/layer/constant.hpp>
 #include <mlpack/methods/ann/layer/concatenate.hpp>
@@ -65,6 +66,7 @@
 namespace mlpack {
 namespace ann {
 
+template<typename InputDataType, typename OutputDataType> class InstanceNorm;
 template<typename InputDataType, typename OutputDataType> class BatchNorm;
 template<typename InputDataType, typename OutputDataType> class DropConnect;
 template<typename InputDataType, typename OutputDataType> class Glimpse;
@@ -237,6 +239,7 @@ using LayerTypes = boost::variant<
     BaseLayer<SoftplusFunction, arma::mat, arma::mat>*,
     BaseLayer<RectifierFunction, arma::mat, arma::mat>*,
     BatchNorm<arma::mat, arma::mat>*,
+    InstanceNorm<arma::mat, arma::mat>*,
     BilinearInterpolation<arma::mat, arma::mat>*,
     CELU<arma::mat, arma::mat>*,
     Concat<arma::mat, arma::mat>*,


### PR DESCRIPTION
Instance Norm Layer.

***Note :*** Currently "InstanceNormLayerTest" and "InstanceNormLayerParametersTest" pass. "GradientInstanceNormLayerTest" crashes and gives weird memory errors for reasons unknown to me as of yet (I need some help debugging this, please.) I am probably missing something minor with the Gradient test calculations.

To compare armadillo functionality implementation with PyTorch implementations, take a look at this [Google Colab notebook](https://colab.research.google.com/drive/18E8a-LTHFOpqa6w53vOsjRz7nbRHLvaf?usp=sharing).

The basic idea followed for this implementation is that, Instance Norm applied on a (N,C,H,W) input is equivalent to Batch Norm applied on a (1,N*C,H,W) input. So, this layer is implemented as a BatchNorm wrapper layer.
This idea is same as the one followed by the original author of the paper [here](https://github.com/DmitryUlyanov/texture_nets/blob/master/InstanceNormalization.lua) and also the same as the PyTorch implementation [here](https://github.com/pytorch/pytorch/pull/1283).