### PR TITLE
Prepend "--" to options when checking that they are there.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Fix incorrect parsing of required matrix/model parameters for command-line
+    bindings (#2600).
 
 ### mlpack 3.4.0
 ###### 2020-09-01

--- a/src/mlpack/bindings/cli/parse_command_line.hpp
+++ b/src/mlpack/bindings/cli/parse_command_line.hpp
@@ -47,8 +47,8 @@ void ParseCommandLine(int argc, char** argv)
   {
     // Add the parameter to desc.
     util::ParamData& d = it->second;
-    IO::GetSingleton().functionMap[d.tname]["AddToCLI11"]
-      (d, NULL, (void*) &app);
+    IO::GetSingleton().functionMap[d.tname]["AddToCLI11"](d, NULL, (void*)
+        &app);
   }
 
   // Mark that we did parsing.
@@ -136,13 +136,15 @@ void ParseCommandLine(int argc, char** argv)
     util::ParamData d = iter->second;
     if (d.required)
     {
-      const std::string cliName;
+      // CLI11 expects the parameter name to have "--" prepended.
+      std::string cliName;
       IO::GetSingleton().functionMap[d.tname]["MapParameterName"](d, NULL,
           (void*) &cliName);
+      cliName = "--" + cliName;
 
       if (!app.count(cliName))
       {
-        Log::Fatal << "Required option --" << cliName << " is undefined."
+        Log::Fatal << "Required option " << cliName << " is undefined."
             << std::endl;
       }
     }

--- a/src/mlpack/tests/io_test.cpp
+++ b/src/mlpack/tests/io_test.cpp
@@ -598,6 +598,105 @@ BOOST_AUTO_TEST_CASE(InputMatrixParamTest)
     BOOST_REQUIRE_CLOSE(dataset[i], dataset2[i], 1e-10);
 }
 
+// Make sure we can correctly load required matrix parameters.
+BOOST_AUTO_TEST_CASE(RequiredInputMatrixParamTest)
+{
+  AddRequiredCLIOptions();
+
+  // --matrix is an input parameter; it won't be transposed.
+  PARAM_MATRIX_IN_REQ("matrix", "Test matrix", "m");
+
+  // Set some fake arguments.
+  const char* argv[3];
+  argv[0] = "./test";
+  argv[1] = "--matrix_file";
+  argv[2] = "test_data_3_1000.csv";
+
+  int argc = 3;
+
+  // The const-cast is a little hacky but should be fine...
+  ParseCommandLine(argc, const_cast<char**>(argv));
+
+  // The --matrix parameter should exist.
+  BOOST_REQUIRE(IO::HasParam("matrix"));
+  // The --matrix_file parameter should not exist (it should be transparent from
+  // inside the program).
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(IO::HasParam("matrix_file"), runtime_error);
+  Log::Fatal.ignoreInput = false;
+
+  arma::mat dataset = IO::GetParam<arma::mat>("matrix");
+  arma::mat dataset2 = IO::GetParam<arma::mat>("matrix");
+
+  BOOST_REQUIRE_EQUAL(dataset.n_rows, 3);
+  BOOST_REQUIRE_EQUAL(dataset.n_cols, 1000);
+  BOOST_REQUIRE_EQUAL(dataset2.n_rows, 3);
+  BOOST_REQUIRE_EQUAL(dataset2.n_cols, 1000);
+
+  for (size_t i = 0; i < dataset.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(dataset[i], dataset2[i], 1e-10);
+}
+
+// Make sure loading required matrix options by alias succeeds.
+BOOST_AUTO_TEST_CASE(RequiredInputMatrixParamAliasTest)
+{
+  AddRequiredCLIOptions();
+
+  // --matrix is an input parameter; it won't be transposed.
+  PARAM_MATRIX_IN_REQ("matrix", "Test matrix", "m");
+
+  // Set some fake arguments.
+  const char* argv[3];
+  argv[0] = "./test";
+  argv[1] = "-m";
+  argv[2] = "test_data_3_1000.csv";
+
+  int argc = 3;
+
+  // The const-cast is a little hacky but should be fine...
+  ParseCommandLine(argc, const_cast<char**>(argv));
+
+  // The --matrix parameter should exist.
+  BOOST_REQUIRE(IO::HasParam("matrix"));
+  // The --matrix_file parameter should not exist (it should be transparent from
+  // inside the program).
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(IO::HasParam("matrix_file"), runtime_error);
+  Log::Fatal.ignoreInput = false;
+
+  arma::mat dataset = IO::GetParam<arma::mat>("matrix");
+  arma::mat dataset2 = IO::GetParam<arma::mat>("matrix");
+
+  BOOST_REQUIRE_EQUAL(dataset.n_rows, 3);
+  BOOST_REQUIRE_EQUAL(dataset.n_cols, 1000);
+  BOOST_REQUIRE_EQUAL(dataset2.n_rows, 3);
+  BOOST_REQUIRE_EQUAL(dataset2.n_cols, 1000);
+
+  for (size_t i = 0; i < dataset.n_elem; ++i)
+    BOOST_REQUIRE_CLOSE(dataset[i], dataset2[i], 1e-10);
+}
+
+// Make sure that when we don't pass a required matrix, parsing fails.
+BOOST_AUTO_TEST_CASE(RequiredUnspecifiedInputMatrixParamTest)
+{
+  AddRequiredCLIOptions();
+
+  // --matrix is an input parameter; it won't be transposed.
+  PARAM_MATRIX_IN_REQ("matrix", "Test matrix", "m");
+
+  // Set some fake arguments.
+  const char* argv[1];
+  argv[0] = "./test";
+
+  int argc = 1;
+
+  // The const-cast is a little hacky but should be fine...
+  Log::Fatal.ignoreInput = true;
+  BOOST_REQUIRE_THROW(ParseCommandLine(argc, const_cast<char**>(argv)),
+      std::exception);
+  Log::Fatal.ignoreInput = false;
+}
+
 BOOST_AUTO_TEST_CASE(InputMatrixNoTransposeParamTest)
 {
   AddRequiredCLIOptions();


### PR DESCRIPTION
This fixes a serious problem found by @Yashwants19 where required matrix options could not be used from the command-line:

```
$ ./bin/mlpack_preprocess_split                                 \
>     --input_file covertype-small.data.csv                     \
>     --input_labels_file covertype-small.labels.csv            \
>     --training_file covertype-small.train.csv                 \
>     --training_labels_file covertype-small.train.labels.csv   \
>     --test_file covertype-small.test.csv                      \
>     --test_labels_file covertype-small.test.labels.csv        \
>     --test_ratio 0.3                                          \
>     --verbose
terminate called after throwing an instance of 'CLI::OptionNotFound'
  what():  input_file not found
Aborted (core dumped)
```

The affected bindings will be any binding that has a required matrix, matrix/DatasetInfo, or serializable model option.  It doesn't appear unless the parameter is required.

The fix is pretty simple, luckily.  I also added some tests to hopefully ensure something like this doesn't happen again.

I believe that we should release mlpack 3.4.1 once this bugfix is committed---and, as a bonus, that will give me an opportunity to try and get mlpack-bot to do the heavy lifting.