### PR TITLE
Adding Copy and Move constructors in Dropout Layer

### DIFF
--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -60,6 +60,18 @@ class Dropout
    */
   Dropout(const double ratio = 0.5);
 
+  //! Copy Constructor
+  Dropout(const Dropout& layer);
+
+  //! Move Constructor
+  Dropout(const Dropout&&);
+
+  //! Copy assignment operator
+  Dropout& operator=(const Dropout& layer);
+
+  //! Move assignment operator
+  Dropout& operator=(Dropout&& layer);
+
   /**
    * Ordinary feed forward pass of the dropout layer.
    *

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -30,6 +30,54 @@ Dropout<InputDataType, OutputDataType>::Dropout(
 }
 
 template<typename InputDataType, typename OutputDataType>
+Dropout<InputDataType, OutputDataType>::Dropout(
+    const Dropout& layer) :
+    ratio(layer.ratio),
+    scale(layer.scale),
+    deterministic(layer.deterministic)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+Dropout<InputDataType, OutputDataType>::Dropout(
+    const Dropout&& layer) :
+    ratio(std::move(layer.ratio)),
+    scale(std::move(scale)),
+    deterministic(std::move(deterministic))
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+Dropout<InputDataType, OutputDataType>&
+Dropout<InputDataType, OutputDataType>::
+operator=(const Dropout& layer)
+{
+  if (this != &layer)
+  {
+    ratio = layer.ratio;
+    scale = layer.scale;
+    deterministic = layer.deterministic;
+  }
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType>
+Dropout<InputDataType, OutputDataType>&
+Dropout<InputDataType, OutputDataType>::
+operator=(Dropout&& layer)
+{
+  if (this != &layer)
+  {
+    ratio = std::move(layer.ratio);
+    scale = std::move(layer.scale);
+    deterministic = std::move(layer.deterministic);
+  }
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Dropout<InputDataType, OutputDataType>::Forward(
     const arma::Mat<eT>& input,

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -208,7 +208,6 @@ TEST_CASE("CheckCopyMovingDropoutNetworkTest", "[FeedForwardNetworkTest]")
   CheckMoveFunction<>(model1, trainData, trainLabels, 1);
 }
 
-
 /**
  * Train the vanilla network on a larger dataset.
  */
@@ -771,4 +770,3 @@ TEST_CASE("OptimizerTest", "[FeedForwardNetworkTest]")
   ens::DE opt(200, 1000, 0.6, 0.8, 1e-5);
   model.Train(trainData, trainLabels, opt);
 }
-

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -154,6 +154,62 @@ TEST_CASE("CheckCopyMovingVanillaNetworkTest", "[FeedForwardNetworkTest]")
 }
 
 /**
+ * Check whether copying and moving network with dropout is working or not.
+ */
+TEST_CASE("CheckCopyMovingDropoutNetworkTest", "[FeedForwardNetworkTest]")
+{
+  // Load the dataset.
+  arma::mat trainData;
+  data::Load("thyroid_train.csv", trainData, true);
+
+  arma::mat trainLabels = trainData.row(trainData.n_rows - 1);
+  trainData.shed_row(trainData.n_rows - 1);
+
+  /*
+   * Construct a feed forward network with trainData.n_rows input nodes,
+   * hiddenLayerSize hidden nodes and trainLabels.n_rows output nodes. The
+   * network structure looks like:
+   *
+   *  Input         Hidden        Output
+   *  Layer         Layer         Layer
+   * +-----+       +-----+       +-----+
+   * |     |       |     |       |     |
+   * |     +------>|     +------>|     |
+   * |     |     +>|     |     +>|     |
+   * +-----+     | +--+--+     | +-----+
+   *             |             |
+   *  Bias       |  Bias       |
+   *  Layer      |  Layer      |
+   * +-----+     | +-----+     |
+   * |     |     | |     |     |
+   * |     +-----+ |     +-----+
+   * |     |       |     |
+   * +-----+       +-----+
+   */
+
+  FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
+  model->Add<Linear<> >(trainData.n_rows, 8);
+  model->Add<SigmoidLayer<> >();
+  model->Add<Dropout<> >(0.3);
+  model->Add<Linear<> >(8, 3);
+  model->Add<LogSoftMax<> >();
+
+  FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;
+  model1->Add<Linear<> >(trainData.n_rows, 8);
+  model1->Add<SigmoidLayer<> >();
+  model1->Add<Dropout<> >(0.3);
+  model1->Add<Linear<> >(8, 3);
+  model1->Add<LogSoftMax<> >();
+
+  // Check whether copy constructor is working or not.
+  CheckCopyFunction<>(model, trainData, trainLabels, 1);
+
+  // Check whether move constructor is working or not.
+  CheckMoveFunction<>(model1, trainData, trainLabels, 1);
+}
+
+
+/**
  * Train the vanilla network on a larger dataset.
  */
 TEST_CASE("FFVanillaNetworkTest", "[FeedForwardNetworkTest]")


### PR DESCRIPTION
This pull request is in reference to #2625 
It adds the copy and move constructors and assignment operators to the Dropout layer.