### PR TITLE
Migrate DBSCAN test from boost to catch2

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -133,7 +133,8 @@ Copyright:
   Copyright 2020, Bisakh Mondal <bisakhmondal00@gmail.com>
   Copyright 2020, Benson Muite <benson_muite@emailplus.org>
   Copyright 2020, Sarthak Bhardwaj <7sarthakbhardwaj@gmail.com>
-  Copyright 2020, Aakash Kaushik <kaushikaakash7539@gmail.com>   
+  Copyright 2020, Aakash Kaushik <kaushikaakash7539@gmail.com>
+  Copyright 2020, Anush Kini <anushkini@gmail.com>   
 
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -78,7 +78,6 @@ add_executable(mlpack_test
   vantage_point_tree_test.cpp
   wgan_test.cpp
   main_tests/cf_test.cpp
-  main_tests/dbscan_test.cpp
   main_tests/det_test.cpp
   main_tests/emst_test.cpp
   main_tests/fastmks_test.cpp
@@ -163,6 +162,7 @@ add_executable(mlpack_catch_test
   main_tests/adaboost_test.cpp
   main_tests/approx_kfn_test.cpp
   main_tests/bayesian_linear_regression_test.cpp
+  main_tests/dbscan_test.cpp
   main_tests/decision_stump_test.cpp
   main_tests/decision_tree_test.cpp
   main_tests/image_converter_test.cpp

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(mlpack_test
   cli_binding_test.cpp
   io_test.cpp
   cosine_tree_test.cpp
-  dbscan_test.cpp
   dcgan_test.cpp
   det_test.cpp
   distribution_test.cpp
@@ -128,6 +127,7 @@ add_executable(mlpack_catch_test
   convolutional_network_test.cpp
   convolution_test.cpp
   cv_test.cpp
+  dbscan_test.cpp
   decision_stump_test.cpp
   decision_tree_test.cpp
   feedforward_network_test.cpp
@@ -273,4 +273,3 @@ add_test(NAME "catch_test" COMMAND mlpack_catch_test WORKING_DIRECTORY ${CMAKE_B
 
 # Use RUN_SERIAL for long running parallel tests
 set_tests_properties(${parallel_tests} PROPERTIES RUN_SERIAL TRUE)
-

--- a/src/mlpack/tests/dbscan_test.cpp
+++ b/src/mlpack/tests/dbscan_test.cpp
@@ -13,17 +13,16 @@
 #include <mlpack/methods/dbscan/dbscan.hpp>
 #include <mlpack/methods/dbscan/random_point_selection.hpp>
 
-#include <boost/test/unit_test.hpp>
-#include "test_tools.hpp"
+#include "test_catch_tools.hpp"
+#include "catch.hpp"
+
 
 using namespace mlpack;
 using namespace mlpack::range;
 using namespace mlpack::dbscan;
 using namespace mlpack::distribution;
 
-BOOST_AUTO_TEST_SUITE(DBSCANTest);
-
-BOOST_AUTO_TEST_CASE(OneClusterTest)
+TEST_CASE("OneClusterTest", "[DBSCANTest]")
 {
   // Make sure that if we have points in the unit box, and if we set epsilon
   // large enough, all points end up as in one cluster.
@@ -34,16 +33,16 @@ BOOST_AUTO_TEST_CASE(OneClusterTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_EQUAL(clusters, 1);
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
+  REQUIRE(clusters == 1);
+  REQUIRE(assignments.n_elem == points.n_cols);
   for (size_t i = 0; i < assignments.n_elem; ++i)
-    BOOST_REQUIRE_EQUAL(assignments[i], 0);
+    REQUIRE(assignments[i] == 0);
 }
 
 /**
  * When epsilon is small enough, every point returned should be noise.
  */
-BOOST_AUTO_TEST_CASE(TinyEpsilonTest)
+TEST_CASE("TinyEpsilonTest", "[DBSCANTest]")
 {
   arma::mat points(10, 200, arma::fill::randu);
 
@@ -52,16 +51,16 @@ BOOST_AUTO_TEST_CASE(TinyEpsilonTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_EQUAL(clusters, 0);
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
+  REQUIRE(clusters == 0);
+  REQUIRE(assignments.n_elem == points.n_cols);
   for (size_t i = 0; i < assignments.n_elem; ++i)
-    BOOST_REQUIRE_EQUAL(assignments[i], SIZE_MAX);
+    REQUIRE(assignments[i] == SIZE_MAX);
 }
 
 /**
  * Check that outliers are properly labeled as noise.
  */
-BOOST_AUTO_TEST_CASE(OutlierTest)
+TEST_CASE("OutlierTest", "[DBSCANTest]")
 {
   arma::mat points(2, 200, arma::fill::randu);
 
@@ -75,17 +74,18 @@ BOOST_AUTO_TEST_CASE(OutlierTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_GT(clusters, 0);
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
-  BOOST_REQUIRE_EQUAL(assignments[15], SIZE_MAX);
-  BOOST_REQUIRE_EQUAL(assignments[45], SIZE_MAX);
-  BOOST_REQUIRE_EQUAL(assignments[101], SIZE_MAX);
+  REQUIRE(clusters > 0);
+  REQUIRE(assignments.n_elem == points.n_cols);
+  REQUIRE(assignments[15] == SIZE_MAX);
+  REQUIRE(assignments[45] == SIZE_MAX);
+  REQUIRE(assignments[101] == SIZE_MAX);
+
 }
 
 /**
  * Check that the Gaussian clusters are correctly found.
  */
-BOOST_AUTO_TEST_CASE(GaussiansTest)
+TEST_CASE("GaussiansTest", "[DBSCANTest]")
 {
   arma::mat points(3, 300);
 
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(GaussiansTest)
   arma::Row<size_t> assignments;
   arma::mat centroids;
   const size_t clusters = d.Cluster(points, assignments, centroids);
-  BOOST_REQUIRE_EQUAL(clusters, 3);
+  REQUIRE(clusters == 3);
 
   // Our centroids should be close to one of our Gaussians.
   arma::Row<size_t> matches(3);
@@ -120,35 +120,35 @@ BOOST_AUTO_TEST_CASE(GaussiansTest)
       matches(2) = j;
   }
 
-  BOOST_REQUIRE_NE(matches(0), matches(1));
-  BOOST_REQUIRE_NE(matches(1), matches(2));
-  BOOST_REQUIRE_NE(matches(2), matches(0));
+  REQUIRE(matches(0) != matches(1));
+  REQUIRE(matches(1) != matches(2));
+  REQUIRE(matches(2) != matches(0));
 
-  BOOST_REQUIRE_NE(matches(0), 3);
-  BOOST_REQUIRE_NE(matches(1), 3);
-  BOOST_REQUIRE_NE(matches(2), 3);
+  REQUIRE(matches(0) != 3);
+  REQUIRE(matches(1) != 3);
+  REQUIRE(matches(2) != 3);
 
   for (size_t i = 0; i < 100; ++i)
   {
     // Each point should either be noise or in cluster matches(0).
-    BOOST_REQUIRE_NE(assignments(i), matches(1));
-    BOOST_REQUIRE_NE(assignments(i), matches(2));
+    REQUIRE(assignments(i) != matches(1));
+    REQUIRE(assignments(i) != matches(2));
   }
 
   for (size_t i = 100; i < 200; ++i)
   {
-    BOOST_REQUIRE_NE(assignments(i), matches(0));
-    BOOST_REQUIRE_NE(assignments(i), matches(2));
+    REQUIRE(assignments(i) != matches(0));
+    REQUIRE(assignments(i) != matches(2));
   }
 
   for (size_t i = 200; i < 300; ++i)
   {
-    BOOST_REQUIRE_NE(assignments(i), matches(0));
-    BOOST_REQUIRE_NE(assignments(i), matches(1));
+    REQUIRE(assignments(i) != matches(0));
+    REQUIRE(assignments(i) != matches(1));
   }
 }
 
-BOOST_AUTO_TEST_CASE(OneClusterSingleModeTest)
+TEST_CASE("OneClusterSingleModeTest", "[DBSCANTest]")
 {
   // Make sure that if we have points in the unit box, and if we set epsilon
   // large enough, all points end up as in one cluster.
@@ -159,16 +159,16 @@ BOOST_AUTO_TEST_CASE(OneClusterSingleModeTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_EQUAL(clusters, 1);
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
+  REQUIRE(clusters == 1);
+  REQUIRE(assignments.n_elem == points.n_cols);
   for (size_t i = 0; i < assignments.n_elem; ++i)
-    BOOST_REQUIRE_EQUAL(assignments[i], 0);
+    REQUIRE(assignments[i] == 0);
 }
 
 /**
  * When epsilon is small enough, every point returned should be noise.
  */
-BOOST_AUTO_TEST_CASE(TinyEpsilonSingleModeTest)
+TEST_CASE("TinyEpsilonSingleModeTest", "[DBSCANTest]")
 {
   arma::mat points(10, 200, arma::fill::randu);
 
@@ -177,16 +177,16 @@ BOOST_AUTO_TEST_CASE(TinyEpsilonSingleModeTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_EQUAL(clusters, 0);
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
+  REQUIRE(clusters == 0);
+  REQUIRE(assignments.n_elem == points.n_cols);
   for (size_t i = 0; i < assignments.n_elem; ++i)
-    BOOST_REQUIRE_EQUAL(assignments[i], SIZE_MAX);
+    REQUIRE(assignments[i] == SIZE_MAX);
 }
 
 /**
  * Check that outliers are properly labeled as noise.
  */
-BOOST_AUTO_TEST_CASE(OutlierSingleModeTest)
+TEST_CASE("OutlierSingleModeTest", "[DBSCANTest]")
 {
   arma::mat points(2, 200, arma::fill::randu);
 
@@ -200,17 +200,17 @@ BOOST_AUTO_TEST_CASE(OutlierSingleModeTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_GT(clusters, 0);
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
-  BOOST_REQUIRE_EQUAL(assignments[15], SIZE_MAX);
-  BOOST_REQUIRE_EQUAL(assignments[45], SIZE_MAX);
-  BOOST_REQUIRE_EQUAL(assignments[101], SIZE_MAX);
+  REQUIRE(clusters > 0);
+  REQUIRE(assignments.n_elem == points.n_cols);
+  REQUIRE(assignments[15] == SIZE_MAX);
+  REQUIRE(assignments[45] == SIZE_MAX);
+  REQUIRE(assignments[101] == SIZE_MAX);
 }
 
 /**
  * Check that the Gaussian clusters are correctly found.
  */
-BOOST_AUTO_TEST_CASE(GaussiansSingleModeTest)
+TEST_CASE("GaussiansSingleModeTest", "[DBSCANTest]")
 {
   arma::mat points(3, 300);
 
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(GaussiansSingleModeTest)
   arma::Row<size_t> assignments;
   arma::mat centroids;
   const size_t clusters = d.Cluster(points, assignments, centroids);
-  BOOST_REQUIRE_EQUAL(clusters, 3);
+  REQUIRE(clusters == 3);
 
   // Our centroids should be close to one of our Gaussians.
   arma::Row<size_t> matches(3);
@@ -245,38 +245,38 @@ BOOST_AUTO_TEST_CASE(GaussiansSingleModeTest)
       matches(2) = j;
   }
 
-  BOOST_REQUIRE_NE(matches(0), matches(1));
-  BOOST_REQUIRE_NE(matches(1), matches(2));
-  BOOST_REQUIRE_NE(matches(2), matches(0));
+  REQUIRE(matches(0) != matches(1));
+  REQUIRE(matches(1) != matches(2));
+  REQUIRE(matches(2) != matches(0));
 
-  BOOST_REQUIRE_NE(matches(0), 3);
-  BOOST_REQUIRE_NE(matches(1), 3);
-  BOOST_REQUIRE_NE(matches(2), 3);
+  REQUIRE(matches(0) != 3);
+  REQUIRE(matches(1) != 3);
+  REQUIRE(matches(2) != 3);
 
   for (size_t i = 0; i < 100; ++i)
   {
     // Each point should either be noise or in cluster matches(0).
-    BOOST_REQUIRE_NE(assignments(i), matches(1));
-    BOOST_REQUIRE_NE(assignments(i), matches(2));
+    REQUIRE(assignments(i) != matches(1));
+    REQUIRE(assignments(i) != matches(2));
   }
 
   for (size_t i = 100; i < 200; ++i)
   {
-    BOOST_REQUIRE_NE(assignments(i), matches(0));
-    BOOST_REQUIRE_NE(assignments(i), matches(2));
+    REQUIRE(assignments(i) != matches(0));
+    REQUIRE(assignments(i) != matches(2));
   }
 
   for (size_t i = 200; i < 300; ++i)
   {
-    BOOST_REQUIRE_NE(assignments(i), matches(0));
-    BOOST_REQUIRE_NE(assignments(i), matches(1));
+    REQUIRE(assignments(i) != matches(0));
+    REQUIRE(assignments(i) != matches(1));
   }
 }
 
 /**
  * Check that OrderedPointSelection works correctly.
  */
-BOOST_AUTO_TEST_CASE(OrderedPointSelectionTest)
+TEST_CASE("OrderedPointSelectionTest", "[DBSCANTest]")
 {
   arma::mat points(10, 200, arma::fill::randu);
 
@@ -285,16 +285,16 @@ BOOST_AUTO_TEST_CASE(OrderedPointSelectionTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_EQUAL(clusters, 1);
+  REQUIRE(clusters == 1);
 
   // The number of assignments returned should be the same as points.
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
+  REQUIRE(assignments.n_elem == points.n_cols);
 }
 
 /**
  * Check that RandomPointSelection works correctly.
  */
-BOOST_AUTO_TEST_CASE(RandomPointSelectionTest)
+TEST_CASE("RandomPointSelectionTest", "[DBSCANTest]")
 {
   arma::mat points(10, 200, arma::fill::randu);
 
@@ -303,10 +303,8 @@ BOOST_AUTO_TEST_CASE(RandomPointSelectionTest)
   arma::Row<size_t> assignments;
   const size_t clusters = d.Cluster(points, assignments);
 
-  BOOST_REQUIRE_EQUAL(clusters, 1);
+  REQUIRE(clusters == 1);
 
   // The number of assignments returned should be the same as points.
-  BOOST_REQUIRE_EQUAL(assignments.n_elem, points.n_cols);
+  REQUIRE(assignments.n_elem == points.n_cols);
 }
-
-BOOST_AUTO_TEST_SUITE_END();

--- a/src/mlpack/tests/dbscan_test.cpp
+++ b/src/mlpack/tests/dbscan_test.cpp
@@ -16,7 +16,6 @@
 #include "test_catch_tools.hpp"
 #include "catch.hpp"
 
-
 using namespace mlpack;
 using namespace mlpack::range;
 using namespace mlpack::dbscan;

--- a/src/mlpack/tests/dbscan_test.cpp
+++ b/src/mlpack/tests/dbscan_test.cpp
@@ -78,7 +78,6 @@ TEST_CASE("OutlierTest", "[DBSCANTest]")
   REQUIRE(assignments[15] == SIZE_MAX);
   REQUIRE(assignments[45] == SIZE_MAX);
   REQUIRE(assignments[101] == SIZE_MAX);
-
 }
 
 /**

--- a/src/mlpack/tests/main_tests/dbscan_test.cpp
+++ b/src/mlpack/tests/main_tests/dbscan_test.cpp
@@ -19,8 +19,8 @@ static const std::string testName = "DBSCAN";
 #include "test_helper.hpp"
 #include <mlpack/methods/dbscan/dbscan_main.cpp>
 
-#include <boost/test/unit_test.hpp>
-#include "../test_tools.hpp"
+#include "../catch.hpp"
+#include "../test_catch_tools.hpp"
 
 using namespace mlpack;
 
@@ -41,17 +41,16 @@ struct DBSCANTestFixture
   }
 };
 
-BOOST_FIXTURE_TEST_SUITE(DBSCANMainTest, DBSCANTestFixture);
-
 /**
  * Check that number of output labels and number of input
  * points are equal.
  */
-BOOST_AUTO_TEST_CASE(DBSCANOutputDimensionTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANOutputDimensionTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   size_t inputSize = inputData.n_cols;
 
@@ -60,45 +59,45 @@ BOOST_AUTO_TEST_CASE(DBSCANOutputDimensionTest)
   mlpackMain();
 
   // Check that number of predicted labels is equal to the input test points.
-  BOOST_REQUIRE_EQUAL(IO::GetParam<arma::Row<size_t>>("assignments").n_cols,
-                      inputSize);
-  BOOST_REQUIRE_EQUAL(IO::GetParam<arma::Row<size_t>>("assignments").n_rows,
-                      1);
-  BOOST_REQUIRE_EQUAL(IO::GetParam<arma::mat>("centroids").n_rows, 4);
-  BOOST_REQUIRE_GE(IO::GetParam<arma::mat>("centroids").n_cols, 1);
+  REQUIRE(IO::GetParam<arma::Row<size_t>>("assignments").n_cols == inputSize);
+  REQUIRE(IO::GetParam<arma::Row<size_t>>("assignments").n_rows == 1);
+  REQUIRE(IO::GetParam<arma::mat>("centroids").n_rows == 4);
+  REQUIRE(IO::GetParam<arma::mat>("centroids").n_cols >= 1);
 }
 
 /**
  * Check that radius of search(epsilon) is always non-negative.
  */
-BOOST_AUTO_TEST_CASE(DBSCANEpsilonTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANEpsilonTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
   SetInputParam("epsilon", (double) -0.5);
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
 /**
  * Check that minimum size of cluster is always non-negative.
  */
-BOOST_AUTO_TEST_CASE(DBSCANMinSizeTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANMinSizeTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
   SetInputParam("min_size", (int) -1);
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
@@ -106,11 +105,12 @@ BOOST_AUTO_TEST_CASE(DBSCANMinSizeTest)
  * Check that no point is labelled as noise point
  * when min_size is equal to 1.
  */
-BOOST_AUTO_TEST_CASE(DBSCANClusterNumberTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANClusterNumberTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
   SetInputParam("min_size", (int) 1);
@@ -122,18 +122,19 @@ BOOST_AUTO_TEST_CASE(DBSCANClusterNumberTest)
   output = std::move(IO::GetParam<arma::Row<size_t>>("assignments"));
 
   for (size_t i = 0; i < output.n_elem; ++i)
-    BOOST_REQUIRE_LT(output[i], inputData.n_cols);
+    REQUIRE(output[i] < inputData.n_cols);
 }
 
 /**
  * Check that the cluster assignment is different for different
  * values of epsilon.
  */
-BOOST_AUTO_TEST_CASE(DBSCANDiffEpsilonTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANDiffEpsilonTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
   SetInputParam("epsilon", (double) 1.0);
@@ -156,18 +157,19 @@ BOOST_AUTO_TEST_CASE(DBSCANDiffEpsilonTest)
   arma::Row<size_t> output2;
   output2 = std::move(IO::GetParam<arma::Row<size_t>>("assignments"));
 
-  BOOST_REQUIRE_GT(arma::accu(output1 != output2), 1);
+  REQUIRE(arma::accu(output1 != output2) > 1);
 }
 
 /**
  * Check that the cluster assignment is different for different
  * values of Min Size.
  */
-BOOST_AUTO_TEST_CASE(DBSCANDiffMinSizeTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANDiffMinSizeTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
   SetInputParam("epsilon", (double) 0.4);
@@ -193,7 +195,7 @@ BOOST_AUTO_TEST_CASE(DBSCANDiffMinSizeTest)
   arma::Row<size_t> output2;
   output2 = std::move(IO::GetParam<arma::Row<size_t>>("assignments"));
 
-  BOOST_REQUIRE_GT(arma::accu(output1 != output2), 1);
+  REQUIRE(arma::accu(output1 != output2) > 1);
 }
 
 /**
@@ -201,17 +203,18 @@ BOOST_AUTO_TEST_CASE(DBSCANDiffMinSizeTest)
  * tree types. ’kd’, ’r’, ’r-star’, ’x’, ’hilbert-r’, ’r-plus’,
  * ’r-plus-plus’, ’cover’, ’ball’.
  */
-BOOST_AUTO_TEST_CASE(DBSCANTreeTypeTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANTreeTypeTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", std::move(inputData));
   SetInputParam("tree_type", std::string("binary"));
 
   Log::Fatal.ignoreInput = true;
-  BOOST_REQUIRE_THROW(mlpackMain(), std::runtime_error);
+  REQUIRE_THROWS_AS(mlpackMain(), std::runtime_error);
   Log::Fatal.ignoreInput = false;
 }
 
@@ -219,11 +222,12 @@ BOOST_AUTO_TEST_CASE(DBSCANTreeTypeTest)
  * Check that the assignment of cluster is same if
  * different tree type is used for search.
  */
-BOOST_AUTO_TEST_CASE(DBSCANDiffTreeTypeTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANDiffTreeTypeTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   // Tree type = kd tree.
 
@@ -369,11 +373,12 @@ BOOST_AUTO_TEST_CASE(DBSCANDiffTreeTypeTest)
  * Check that the assignment of cluster is same if
  * single tree is used for search.
  */
-BOOST_AUTO_TEST_CASE(DBSCANSingleTreeTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANSingleTreeTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
 
@@ -401,11 +406,12 @@ BOOST_AUTO_TEST_CASE(DBSCANSingleTreeTest)
  * Check that the assignment of cluster is same if
  * single tree is used for search.
  */
-BOOST_AUTO_TEST_CASE(DBSCANNaiveSearchTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANNaiveSearchTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
 
@@ -433,11 +439,12 @@ BOOST_AUTO_TEST_CASE(DBSCANNaiveSearchTest)
  * Check that the assignment of cluster is different if
  * point selection policies are different.
  */
-BOOST_AUTO_TEST_CASE(DBSCANRandomSelectionFlagTest)
+TEST_CASE_METHOD(DBSCANTestFixture, "DBSCANRandomSelectionFlagTest",
+                 "[DBSCANMainTest][BindingTests]")
 {
   arma::mat inputData;
   if (!data::Load("iris.csv", inputData))
-    BOOST_FAIL("Unable to load dataset iris.csv!");
+    FAIL("Unable to load dataset iris.csv!");
 
   SetInputParam("input", inputData);
   SetInputParam("epsilon", (double) 0.358);
@@ -466,7 +473,5 @@ BOOST_AUTO_TEST_CASE(DBSCANRandomSelectionFlagTest)
   arma::Row<size_t> randomOutput;
   randomOutput = std::move(IO::GetParam<arma::Row<size_t>>("assignments"));
 
-  BOOST_REQUIRE_GT(arma::accu(orderedOutput != randomOutput), 0);
+  REQUIRE(arma::accu(orderedOutput != randomOutput) > 0);
 }
-
-BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Regarding issue #2523 

The tests ran successfully on my local system build.