### PR TITLE
Avoid accidental deallocations in bindings for Armadillo 10+

### DIFF
--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -21,9 +21,11 @@ steps:
       pip install cython numpy pandas zipp configparser
     fi
 
-    if [ "a$(julia.version)" != "a" ]; then
-      brew cask install julia@1.5.1
-    fi
+    # Install Julia manually.
+    wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.2-mac64.dmg
+    sudo hdiutil mount julia-1.5.2-mac64.dmg
+    sudo cp -R /Volumes/julia-1.5.2-mac64/julia-1.5.2-mac64.app /Applications
+    sudo ln -s /Applications/julia-1.5.2-mac64.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -22,10 +22,10 @@ steps:
     fi
 
     # Install Julia manually.
-    wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.2-mac64.dmg
-    sudo hdiutil mount julia-1.5.2-mac64.dmg
-    ls /Volumes/Julia-1.5.2/Julia-1.5.app/
-    sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.app /Applications
+    wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.1-mac64.dmg
+    sudo hdiutil mount julia-1.5.1-mac64.dmg
+    ls /Volumes/Julia-1.5.1/Julia-1.5.app/
+    sudo cp -R /Volumes/Julia-1.5.1/Julia-1.5.app /Applications
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -24,8 +24,8 @@ steps:
     # Install Julia manually.
     wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.2-mac64.dmg
     sudo hdiutil mount julia-1.5.2-mac64.dmg
-    sudo cp -R /Volumes/julia-1.5.2-mac64/julia-1.5.2-mac64.app /Applications
-    sudo ln -s /Applications/julia-1.5.2-mac64.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
+    sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.2.app /Applications
+    sudo ln -s /Applications/Julia-1.5.2.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -21,11 +21,9 @@ steps:
       pip install cython numpy pandas zipp configparser
     fi
 
-    # Install Julia manually.
-    wget https://julialang-s3.julialang.org/bin/mac/x64/1.4/julia-1.4.2-mac64.dmg
-    sudo hdiutil mount julia-1.4.2-mac64.dmg
-    ls /Volumes/Julia-1.4.2/Julia-1.4.app/
-    sudo cp -R /Volumes/Julia-1.4.2/Julia-1.4.app /Applications
+    if [ "a$(julia.version)" != "a" ]; then
+      brew cask install julia
+    fi
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -26,6 +26,7 @@ steps:
     sudo hdiutil mount julia-1.5.2-mac64.dmg
     ls /Volumes/Julia-1.5.2/Julia-1.5.app/
     sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.app /Applications
+    ls -l /usr/local/bin/
     sudo ln -s /Applications/Julia-1.5.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -22,10 +22,10 @@ steps:
     fi
 
     # Install Julia manually.
-    wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.1-mac64.dmg
-    sudo hdiutil mount julia-1.5.1-mac64.dmg
-    ls /Volumes/Julia-1.5.1/Julia-1.5.app/
-    sudo cp -R /Volumes/Julia-1.5.1/Julia-1.5.app /Applications
+    wget https://julialang-s3.julialang.org/bin/mac/x64/1.4/julia-1.4.2-mac64.dmg
+    sudo hdiutil mount julia-1.4.2-mac64.dmg
+    ls /Volumes/Julia-1.4.2/Julia-1.4.app/
+    sudo cp -R /Volumes/Julia-1.4.2/Julia-1.4.app /Applications
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -24,6 +24,7 @@ steps:
     # Install Julia manually.
     wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.2-mac64.dmg
     sudo hdiutil mount julia-1.5.2-mac64.dmg
+    ls /Volumes/Julia-1.5.2/
     sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.2.app /Applications
     sudo ln -s /Applications/Julia-1.5.2.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -22,7 +22,7 @@ steps:
     fi
 
     if [ "a$(julia.version)" != "a" ]; then
-      brew cask install julia
+      brew cask install julia@1.5.1
     fi
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -24,9 +24,9 @@ steps:
     # Install Julia manually.
     wget https://julialang-s3.julialang.org/bin/mac/x64/1.5/julia-1.5.2-mac64.dmg
     sudo hdiutil mount julia-1.5.2-mac64.dmg
-    ls /Volumes/Julia-1.5.2/
-    sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.2.app /Applications
-    sudo ln -s /Applications/Julia-1.5.2.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
+    ls /Volumes/Julia-1.5.2/Julia-1.5.app/
+    sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.app /Applications
+    sudo ln -s /Applications/Julia-1.5.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -26,8 +26,6 @@ steps:
     sudo hdiutil mount julia-1.5.2-mac64.dmg
     ls /Volumes/Julia-1.5.2/Julia-1.5.app/
     sudo cp -R /Volumes/Julia-1.5.2/Julia-1.5.app /Applications
-    ls -l /usr/local/bin/
-    sudo ln -s /Applications/Julia-1.5.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'

--- a/src/mlpack/bindings/go/mlpack/capi/arma_util.hpp
+++ b/src/mlpack/bindings/go/mlpack/capi/arma_util.hpp
@@ -37,6 +37,11 @@ inline typename T::elem_type* GetMemory(T& m)
   else
   {
     arma::access::rw(m.mem_state) = 1;
+    // With Armadillo 10 and newer, we must set `n_alloc` to 0 so that
+    // Armadillo does not deallocate the memory.
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(m.n_alloc) = 0;
+    #endif
     return m.memptr();
   }
 }

--- a/src/mlpack/bindings/julia/julia_util.cpp
+++ b/src/mlpack/bindings/julia/julia_util.cpp
@@ -347,6 +347,9 @@ size_t IO_GetParamUMatCols(const char* paramName)
 size_t* IO_GetParamUMat(const char* paramName)
 {
   arma::Mat<size_t>& mat = IO::GetParam<arma::Mat<size_t>>(paramName);
+
+  // Are we using preallocated memory?  If so we have to handle this more
+  // carefully.
   if (mat.n_elem <= arma::arma_config::mat_prealloc)
   {
     // Copy the memory to something that we can give back to Julia.
@@ -415,6 +418,9 @@ size_t IO_GetParamUColRows(const char* paramName)
 size_t* IO_GetParamUCol(const char* paramName)
 {
   arma::Col<size_t>& vec = IO::GetParam<arma::Col<size_t>>(paramName);
+
+  // Are we using preallocated memory?  If so we have to handle this more
+  // carefully.
   if (vec.n_elem <= arma::arma_config::mat_prealloc)
   {
     // Copy the memory to something we can give back to Julia.
@@ -483,6 +489,9 @@ size_t IO_GetParamURowCols(const char* paramName)
 size_t* IO_GetParamURow(const char* paramName)
 {
   arma::Row<size_t>& vec = IO::GetParam<arma::Row<size_t>>(paramName);
+
+  // Are we using preallocated memory?  If so we have to handle this more
+  // carefully.
   if (vec.n_elem <= arma::arma_config::mat_prealloc)
   {
     // Copy the memory to something we can give back to Julia.

--- a/src/mlpack/bindings/julia/julia_util.cpp
+++ b/src/mlpack/bindings/julia/julia_util.cpp
@@ -66,7 +66,7 @@ void IO_SetParamBool(const char* paramName, bool paramValue)
  * Call IO::SetParam<std::vector<std::string>>() to set the length.
  */
 void IO_SetParamVectorStrLen(const char* paramName,
-                              const size_t length)
+                             const size_t length)
 {
   IO::GetParam<std::vector<std::string>>(paramName).clear();
   IO::GetParam<std::vector<std::string>>(paramName).resize(length);
@@ -77,8 +77,8 @@ void IO_SetParamVectorStrLen(const char* paramName,
  * Call IO::SetParam<std::vector<std::string>>() to set an individual element.
  */
 void IO_SetParamVectorStrStr(const char* paramName,
-                              const char* str,
-                              const size_t element)
+                             const char* str,
+                             const size_t element)
 {
   IO::GetParam<std::vector<std::string>>(paramName)[element] =
       std::string(str);
@@ -88,8 +88,8 @@ void IO_SetParamVectorStrStr(const char* paramName,
  * Call IO::SetParam<std::vector<int>>().
  */
 void IO_SetParamVectorInt(const char* paramName,
-                           int* ints,
-                           const size_t length)
+                          int* ints,
+                          const size_t length)
 {
   // Create a std::vector<int> object; unfortunately this requires copying the
   // vector elements.
@@ -106,10 +106,10 @@ void IO_SetParamVectorInt(const char* paramName,
  * Call IO::SetParam<arma::mat>().
  */
 void IO_SetParamMat(const char* paramName,
-                     double* memptr,
-                     const size_t rows,
-                     const size_t cols,
-                     const bool pointsAsRows)
+                    double* memptr,
+                    const size_t rows,
+                    const size_t cols,
+                    const bool pointsAsRows)
 {
   // Create the matrix as an alias.
   arma::mat m(memptr, arma::uword(rows), arma::uword(cols), false, true);
@@ -121,10 +121,10 @@ void IO_SetParamMat(const char* paramName,
  * Call IO::SetParam<arma::Mat<size_t>>().
  */
 void IO_SetParamUMat(const char* paramName,
-                      size_t* memptr,
-                      const size_t rows,
-                      const size_t cols,
-                      const bool pointsAsRows)
+                     size_t* memptr,
+                     const size_t rows,
+                     const size_t cols,
+                     const bool pointsAsRows)
 {
   // Create the matrix as an alias.
   arma::Mat<size_t> m(memptr, arma::uword(rows), arma::uword(cols), false,
@@ -138,8 +138,8 @@ void IO_SetParamUMat(const char* paramName,
  * Call IO::SetParam<arma::rowvec>().
  */
 void IO_SetParamRow(const char* paramName,
-                     double* memptr,
-                     const size_t cols)
+                    double* memptr,
+                    const size_t cols)
 {
   arma::rowvec m(memptr, arma::uword(cols), false, true);
   IO::GetParam<arma::rowvec>(paramName) = std::move(m);
@@ -150,8 +150,8 @@ void IO_SetParamRow(const char* paramName,
  * Call IO::SetParam<arma::Row<size_t>>().
  */
 void IO_SetParamURow(const char* paramName,
-                      size_t* memptr,
-                      const size_t cols)
+                     size_t* memptr,
+                     const size_t cols)
 {
   arma::Row<size_t> m(memptr, arma::uword(cols), false, true);
   IO::GetParam<arma::Row<size_t>>(paramName) = std::move(m);
@@ -162,8 +162,8 @@ void IO_SetParamURow(const char* paramName,
  * Call IO::SetParam<arma::vec>().
  */
 void IO_SetParamCol(const char* paramName,
-                     double* memptr,
-                     const size_t rows)
+                    double* memptr,
+                    const size_t rows)
 {
   arma::vec m(memptr, arma::uword(rows), false, true);
   IO::GetParam<arma::vec>(paramName) = std::move(m);
@@ -174,8 +174,8 @@ void IO_SetParamCol(const char* paramName,
  * Call IO::SetParam<arma::Row<size_t>>().
  */
 void IO_SetParamUCol(const char* paramName,
-                      size_t* memptr,
-                      const size_t rows)
+                     size_t* memptr,
+                     const size_t rows)
 {
   arma::Col<size_t> m(memptr, arma::uword(rows), false, true);
   IO::GetParam<arma::Col<size_t>>(paramName) = std::move(m);
@@ -186,11 +186,11 @@ void IO_SetParamUCol(const char* paramName,
  * Call IO::SetParam<std::tuple<data::DatasetInfo, arma::mat>>().
  */
 void IO_SetParamMatWithInfo(const char* paramName,
-                             bool* dimensions,
-                             double* memptr,
-                             const size_t rows,
-                             const size_t cols,
-                             const bool pointsAreRows)
+                            bool* dimensions,
+                            double* memptr,
+                            const size_t rows,
+                            const size_t cols,
+                            const bool pointsAreRows)
 {
   data::DatasetInfo d(pointsAreRows ? cols : rows);
   for (size_t i = 0; i < d.Dimensionality(); ++i)
@@ -316,6 +316,9 @@ double* IO_GetParamMat(const char* paramName)
   else
   {
     arma::access::rw(mat.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(mat.n_alloc) = 0;
+    #endif
     return mat.memptr();
   }
 }
@@ -344,20 +347,19 @@ size_t IO_GetParamUMatCols(const char* paramName)
 size_t* IO_GetParamUMat(const char* paramName)
 {
   arma::Mat<size_t>& mat = IO::GetParam<arma::Mat<size_t>>(paramName);
-
-  // Are we using preallocated memory?  If so we have to handle this more
-  // carefully.
   if (mat.n_elem <= arma::arma_config::mat_prealloc)
   {
     // Copy the memory to something that we can give back to Julia.
     size_t* newMem = new size_t[mat.n_elem];
     arma::arrayops::copy(newMem, mat.mem, mat.n_elem);
-    // We believe Julia will free it.  Hopefully we are right.
-    return newMem;
+    return newMem; // We believe Julia will free it.  Hopefully we are right.
   }
   else
   {
     arma::access::rw(mat.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(mat.n_alloc) = 0;
+    #endif
     return mat.memptr();
   }
 }
@@ -390,6 +392,9 @@ double* IO_GetParamCol(const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(vec.n_alloc) = 0;
+    #endif
     return vec.memptr();
   }
 }
@@ -410,20 +415,19 @@ size_t IO_GetParamUColRows(const char* paramName)
 size_t* IO_GetParamUCol(const char* paramName)
 {
   arma::Col<size_t>& vec = IO::GetParam<arma::Col<size_t>>(paramName);
-
-  // Are we using preallocated memory?  If so we have to handle this more
-  // carefully.
   if (vec.n_elem <= arma::arma_config::mat_prealloc)
   {
     // Copy the memory to something we can give back to Julia.
     size_t* newMem = new size_t[vec.n_elem];
     arma::arrayops::copy(newMem, vec.mem, vec.n_elem);
-    // We believe Julia will free it.  Hopefully we are right.
-    return newMem;
+    return newMem; // We believe Julia will free it.  Hopefully we are right.
   }
   else
   {
     arma::access::rw(vec.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(vec.n_alloc) = 0;
+    #endif
     return vec.memptr();
   }
 }
@@ -456,6 +460,9 @@ double* IO_GetParamRow(const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(vec.n_alloc) = 0;
+    #endif
     return vec.memptr();
   }
 }
@@ -476,9 +483,6 @@ size_t IO_GetParamURowCols(const char* paramName)
 size_t* IO_GetParamURow(const char* paramName)
 {
   arma::Row<size_t>& vec = IO::GetParam<arma::Row<size_t>>(paramName);
-
-  // Are we using preallocated memory?  If so we have to handle this more
-  // carefully.
   if (vec.n_elem <= arma::arma_config::mat_prealloc)
   {
     // Copy the memory to something we can give back to Julia.
@@ -489,6 +493,9 @@ size_t* IO_GetParamURow(const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(vec.n_alloc) = 0;
+    #endif
     return vec.memptr();
   }
 }
@@ -547,6 +554,9 @@ double* IO_GetParamMatWithInfoPtr(const char* paramName)
   else
   {
     arma::access::rw(m.mem_state) = 1;
+    #if ARMA_VERSION_MAJOR >= 10
+      arma::access::rw(m.n_alloc) = 0;
+    #endif
     return m.memptr();
   }
 }

--- a/src/mlpack/bindings/python/mlpack/arma_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/arma_util.hpp
@@ -22,6 +22,12 @@ template<typename T>
 void SetMemState(T& t, int state)
 {
   const_cast<arma::uhword&>(t.mem_state) = state;
+  // If we just "released" the memory, so that the matrix does not own it, with
+  // Armadillo 10 we must also ensure that the matrix does not deallocate the
+  // memory by specifying `n_alloc = 0`.
+  #if ARMA_VERSION_MAJOR >= 10
+    const_cast<arma::uword&>(t.n_alloc) = 0;
+  #endif
 }
 
 /**


### PR DESCRIPTION
*(updated description now that it is fixed)*

It turns out that our CI failures on OS X with the Julia and Python bindings are not actually the result of Julia or Python versioning issues but instead a change with how Armadillo handles its deallocation decisions.

Armadillo objects have a `mem_state` parameter, which internally indicates whether or not the object is "responsible" for the memory it is using.  In older versions of Armadillo, in the destructors, if `mem_state` was `0` then the memory was deallocated, and if it was `1` then this meant the memory was just an alias of some other object and no deallocation should happen.

Our bindings were written to depend on this internal behavior, but with Armadillo 10 the behavior is changed, because now Armadillo can "reuse" memory if you shrink a matrix.  Thus, the `n_alloc` member was introduced, which represents how many bytes the Armadillo object has allocated (and is thus responsible for).  Therefore, now, to avoid deallocation, we must set `n_alloc` to `0`.

I've made these changes to the Go, Python, and Julia bindings.  For R, we are using RcppArmadillo, which handles this for us (though I am going to ping them and make sure that they are handling this case too).

I haven't seen the build pass quite yet, but it did build locally just fine.  So I think this will get us at least a step closer to having green builds again, finally. :)

======
*(old description before I figured it out)*

I am wondering if maybe just the version of Julia has some issues---this often happens with Julia.  At my company we are often fighting Julia segfaults. :smile:  So, an older version might work just fine, and probably the next version (1.5.3 and then 1.6.0) will work fine too.  But for now maybe we can work around it.