### PR TITLE
migrate kernel_* related test from boost to catch2

### DIFF
--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -27,9 +27,6 @@ add_executable(mlpack_test
   hyperplane_test.cpp
   init_rules_test.cpp
   kde_test.cpp
-  kernel_pca_test.cpp
-  kernel_test.cpp
-  kernel_traits_test.cpp
   kmeans_test.cpp
   krann_search_test.cpp
   ksinit_test.cpp
@@ -106,7 +103,6 @@ add_executable(mlpack_test
   main_tests/hmm_viterbi_test.cpp
   main_tests/hoeffding_tree_test.cpp
   main_tests/kde_test.cpp
-  main_tests/kernel_pca_test.cpp
   main_tests/kmeans_test.cpp
   main_tests/krann_test.cpp
   main_tests/linear_svm_test.cpp
@@ -147,6 +143,9 @@ add_executable(mlpack_catch_test
   decision_tree_test.cpp
   image_load_test.cpp
   imputation_test.cpp
+  kernel_pca_test.cpp
+  kernel_test.cpp
+  kernel_traits_test.cpp
   kfn_test.cpp
   knn_test.cpp
   linear_regression_test.cpp
@@ -169,6 +168,7 @@ add_executable(mlpack_catch_test
   main_tests/decision_stump_test.cpp
   main_tests/decision_tree_test.cpp
   main_tests/image_converter_test.cpp
+  main_tests/kernel_pca_test.cpp
   main_tests/kfn_test.cpp
   main_tests/knn_test.cpp
   main_tests/linear_regression_test.cpp

--- a/src/mlpack/tests/kernel_pca_test.cpp
+++ b/src/mlpack/tests/kernel_pca_test.cpp
@@ -14,10 +14,8 @@
 #include <mlpack/methods/kernel_pca/kernel_rules/nystroem_method.hpp>
 #include <mlpack/methods/kernel_pca/kernel_pca.hpp>
 
-#include <boost/test/unit_test.hpp>
-#include "test_tools.hpp"
-
-BOOST_AUTO_TEST_SUITE(KernelPCATest);
+#include "catch.hpp"
+#include "test_catch_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::math;
@@ -30,7 +28,7 @@ using namespace arma;
  * If KernelPCA is working right, then it should turn a circle dataset into a
  * linearly separable dataset in one dimension (which is easy to check).
  */
-BOOST_AUTO_TEST_CASE(CircleTransformationTestNaive)
+TEST_CASE("CircleTransformationTestNaive", "[KernelPCATest]")
 {
   // The dataset, which will have three concentric rings in three dimensions.
   arma::mat dataset;
@@ -83,16 +81,16 @@ BOOST_AUTO_TEST_CASE(CircleTransformationTestNaive)
 
   // None of these ranges should overlap -- the classes should be linearly
   // separable.
-  BOOST_REQUIRE_EQUAL(ranges[0].Contains(ranges[1]), false);
-  BOOST_REQUIRE_EQUAL(ranges[0].Contains(ranges[2]), false);
-  BOOST_REQUIRE_EQUAL(ranges[1].Contains(ranges[2]), false);
+  REQUIRE(ranges[0].Contains(ranges[1]) == false);
+  REQUIRE(ranges[0].Contains(ranges[2]) == false);
+  REQUIRE(ranges[1].Contains(ranges[2]) == false);
 }
 
 /**
  * If KernelPCA is working right, then it should turn a circle dataset into a
  * linearly separable dataset in one dimension (which is easy to check).
  */
-BOOST_AUTO_TEST_CASE(CircleTransformationTestNystroem)
+TEST_CASE("CircleTransformationTestNystroem", "[KernelPCATest]")
 {
   // The dataset, which will have three concentric rings in three dimensions.
   arma::mat dataset;
@@ -145,9 +143,7 @@ BOOST_AUTO_TEST_CASE(CircleTransformationTestNystroem)
 
   // None of these ranges should overlap -- the classes should be linearly
   // separable.
-  BOOST_REQUIRE_EQUAL(ranges[0].Contains(ranges[1]), false);
-  BOOST_REQUIRE_EQUAL(ranges[0].Contains(ranges[2]), false);
-  BOOST_REQUIRE_EQUAL(ranges[1].Contains(ranges[2]), false);
+  REQUIRE(ranges[0].Contains(ranges[1]) == false);
+  REQUIRE(ranges[0].Contains(ranges[2]) == false);
+  REQUIRE(ranges[1].Contains(ranges[2]) == false);
 }
-
-BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/kernel_test.cpp
+++ b/src/mlpack/tests/kernel_test.cpp
@@ -57,8 +57,10 @@ TEST_CASE("SquaredEuclideanDistanceTest", "[KernelTest]")
   arma::vec a = "1.0  2.0";
   arma::vec b = "0.0 -2.0";
 
-  REQUIRE(SquaredEuclideanDistance::Evaluate(a, b) == Approx(17.0).epsilon(1e-7));
-  REQUIRE(SquaredEuclideanDistance::Evaluate(b, a) == Approx(17.0).epsilon(1e-7));
+  REQUIRE(SquaredEuclideanDistance::Evaluate(a, b) ==
+      Approx(17.0).epsilon(1e-7));
+  REQUIRE(SquaredEuclideanDistance::Evaluate(b, a) ==
+      Approx(17.0).epsilon(1e-7));
 }
 
 /**
@@ -69,8 +71,10 @@ TEST_CASE("EuclideanDistanceTest", "[KernelTest]")
   arma::vec a = "1.0 3.0 5.0 7.0";
   arma::vec b = "4.0 0.0 2.0 0.0";
 
-  REQUIRE(EuclideanDistance::Evaluate(a, b) == Approx(sqrt(76.0)).epsilon(1e-7));
-  REQUIRE(EuclideanDistance::Evaluate(b, a) == Approx(sqrt(76.0)).epsilon(1e-7));
+  REQUIRE(EuclideanDistance::Evaluate(a, b) ==
+      Approx(sqrt(76.0)).epsilon(1e-7));
+  REQUIRE(EuclideanDistance::Evaluate(b, a) ==
+      Approx(sqrt(76.0)).epsilon(1e-7));
 }
 
 /**
@@ -84,8 +88,10 @@ TEST_CASE("ArbitraryCaseTest", "[KernelTest]")
   REQUIRE((LMetric<3, false>::Evaluate(a, b)) == Approx(503.0).epsilon(1e-7));
   REQUIRE((LMetric<3, false>::Evaluate(b, a)) == Approx(503.0).epsilon(1e-7));
 
-  REQUIRE((LMetric<3, true>::Evaluate(a, b)) == Approx(7.95284762).epsilon(1e-7));
-  REQUIRE((LMetric<3, true>::Evaluate(b, a)) == Approx(7.95284762).epsilon(1e-7));
+  REQUIRE((LMetric<3, true>::Evaluate(a, b)) ==
+      Approx(7.95284762).epsilon(1e-7));
+  REQUIRE((LMetric<3, true>::Evaluate(b, a)) ==
+      Approx(7.95284762).epsilon(1e-7));
 }
 
 /**
@@ -239,8 +245,10 @@ TEST_CASE("CosineDistanceRandomTest", "[KernelTest]")
   arma::vec a = "0.1 0.2 0.3 0.4 0.5";
   arma::vec b = "1.2 1.0 0.8 -0.3 -0.5";
 
-  REQUIRE(CosineDistance::Evaluate(a, b) == Approx(0.1385349024).epsilon(1e-7));
-  REQUIRE(CosineDistance::Evaluate(b, a) == Approx(0.1385349024).epsilon(1e-7));
+  REQUIRE(CosineDistance::Evaluate(a, b) ==
+      Approx(0.1385349024).epsilon(1e-7));
+  REQUIRE(CosineDistance::Evaluate(b, a) ==
+      Approx(0.1385349024).epsilon(1e-7));
 }
 
 /**
@@ -292,9 +300,12 @@ TEST_CASE("GaussianKernelTest", "[KernelTest]")
   REQUIRE(gk.Normalizer(3) == Approx(1.9687012432153019).epsilon(1e-7));
   REQUIRE(gk.Normalizer(4) == Approx(2.4674011002723386).epsilon(1e-7));
   /* check the convolution integral */
-  REQUIRE(gk.ConvolutionIntegral(a, b) == Approx(0.024304474038457577).epsilon(1e-7));
-  REQUIRE(gk.ConvolutionIntegral(a, c) == Approx(0.024304474038457577).epsilon(1e-7));
-  REQUIRE(gk.ConvolutionIntegral(b, c) == Approx(0.024304474038457577).epsilon(1e-7));
+  REQUIRE(gk.ConvolutionIntegral(a, b) ==
+      Approx(0.024304474038457577).epsilon(1e-7));
+  REQUIRE(gk.ConvolutionIntegral(a, c) ==
+      Approx(0.024304474038457577).epsilon(1e-7));
+  REQUIRE(gk.ConvolutionIntegral(b, c) ==
+      Approx(0.024304474038457577).epsilon(1e-7));
 }
 
 TEST_CASE("GaussianKernelSerializationTest", "[KernelTest]")
@@ -334,7 +345,8 @@ TEST_CASE("SphericalKernelTest", "[KernelTest]")
   /* check the convolution integral */
   REQUIRE(sk.ConvolutionIntegral(a, b) == Approx(0.0).epsilon(1e-7));
   REQUIRE(sk.ConvolutionIntegral(a, c) == Approx(0.0).epsilon(1e-7));
-  REQUIRE(sk.ConvolutionIntegral(b, c) == Approx(1.0021155029652784).epsilon(1e-7));
+  REQUIRE(sk.ConvolutionIntegral(b, c) ==
+      Approx(1.0021155029652784).epsilon(1e-7));
 }
 
 TEST_CASE("EpanechnikovKernelTest", "[KernelTest]")
@@ -360,7 +372,8 @@ TEST_CASE("EpanechnikovKernelTest", "[KernelTest]")
   /* check the convolution integral */
   REQUIRE(ek.ConvolutionIntegral(a, b) == Approx(0.0).epsilon(1e-7));
   REQUIRE(ek.ConvolutionIntegral(a, c) == Approx(0.0).epsilon(1e-7));
-  REQUIRE(ek.ConvolutionIntegral(b, c) == Approx(1.5263455690698258).epsilon(1e-7));
+  REQUIRE(ek.ConvolutionIntegral(b, c) ==
+      Approx(1.5263455690698258).epsilon(1e-7));
 }
 
 TEST_CASE("PolynomialKernelTest", "[KernelTest]")

--- a/src/mlpack/tests/kernel_test.cpp
+++ b/src/mlpack/tests/kernel_test.cpp
@@ -23,158 +23,156 @@
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/metrics/mahalanobis_distance.hpp>
 
-#include <boost/test/unit_test.hpp>
-#include "test_tools.hpp"
-#include "serialization.hpp"
+#include "catch.hpp"
+#include "test_catch_tools.hpp"
+#include "serialization_catch.hpp"
 
 using namespace mlpack;
 using namespace mlpack::kernel;
 using namespace mlpack::metric;
 
-BOOST_AUTO_TEST_SUITE(KernelTest);
-
 /**
  * Basic test of the Manhattan distance.
  */
-BOOST_AUTO_TEST_CASE(ManhattanDistanceTest)
+TEST_CASE("ManhattanDistanceTest", "[KernelTest]")
 {
   // A couple quick tests.
   arma::vec a = "1.0 3.0 4.0";
   arma::vec b = "3.0 3.0 5.0";
 
-  BOOST_REQUIRE_CLOSE(ManhattanDistance::Evaluate(a, b), 3.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(ManhattanDistance::Evaluate(b, a), 3.0, 1e-5);
+  REQUIRE(ManhattanDistance::Evaluate(a, b) == Approx(3.0).epsilon(1e-7));
+  REQUIRE(ManhattanDistance::Evaluate(b, a) == Approx(3.0).epsilon(1e-7));
 
   // Check also for when the root is taken (should be the same).
-  BOOST_REQUIRE_CLOSE((LMetric<1, true>::Evaluate(a, b)), 3.0, 1e-5);
-  BOOST_REQUIRE_CLOSE((LMetric<1, true>::Evaluate(b, a)), 3.0, 1e-5);
+  REQUIRE((LMetric<1, true>::Evaluate(a, b)) == Approx(3.0).epsilon(1e-7));
+  REQUIRE((LMetric<1, true>::Evaluate(b, a)) == Approx(3.0).epsilon(1e-7));
 }
 
 /**
  * Basic test of squared Euclidean distance.
  */
-BOOST_AUTO_TEST_CASE(SquaredEuclideanDistanceTest)
+TEST_CASE("SquaredEuclideanDistanceTest", "[KernelTest]")
 {
   // Sample 2-dimensional vectors.
   arma::vec a = "1.0  2.0";
   arma::vec b = "0.0 -2.0";
 
-  BOOST_REQUIRE_CLOSE(SquaredEuclideanDistance::Evaluate(a, b), 17.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(SquaredEuclideanDistance::Evaluate(b, a), 17.0, 1e-5);
+  REQUIRE(SquaredEuclideanDistance::Evaluate(a, b) == Approx(17.0).epsilon(1e-7));
+  REQUIRE(SquaredEuclideanDistance::Evaluate(b, a) == Approx(17.0).epsilon(1e-7));
 }
 
 /**
  * Basic test of Euclidean distance.
  */
-BOOST_AUTO_TEST_CASE(EuclideanDistanceTest)
+TEST_CASE("EuclideanDistanceTest", "[KernelTest]")
 {
   arma::vec a = "1.0 3.0 5.0 7.0";
   arma::vec b = "4.0 0.0 2.0 0.0";
 
-  BOOST_REQUIRE_CLOSE(EuclideanDistance::Evaluate(a, b), sqrt(76.0), 1e-5);
-  BOOST_REQUIRE_CLOSE(EuclideanDistance::Evaluate(b, a), sqrt(76.0), 1e-5);
+  REQUIRE(EuclideanDistance::Evaluate(a, b) == Approx(sqrt(76.0)).epsilon(1e-7));
+  REQUIRE(EuclideanDistance::Evaluate(b, a) == Approx(sqrt(76.0)).epsilon(1e-7));
 }
 
 /**
  * Arbitrary test case for coverage.
  */
-BOOST_AUTO_TEST_CASE(ArbitraryCaseTest)
+TEST_CASE("ArbitraryCaseTest", "[KernelTest]")
 {
   arma::vec a = "3.0 5.0 6.0 7.0";
   arma::vec b = "1.0 2.0 1.0 0.0";
 
-  BOOST_REQUIRE_CLOSE((LMetric<3, false>::Evaluate(a, b)), 503.0, 1e-5);
-  BOOST_REQUIRE_CLOSE((LMetric<3, false>::Evaluate(b, a)), 503.0, 1e-5);
+  REQUIRE((LMetric<3, false>::Evaluate(a, b)) == Approx(503.0).epsilon(1e-7));
+  REQUIRE((LMetric<3, false>::Evaluate(b, a)) == Approx(503.0).epsilon(1e-7));
 
-  BOOST_REQUIRE_CLOSE((LMetric<3, true>::Evaluate(a, b)), 7.95284762, 1e-5);
-  BOOST_REQUIRE_CLOSE((LMetric<3, true>::Evaluate(b, a)), 7.95284762, 1e-5);
+  REQUIRE((LMetric<3, true>::Evaluate(a, b)) == Approx(7.95284762).epsilon(1e-7));
+  REQUIRE((LMetric<3, true>::Evaluate(b, a)) == Approx(7.95284762).epsilon(1e-7));
 }
 
 /**
  * Make sure two vectors of all zeros return zero distance, for a few different
  * powers.
  */
-BOOST_AUTO_TEST_CASE(LMetricZerosTest)
+TEST_CASE("LMetricZerosTest", "[KernelTest]")
 {
   arma::vec a(250);
   a.fill(0.0);
 
   // We cannot use a loop because compilers seem to be unable to unroll the loop
   // and realize the variable actually is knowable at compile-time.
-  BOOST_REQUIRE((LMetric<1, false>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<1, true>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<2, false>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<2, true>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<3, false>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<3, true>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<4, false>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<4, true>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<5, false>::Evaluate(a, a)) == 0);
-  BOOST_REQUIRE((LMetric<5, true>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<1, false>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<1, true>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<2, false>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<2, true>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<3, false>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<3, true>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<4, false>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<4, true>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<5, false>::Evaluate(a, a)) == 0);
+  REQUIRE((LMetric<5, true>::Evaluate(a, a)) == 0);
 }
 
 /**
  * Simple test of Mahalanobis distance with unset covariance matrix in
  * constructor.
  */
-BOOST_AUTO_TEST_CASE(MDUnsetCovarianceTest)
+TEST_CASE("MDUnsetCovarianceTest", "[KernelTest]")
 {
   MahalanobisDistance<false> md;
   md.Covariance() = arma::eye<arma::mat>(4, 4);
   arma::vec a = "1.0 2.0 2.0 3.0";
   arma::vec b = "0.0 0.0 1.0 3.0";
 
-  BOOST_REQUIRE_CLOSE(md.Evaluate(a, b), 6.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(md.Evaluate(b, a), 6.0, 1e-5);
+  REQUIRE(md.Evaluate(a, b) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(md.Evaluate(b, a) == Approx(6.0).epsilon(1e-7));
 }
 
 /**
  * Simple test of Mahalanobis distance with unset covariance matrix in
  * constructor and t_take_root set to true.
  */
-BOOST_AUTO_TEST_CASE(MDRootUnsetCovarianceTest)
+TEST_CASE("MDRootUnsetCovarianceTest", "[KernelTest]")
 {
   MahalanobisDistance<true> md;
   md.Covariance() = arma::eye<arma::mat>(4, 4);
   arma::vec a = "1.0 2.0 2.5 5.0";
   arma::vec b = "0.0 2.0 0.5 8.0";
 
-  BOOST_REQUIRE_CLOSE(md.Evaluate(a, b), sqrt(14.0), 1e-5);
-  BOOST_REQUIRE_CLOSE(md.Evaluate(b, a), sqrt(14.0), 1e-5);
+  REQUIRE(md.Evaluate(a, b) == Approx(sqrt(14.0)).epsilon(1e-7));
+  REQUIRE(md.Evaluate(b, a) == Approx(sqrt(14.0)).epsilon(1e-7));
 }
 
 /**
  * Simple test of Mahalanobis distance setting identity covariance in
  * constructor.
  */
-BOOST_AUTO_TEST_CASE(MDEyeCovarianceTest)
+TEST_CASE("MDEyeCovarianceTest", "[KernelTest]")
 {
   MahalanobisDistance<false> md(4);
   arma::vec a = "1.0 2.0 2.0 3.0";
   arma::vec b = "0.0 0.0 1.0 3.0";
 
-  BOOST_REQUIRE_CLOSE(md.Evaluate(a, b), 6.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(md.Evaluate(b, a), 6.0, 1e-5);
+  REQUIRE(md.Evaluate(a, b) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(md.Evaluate(b, a) == Approx(6.0).epsilon(1e-7));
 }
 
 /**
  * Simple test of Mahalanobis distance setting identity covariance in
  * constructor and t_take_root set to true.
  */
-BOOST_AUTO_TEST_CASE(MDRootEyeCovarianceTest)
+TEST_CASE("MDRootEyeCovarianceTest", "[KernelTest]")
 {
   MahalanobisDistance<true> md(4);
   arma::vec a = "1.0 2.0 2.5 5.0";
   arma::vec b = "0.0 2.0 0.5 8.0";
 
-  BOOST_REQUIRE_CLOSE(md.Evaluate(a, b), sqrt(14.0), 1e-5);
-  BOOST_REQUIRE_CLOSE(md.Evaluate(b, a), sqrt(14.0), 1e-5);
+  REQUIRE(md.Evaluate(a, b) == Approx(sqrt(14.0)).epsilon(1e-7));
+  REQUIRE(md.Evaluate(b, a) == Approx(sqrt(14.0)).epsilon(1e-7));
 }
 
 /**
  * Simple test with diagonal covariance matrix.
  */
-BOOST_AUTO_TEST_CASE(MDDiagonalCovarianceTest)
+TEST_CASE("MDDiagonalCovarianceTest", "[KernelTest]")
 {
   arma::mat cov = arma::eye<arma::mat>(5, 5);
   cov(0, 0) = 2.0;
@@ -187,14 +185,14 @@ BOOST_AUTO_TEST_CASE(MDDiagonalCovarianceTest)
   arma::vec a = "1.0 2.0 2.0 4.0 5.0";
   arma::vec b = "2.0 3.0 1.0 1.0 0.0";
 
-  BOOST_REQUIRE_CLOSE(md.Evaluate(a, b), 52.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(md.Evaluate(b, a), 52.0, 1e-5);
+  REQUIRE(md.Evaluate(a, b) == Approx(52.0).epsilon(1e-7));
+  REQUIRE(md.Evaluate(b, a) == Approx(52.0).epsilon(1e-7));
 }
 
 /**
  * More specific case with more difficult covariance matrix.
  */
-BOOST_AUTO_TEST_CASE(MDFullCovarianceTest)
+TEST_CASE("MDFullCovarianceTest", "[KernelTest]")
 {
   arma::mat cov = "1.0 2.0 3.0 4.0;"
                   "0.5 0.6 0.7 0.1;"
@@ -205,101 +203,101 @@ BOOST_AUTO_TEST_CASE(MDFullCovarianceTest)
   arma::vec a = "1.0 2.0 2.0 4.0";
   arma::vec b = "2.0 3.0 1.0 1.0";
 
-  BOOST_REQUIRE_CLOSE(md.Evaluate(a, b), 15.7, 1e-5);
-  BOOST_REQUIRE_CLOSE(md.Evaluate(b, a), 15.7, 1e-5);
+  REQUIRE(md.Evaluate(a, b) == Approx(15.7).epsilon(1e-7));
+  REQUIRE(md.Evaluate(b, a) == Approx(15.7).epsilon(1e-7));
 }
 
 /**
  * Simple test case for the cosine distance.
  */
-BOOST_AUTO_TEST_CASE(CosineDistanceSameAngleTest)
+TEST_CASE("CosineDistanceSameAngleTest", "[KernelTest]")
 {
   arma::vec a = "1.0 2.0 3.0";
   arma::vec b = "2.0 4.0 6.0";
 
-  BOOST_REQUIRE_CLOSE(CosineDistance::Evaluate(a, b), 1.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(CosineDistance::Evaluate(b, a), 1.0, 1e-5);
+  REQUIRE(CosineDistance::Evaluate(a, b) == Approx(1.0).epsilon(1e-7));
+  REQUIRE(CosineDistance::Evaluate(b, a) == Approx(1.0).epsilon(1e-7));
 }
 
 /**
  * Now let's have them be orthogonal.
  */
-BOOST_AUTO_TEST_CASE(CosineDistanceOrthogonalTest)
+TEST_CASE("CosineDistanceOrthogonalTest", "[KernelTest]")
 {
   arma::vec a = "0.0 1.0";
   arma::vec b = "1.0 0.0";
 
-  BOOST_REQUIRE_SMALL(CosineDistance::Evaluate(a, b), 1e-5);
-  BOOST_REQUIRE_SMALL(CosineDistance::Evaluate(b, a), 1e-5);
+  REQUIRE(CosineDistance::Evaluate(a, b) == Approx(0.0).margin(1e-5));
+  REQUIRE(CosineDistance::Evaluate(b, a) == Approx(0.0).margin(1e-5));
 }
 
 /**
  * Some random angle test.
  */
-BOOST_AUTO_TEST_CASE(CosineDistanceRandomTest)
+TEST_CASE("CosineDistanceRandomTest", "[KernelTest]")
 {
   arma::vec a = "0.1 0.2 0.3 0.4 0.5";
   arma::vec b = "1.2 1.0 0.8 -0.3 -0.5";
 
-  BOOST_REQUIRE_CLOSE(CosineDistance::Evaluate(a, b), 0.1385349024, 1e-5);
-  BOOST_REQUIRE_CLOSE(CosineDistance::Evaluate(b, a), 0.1385349024, 1e-5);
+  REQUIRE(CosineDistance::Evaluate(a, b) == Approx(0.1385349024).epsilon(1e-7));
+  REQUIRE(CosineDistance::Evaluate(b, a) == Approx(0.1385349024).epsilon(1e-7));
 }
 
 /**
  * Linear Kernel test.
  */
-BOOST_AUTO_TEST_CASE(LinearKernelTest)
+TEST_CASE("LinearKernelTest", "[KernelTest]")
 {
   arma::vec a = ".2 .3 .4 .1";
   arma::vec b = ".56 .21 .623 .82";
 
   LinearKernel lk;
-  BOOST_REQUIRE_CLOSE(lk.Evaluate(a, b), .5062, 1e-5);
-  BOOST_REQUIRE_CLOSE(lk.Evaluate(b, a), .5062, 1e-5);
+  REQUIRE(lk.Evaluate(a, b) == Approx(.5062).epsilon(1e-7));
+  REQUIRE(lk.Evaluate(b, a) == Approx(.5062).epsilon(1e-7));
 }
 
 /**
  * Linear Kernel test, orthogonal vectors.
  */
-BOOST_AUTO_TEST_CASE(LinearKernelOrthogonalTest)
+TEST_CASE("LinearKernelOrthogonalTest", "[KernelTest]")
 {
   arma::vec a = "1 0 0";
   arma::vec b = "0 0 1";
 
   LinearKernel lk;
-  BOOST_REQUIRE_SMALL(lk.Evaluate(a, b), 1e-5);
-  BOOST_REQUIRE_SMALL(lk.Evaluate(b, a), 1e-5);
+  REQUIRE(lk.Evaluate(a, b) == Approx(0.0).margin(1e-5));
+  REQUIRE(lk.Evaluate(a, b) == Approx(0.0).margin(1e-5));
 }
 
-BOOST_AUTO_TEST_CASE(GaussianKernelTest)
+TEST_CASE("GaussianKernelTest", "[KernelTest]")
 {
   arma::vec a = "1 0 0";
   arma::vec b = "0 1 0";
   arma::vec c = "0 0 1";
 
   GaussianKernel gk(.5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(a, b), .018315638888734, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(b, a), .018315638888734, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(a, c), .018315638888734, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(c, a), .018315638888734, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(b, c), .018315638888734, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(c, b), .018315638888734, 1e-5);
+  REQUIRE(gk.Evaluate(a, b) == Approx(.018315638888734).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(b, a) == Approx(.018315638888734).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(a, c) == Approx(.018315638888734).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(c, a) == Approx(.018315638888734).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(b, c) == Approx(.018315638888734).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(c, b) == Approx(.018315638888734).epsilon(1e-7));
   /* check the single dimension evaluate function */
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(1.0), 0.1353352832366127, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(2.0), 0.00033546262790251185, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Evaluate(3.0), 1.5229979744712629e-08, 1e-5);
+  REQUIRE(gk.Evaluate(1.0) == Approx(0.1353352832366127).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(2.0) == Approx(0.00033546262790251185).epsilon(1e-7));
+  REQUIRE(gk.Evaluate(3.0) == Approx(1.5229979744712629e-08).epsilon(1e-7));
   /* check the normalization constant */
-  BOOST_REQUIRE_CLOSE(gk.Normalizer(1), 1.2533141373155001, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Normalizer(2), 1.5707963267948963, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Normalizer(3), 1.9687012432153019, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.Normalizer(4), 2.4674011002723386, 1e-5);
+  REQUIRE(gk.Normalizer(1) == Approx(1.2533141373155001).epsilon(1e-7));
+  REQUIRE(gk.Normalizer(2) == Approx(1.5707963267948963).epsilon(1e-7));
+  REQUIRE(gk.Normalizer(3) == Approx(1.9687012432153019).epsilon(1e-7));
+  REQUIRE(gk.Normalizer(4) == Approx(2.4674011002723386).epsilon(1e-7));
   /* check the convolution integral */
-  BOOST_REQUIRE_CLOSE(gk.ConvolutionIntegral(a, b), 0.024304474038457577, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.ConvolutionIntegral(a, c), 0.024304474038457577, 1e-5);
-  BOOST_REQUIRE_CLOSE(gk.ConvolutionIntegral(b, c), 0.024304474038457577, 1e-5);
+  REQUIRE(gk.ConvolutionIntegral(a, b) == Approx(0.024304474038457577).epsilon(1e-7));
+  REQUIRE(gk.ConvolutionIntegral(a, c) == Approx(0.024304474038457577).epsilon(1e-7));
+  REQUIRE(gk.ConvolutionIntegral(b, c) == Approx(0.024304474038457577).epsilon(1e-7));
 }
 
-BOOST_AUTO_TEST_CASE(GaussianKernelSerializationTest)
+TEST_CASE("GaussianKernelSerializationTest", "[KernelTest]")
 {
   GaussianKernel gk(0.5);
   GaussianKernel xmlGk(1.5), textGk, binaryGk(15.0);
@@ -307,97 +305,97 @@ BOOST_AUTO_TEST_CASE(GaussianKernelSerializationTest)
   // Serialize the kernels.
   SerializeObjectAll(gk, xmlGk, textGk, binaryGk);
 
-  BOOST_REQUIRE_CLOSE(gk.Bandwidth(), 0.5, 1e-5);
-  BOOST_REQUIRE_CLOSE(xmlGk.Bandwidth(), 0.5, 1e-5);
-  BOOST_REQUIRE_CLOSE(textGk.Bandwidth(), 0.5, 1e-5);
-  BOOST_REQUIRE_CLOSE(binaryGk.Bandwidth(), 0.5, 1e-5);
+  REQUIRE(gk.Bandwidth() == Approx(0.5).epsilon(1e-7));
+  REQUIRE(xmlGk.Bandwidth() == Approx(0.5).epsilon(1e-7));
+  REQUIRE(textGk.Bandwidth() == Approx(0.5).epsilon(1e-7));
+  REQUIRE(binaryGk.Bandwidth() == Approx(0.5).epsilon(1e-7));
 }
 
-BOOST_AUTO_TEST_CASE(SphericalKernelTest)
+TEST_CASE("SphericalKernelTest", "[KernelTest]")
 {
   arma::vec a = "1.0 0.0";
   arma::vec b = "0.0 1.0";
   arma::vec c = "0.2 0.9";
 
   SphericalKernel sk(.5);
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(a, b), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(a, c), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(b, c), 1.0, 1e-5);
+  REQUIRE(sk.Evaluate(a, b) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(sk.Evaluate(a, c) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(sk.Evaluate(b, c) == Approx(1.0).epsilon(1e-7));
   /* check the single dimension evaluate function */
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(0.10), 1.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(0.25), 1.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(0.50), 1.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Evaluate(1.00), 0.0, 1e-5);
+  REQUIRE(sk.Evaluate(0.10) == Approx(1.0).epsilon(1e-7));
+  REQUIRE(sk.Evaluate(0.25) == Approx(1.0).epsilon(1e-7));
+  REQUIRE(sk.Evaluate(0.50) == Approx(1.0).epsilon(1e-7));
+  REQUIRE(sk.Evaluate(1.00) == Approx(0.0).epsilon(1e-7));
   /* check the normalization constant */
-  BOOST_REQUIRE_CLOSE(sk.Normalizer(1), 1.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Normalizer(2), 0.78539816339744828, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Normalizer(3), 0.52359877559829893, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.Normalizer(4), 0.30842513753404244, 1e-5);
+  REQUIRE(sk.Normalizer(1) == Approx(1.0).epsilon(1e-7));
+  REQUIRE(sk.Normalizer(2) == Approx(0.78539816339744828).epsilon(1e-7));
+  REQUIRE(sk.Normalizer(3) == Approx(0.52359877559829893).epsilon(1e-7));
+  REQUIRE(sk.Normalizer(4) == Approx(0.30842513753404244).epsilon(1e-7));
   /* check the convolution integral */
-  BOOST_REQUIRE_CLOSE(sk.ConvolutionIntegral(a, b), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.ConvolutionIntegral(a, c), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(sk.ConvolutionIntegral(b, c), 1.0021155029652784, 1e-5);
+  REQUIRE(sk.ConvolutionIntegral(a, b) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(sk.ConvolutionIntegral(a, c) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(sk.ConvolutionIntegral(b, c) == Approx(1.0021155029652784).epsilon(1e-7));
 }
 
-BOOST_AUTO_TEST_CASE(EpanechnikovKernelTest)
+TEST_CASE("EpanechnikovKernelTest", "[KernelTest]")
 {
   arma::vec a = "1.0 0.0";
   arma::vec b = "0.0 1.0";
   arma::vec c = "0.1 0.9";
 
   EpanechnikovKernel ek(.5);
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(a, b), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(b, c), 0.92, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(a, c), 0.0, 1e-5);
+  REQUIRE(ek.Evaluate(a, b) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(ek.Evaluate(b, c) == Approx(0.92).epsilon(1e-7));
+  REQUIRE(ek.Evaluate(a, c) == Approx(0.0).epsilon(1e-7));
   /* check the single dimension evaluate function */
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(0.10), 0.96, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(0.25), 0.75, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(0.50), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Evaluate(1.00), 0.0, 1e-5);
+  REQUIRE(ek.Evaluate(0.10) == Approx(0.96).epsilon(1e-7));
+  REQUIRE(ek.Evaluate(0.25) == Approx(0.75).epsilon(1e-7));
+  REQUIRE(ek.Evaluate(0.50) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(ek.Evaluate(1.00) == Approx(0.0).epsilon(1e-7));
   /* check the normalization constant */
-  BOOST_REQUIRE_CLOSE(ek.Normalizer(1), 0.666666666666666, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Normalizer(2), 0.39269908169872414, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Normalizer(3), 0.20943951023931956, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.Normalizer(4), 0.10280837917801415, 1e-5);
+  REQUIRE(ek.Normalizer(1) == Approx(0.666666666666666).epsilon(1e-7));
+  REQUIRE(ek.Normalizer(2) == Approx(0.39269908169872414).epsilon(1e-7));
+  REQUIRE(ek.Normalizer(3) == Approx(0.20943951023931956).epsilon(1e-7));
+  REQUIRE(ek.Normalizer(4) == Approx(0.10280837917801415).epsilon(1e-7));
   /* check the convolution integral */
-  BOOST_REQUIRE_CLOSE(ek.ConvolutionIntegral(a, b), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.ConvolutionIntegral(a, c), 0.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(ek.ConvolutionIntegral(b, c), 1.5263455690698258, 1e-5);
+  REQUIRE(ek.ConvolutionIntegral(a, b) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(ek.ConvolutionIntegral(a, c) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(ek.ConvolutionIntegral(b, c) == Approx(1.5263455690698258).epsilon(1e-7));
 }
 
-BOOST_AUTO_TEST_CASE(PolynomialKernelTest)
+TEST_CASE("PolynomialKernelTest", "[KernelTest]")
 {
   arma::vec a = "0 0 1";
   arma::vec b = "0 1 0";
 
   PolynomialKernel pk(5.0, 5.0);
-  BOOST_REQUIRE_CLOSE(pk.Evaluate(a, b), 3125.0, 0);
-  BOOST_REQUIRE_CLOSE(pk.Evaluate(b, a), 3125.0, 0);
+  REQUIRE(pk.Evaluate(a, b) == Approx(3125).epsilon(0));
+  REQUIRE(pk.Evaluate(b, a) == Approx(3125).epsilon(0));
 }
 
-BOOST_AUTO_TEST_CASE(HyperbolicTangentKernelTest)
+TEST_CASE("HyperbolicTangentKernelTest", "[KernelTest]")
 {
   arma::vec a = "0 0 1";
   arma::vec b = "0 1 0";
 
   HyperbolicTangentKernel tk(5.0, 5.0);
-  BOOST_REQUIRE_CLOSE(tk.Evaluate(a, b), 0.9999092, 1e-5);
-  BOOST_REQUIRE_CLOSE(tk.Evaluate(b, a), 0.9999092, 1e-5);
+  REQUIRE(tk.Evaluate(a, b) == Approx(0.9999092).epsilon(1e-7));
+  REQUIRE(tk.Evaluate(b, a) == Approx(0.9999092).epsilon(1e-7));
 }
 
-BOOST_AUTO_TEST_CASE(LaplacianKernelTest)
+TEST_CASE("LaplacianKernelTest", "[KernelTest]")
 {
   arma::vec a = "0 0 1";
   arma::vec b = "0 1 0";
 
   LaplacianKernel lk(1.0);
-  BOOST_REQUIRE_CLOSE(lk.Evaluate(a, b), 0.243116734, 5e-5);
-  BOOST_REQUIRE_CLOSE(lk.Evaluate(b, a), 0.243116734, 5e-5);
+  REQUIRE(lk.Evaluate(a, b) == Approx(0.243116734).epsilon(5e-7));
+  REQUIRE(lk.Evaluate(b, a) == Approx(0.243116734).epsilon(5e-7));
 }
 
 // Ensure that the p-spectrum kernel successfully extracts all length-p
 // substrings from the data.
-BOOST_AUTO_TEST_CASE(PSpectrumSubstringExtractionTest)
+TEST_CASE("PSpectrumSubstringExtractionTest", "[KernelTest]")
 {
   std::vector<std::vector<std::string> > datasets;
 
@@ -421,138 +419,138 @@ BOOST_AUTO_TEST_CASE(PSpectrumSubstringExtractionTest)
   PSpectrumStringKernel p(datasets, 3);
 
   // Ensure the sizes are correct.
-  BOOST_REQUIRE_EQUAL(p.Counts().size(), 2);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0].size(), 4);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1].size(), 7);
+  REQUIRE(p.Counts().size() == 2);
+  REQUIRE(p.Counts()[0].size() == 4);
+  REQUIRE(p.Counts()[1].size() == 7);
 
   // herpgle: her, erp, rpg, pgl, gle
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][0].size(), 5);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][0]["her"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][0]["erp"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][0]["rpg"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][0]["pgl"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][0]["gle"], 1);
+  REQUIRE(p.Counts()[0][0].size() == 5);
+  REQUIRE(p.Counts()[0][0]["her"] == 1);
+  REQUIRE(p.Counts()[0][0]["erp"] == 1);
+  REQUIRE(p.Counts()[0][0]["rpg"] == 1);
+  REQUIRE(p.Counts()[0][0]["pgl"] == 1);
+  REQUIRE(p.Counts()[0][0]["gle"] == 1);
 
   // herpagkle: her, erp, rpa, pag, agk, gkl, kle
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1].size(), 7);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["her"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["erp"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["rpa"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["pag"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["agk"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["gkl"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][1]["kle"], 1);
+  REQUIRE(p.Counts()[0][1].size() == 7);
+  REQUIRE(p.Counts()[0][1]["her"] == 1);
+  REQUIRE(p.Counts()[0][1]["erp"] == 1);
+  REQUIRE(p.Counts()[0][1]["rpa"] == 1);
+  REQUIRE(p.Counts()[0][1]["pag"] == 1);
+  REQUIRE(p.Counts()[0][1]["agk"] == 1);
+  REQUIRE(p.Counts()[0][1]["gkl"] == 1);
+  REQUIRE(p.Counts()[0][1]["kle"] == 1);
 
   // klunktor: klu, lun, unk, nkt, kto, tor
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2].size(), 6);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2]["klu"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2]["lun"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2]["unk"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2]["nkt"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2]["kto"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][2]["tor"], 1);
+  REQUIRE(p.Counts()[0][2].size() == 6);
+  REQUIRE(p.Counts()[0][2]["klu"] == 1);
+  REQUIRE(p.Counts()[0][2]["lun"] == 1);
+  REQUIRE(p.Counts()[0][2]["unk"] == 1);
+  REQUIRE(p.Counts()[0][2]["nkt"] == 1);
+  REQUIRE(p.Counts()[0][2]["kto"] == 1);
+  REQUIRE(p.Counts()[0][2]["tor"] == 1);
 
   // flibbynopple: fli lib ibb bby byn yno nop opp ppl ple
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3].size(), 10);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["fli"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["lib"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["ibb"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["bby"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["byn"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["yno"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["nop"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["opp"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["ppl"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[0][3]["ple"], 1);
+  REQUIRE(p.Counts()[0][3].size() == 10);
+  REQUIRE(p.Counts()[0][3]["fli"] == 1);
+  REQUIRE(p.Counts()[0][3]["lib"] == 1);
+  REQUIRE(p.Counts()[0][3]["ibb"] == 1);
+  REQUIRE(p.Counts()[0][3]["bby"] == 1);
+  REQUIRE(p.Counts()[0][3]["byn"] == 1);
+  REQUIRE(p.Counts()[0][3]["yno"] == 1);
+  REQUIRE(p.Counts()[0][3]["nop"] == 1);
+  REQUIRE(p.Counts()[0][3]["opp"] == 1);
+  REQUIRE(p.Counts()[0][3]["ppl"] == 1);
+  REQUIRE(p.Counts()[0][3]["ple"] == 1);
 
   // floggy3245: flo log ogg ggy gy3 y32 324 245
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0].size(), 8);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["flo"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["log"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["ogg"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["ggy"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["gy3"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["y32"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["324"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][0]["245"], 1);
+  REQUIRE(p.Counts()[1][0].size() == 8);
+  REQUIRE(p.Counts()[1][0]["flo"] == 1);
+  REQUIRE(p.Counts()[1][0]["log"] == 1);
+  REQUIRE(p.Counts()[1][0]["ogg"] == 1);
+  REQUIRE(p.Counts()[1][0]["ggy"] == 1);
+  REQUIRE(p.Counts()[1][0]["gy3"] == 1);
+  REQUIRE(p.Counts()[1][0]["y32"] == 1);
+  REQUIRE(p.Counts()[1][0]["324"] == 1);
+  REQUIRE(p.Counts()[1][0]["245"] == 1);
 
   // flippydopflip: fli lip ipp ppy pyd ydo dop opf pfl fli lip
   // fli(2) lip(2) ipp ppy pyd ydo dop opf pfl
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1].size(), 9);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["fli"], 2);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["lip"], 2);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["ipp"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["ppy"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["pyd"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["ydo"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["dop"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["opf"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][1]["pfl"], 1);
+  REQUIRE(p.Counts()[1][1].size() == 9);
+  REQUIRE(p.Counts()[1][1]["fli"] == 2);
+  REQUIRE(p.Counts()[1][1]["lip"] == 2);
+  REQUIRE(p.Counts()[1][1]["ipp"] == 1);
+  REQUIRE(p.Counts()[1][1]["ppy"] == 1);
+  REQUIRE(p.Counts()[1][1]["pyd"] == 1);
+  REQUIRE(p.Counts()[1][1]["ydo"] == 1);
+  REQUIRE(p.Counts()[1][1]["dop"] == 1);
+  REQUIRE(p.Counts()[1][1]["opf"] == 1);
+  REQUIRE(p.Counts()[1][1]["pfl"] == 1);
 
   // stupid fricking cat: stu tup upi pid fri ric ick cki kin ing cat
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2].size(), 11);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["stu"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["tup"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["upi"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["pid"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["fri"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["ric"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["ick"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["cki"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["kin"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["ing"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][2]["cat"], 1);
+  REQUIRE(p.Counts()[1][2].size() == 11);
+  REQUIRE(p.Counts()[1][2]["stu"] == 1);
+  REQUIRE(p.Counts()[1][2]["tup"] == 1);
+  REQUIRE(p.Counts()[1][2]["upi"] == 1);
+  REQUIRE(p.Counts()[1][2]["pid"] == 1);
+  REQUIRE(p.Counts()[1][2]["fri"] == 1);
+  REQUIRE(p.Counts()[1][2]["ric"] == 1);
+  REQUIRE(p.Counts()[1][2]["ick"] == 1);
+  REQUIRE(p.Counts()[1][2]["cki"] == 1);
+  REQUIRE(p.Counts()[1][2]["kin"] == 1);
+  REQUIRE(p.Counts()[1][2]["ing"] == 1);
+  REQUIRE(p.Counts()[1][2]["cat"] == 1);
 
   // food time isn't until later: foo ood tim ime isn unt nti til lat ate ter
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3].size(), 11);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["foo"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["ood"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["tim"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["ime"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["isn"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["unt"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["nti"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["til"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["lat"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["ate"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][3]["ter"], 1);
+  REQUIRE(p.Counts()[1][3].size() == 11);
+  REQUIRE(p.Counts()[1][3]["foo"] == 1);
+  REQUIRE(p.Counts()[1][3]["ood"] == 1);
+  REQUIRE(p.Counts()[1][3]["tim"] == 1);
+  REQUIRE(p.Counts()[1][3]["ime"] == 1);
+  REQUIRE(p.Counts()[1][3]["isn"] == 1);
+  REQUIRE(p.Counts()[1][3]["unt"] == 1);
+  REQUIRE(p.Counts()[1][3]["nti"] == 1);
+  REQUIRE(p.Counts()[1][3]["til"] == 1);
+  REQUIRE(p.Counts()[1][3]["lat"] == 1);
+  REQUIRE(p.Counts()[1][3]["ate"] == 1);
+  REQUIRE(p.Counts()[1][3]["ter"] == 1);
 
   // leave me alone until 6:00: lea eav ave alo lon one unt nti til
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4].size(), 9);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["lea"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["eav"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["ave"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["alo"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["lon"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["one"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["unt"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["nti"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][4]["til"], 1);
+  REQUIRE(p.Counts()[1][4].size() == 9);
+  REQUIRE(p.Counts()[1][4]["lea"] == 1);
+  REQUIRE(p.Counts()[1][4]["eav"] == 1);
+  REQUIRE(p.Counts()[1][4]["ave"] == 1);
+  REQUIRE(p.Counts()[1][4]["alo"] == 1);
+  REQUIRE(p.Counts()[1][4]["lon"] == 1);
+  REQUIRE(p.Counts()[1][4]["one"] == 1);
+  REQUIRE(p.Counts()[1][4]["unt"] == 1);
+  REQUIRE(p.Counts()[1][4]["nti"] == 1);
+  REQUIRE(p.Counts()[1][4]["til"] == 1);
 
   // only after that do you get any food.:
   // onl nly aft fte ter tha hat you get any foo ood
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5].size(), 12);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["onl"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["nly"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["aft"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["fte"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["ter"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["tha"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["hat"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["you"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["get"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["any"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["foo"], 1);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][5]["ood"], 1);
+  REQUIRE(p.Counts()[1][5].size() == 12);
+  REQUIRE(p.Counts()[1][5]["onl"] == 1);
+  REQUIRE(p.Counts()[1][5]["nly"] == 1);
+  REQUIRE(p.Counts()[1][5]["aft"] == 1);
+  REQUIRE(p.Counts()[1][5]["fte"] == 1);
+  REQUIRE(p.Counts()[1][5]["ter"] == 1);
+  REQUIRE(p.Counts()[1][5]["tha"] == 1);
+  REQUIRE(p.Counts()[1][5]["hat"] == 1);
+  REQUIRE(p.Counts()[1][5]["you"] == 1);
+  REQUIRE(p.Counts()[1][5]["get"] == 1);
+  REQUIRE(p.Counts()[1][5]["any"] == 1);
+  REQUIRE(p.Counts()[1][5]["foo"] == 1);
+  REQUIRE(p.Counts()[1][5]["ood"] == 1);
 
   // obloblobloblobloblobloblob: obl(8) blo(8) lob(8)
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][6].size(), 3);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][6]["obl"], 8);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][6]["blo"], 8);
-  BOOST_REQUIRE_EQUAL(p.Counts()[1][6]["lob"], 8);
+  REQUIRE(p.Counts()[1][6].size() == 3);
+  REQUIRE(p.Counts()[1][6]["obl"] == 8);
+  REQUIRE(p.Counts()[1][6]["blo"] == 8);
+  REQUIRE(p.Counts()[1][6]["lob"] == 8);
 }
 
-BOOST_AUTO_TEST_CASE(PSpectrumStringEvaluateTest)
+TEST_CASE("PSpectrumStringEvaluateTest", "[KernelTest]")
 {
   // Construct simple dataset.
   std::vector<std::vector<std::string> > dataset;
@@ -567,59 +565,57 @@ BOOST_AUTO_TEST_CASE(PSpectrumStringEvaluateTest)
   arma::vec a("0 0");
   arma::vec b("0 0");
 
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 3.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 3.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(3.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(3.0).epsilon(1e-7));
 
   b = "0 1";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 2.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 2.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(2.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(2.0).epsilon(1e-7));
 
   b = "0 2";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 2.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 2.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(2.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(2.0).epsilon(1e-7));
 
   b = "0 3";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 4.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 4.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(4.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(4.0).epsilon(1e-7));
 
   a = "0 1";
   b = "0 1";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 3.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 3.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(3.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(3.0).epsilon(1e-7));
 
   b = "0 2";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 2.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 2.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(2.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(2.0).epsilon(1e-7));
 
   b = "0 3";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 5.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 5.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(5.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(5.0).epsilon(1e-7));
 
   a = "0 2";
   b = "0 2";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 4.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 4.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(4.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(4.0).epsilon(1e-7));
 
   b = "0 3";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 6.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 6.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(6.0).epsilon(1e-7));
 
   a = "0 3";
-  BOOST_REQUIRE_CLOSE(p.Evaluate(a, b), 11.0, 1e-5);
-  BOOST_REQUIRE_CLOSE(p.Evaluate(b, a), 11.0, 1e-5);
+  REQUIRE(p.Evaluate(a, b) == Approx(11.0).epsilon(1e-7));
+  REQUIRE(p.Evaluate(b, a) == Approx(11.0).epsilon(1e-7));
 }
 
 /**
  * Cauchy Kernel test.
  */
-BOOST_AUTO_TEST_CASE(CauchyKernelTest)
+TEST_CASE("CauchyKernelTest", "[KernelTest]")
 {
   arma::vec a = "0 0 1";
   arma::vec b = "0 1 0";
 
   CauchyKernel ck(5.0);
-  BOOST_REQUIRE_CLOSE(ck.Evaluate(a, b), 0.92592588, 1e-5);
-  BOOST_REQUIRE_CLOSE(ck.Evaluate(b, a), 0.92592588, 1e-5);
+  REQUIRE(ck.Evaluate(a, b) == Approx(0.92592588).epsilon(1e-7));
+  REQUIRE(ck.Evaluate(b, a) == Approx(0.92592588).epsilon(1e-7));
 }
-
-BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/kernel_test.cpp
+++ b/src/mlpack/tests/kernel_test.cpp
@@ -105,16 +105,16 @@ TEST_CASE("LMetricZerosTest", "[KernelTest]")
 
   // We cannot use a loop because compilers seem to be unable to unroll the loop
   // and realize the variable actually is knowable at compile-time.
-  REQUIRE((LMetric<1, false>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<1, true>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<2, false>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<2, true>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<3, false>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<3, true>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<4, false>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<4, true>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<5, false>::Evaluate(a, a)) == 0);
-  REQUIRE((LMetric<5, true>::Evaluate(a, a)) == 0);
+  REQUIRE(LMetric<1, false>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<1, true>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<2, false>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<2, true>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<3, false>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<3, true>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<4, false>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<4, true>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<5, false>::Evaluate(a, a) == 0);
+  REQUIRE(LMetric<5, true>::Evaluate(a, a) == 0);
 }
 
 /**

--- a/src/mlpack/tests/kernel_traits_test.cpp
+++ b/src/mlpack/tests/kernel_traits_test.cpp
@@ -13,20 +13,18 @@
  */
 #include <mlpack/core.hpp>
 
-#include <boost/test/unit_test.hpp>
-#include "test_tools.hpp"
+#include "catch.hpp"
+#include "test_catch_tools.hpp"
 
 using namespace mlpack;
 using namespace mlpack::kernel;
 
-BOOST_AUTO_TEST_SUITE(KernelTraitsTest);
-
-BOOST_AUTO_TEST_CASE(IsNormalizedTest)
+TEST_CASE("IsNormalizedTest", "[KernelTraitsTest]")
 {
   // Reason number ten billion why macros are bad:
   //
   // The Boost unit test framework is built on macros.  When I write
-  // BOOST_REQUIRE_EQUAL(KernelTraits<int>::IsNormalized, false), what actually
+  // REQUIRE(KernelTraits<int>::IsNormalized, false) == what actually
   // happens (in gcc at least) is that the 'false' gets implicitly converted to
   // an int; then, the compiler goes looking for an int IsNormalized variable in
   // KernelTraits.  But this doesn't exist, so we get this error at linker time:
@@ -41,25 +39,19 @@ BOOST_AUTO_TEST_CASE(IsNormalizedTest)
 
   // Test each kernel individually.
   // If the type is not a valid kernel, it should be false (default value).
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<int>::IsNormalized, false);
+  REQUIRE((bool) KernelTraits<int>::IsNormalized == false);
 
   // Normalized kernels.
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<CosineDistance>::IsNormalized, true);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<EpanechnikovKernel>::IsNormalized,
-      true);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<GaussianKernel>::IsNormalized, true);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<LaplacianKernel>::IsNormalized, true);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<SphericalKernel>::IsNormalized, true);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<TriangularKernel>::IsNormalized,
-      true);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<CauchyKernel>::IsNormalized, true);
+  REQUIRE((bool) KernelTraits<CosineDistance>::IsNormalized == true);
+  REQUIRE((bool) KernelTraits<EpanechnikovKernel>::IsNormalized == true);
+  REQUIRE((bool) KernelTraits<GaussianKernel>::IsNormalized == true);
+  REQUIRE((bool) KernelTraits<LaplacianKernel>::IsNormalized == true);
+  REQUIRE((bool) KernelTraits<SphericalKernel>::IsNormalized == true);
+  REQUIRE((bool) KernelTraits<TriangularKernel>::IsNormalized == true);
+  REQUIRE((bool) KernelTraits<CauchyKernel>::IsNormalized == true);
 
   // Unnormalized kernels.
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<LinearKernel>::IsNormalized, false);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<PolynomialKernel>::IsNormalized,
-      false);
-  BOOST_REQUIRE_EQUAL((bool) KernelTraits<PSpectrumStringKernel>::IsNormalized,
-      false);
+  REQUIRE((bool) KernelTraits<LinearKernel>::IsNormalized == false);
+  REQUIRE((bool) KernelTraits<PolynomialKernel>::IsNormalized == false);
+  REQUIRE((bool) KernelTraits<PSpectrumStringKernel>::IsNormalized == false);
 }
-
-BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/main_tests/kernel_pca_test.cpp
+++ b/src/mlpack/tests/main_tests/kernel_pca_test.cpp
@@ -18,8 +18,8 @@ static const std::string testName = "KernelPrincipalComponentsAnalysis";
 #include "test_helper.hpp"
 #include <mlpack/methods/kernel_pca/kernel_pca_main.cpp>
 
-#include <boost/test/unit_test.hpp>
-#include "../test_tools.hpp"
+#include "../catch.hpp"
+#include "../test_catch_tools.hpp"
 
 using namespace mlpack;
 
@@ -47,12 +47,11 @@ static void ResetSettings()
   IO::RestoreSettings(testName);
 }
 
-BOOST_FIXTURE_TEST_SUITE(KernelPCAMainTest, KernelPCATestFixture);
-
 /**
  * Make sure that all valid kernels return correct output dimension.
  */
-BOOST_AUTO_TEST_CASE(KernelPCADimensionTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCADimensionTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   std::string kernels[] = {
       "linear", "gaussian", "polynomial",
@@ -70,15 +69,16 @@ BOOST_AUTO_TEST_CASE(KernelPCADimensionTest)
     mlpackMain();
 
     // Now check that the output has 3 dimensions.
-    BOOST_REQUIRE_EQUAL(IO::GetParam<arma::mat>("output").n_rows, 3);
-    BOOST_REQUIRE_EQUAL(IO::GetParam<arma::mat>("output").n_cols, 5);
+    REQUIRE(IO::GetParam<arma::mat>("output").n_rows == 3);
+    REQUIRE(IO::GetParam<arma::mat>("output").n_cols == 5);
   }
 }
 
 /**
  * Check that error is thrown when no kernel is specified.
  */
-BOOST_AUTO_TEST_CASE(KernelPCANoKernelTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCANoKernelTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -86,14 +86,15 @@ BOOST_AUTO_TEST_CASE(KernelPCANoKernelTest)
   SetInputParam("new_dimensionality", (int) 3);
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
 /**
  * Check that error is thrown when an invalid kernel is specified.
  */
-BOOST_AUTO_TEST_CASE(KernelPCAInvalidKernelTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCAInvalidKernelTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -102,7 +103,7 @@ BOOST_AUTO_TEST_CASE(KernelPCAInvalidKernelTest)
   SetInputParam("kernel", (std::string) "badName");
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
@@ -110,7 +111,8 @@ BOOST_AUTO_TEST_CASE(KernelPCAInvalidKernelTest)
  * Ensure for zero dimensionality, we get a dataset with the same dimensionality
  * as the input dataset.
  */
-BOOST_AUTO_TEST_CASE(KernelPCA0DimensionalityTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCA0DimensionalityTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -120,14 +122,15 @@ BOOST_AUTO_TEST_CASE(KernelPCA0DimensionalityTest)
   mlpackMain();
 
   // Now check that the output has same dimensions as input.
-  BOOST_REQUIRE_EQUAL(IO::GetParam<arma::mat>("output").n_rows, 5);
-  BOOST_REQUIRE_EQUAL(IO::GetParam<arma::mat>("output").n_cols, 5);
+  REQUIRE(IO::GetParam<arma::mat>("output").n_rows == 5);
+  REQUIRE(IO::GetParam<arma::mat>("output").n_cols == 5);
 }
 
 /**
  * Make sure that centering the dataset makes a difference.
  */
-BOOST_AUTO_TEST_CASE(KernelPCACenterTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCACenterTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -145,13 +148,14 @@ BOOST_AUTO_TEST_CASE(KernelPCACenterTest)
   arma::mat output2 = IO::GetParam<arma::mat>("output");
 
   // The resulting matrices should be different.
-  BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output2)));
+  REQUIRE(arma::any(arma::vectorise(output1 != output2)));
 }
 
 /**
  * Check that we can't specify an invalid new dimensionality.
  */
-BOOST_AUTO_TEST_CASE(KernelPCATooHighNewDimensionalityTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCATooHighNewDimensionalityTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -160,14 +164,15 @@ BOOST_AUTO_TEST_CASE(KernelPCATooHighNewDimensionalityTest)
   SetInputParam("kernel", (std::string) "linear");
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
 /**
  * Check that error is thrown when no input is specified.
  */
-BOOST_AUTO_TEST_CASE(KernelPCANoInputTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCANoInputTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -175,14 +180,15 @@ BOOST_AUTO_TEST_CASE(KernelPCANoInputTest)
   SetInputParam("kernel", (std::string) "linear");
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
 /**
  * Check that error is thrown if invalid sampling scheme is specified.
  */
-BOOST_AUTO_TEST_CASE(KernelPCABadSamplingTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCABadSamplingTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -193,7 +199,7 @@ BOOST_AUTO_TEST_CASE(KernelPCABadSamplingTest)
   SetInputParam("sampling", (std::string) "badName");
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
@@ -201,7 +207,8 @@ BOOST_AUTO_TEST_CASE(KernelPCABadSamplingTest)
  * Test that bandwidth effects the result for gaussian, epanechnikov
  * and laplacian kernels.
  */
-BOOST_AUTO_TEST_CASE(KernelPCABandWidthTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCABandWidthTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   std::string kernels[] = {
       "gaussian", "epanechnikov", "laplacian"
@@ -229,14 +236,15 @@ BOOST_AUTO_TEST_CASE(KernelPCABandWidthTest)
     arma::mat output2 = IO::GetParam<arma::mat>("output");
 
     // The resulting matrices should be different.
-    BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output2)));
+    REQUIRE(arma::any(arma::vectorise(output1 != output2)));
   }
 }
 
 /**
  * Test that offset effects the result for polynomial and hyptan kernels.
  */
-BOOST_AUTO_TEST_CASE(KernelPCAOffsetTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCAOffsetTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   std::string kernels[] = {
       "polynomial", "hyptan"
@@ -262,14 +270,15 @@ BOOST_AUTO_TEST_CASE(KernelPCAOffsetTest)
     arma::mat output2 = IO::GetParam<arma::mat>("output");
 
     // The resulting matrices should be different.
-    BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output2)));
+    REQUIRE(arma::any(arma::vectorise(output1 != output2)));
   }
 }
 
 /**
  * Test that degree effects the result for polynomial kernel.
  */
-BOOST_AUTO_TEST_CASE(KernelPCADegreeTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCADegreeTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -288,13 +297,14 @@ BOOST_AUTO_TEST_CASE(KernelPCADegreeTest)
   arma::mat output2 = IO::GetParam<arma::mat>("output");
 
   // The resulting matrices should be different.
-  BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output2)));
+  REQUIRE(arma::any(arma::vectorise(output1 != output2)));
 }
 
 /**
  * Test that kernel scale effects the result for hyptan kernel.
  */
-BOOST_AUTO_TEST_CASE(KernelPCAKernelScaleTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCAKernelScaleTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   arma::mat x = arma::randu<arma::mat>(5, 5);
 
@@ -313,13 +323,14 @@ BOOST_AUTO_TEST_CASE(KernelPCAKernelScaleTest)
   arma::mat output2 = IO::GetParam<arma::mat>("output");
 
   // The resulting matrices should be different.
-  BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output2)));
+  REQUIRE(arma::any(arma::vectorise(output1 != output2)));
 }
 
 /**
  * Test that using a sampling scheme with nystroem method makes a difference.
  */
-BOOST_AUTO_TEST_CASE(KernelPCASamplingSchemeTest)
+TEST_CASE_METHOD(KernelPCATestFixture, "KernelPCASamplingSchemeTest",
+                 "[KernelPCAMainTest][BindingTests]")
 {
   ResetSettings();
 
@@ -348,9 +359,7 @@ BOOST_AUTO_TEST_CASE(KernelPCASamplingSchemeTest)
   arma::mat output3 = IO::GetParam<arma::mat>("output");
 
   // The resulting matrices should be different.
-  BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output2)));
-  BOOST_REQUIRE(arma::any(arma::vectorise(output2 != output3)));
-  BOOST_REQUIRE(arma::any(arma::vectorise(output1 != output3)));
+  REQUIRE(arma::any(arma::vectorise(output1 != output2)));
+  REQUIRE(arma::any(arma::vectorise(output2 != output3)));
+  REQUIRE(arma::any(arma::vectorise(output1 != output3)));
 }
-
-BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Refer #2523 