### PR TITLE
Increase threshold to avoid occasional test failures.

### DIFF
--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4744,5 +4744,5 @@ TEST_CASE("GradientMultiheadAttentionTest", "[ANNLayerTest]")
     const size_t batchSize = 2;
   } function;
 
-  REQUIRE(CheckGradient(function) <= 1e-06);
+  REQUIRE(CheckGradient(function) <= 2e-06);
 }


### PR DESCRIPTION
Looks like the `GradientMultiheadAttentionTest` sometimes fails by a really small margin, so I just increased the threshold.