### PR TITLE
Improved variable names in MSE

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -43,12 +43,12 @@ class MeanSquaredError
    * Computes the mean squared error function.
    *
    * @param prediction Predictions used for evaluating the specified loss
-   * function.
+   *     function.
    * @param target The target vector.
    */
   template<typename PredictionType, typename TargetType>
   typename PredictionType::elem_type Forward(const PredictionType& prediction,
-                                        const TargetType& target);
+                                             const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -42,24 +42,26 @@ class MeanSquaredError
   /**
    * Computes the mean squared error function.
    *
-   * @param input Input data used for evaluating the specified function.
+   * @param prediction Predictions used for evaluating the specified loss
+   * function.
    * @param target The target vector.
    */
-  template<typename InputType, typename TargetType>
-  typename InputType::elem_type Forward(const InputType& input,
+  template<typename PredictionType, typename TargetType>
+  typename PredictionType::elem_type Forward(const PredictionType& prediction,
                                         const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
    *
-   * @param input The propagated input activation.
+   * @param prediction Predictions used for evaluating the specified loss
+   * function
    * @param target The target vector.
-   * @param output The calculated error.
+   * @param loss The calculated error.
    */
-  template<typename InputType, typename TargetType, typename OutputType>
-  void Backward(const InputType& input,
+  template<typename PredictionType, typename TargetType, typename LossType>
+  void Backward(const PredictionType& prediction,
                 const TargetType& target,
-                OutputType& output);
+                LossType& loss);
 
   //! Get the output parameter.
   OutputDataType& OutputParameter() const { return outputParameter; }

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
@@ -25,23 +25,23 @@ MeanSquaredError<InputDataType, OutputDataType>::MeanSquaredError()
 }
 
 template<typename InputDataType, typename OutputDataType>
-template<typename InputType, typename TargetType>
-typename InputType::elem_type
+template<typename PredictionType, typename TargetType>
+typename PredictionType::elem_type
 MeanSquaredError<InputDataType, OutputDataType>::Forward(
-    const InputType& input,
+    const PredictionType& prediction,
     const TargetType& target)
 {
-  return arma::accu(arma::square(input - target)) / target.n_cols;
+  return arma::accu(arma::square(prediction - target)) / target.n_cols;
 }
 
 template<typename InputDataType, typename OutputDataType>
-template<typename InputType, typename TargetType, typename OutputType>
+template<typename PredictionType, typename TargetType, typename LossType>
 void MeanSquaredError<InputDataType, OutputDataType>::Backward(
-    const InputType& input,
+    const PredictionType& prediction,
     const TargetType& target,
-    OutputType& output)
+    LossType& loss)
 {
-  output = 2 * (input - target) / target.n_cols;
+  loss = 2 * (prediction - target) / target.n_cols;
 }
 
 template<typename InputDataType, typename OutputDataType>


### PR DESCRIPTION
In accordance with #2005 ,
After giving a careful thought and looking at the code, I figured out that it is not just the `input` variable that is somewhat misleading, but the `output` variables is also a little imprecise. 
To, explain my thoughts, consider a neural network or in general any ML `model`. The `model` takes some `input` and spits out some `predictions`. Then those `predictions` along with the `target labels` are fed into a `loss function` that returns `loss` which measures the goodness of `prediction`. (Being precise with the choice of words here)

Now, in the current implementation of loss functions, we have an `input` variable, that is actually the `prediction` and `output` is actually the calculated `loss` value.

Although all the variable names in the current implementation are correct, but they are somewhat generic in the sense that by nature, every function takes some input and spits output. This sometimes misleads contributors to do wrong implementations. So, as far as the loss functions are concerned, we can be a bit more precise with these names and choose them so that they are intuitive, i.e., we can replace 

- input -> prediction 
- output -> loss

These are exactly the changes that I have dome in this PR. Although this confusion was mostly in `Backward()` function, but to be consistent with the naming, it had to be changed in all the functions.

In this PR, I have done it for just a single one and once these changes are accepted, I will change the remaining ones too. Also, there is no right or wrong way to tackle this issue. It is just a naming convention. So, if anyone has some better naming convention than this one, then please freely suggest here. I am open to discuss it :)

Also, sorry for being too much verbose here, but I felt that I needed to explain my thought process here :D
