### PR TITLE
Release version 3.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,14 +360,14 @@ endif ()
 find_package(Ensmallen "${ENSMALLEN_VERSION}")
 if (NOT ENSMALLEN_FOUND)
   if (DOWNLOAD_ENSMALLEN)
-    file(DOWNLOAD http://www.ensmallen.org/files/ensmallen-2.14.2.tar.gz
-        "${CMAKE_BINARY_DIR}/deps/ensmallen-2.14.2.tar.gz"
+    file(DOWNLOAD http://www.ensmallen.org/files/ensmallen-latest.tar.gz
+        "${CMAKE_BINARY_DIR}/deps/ensmallen-latest.tar.gz"
         STATUS ENS_DOWNLOAD_STATUS_LIST LOG ENS_DOWNLOAD_LOG
         SHOW_PROGRESS)
     list(GET ENS_DOWNLOAD_STATUS_LIST 0 ENS_DOWNLOAD_STATUS)
     if (ENS_DOWNLOAD_STATUS EQUAL 0)
       execute_process(COMMAND ${CMAKE_COMMAND} -E
-          tar xzf "${CMAKE_BINARY_DIR}/deps/ensmallen-2.14.2.tar.gz"
+          tar xzf "${CMAKE_BINARY_DIR}/deps/ensmallen-latest.tar.gz"
           WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/deps/")
 
       # Get the name of the directory.
@@ -375,7 +375,7 @@ if (NOT ENSMALLEN_FOUND)
           "${CMAKE_BINARY_DIR}/deps/ensmallen-[0-9]*.[0-9]*.[0-9]*")
       # list(FILTER) is not available on 3.5 or older, but try to keep
       # configuring without filtering the list anyway (it might work if only
-      # the file ensmallen-2.14.2.tar.gz is present.
+      # the file ensmallen-latest.tar.gz is present.
       if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.6.0")
         list(FILTER ENS_DIRECTORIES EXCLUDE REGEX "ensmallen-.*\.tar\.gz")
       endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,14 +360,14 @@ endif ()
 find_package(Ensmallen "${ENSMALLEN_VERSION}")
 if (NOT ENSMALLEN_FOUND)
   if (DOWNLOAD_ENSMALLEN)
-    file(DOWNLOAD http://www.ensmallen.org/files/ensmallen-latest.tar.gz
-        "${CMAKE_BINARY_DIR}/deps/ensmallen-latest.tar.gz"
+    file(DOWNLOAD http://www.ensmallen.org/files/ensmallen-2.14.2.tar.gz
+        "${CMAKE_BINARY_DIR}/deps/ensmallen-2.14.2.tar.gz"
         STATUS ENS_DOWNLOAD_STATUS_LIST LOG ENS_DOWNLOAD_LOG
         SHOW_PROGRESS)
     list(GET ENS_DOWNLOAD_STATUS_LIST 0 ENS_DOWNLOAD_STATUS)
     if (ENS_DOWNLOAD_STATUS EQUAL 0)
       execute_process(COMMAND ${CMAKE_COMMAND} -E
-          tar xzf "${CMAKE_BINARY_DIR}/deps/ensmallen-latest.tar.gz"
+          tar xzf "${CMAKE_BINARY_DIR}/deps/ensmallen-2.14.2.tar.gz"
           WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/deps/")
 
       # Get the name of the directory.
@@ -375,7 +375,7 @@ if (NOT ENSMALLEN_FOUND)
           "${CMAKE_BINARY_DIR}/deps/ensmallen-[0-9]*.[0-9]*.[0-9]*")
       # list(FILTER) is not available on 3.5 or older, but try to keep
       # configuring without filtering the list anyway (it might work if only
-      # the file ensmallen-latest.tar.gz is present.
+      # the file ensmallen-2.14.2.tar.gz is present.
       if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.6.0")
         list(FILTER ENS_DIRECTORIES EXCLUDE REGEX "ensmallen-.*\.tar\.gz")
       endif ()

--- a/Doxyfile
+++ b/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 PROJECT_NAME           = mlpack
-PROJECT_NUMBER         = 3.4.1
+PROJECT_NUMBER         = 3.4.2
 OUTPUT_DIRECTORY       = ./doc
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### mlpack ?.?.?
-###### ????-??-??
+### mlpack 3.4.2
+###### 2020-10-26
   * Added Mean Absolute Percentage Error.
 
   * Added Softmin activation function as layer in ann/layer.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### mlpack ?.?.?
+###### ????-??-??
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ src="https://cdn.rawgit.com/mlpack/mlpack.org/e7d36ed8/mlpack-black.svg" style="
 <p align="center">
   <em>
     Download:
-    <a href="https://www.mlpack.org/files/mlpack-3.4.1.tar.gz">current stable version (3.4.1)</a>
+    <a href="https://www.mlpack.org/files/mlpack-3.4.2.tar.gz">current stable version (3.4.2)</a>
   </em>
 </p>
 
@@ -152,7 +152,7 @@ on Ubuntu, you can install mlpack with the following command:
 
 Note: Older Ubuntu versions may not have the most recent version of mlpack
 available---for instance, at the time of this writing, Ubuntu 16.04 only has
-mlpack 3.4.1 available.  Options include upgrading your Ubuntu version, finding
+mlpack 3.4.2 available.  Options include upgrading your Ubuntu version, finding
 a PPA or other non-official sources, or installing with a manual build.
 
 There are some useful pages to consult in addition to this section:

--- a/doc/examples/sample-ml-app/sample-ml-app/sample-ml-app.vcxproj
+++ b/doc/examples/sample-ml-app/sample-ml-app/sample-ml-app.vcxproj
@@ -104,16 +104,16 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
-      <AdditionalIncludeDirectories>C:\boost\boost_1_66_0;C:\mlpack\armadillo-8.500.1\include;C:\mlpack\mlpack-3.4.1\build\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\boost\boost_1_66_0;C:\mlpack\armadillo-8.500.1\include;C:\mlpack\mlpack-3.4.2\build\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>C:\mlpack\mlpack-3.4.1\build\Debug\mlpack.lib;C:\boost\boost_1_66_0\lib64-msvc-14.1\libboost_serialization-vc141-mt-gd-x64-1_66.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>C:\mlpack\mlpack-3.4.2\build\Debug\mlpack.lib;C:\boost\boost_1_66_0\lib64-msvc-14.1\libboost_serialization-vc141-mt-gd-x64-1_66.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y "C:\mlpack\mlpack-3.4.1\build\Debug\mlpack.dll" $(OutDir)
-xcopy /y "C:\mlpack\mlpack-3.4.1\packages\OpenBLAS.0.2.14.1\lib\native\bin\x64\*.dll" $(OutDir)
+      <Command>xcopy /y "C:\mlpack\mlpack-3.4.2\build\Debug\mlpack.dll" $(OutDir)
+xcopy /y "C:\mlpack\mlpack-3.4.2\packages\OpenBLAS.0.2.14.1\lib\native\bin\x64\*.dll" $(OutDir)
 xcopy /y "$(ProjectDir)..\..\..\..\src\mlpack\tests\data\german.csv" "$(ProjectDir)data\german.csv*"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -30,7 +30,7 @@ to build mlpack on Windows, see \ref build_windows (alternatively, you can read
 is based on older versions).
 
 You can download the latest mlpack release from here:
-<a href="https://www.mlpack.org/files/mlpack-3.4.1.tar.gz">mlpack-3.4.1</a>
+<a href="https://www.mlpack.org/files/mlpack-3.4.2.tar.gz">mlpack-3.4.2</a>
 
 @section build_simple Simple Linux build instructions
 
@@ -38,9 +38,9 @@ Assuming all dependencies are installed in the system, you can run the commands
 below directly to build and install mlpack.
 
 @code
-$ wget https://www.mlpack.org/files/mlpack-3.4.1.tar.gz
-$ tar -xvzpf mlpack-3.4.1.tar.gz
-$ mkdir mlpack-3.4.1/build && cd mlpack-3.4.1/build
+$ wget https://www.mlpack.org/files/mlpack-3.4.2.tar.gz
+$ tar -xvzpf mlpack-3.4.2.tar.gz
+$ mkdir mlpack-3.4.2/build && cd mlpack-3.4.2/build
 $ cmake ../
 $ make -j4  # The -j is the number of cores you want to use for a build.
 $ sudo make install
@@ -65,8 +65,8 @@ configure mlpack.
 First we should unpack the mlpack source and create a build directory.
 
 @code
-$ tar -xvzpf mlpack-3.4.1.tar.gz
-$ cd mlpack-3.4.1
+$ tar -xvzpf mlpack-3.4.2.tar.gz
+$ cd mlpack-3.4.2
 $ mkdir build
 @endcode
 

--- a/doc/guide/python_quickstart.hpp
+++ b/doc/guide/python_quickstart.hpp
@@ -32,9 +32,9 @@ build and install mlpack.  You can copy-paste the commands into your shell.
 @code{.sh}
 sudo apt-get install libboost-all-dev g++ cmake libarmadillo-dev python-pip wget
 sudo pip install cython setuptools distutils numpy pandas
-wget https://www.mlpack.org/files/mlpack-3.4.1.tar.gz
-tar -xvzpf mlpack-3.4.1.tar.gz
-mkdir -p mlpack-3.4.1/build/ && cd mlpack-3.4.1/build/
+wget https://www.mlpack.org/files/mlpack-3.4.2.tar.gz
+tar -xvzpf mlpack-3.4.2.tar.gz
+mkdir -p mlpack-3.4.2/build/ && cd mlpack-3.4.2/build/
 cmake ../ && make -j4 && sudo make install
 @endcode
 

--- a/doc/guide/sample_ml_app.hpp
+++ b/doc/guide/sample_ml_app.hpp
@@ -29,17 +29,17 @@ mlpack and dependencies in Release Mode).
 @code
  - C:\boost\boost_1_71_0\lib\native\include
  - C:\mlpack\armadillo-9.800.3\include
- - C:\mlpack\mlpack-3.4.1\build\include
+ - C:\mlpack\mlpack-3.4.2\build\include
 @endcode
 - Under Linker > Input > Additional Dependencies add:
 @code
- - C:\mlpack\mlpack-3.4.1\build\Debug\mlpack.lib
+ - C:\mlpack\mlpack-3.4.2\build\Debug\mlpack.lib
  - C:\boost\boost_1_71_0\lib64-msvc-14.2\libboost_serialization-vc142-mt-gd-x64-1_71.lib
 @endcode
 - Under Build Events > Post-Build Event > Command Line add:
 @code
- - xcopy /y "C:\mlpack\mlpack-3.4.1\build\Debug\mlpack.dll" $(OutDir)
- - xcopy /y "C:\mlpack\mlpack-3.4.1\packages\OpenBLAS.0.2.14.1\lib\native\bin\x64\*.dll" $(OutDir)
+ - xcopy /y "C:\mlpack\mlpack-3.4.2\build\Debug\mlpack.dll" $(OutDir)
+ - xcopy /y "C:\mlpack\mlpack-3.4.2\packages\OpenBLAS.0.2.14.1\lib\native\bin\x64\*.dll" $(OutDir)
 @endcode
 
 @note Recent versions of Visual Studio set "Conformance Mode" enabled by default. This causes some issues with

--- a/src/mlpack/core/util/version.hpp
+++ b/src/mlpack/core/util/version.hpp
@@ -18,7 +18,7 @@
 // with higher number than the most recent release.
 #define MLPACK_VERSION_MAJOR 3
 #define MLPACK_VERSION_MINOR 4
-#define MLPACK_VERSION_PATCH 2
+#define MLPACK_VERSION_PATCH 3
 
 // The name of the version (for use by --version).
 namespace mlpack {


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to
make the 3.4.2 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so
that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

  * Added Mean Absolute Percentage Error.
 * Added Softmin activation function as layer in ann/layer.
 * Fix spurious ARMA_64BIT_WORD compilation warnings on 32-bit systems (#2665).