### PR TITLE
Pass CMAKE_SIZEOF_VOID_P explicitly to CreateArmaConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,7 @@ add_custom_target(mlpack_arma_config ALL
     COMMAND ${CMAKE_COMMAND}
         -D ARMADILLO_INCLUDE_DIR="${ARMADILLO_INCLUDE_DIR}"
         -D OPENMP_FOUND="${OPENMP_FOUND}"
+        -D CMAKE_SIZEOF_VOID_P="${CMAKE_SIZEOF_VOID_P}"
         -P CMake/CreateArmaConfigInfo.cmake
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Updating arma_config.hpp (if necessary)")

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
   * Added Softmin activation function as layer in ann/layer.
 
-  * Fix spurious ARMA_64BIT_WORD compilation warnings on 32-bit systems.
+  * Fix spurious ARMA_64BIT_WORD compilation warnings on 32-bit systems (#2665).
 
 ### mlpack 3.4.1
 ###### 2020-09-07

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
   * Added Softmin activation function as layer in ann/layer.
 
+  * Fix spurious ARMA_64BIT_WORD compilation warnings on 32-bit systems.
+
 ### mlpack 3.4.1
 ###### 2020-09-07
   * Fix incorrect parsing of required matrix/model parameters for command-line


### PR DESCRIPTION
This fixes #2615 .

*A bunch of context*:

Armadillo has, as an internal configuration option, the preprocessor macro `ARMA_64BIT_WORD`.  If this is set (which it is by default), then during compilation, Armadillo matrix indices will be 64 bit integers.  If it isn't set, they will be 32 bit.  Now, this is a little bit of a problem because mlpack is *not* a header-only library, and so if mlpack itself is compiled with `ARMA_64BIT_WORD`, but then a program that links against mlpack is compiled *without* `ARMA_64BIT_WORD`, a nightmare of debugging awaits, because any symbols in the compiled program will have 32-bit `arma::uword` but libmlpack.so will expect 64-bit `arma::uword`.  One time, I did this inadvertently, and lost several hours of my life trying to figure out what in the world was going on.  It wasn't pleasant.

Therefore, we created a utility script in `CMake/CreateArmaConfigInfo.cmake`; during mlpack compilation time, it creates a header file `mlpack/core/util/arma_config.hpp` which is used in tandem with `mlpack/core/util/arma_config_check.hpp` in order to print a nasty-looking warning if someone tries to compile a program that links against mlpack with a different setting of `ARMA_64BIT_WORD`.

However, in #2615, @barak pointed out that there are all kinds of warnings for this... but these warnings didn't make sense, because on those 32-bit systems, `ARMA_64BIT_WORD` should not be enabled, and it should be as simple as that.

I managed to reproduce and dig into the issue a bit, and what I found was that `arma_config.hpp` was being created incorrectly... because `CMAKE_SIZEOF_VOID_P` is apparently *not set* when calling out to separate CMake scripts.  It seems to be only set in my original call to `cmake`.  So, I simply modified the callout to `CreateArmaConfigInfo.cmake` to *also* pass `CMAKE_SIZEOF_VOID_P`.

Wow, I wrote a lot about that.  I hope you enjoyed the story! :+1: