### PR TITLE
Fix regex for versions of Go without a patch version

### DIFF
--- a/CMake/FindGo.cmake
+++ b/CMake/FindGo.cmake
@@ -14,9 +14,9 @@ if (GO_EXECUTABLE)
        RESULT_VARIABLE RESULT
   )
   if (RESULT EQUAL 0)
-    string(REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1"
+    string(REGEX REPLACE ".*([0-9]+\\.[0-9]+\(\\.[0-9]+\)?).*" "\\1"
         GO_VERSION_STRING ${GO_VERSION_STRING})
-    endif()
+  endif()
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
I noticed that the OS X Go builds were failing during CMake configuration like this:

```
-- Go not found: Found unsuitable version "go version go1.15 darwin/amd64
", but required is at least "1.11.0" (found /usr/local/bin/go)
```

See, e.g., https://dev.azure.com/mlpack/mlpack/_build/results?buildId=4307&view=logs&jobId=4ad28a20-a210-5db1-5cbb-cda6f2d26943&j=4ad28a20-a210-5db1-5cbb-cda6f2d26943&t=dbf69b48-0c7c-5f5f-9546-6e5df880e0ba

So, this PR just fixes the regex that extracts the version from Go to accept when there is no patch version.

@Yashwants19 let me know what you think or if I overlooked something. :+1: