### PR TITLE
Forward implementation changed for softmin and softmax activation function

### DIFF
--- a/src/mlpack/methods/ann/layer/softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/softmax_impl.hpp
@@ -28,12 +28,12 @@ Softmax<InputDataType, OutputDataType>::Softmax()
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void Softmax<InputDataType, OutputDataType>::Forward(
-    const InputType& input, OutputType& output)
+    const InputType& input,
+    OutputType& output)
 {
-  InputType inputMax = arma::repmat(arma::max(input, 0), input.n_rows, 1);
-  output = inputMax + arma::log(arma::repmat(
-      arma::sum(arma::exp(input - inputMax), 0), input.n_rows, 1));
-  output = arma::exp(input - output);
+  InputType softmaxInput = arma::exp(input.each_row() -
+      arma::max(input, 0));
+  output = softmaxInput.each_row() / sum(softmaxInput, 0);
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/softmin_impl.hpp
+++ b/src/mlpack/methods/ann/layer/softmin_impl.hpp
@@ -30,10 +30,9 @@ void Softmin<InputDataType, OutputDataType>::Forward(
     const InputType& input,
     OutputType& output)
 { 
-  InputType inputMin = arma::repmat(arma::min(input,0), input.n_rows, 1);
-  output = arma::repmat(arma::log(arma::sum(
-      arma::exp(-(input - inputMin)),0)), input.n_rows, 1);
-  output = arma::exp(-(input - inputMin) - output);
+  InputType softminInput = arma::exp(-(input.each_row() -
+      arma::min(input, 0)));
+  output = softminInput.each_row() / sum(softminInput, 0);
 }
 
 template<typename InputDataType, typename OutputDataType>


### PR DESCRIPTION
This PR is a result from the discussion and the results [here](https://github.com/mlpack/mlpack/pull/2621#discussion_r499231425). The current forward implementation of Softmax and Softmin activation functions were considerably slow than what @zoq proposed in the previously mentioned discussion.

The decision was took based upon the Softmin implementation and the code for testing could be seen here for the  [current implementation](https://gist.github.com/Aakash-kaushik/a51a1543ef76b8c0a8285e5ce51c5de4) and here for the [implementation](https://gist.github.com/Aakash-kaushik/d877015f971001787fd2e43f0b2596c9) in this PR .

execution time for current implementation: `222150`
execution time for implementation in this PR: `149912`
Approx `48%` faster than the current implementation.

![](https://media1.tenor.com/images/eab616477cc18ea846b5f7b3dd27f189/tenor.gif?itemid=14031708)