### PR TITLE
Add WeightSize to BatchNorm and Conv Layer.

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -160,6 +160,9 @@ class BatchNorm
   //! Get the average parameter.
   bool Average() const { return average; }
 
+  //! Get size of weights.
+  size_t WeightSize() const { return 2 * size; }
+
   /**
    * Serialize the layer
    */

--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -50,7 +50,7 @@ BatchNorm<InputDataType, OutputDataType>::BatchNorm(
     count(0),
     averageFactor(0.0)
 {
-  weights.set_size(size + size, 1);
+  weights.set_size(WeightSize(), 1);
   runningMean.zeros(size, 1);
   runningVariance.ones(size, 1);
 }

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -253,6 +253,12 @@ class Convolution
   //! Modify the right padding width.
   size_t& PadWRight() { return padWRight; }
 
+  //! Get size of weights for the layer.
+  size_t WeightSize() const
+  {
+    return (outSize * inSize * kernelWidth *kernelHeight) + outSize;
+  }
+
   /**
    * Serialize the layer.
    */

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -256,7 +256,7 @@ class Convolution
   //! Get size of weights for the layer.
   size_t WeightSize() const
   {
-    return (outSize * inSize * kernelWidth *kernelHeight) + outSize;
+    return (outSize * inSize * kernelWidth * kernelHeight) + outSize;
   }
 
   /**

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -117,8 +117,7 @@ Convolution<
     outputWidth(0),
     outputHeight(0)
 {
-  weights.set_size((outSize * inSize * kernelWidth * kernelHeight) + outSize,
-      1);
+  weights.set_size(WeightSize(), 1);
 
   // Transform paddingType to lowercase.
   std::string paddingTypeLow = paddingType;

--- a/src/mlpack/tests/ann_visitor_test.cpp
+++ b/src/mlpack/tests/ann_visitor_test.cpp
@@ -102,8 +102,7 @@ TEST_CASE("WeightSizeVisitorTestForConvLayer", "[ANNVisitorTest]")
   size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
                                            convLayer);
 
-  REQUIRE(weightSize == (randomOutSize * randomInSize * randomKernelWidth *
-      randomKernelHeight) + randomOutSize);
+  REQUIRE(weightSize == convLayer.Parameters().n_elem);
 }
 
 /**
@@ -118,5 +117,5 @@ TEST_CASE("WeightSizeVisitorTestForBatchNormLayer", "[ANNVisitorTest]")
   size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
                                            batchNorm);
 
-  REQUIRE(weightSize == 2 * randomSize);
+  REQUIRE(weightSize == batchNorm.Parameters().n_elem);
 }

--- a/src/mlpack/tests/ann_visitor_test.cpp
+++ b/src/mlpack/tests/ann_visitor_test.cpp
@@ -86,3 +86,37 @@ TEST_CASE("WeightSizeVisitorTest", "[ANNVisitorTest]")
   REQUIRE(weightSize == randomSize * randomSize + randomSize);
 }
 
+/**
+ * Test that WeightSizeVisitor works properly for Convolution layer.
+ */
+TEST_CASE("WeightSizeVisitorTestForConvLayer", "[ANNVisitorTest]")
+{
+  size_t randomInSize = arma::randi(arma::distr_param(1, 100));
+  size_t randomOutSize = arma::randi(arma::distr_param(1, 100));
+  size_t randomKernelWidth = arma::randi(arma::distr_param(1, 100));
+  size_t randomKernelHeight = arma::randi(arma::distr_param(1, 100));
+
+  LayerTypes<> convLayer = new Convolution<>(randomInSize, randomOutSize,
+      randomKernelWidth, randomKernelHeight);
+
+  size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
+                                           convLayer);
+
+  REQUIRE(weightSize == (randomOutSize * randomInSize * randomKernelWidth *
+      randomKernelHeight) + randomOutSize);
+}
+
+/**
+ * Test that WeightSizeVisitor works properly for BatchNorm layer.
+ */
+TEST_CASE("WeightSizeVisitorTestForBatchNormLayer", "[ANNVisitorTest]")
+{
+  size_t randomSize = arma::randi(arma::distr_param(1, 100));
+
+  LayerTypes<> batchNorm = new BatchNorm<>(randomSize);
+
+  size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
+                                           batchNorm);
+
+  REQUIRE(weightSize == 2 * randomSize);
+}

--- a/src/mlpack/tests/ann_visitor_test.cpp
+++ b/src/mlpack/tests/ann_visitor_test.cpp
@@ -54,6 +54,20 @@ TEST_CASE("BiasSetVisitorTest", "[ANNVisitorTest]")
 }
 
 /**
+ * Check correctness of WeightSize() for a layer.
+ */
+void CheckCorrectnessOfWeightSize(LayerTypes<>& layer)
+{
+  size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
+      layer);
+
+  arma::mat parameters;
+  boost::apply_visitor(ParametersVisitor(parameters), layer);
+
+  REQUIRE(weightSize == parameters.n_elem);
+}
+
+/**
  * Test that WeightSetVisitor works properly.
  */
 TEST_CASE("WeightSetVisitorTest", "[ANNVisitorTest]")
@@ -80,11 +94,9 @@ TEST_CASE("WeightSizeVisitorTest", "[ANNVisitorTest]")
 
   LayerTypes<> linear = new Linear<>(randomSize, randomSize);
 
-  size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
-      linear);
-
-  REQUIRE(weightSize == randomSize * randomSize + randomSize);
+  CheckCorrectnessOfWeightSize(linear);
 }
+
 
 /**
  * Test that WeightSizeVisitor works properly for Convolution layer.
@@ -98,11 +110,7 @@ TEST_CASE("WeightSizeVisitorTestForConvLayer", "[ANNVisitorTest]")
 
   LayerTypes<> convLayer = new Convolution<>(randomInSize, randomOutSize,
       randomKernelWidth, randomKernelHeight);
-
-  size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
-                                           convLayer);
-
-  REQUIRE(weightSize == convLayer.Parameters().n_elem);
+  CheckCorrectnessOfWeightSize(convLayer);
 }
 
 /**
@@ -113,9 +121,5 @@ TEST_CASE("WeightSizeVisitorTestForBatchNormLayer", "[ANNVisitorTest]")
   size_t randomSize = arma::randi(arma::distr_param(1, 100));
 
   LayerTypes<> batchNorm = new BatchNorm<>(randomSize);
-
-  size_t weightSize = boost::apply_visitor(WeightSizeVisitor(),
-                                           batchNorm);
-
-  REQUIRE(weightSize == batchNorm.Parameters().n_elem);
+  CheckCorrectnessOfWeightSize(batchNorm);
 }


### PR DESCRIPTION
Hey everyone,
This PR adds weights size to BatchNorm and Conv Layer.
Related Issue : #2590

Regards.