### PR TITLE
bux fix in perceptron_main: unnecessary transpose caused segfault when training on a loaded model

### DIFF
--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -284,7 +284,7 @@ static void mlpackMain()
       // Now train.
       Timer::Start("training");
       p->P().MaxIterations() = maxIterations;
-      p->P().Train(trainingData, labels.t(), numClasses);
+      p->P().Train(trainingData, labels, numClasses);
       Timer::Stop("training");
     }
   }


### PR DESCRIPTION
I believe there is a bug in mlpack_perceptron where training on a previously trained model results in a segmentation fault due to a unnecessary transpose operation on the labels matrix. 

To reproduce:
```
echo -e "0\n0\n0\n0\n0" > label.csv 
echo -e "0\n0\n0\n0\n0" > data.csv 
mlpack_perceptron -l labels.csv -t train.csv -M model.json
mlpack_perceptron -l labels.csv -t train.csv -M model.json -m model.json
Segmentation fault (core dumped)
```

If the transpose is left in, the UpdateWeights operation crashes, but cause of crash occurs on lines 175 and 179 of perceptron_impl.hpp, when labels(0,j) reads out of bounds when j > 1.