### PR TITLE
Adding Coefficient of Determination (R-squared and Adjusted R-squared) statistic to Linear Regression method

### DIFF
--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -154,9 +154,9 @@ double LinearRegression::Coef_Det(const arma::mat& predictors,
 {
   // Getting the number of observations and independent variables
   double n = predictors.n_cols; // number of observations
-  double k = predictors.n_rows;// number of independent variables
-  arma::rowvec predictions;// creating a vector to store y_hat values
-  Predict(predictors, predictions);// predicting y values == y_hat
+  double k = predictors.n_rows; // number of independent variables
+  arma::rowvec predictions; // creating a vector to store y_hat values
+  Predict(predictors, predictions); // predicting y values == y_hat
   // calculating the mean of actual y values
   double responses_mean = arma::mean(responses);
   // Calculating Sum of squared residuals  - sum((y_hat - y_mean)^2)

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -148,7 +148,7 @@ double LinearRegression::ComputeError(const arma::mat& predictors,
   return cost;
 }
 
-double LinearRegression::Coef_Det(const arma::mat& predictors,
+double LinearRegression::CoefDet(const arma::mat& predictors,
                                   const arma::rowvec& responses,
                                   const bool adj_r2) const
 {

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -149,23 +149,26 @@ double LinearRegression::ComputeError(const arma::mat& predictors,
 }
 
 double LinearRegression::coef_det(const arma::mat& predictors,
-                const arma::rowvec& responses,
-                const bool adj_r2) const
+                                  const arma::rowvec& responses,
+                                  const bool adj_r2) const
 {
-  // Get the number of columns and rows of the dataset, useful for calculating Adjusted R^2
-  int n = predictors.n_cols;
-  int k = predictors.n_rows;
-  arma::rowvec predictions;
-  Predict(predictors, predictions);
-  double responses_mean = arma::mean(responses);
-  
-  // Calculate sum of squared residuals
+  // Getting the number of observations and independent variables
+  double n = predictors.n_cols; // number of observations
+  double k = predictors.n_rows;// number of independent variables
+  arma::rowvec predictions;// creating a vector to store y_hat values
+  Predict(predictors, predictions);// predicting y values == y_hat
+  double responses_mean = arma::mean(responses);// calculating the mean of actual y values
+  // Calculating Sum of squared residuals  - sum((y_hat - y_mean)^2)
   double ssr = arma::accu(arma::square(predictions - responses_mean));
-  //Calculate total sum of squares
+  // Calculating Total sum of squares - sum((y_actual - y_mean)^2)
   double ssto = arma::accu(arma::square(responses - responses_mean));
-  if(adj_r2)
-  {
-    return (1 - (1-(ssr/ssto)))*(n-1)/(n-k-1);
+  // Calculating R-squared
+  double rsq = ssr/ssto;
+  if(adj_r2){
+    // Returning Adjusted R-squared
+    return (1-((1 - rsq)*((n-1)/(n-k-1))));
+  } else {
+    // Returning R-squared
+    return rsq;
   }
-  return ssr/ssto;
 }

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -147,3 +147,21 @@ double LinearRegression::ComputeError(const arma::mat& predictors,
 
   return cost;
 }
+
+double LinearRegression::coef_det(const arma::mat& predictors,
+                const arma::rowvec& responses,
+                const bool adj_r2) const
+{
+  int n = predictors.n_cols;
+  int k = predictors.n_rows;
+  arma::rowvec predictions;
+  Predict(predictors, predictions);
+  double responses_mean = arma::mean(responses);
+  double ssr = arma::accu(arma::square(predictions - responses_mean));
+  double ssto = arma::accu(arma::square(responses - responses_mean));
+  if(adj_r2)
+  {
+    return (1 - (1-(ssr/ssto)))*(n-1)/(n-k-1);
+  }
+  return ssr/ssto;
+}

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -148,7 +148,7 @@ double LinearRegression::ComputeError(const arma::mat& predictors,
   return cost;
 }
 
-double LinearRegression::coef_det(const arma::mat& predictors,
+double LinearRegression::Coef_Det(const arma::mat& predictors,
                                   const arma::rowvec& responses,
                                   const bool adj_r2) const
 {
@@ -157,16 +157,17 @@ double LinearRegression::coef_det(const arma::mat& predictors,
   double k = predictors.n_rows;// number of independent variables
   arma::rowvec predictions;// creating a vector to store y_hat values
   Predict(predictors, predictions);// predicting y values == y_hat
-  double responses_mean = arma::mean(responses);// calculating the mean of actual y values
+  // calculating the mean of actual y values
+  double responses_mean = arma::mean(responses);
   // Calculating Sum of squared residuals  - sum((y_hat - y_mean)^2)
   double ssr = arma::accu(arma::square(predictions - responses_mean));
   // Calculating Total sum of squares - sum((y_actual - y_mean)^2)
   double ssto = arma::accu(arma::square(responses - responses_mean));
   // Calculating R-squared
   double rsq = ssr/ssto;
-  if(adj_r2){
+  if (adj_r2){
     // Returning Adjusted R-squared
-    return (1-((1 - rsq)*((n-1)/(n-k-1))));
+    return (1 - ((1 - rsq) * ((n - 1) / (n - k - 1))));
   } else {
     // Returning R-squared
     return rsq;

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -152,12 +152,16 @@ double LinearRegression::coef_det(const arma::mat& predictors,
                 const arma::rowvec& responses,
                 const bool adj_r2) const
 {
+  // Get the number of columns and rows of the dataset, useful for calculating Adjusted R^2
   int n = predictors.n_cols;
   int k = predictors.n_rows;
   arma::rowvec predictions;
   Predict(predictors, predictions);
   double responses_mean = arma::mean(responses);
+  
+  // Calculate sum of squared residuals
   double ssr = arma::accu(arma::square(predictions - responses_mean));
+  //Calculate total sum of squares
   double ssto = arma::accu(arma::square(responses - responses_mean));
   if(adj_r2)
   {

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -140,9 +140,9 @@ class LinearRegression
    * @param adj_r2 if true the function will return the Adjusted \f$R^2\f$,
    * otherwise, it will return \f$R^2\f$.
    */
-  double Coef_Det(const arma::mat& predictors,
-                  const arma::rowvec& responses,
-                  const bool adj_r2 = false) const;
+  double CoefDet(const arma::mat& predictors,
+                 const arma::rowvec& responses,
+                 const bool adj_r2 = false) const;
 
   //! Return the parameters (the b vector).
   const arma::vec& Parameters() const { return parameters; }

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -140,7 +140,7 @@ class LinearRegression
    */
   double coef_det(const arma::mat& predictors,
                   const arma::rowvec& responses,
-                  bool adj_r2 = false) const;
+                  const bool adj_r2 = false) const;
 
  
   //! Return the parameters (the b vector).

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -122,7 +122,7 @@ class LinearRegression
    */
   double ComputeError(const arma::mat& points,
                       const arma::rowvec& responses) const;
- 
+
   /**
    * Calculate the Coefficient of determination - \f$R^2\f$ or
    * Adjusted \f$R^2\f$
@@ -143,7 +143,7 @@ class LinearRegression
   double Coef_Det(const arma::mat& predictors,
                   const arma::rowvec& responses,
                   const bool adj_r2 = false) const;
- 
+
   //! Return the parameters (the b vector).
   const arma::vec& Parameters() const { return parameters; }
   //! Modify the parameters (the b vector).

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -124,7 +124,8 @@ class LinearRegression
                       const arma::rowvec& responses) const;
  
   /**
-   * Calculate the Coefficient of determination - \f$R^2\f$ or Adjusted \f$R^2\f$
+   * Calculate the Coefficient of determination - \f$R^2\f$ or
+   * Adjusted \f$R^2\f$
    *
    * \f[
    * R^2 = \dfrac{\sum(\hat{y} - \bar{y})^2}{\sum(y - \bar{y})^2}
@@ -136,12 +137,12 @@ class LinearRegression
    *
    * @param predictors X, the matrix on which the model was trained.
    * @param responses y, the reponses to the data points.
-   * @param adj_r2 if true the function will return the Adjusted \f$R^2\f$, otherwise, it will return \f$R^2\f$.
+   * @param adj_r2 if true the function will return the Adjusted \f$R^2\f$,
+   * otherwise, it will return \f$R^2\f$.
    */
-  double coef_det(const arma::mat& predictors,
+  double Coef_Det(const arma::mat& predictors,
                   const arma::rowvec& responses,
                   const bool adj_r2 = false) const;
-
  
   //! Return the parameters (the b vector).
   const arma::vec& Parameters() const { return parameters; }

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -140,7 +140,8 @@ class LinearRegression
    */
   double coef_det(const arma::mat& predictors,
                   const arma::rowvec& responses,
-                  const bool adj_r2 = false) const;
+                  bool adj_r2 = false) const;
+
  
   //! Return the parameters (the b vector).
   const arma::vec& Parameters() const { return parameters; }

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -122,7 +122,26 @@ class LinearRegression
    */
   double ComputeError(const arma::mat& points,
                       const arma::rowvec& responses) const;
-
+ 
+  /**
+   * Calculate the Coefficient of determination - \f$R^2\f$ or Adjusted \f$R^2\f$
+   *
+   * \f[
+   * R^2 = \dfrac{\sum(\hat{y} - \bar{y})^2}{\sum(y - \bar{y})^2}
+   * \f]
+   *
+   * \f[
+   * Adj R^2 = (1 - (1 - R^2))*\dfrac{n - 1}{n - k - 1}
+   * \f]
+   *
+   * @param predictors X, the matrix on which the model was trained.
+   * @param responses y, the reponses to the data points.
+   * @param adj_r2 if true the function will return the Adjusted \f$R^2\f$, otherwise, it will return \f$R^2\f$.
+   */
+  double coef_det(const arma::mat& predictors,
+                  const arma::rowvec& responses,
+                  const bool adj_r2 = false) const;
+ 
   //! Return the parameters (the b vector).
   const arma::vec& Parameters() const { return parameters; }
   //! Modify the parameters (the b vector).

--- a/src/mlpack/tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/linear_regression_test.cpp
@@ -285,7 +285,7 @@ TEST_CASE("LinearRegressionCoefDetCorr", "[LinearRegressionTest]")
   LinearRegression lr;
   lr.Train(predictors, responses);
   double act_rsq = 1.0;
-  double calc_rsq = lr.Coef_Det(predictors, responses);
+  double calc_rsq = lr.CoefDet(predictors, responses);
   double err = std::abs(act_rsq - calc_rsq);
   REQUIRE(err <= 1e-8);
 }

--- a/src/mlpack/tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/linear_regression_test.cpp
@@ -266,3 +266,26 @@ TEST_CASE("LinearRegressionTrainReturnObjective", "[LinearRegressionTest]")
 
   REQUIRE(std::isfinite(error) == true);
 }
+
+/**
+ * Test whether Coefficient of Determination gives correct answers
+ */
+TEST_CASE("LinearRegressionCoefDetCorr", "[LinearRegressionTest]")
+{
+  // Make a matrix
+  arma::mat predictors;
+  predictors << 1 << 2 << 3 << 4 << 5 << 6 << 7 << 8 << arma::endr // a
+             << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << arma::endr; // b
+  arma::rowvec responses;
+  responses << 3 << 5 << 7 << 9 << 11  << 13 << 15 << 17; // y
+  // Theoretically, the above matrices will for the following linear regression
+  // equation (1*a) + (1*b) = y, with no errors
+  // since there is not stochastic or noise term.
+  // Hence theoretically, R-squared should be equal to 1.0
+  LinearRegression lr;
+  lr.Train(predictors, responses);
+  double act_rsq = 1.0;
+  double calc_rsq = lr.Coef_Det(predictors, responses);
+  double err = std::abs(act_rsq - calc_rsq);
+  REQUIRE(err <= 1e-8);
+}


### PR DESCRIPTION
Coefficient of Determination (R-squared) is a measure which represents the proportion of variance of dependent variable explained by the variation in the independent variable/variables. For ex - `R^2` of 0.5 means that 50% of variation in the dependent variable is explained by the dependent variable/variables.
Adjusted R-squared "is an attempt to account for the phenomenon of the R2 automatically and spuriously increasing when extra explanatory variables are added to the model" ([Wikipedia](https://en.wikipedia.org/wiki/Coefficient_of_determination#Adjusted_R2)). 

It is pretty common for people to perform analysis using Linear Regression to judge the goodness of fit of their model by using Coefficient of Determination. But the present library on the master branch did not have this. Hence, I added a `LinearRegression` class member function called `coef_det`. It takes three inputs:-
1) predictors - which is basically your X dataset.
2) responses - which is your actual Y dataset and not the predicted Y.
3) adj_r2 - a boolean argument which is by default set to `false`. If it is set to `true` it calculates the adjusted R-squared, otherwise, by default it calculated R-squared.

I have only added C++ functionality.