### PR TITLE
Re-based to 3.4.1 tag for CRAN corrections on R bindings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Testing/
 *.swp
 *.swo
 *~
+.Rproj.user

--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -166,6 +166,9 @@ if (BUILD_R_BINDINGS)
   set(LICENSE_SOURCES
     "${CMAKE_SOURCE_DIR}/LICENSE.txt"
   )
+  set(COPYRIGHT_SOURCES
+    "${CMAKE_SOURCE_DIR}/COPYRIGHT.txt"
+  )
   add_custom_target(r_copy ALL)
 
   # First we have to create all the required directories for copy.
@@ -220,6 +223,7 @@ if (BUILD_R_BINDINGS)
       COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different
           ${R_TESTS_SOURCES}
           ${CMAKE_CURRENT_BINARY_DIR}/mlpack/tests)
+  # Retrieve license files
   add_custom_command(TARGET r_copy PRE_BUILD
       COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different
           ${LICENSE_SOURCES}
@@ -228,6 +232,15 @@ if (BUILD_R_BINDINGS)
       COMMAND ${CMAKE_COMMAND} ARGS -E rename
           "${CMAKE_CURRENT_BINARY_DIR}/mlpack/LICENSE.txt"
           "${CMAKE_CURRENT_BINARY_DIR}/mlpack/LICENSE")
+  # Add copyright files
+  add_custom_command(TARGET r_copy PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different
+          ${COPYRIGHT_SOURCES}
+          ${CMAKE_CURRENT_BINARY_DIR}/mlpack/inst)
+  add_custom_command(TARGET r_copy PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} ARGS -E rename
+          "${CMAKE_CURRENT_BINARY_DIR}/mlpack/inst/COPYRIGHT.txt"
+          "${CMAKE_CURRENT_BINARY_DIR}/mlpack/inst/COPYRIGHTS")
   # This file will take care of multiple definition of functions in .cpp files.
   add_custom_command(TARGET r_copy PRE_BUILD
       COMMAND ${CMAKE_COMMAND} ARGS -E touch

--- a/src/mlpack/bindings/R/mlpack/.Rbuildignore
+++ b/src/mlpack/bindings/R/mlpack/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
+++ b/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
@@ -3,13 +3,24 @@ Title: 'Rcpp' Integration for the 'mlpack' Library
 Version: @PACKAGE_VERSION@
 Date: @PACKAGE_DATE@
 Author: mlpack Team
-Maintainer: Ryan Curtin <ryan@ratml.org>
+Maintainer: James Joseph Balamuta <balamut2@illinois.edu>
 Description: 'mlpack' is a fast, flexible machine learning library, written
              in C++, that aims to provide fast, extensible implementations of
-             cutting-edge machine learning algorithms.
+             cutting-edge machine learning algorithms. Note that 'mlpack' is
+             licensed under 3-clause BSD, some reproductions of 'boost' source
+             code inside 'mlpack' are licensed under Boost Software License 1,
+             uses of 'stb' are licensed under MIT License and the Public Domain,
+             'Ensmallen' is licensed under 3-clause BSD,
+             'Armadillo' starting from 7.800.0 is licensed under Apache License 2,
+             'RcppArmadillo' and 'RcppEnsmallen' (the 'Rcpp' bindings/bridge to
+             'Armadillo' and 'Ensmallen' libraries) are
+             licensed under the GNU GPL version 2 or later. Thus, 'mlpack' bindings
+             for R are also licensed under similar terms. Note that
+             'mlpack' requires a compiler that supports 'C++11',
+             'Armadillo' 8.400 or later, and 'Ensmallen' 2.10.0 or later.
 SystemRequirements: A C++11 compiler. Versions 4.8.*, 4.9.* or later of GCC
                     will be fine.
-License: BSD_3_clause + file LICENSE
+License: file LICENSE
 Depends: R (>= 4.0.0)
 Imports: Rcpp (>= 0.12.12)
 LinkingTo: Rcpp,

--- a/src/mlpack/bindings/R/mlpack/mlpack.Rproj
+++ b/src/mlpack/bindings/R/mlpack/mlpack.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX


### PR DESCRIPTION
@rcurtin / MLPACK PR reviewers, please avoid merging this PR.  The PR is a WIP that changes depending on feedback from CRAN to get the _R_ bindings listed. 

Inside this PR, we've addressed:

- Licensing issues that arose on the first submission by: 
  - adding `inst/COPYRIGHTS` containing `COPYRIGHT.txt`
  - removing the `BSD_3_clause + file LICENSE` in favor of just `file LICENSE` 
  - explicitly detailing licensing within the package description.
  - Details:  [WRE 1.1.2: Licensing](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Licensing)


Note: #2633 was closed out because it was branched off of master instead of the 3.4.1 tag. 

/cc @eddelbuettel @Yashwants19 