### PR TITLE
Clarify that the type should be size_t for numClasses in CVBase

### DIFF
--- a/src/mlpack/core/cv/cv_base_impl.hpp
+++ b/src/mlpack/core/cv/cv_base_impl.hpp
@@ -26,7 +26,8 @@ CVBase<MLAlgorithm,
     isDatasetInfoPassed(false)
 {
   static_assert(!MIE::TakesNumClasses,
-      "The given MLAlgorithm requires the numClasses parameter");
+      "The given MLAlgorithm requires the numClasses parameter; "
+      "make sure that you pass numClasses with type size_t!");
 }
 
 template<typename MLAlgorithm,

--- a/src/mlpack/core/cv/cv_base_impl.hpp
+++ b/src/mlpack/core/cv/cv_base_impl.hpp
@@ -23,7 +23,8 @@ CVBase<MLAlgorithm,
        MatType,
        PredictionsType,
        WeightsType>::CVBase() :
-    isDatasetInfoPassed(false)
+    isDatasetInfoPassed(false),
+    numClasses(0)
 {
   static_assert(!MIE::TakesNumClasses,
       "The given MLAlgorithm requires the numClasses parameter; "


### PR DESCRIPTION
This is a follow-up to #2614.  It just means that when the user tries to construct a `KFoldCV` or `SimpleCV` object, if they pass the number of classes incorrectly (i.e. as an `int`), then the warning will now point out that the type should be `size_t`.

So, for instance, this code does not work:

```
int numClasses = 2;
double validationSize = 0.2;
SimpleCV<DecisionTree<>, Accuracy> scv(validationSize, testData, testLabel, numClasses);
```

but this code does:

```
size_t numClasses = 2;
double validationSize = 0.2;
SimpleCV<DecisionTree<>, Accuracy> scv(validationSize, testData, testLabel, numClasses);
```

So now, if you write the first thing, the error that you get points out that the type of `numClasses` should be `size_t`.

@GLmontanari let me know if you think this message would have saved you time! :+1:

@micyril if you like, feel free to take a look and let me know if you think the error message makes sense or it could be further improved.  I thought it could be cool to adapt the code so that `MetaInfoExtractor` will take an `int` for `numClasses`, but I didn't have the time to dig in.