### PR TITLE
adding FAIL message to akfn_test, aknn_test and 4 more tests when calling data::Load

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -134,7 +134,8 @@ Copyright:
   Copyright 2020, Benson Muite <benson_muite@emailplus.org>
   Copyright 2020, Sarthak Bhardwaj <7sarthakbhardwaj@gmail.com>
   Copyright 2020, Aakash Kaushik <kaushikaakash7539@gmail.com>
-  Copyright 2020, Anush Kini <anushkini@gmail.com>   
+  Copyright 2020, Anush Kini <anushkini@gmail.com>
+  Copyright 2020, Nippun Sharma <inbox.nippun@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -167,7 +167,7 @@ TEST_CASE("AKFNDualCoverTreeTest", "[AKFNTest]")
 {
   arma::mat dataset;
   if (!data::Load("test_data_3_1000.csv", dataset))
-    FAIL("Unable to load data test_data_3_1000.csv!");
+    FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
   KFN exact(dataset);
   arma::Mat<size_t> neighborsExact;
@@ -225,7 +225,7 @@ TEST_CASE("AKFNDualBallTreeTest", "[AKFNTest]")
 {
   arma::mat dataset;
   if (!data::Load("test_data_3_1000.csv", dataset))
-    FAIL("Unable to load data test_data_3_1000.csv!");
+    FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
   KFN exact(dataset);
   arma::Mat<size_t> neighborsExact;

--- a/src/mlpack/tests/akfn_test.cpp
+++ b/src/mlpack/tests/akfn_test.cpp
@@ -166,7 +166,8 @@ TEST_CASE("AKFNSingleCoverTreeTest", "[AKFNTest]")
 TEST_CASE("AKFNDualCoverTreeTest", "[AKFNTest]")
 {
   arma::mat dataset;
-  data::Load("test_data_3_1000.csv", dataset);
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    FAIL("Unable to load data test_data_3_1000.csv!");
 
   KFN exact(dataset);
   arma::Mat<size_t> neighborsExact;
@@ -223,7 +224,8 @@ TEST_CASE("AKFNSingleBallTreeTest", "[AKFNTest]")
 TEST_CASE("AKFNDualBallTreeTest", "[AKFNTest]")
 {
   arma::mat dataset;
-  data::Load("test_data_3_1000.csv", dataset);
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    FAIL("Unable to load data test_data_3_1000.csv!");
 
   KFN exact(dataset);
   arma::Mat<size_t> neighborsExact;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -170,7 +170,7 @@ TEST_CASE("AKNNDualCoverTreeTest", "[AKNNTest]")
 {
   arma::mat dataset;
   if (!data::Load("test_data_3_1000.csv", dataset))
-    FAIL("Unable to load data test_data_3_1000.csv!");
+    FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
   KNN exact(dataset);
   arma::Mat<size_t> neighborsExact;
@@ -225,7 +225,7 @@ TEST_CASE("AKNNDualBallTreeTest", "[AKNNTest]")
 {
   arma::mat dataset;
   if (!data::Load("test_data_3_1000.csv", dataset))
-    FAIL("Unable to load data test_data_3_1000.csv!");
+    FAIL("Cannot load test dataset test_data_3_1000.csv!");
 
   KNN exact(dataset);
   arma::Mat<size_t> neighborsExact;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -169,7 +169,8 @@ TEST_CASE("AKNNSingleCoverTreeTest", "[AKNNTest]")
 TEST_CASE("AKNNDualCoverTreeTest", "[AKNNTest]")
 {
   arma::mat dataset;
-  data::Load("test_data_3_1000.csv", dataset);
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    FAIL("Unable to load data test_data_3_1000.csv!");
 
   KNN exact(dataset);
   arma::Mat<size_t> neighborsExact;
@@ -223,7 +224,8 @@ TEST_CASE("AKNNSingleBallTreeTest", "[AKNNTest]")
 TEST_CASE("AKNNDualBallTreeTest", "[AKNNTest]")
 {
   arma::mat dataset;
-  data::Load("test_data_3_1000.csv", dataset);
+  if (!data::Load("test_data_3_1000.csv", dataset))
+    FAIL("Unable to load data test_data_3_1000.csv!");
 
   KNN exact(dataset);
   arma::Mat<size_t> neighborsExact;

--- a/src/mlpack/tests/callback_test.cpp
+++ b/src/mlpack/tests/callback_test.cpp
@@ -42,8 +42,10 @@ TEST_CASE("FFNCallbackTest", "[CallbackTest]")
   arma::mat data;
   arma::mat labels;
 
-  data::Load("lab1.csv", data, true);
-  data::Load("lab3.csv", labels, true);
+  if (!data::Load("lab1.csv", data, true))
+    FAIL("Unable to load data lab1.csv!");
+  if (!data::Load("lab3.csv", labels, true))
+    FAIL("Unable to load data lab3.csv!");
 
   FFN<MeanSquaredError<>, RandomInitialization> model;
 
@@ -66,8 +68,10 @@ TEST_CASE("FFNWithOptimizerCallbackTest", "[CallbackTest]")
   arma::mat data;
   arma::mat labels;
 
-  data::Load("lab1.csv", data, true);
-  data::Load("lab3.csv", labels, true);
+  if (!data::Load("lab1.csv", data, true))
+    FAIL("Unable to load data lab1.csv!");
+  if (!data::Load("lab3.csv", labels, true))
+    FAIL("Unable to load data lab3.csv!");
 
   FFN<MeanSquaredError<>, RandomInitialization> model;
 

--- a/src/mlpack/tests/callback_test.cpp
+++ b/src/mlpack/tests/callback_test.cpp
@@ -43,9 +43,9 @@ TEST_CASE("FFNCallbackTest", "[CallbackTest]")
   arma::mat labels;
 
   if (!data::Load("lab1.csv", data, true))
-    FAIL("Unable to load data lab1.csv!");
+    FAIL("Cannot load test dataset lab1.csv!");
   if (!data::Load("lab3.csv", labels, true))
-    FAIL("Unable to load data lab3.csv!");
+    FAIL("Cannot load test dataset lab3.csv!");
 
   FFN<MeanSquaredError<>, RandomInitialization> model;
 
@@ -69,9 +69,9 @@ TEST_CASE("FFNWithOptimizerCallbackTest", "[CallbackTest]")
   arma::mat labels;
 
   if (!data::Load("lab1.csv", data, true))
-    FAIL("Unable to load data lab1.csv!");
+    FAIL("Cannot load test dataset lab1.csv!");
   if (!data::Load("lab3.csv", labels, true))
-    FAIL("Unable to load data lab3.csv!");
+    FAIL("Cannot load test dataset lab3.csv!");
 
   FFN<MeanSquaredError<>, RandomInitialization> model;
 

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -47,7 +47,7 @@ using namespace std;
 static void GetDatasets(arma::mat& dataset, arma::mat& savedCols)
 {
   if (!data::Load("GroupLensSmall.csv", dataset))
-    FAIL("Unable to load data GroupLensSmall.csv!");
+    FAIL("Cannot load test dataset GroupLensSmall.csv!");
   savedCols.set_size(3, 50);
 
   // Save the columns we've removed.
@@ -103,7 +103,7 @@ void GetRecommendationsAllUsers()
   // Load GroupLens data.
   arma::mat dataset;
   if (!data::Load("GroupLensSmall.csv", dataset))
-    FAIL("Unable to load data GroupLensSamll.csv!");
+    FAIL("Cannot load test dataset GroupLensSamll.csv!");
 
   CFType<DecompositionPolicy> c(dataset, decomposition, 5, 5, 30);
 
@@ -141,7 +141,7 @@ void GetRecommendationsQueriedUser()
   // Load GroupLens data.
   arma::mat dataset;
   if (!data::Load("GroupLensSmall.csv", dataset))
-    FAIL("Unable to load data GroupLensSmall.csv!");
+    FAIL("Cannot load test dataset GroupLensSmall.csv!");
 
   CFType<DecompositionPolicy> c(dataset, decomposition, 5, 5, 30);
 
@@ -431,7 +431,7 @@ void Serialization()
   // Load a dataset to train on.
   arma::mat dataset;
   if (!data::Load("GroupLensSmall.csv", dataset))
-    FAIL("Unable to load data GroupLensSmall.csv!");
+    FAIL("Cannot load test dataset GroupLensSmall.csv!");
 
   arma::sp_mat cleanedData;
   CFType<DecompositionPolicy,

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -46,7 +46,8 @@ using namespace std;
 // Get train and test datasets.
 static void GetDatasets(arma::mat& dataset, arma::mat& savedCols)
 {
-  data::Load("GroupLensSmall.csv", dataset);
+  if (!data::Load("GroupLensSmall.csv", dataset))
+    FAIL("Unable to load data GroupLensSmall.csv!");
   savedCols.set_size(3, 50);
 
   // Save the columns we've removed.
@@ -101,7 +102,8 @@ void GetRecommendationsAllUsers()
 
   // Load GroupLens data.
   arma::mat dataset;
-  data::Load("GroupLensSmall.csv", dataset);
+  if (!data::Load("GroupLensSmall.csv", dataset))
+    FAIL("Unable to load data GroupLensSamll.csv!");
 
   CFType<DecompositionPolicy> c(dataset, decomposition, 5, 5, 30);
 
@@ -138,7 +140,8 @@ void GetRecommendationsQueriedUser()
 
   // Load GroupLens data.
   arma::mat dataset;
-  data::Load("GroupLensSmall.csv", dataset);
+  if (!data::Load("GroupLensSmall.csv", dataset))
+    FAIL("Unable to load data GroupLensSmall.csv!");
 
   CFType<DecompositionPolicy> c(dataset, decomposition, 5, 5, 30);
 
@@ -427,7 +430,8 @@ void Serialization()
   DecompositionPolicy decomposition;
   // Load a dataset to train on.
   arma::mat dataset;
-  data::Load("GroupLensSmall.csv", dataset);
+  if (!data::Load("GroupLensSmall.csv", dataset))
+    FAIL("Unable to load data GroupLensSmall.csv!");
 
   arma::sp_mat cleanedData;
   CFType<DecompositionPolicy,

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -805,9 +805,9 @@ TEST_CASE("WeightedDecisionTreeTest", "[DecisionTreeTest]")
   arma::mat dataset;
   arma::Row<size_t> labels;
   if (!data::Load("vc2.csv", dataset))
-    FAIL("Unable to load data vc2.csv!");
+    FAIL("Cannot load test dataset vc2.csv!");
   if (!data::Load("vc2_labels.txt", labels))
-    FAIL("Unable to load data vc2_labels.txt!");
+    FAIL("Cannot load labels for vc2_labels.txt!");
 
   // Add some noise.
   arma::mat noise(dataset.n_rows, 1000, arma::fill::randu);
@@ -833,9 +833,9 @@ TEST_CASE("WeightedDecisionTreeTest", "[DecisionTreeTest]")
   arma::mat testData;
   arma::Row<size_t> testLabels;
   if (!data::Load("vc2_test.csv", testData))
-    FAIL("Unable to load data vc2_test.csv!");
+    FAIL("Cannot load test dataset vc2_test.csv!");
   if (!data::Load("vc2_test_labels.txt", testLabels))
-    FAIL("Unable to load data vc2_test_labels.txt!");
+    FAIL("Cannot load labels for vc2_test_labels.txt!");
 
   arma::Row<size_t> predictions;
   d.Classify(testData, predictions);
@@ -918,9 +918,9 @@ TEST_CASE("WeightedDecisionTreeInformationGainTest", "[DecisionTreeTest]")
   arma::mat dataset;
   arma::Row<size_t> labels;
   if (!data::Load("vc2.csv", dataset))
-    FAIL("Unable to load data vc2.csv!");
+    FAIL("Cannot load test dataset vc2.csv!");
   if (!data::Load("vc2_labels.txt", labels))
-    FAIL("Unable to load vc2_labels.txt!");
+    FAIL("Cannot load labels for vc2_labels.txt!");
 
   // Add some noise.
   arma::mat noise(dataset.n_rows, 1000, arma::fill::randu);
@@ -946,9 +946,9 @@ TEST_CASE("WeightedDecisionTreeInformationGainTest", "[DecisionTreeTest]")
   arma::mat testData;
   arma::Row<size_t> testLabels;
   if (!data::Load("vc2_test.csv", testData))
-    FAIL("Unable to load data vc2_test.csv!");
+    FAIL("Cannot load test dataset vc2_test.csv!");
   if (!data::Load("vc2_test_labels.txt", testLabels))
-    FAIL("Unable to load data vc2_test_labels.txt!");
+    FAIL("Cannot load labels for vc2_test_labels.txt!");
 
   arma::Row<size_t> predictions;
   d.Classify(testData, predictions);
@@ -1108,9 +1108,9 @@ TEST_CASE("NumClassesTest", "[DecisionTreeTest]")
   arma::mat dataset;
   arma::Row<size_t> labels;
   if (!data::Load("vc2.csv", dataset))
-    FAIL("Unable to load data vc2.csv!");
+    FAIL("Cannot load test dataset vc2.csv!");
   if (!data::Load("vc2_labels.txt", labels))
-    FAIL("Unable to load data vc2_labels.txt!");
+    FAIL("Cannot load labels for vc2_labels.txt!");
 
   DecisionTree<> dt(dataset, labels, 3);
 
@@ -1240,9 +1240,9 @@ TEST_CASE("DifferentMaximumDepthTest", "[DecisionTreeTest]")
   arma::mat dataset;
   arma::Row<size_t> labels;
   if (!data::Load("vc2.csv", dataset))
-    FAIL("Unable to load data vc2.csv!");
+    FAIL("Cannot load test dataset vc2.csv!");
   if (!data::Load("vc2_labels.txt", labels))
-    FAIL("Unable to load data vc2_labels.txt!");
+    FAIL("Cannot load labels for vc2_labels.txt!");
 
   DecisionTree<> d(dataset, labels, 3, 10, 1e-7, 1);
 

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -804,8 +804,10 @@ TEST_CASE("WeightedDecisionTreeTest", "[DecisionTreeTest]")
 {
   arma::mat dataset;
   arma::Row<size_t> labels;
-  data::Load("vc2.csv", dataset);
-  data::Load("vc2_labels.txt", labels);
+  if (!data::Load("vc2.csv", dataset))
+    FAIL("Unable to load data vc2.csv!");
+  if (!data::Load("vc2_labels.txt", labels))
+    FAIL("Unable to load data vc2_labels.txt!");
 
   // Add some noise.
   arma::mat noise(dataset.n_rows, 1000, arma::fill::randu);
@@ -830,8 +832,10 @@ TEST_CASE("WeightedDecisionTreeTest", "[DecisionTreeTest]")
   // Now we can check that we get good performance on the VC2 test set.
   arma::mat testData;
   arma::Row<size_t> testLabels;
-  data::Load("vc2_test.csv", testData);
-  data::Load("vc2_test_labels.txt", testLabels);
+  if (!data::Load("vc2_test.csv", testData))
+    FAIL("Unable to load data vc2_test.csv!");
+  if (!data::Load("vc2_test_labels.txt", testLabels))
+    FAIL("Unable to load data vc2_test_labels.txt!");
 
   arma::Row<size_t> predictions;
   d.Classify(testData, predictions);
@@ -913,8 +917,10 @@ TEST_CASE("WeightedDecisionTreeInformationGainTest", "[DecisionTreeTest]")
 {
   arma::mat dataset;
   arma::Row<size_t> labels;
-  data::Load("vc2.csv", dataset);
-  data::Load("vc2_labels.txt", labels);
+  if (!data::Load("vc2.csv", dataset))
+    FAIL("Unable to load data vc2.csv!");
+  if (!data::Load("vc2_labels.txt", labels))
+    FAIL("Unable to load vc2_labels.txt!");
 
   // Add some noise.
   arma::mat noise(dataset.n_rows, 1000, arma::fill::randu);
@@ -939,8 +945,10 @@ TEST_CASE("WeightedDecisionTreeInformationGainTest", "[DecisionTreeTest]")
   // Now we can check that we get good performance on the VC2 test set.
   arma::mat testData;
   arma::Row<size_t> testLabels;
-  data::Load("vc2_test.csv", testData);
-  data::Load("vc2_test_labels.txt", testLabels);
+  if (!data::Load("vc2_test.csv", testData))
+    FAIL("Unable to load data vc2_test.csv!");
+  if (!data::Load("vc2_test_labels.txt", testLabels))
+    FAIL("Unable to load data vc2_test_labels.txt!");
 
   arma::Row<size_t> predictions;
   d.Classify(testData, predictions);
@@ -1099,8 +1107,10 @@ TEST_CASE("NumClassesTest", "[DecisionTreeTest]")
   // Load a dataset to train with.
   arma::mat dataset;
   arma::Row<size_t> labels;
-  data::Load("vc2.csv", dataset);
-  data::Load("vc2_labels.txt", labels);
+  if (!data::Load("vc2.csv", dataset))
+    FAIL("Unable to load data vc2.csv!");
+  if (!data::Load("vc2_labels.txt", labels))
+    FAIL("Unable to load data vc2_labels.txt!");
 
   DecisionTree<> dt(dataset, labels, 3);
 
@@ -1229,8 +1239,10 @@ TEST_CASE("DifferentMaximumDepthTest", "[DecisionTreeTest]")
 {
   arma::mat dataset;
   arma::Row<size_t> labels;
-  data::Load("vc2.csv", dataset);
-  data::Load("vc2_labels.txt", labels);
+  if (!data::Load("vc2.csv", dataset))
+    FAIL("Unable to load data vc2.csv!");
+  if (!data::Load("vc2_labels.txt", labels))
+    FAIL("Unable to load data vc2_labels.txt!");
 
   DecisionTree<> d(dataset, labels, 3, 10, 1e-7, 1);
 

--- a/src/mlpack/tests/facilities_test.cpp
+++ b/src/mlpack/tests/facilities_test.cpp
@@ -28,11 +28,11 @@ TEST_CASE("AssertSizesTest", "[FacilitiesTest]")
   // Load the dataset.
   arma::mat dataset;
   if (!data::Load("iris_train.csv", dataset))
-    FAIL("Unable to load data iris_train.csv!");
+    FAIL("Cannot load test dataset iris_train.csv!");
   // Load the labels.
   arma::Row<size_t> labels;
   if (!data::Load("iris_test_labels.csv", labels))
-    FAIL("Unable to load data iris_test_labels.csv!");
+    FAIL("Cannot load test dataset iris_test_labels.csv!");
 
   REQUIRE_THROWS_AS(
     AssertSizes(dataset, labels, "test"), std::invalid_argument);

--- a/src/mlpack/tests/facilities_test.cpp
+++ b/src/mlpack/tests/facilities_test.cpp
@@ -27,10 +27,12 @@ TEST_CASE("AssertSizesTest", "[FacilitiesTest]")
 {
   // Load the dataset.
   arma::mat dataset;
-  data::Load("iris_train.csv", dataset);
+  if (!data::Load("iris_train.csv", dataset))
+    FAIL("Unable to load data iris_train.csv!");
   // Load the labels.
   arma::Row<size_t> labels;
-  data::Load("iris_test_labels.csv", labels);
+  if (!data::Load("iris_test_labels.csv", labels))
+    FAIL("Unable to load data iris_test_labels.csv!");
 
   REQUIRE_THROWS_AS(
     AssertSizes(dataset, labels, "test"), std::invalid_argument);


### PR DESCRIPTION
This is in reference to issue #2715 .
Adding FAIL message when calling data::Load in following files:
`aknn_test.cpp`
`akfn_test.cpp`
`callback_test.cpp`
`cf_test.cpp`
`decision_tree_test.cpp`
`facilities_test.cpp`