### PR TITLE
Doxygen size_t workaround

### DIFF
--- a/src/mlpack/bindings/go/mlpack/capi/io_util.hpp
+++ b/src/mlpack/bindings/go/mlpack/capi/io_util.hpp
@@ -21,14 +21,11 @@ namespace util {
 
 /**
  * Set the parameter to the given value.
- *
- * @param identifier Name of parameter.
- * @param value Value to set parameter to.
  */
 template<typename T>
 inline void SetParam(const std::string& identifier, T& value)
 {
-  IO::GetParam<T>(identifier) = std::move(value);
+  IO::GetParam<T>(identifierIn) = std::move(value);
 }
 
 /**

--- a/src/mlpack/bindings/python/mlpack/io_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/io_util.hpp
@@ -24,9 +24,6 @@ namespace util {
  *
  * This function exists to work around Cython's lack of support for lvalue
  * references.
- *
- * @param identifier Name of parameter.
- * @param value Value to set parameter to.
  */
 template<typename T>
 inline void SetParam(const std::string& identifier, T& value)

--- a/src/mlpack/core/data/string_encoding_policies/bag_of_words_encoding_policy.hpp
+++ b/src/mlpack/core/data/string_encoding_policies/bag_of_words_encoding_policy.hpp
@@ -51,8 +51,8 @@ class BagOfWordsEncodingPolicy
    *
    * @param output Output matrix to store the encoded results (sp_mat or mat).
    * @param datasetSize The number of strings in the input dataset.
-   * @param * (maxNumTokens) The maximum number of tokens in the strings of the
-   *                     input dataset (not used).
+   * @param size_t (maxNumTokens) The maximum number of tokens in the strings of the
+   *     input dataset (not used).
    * @param dictionarySize The size of the dictionary.
    */
   template<typename MatType>
@@ -74,8 +74,8 @@ class BagOfWordsEncodingPolicy
    *
    * @param output Output matrix to store the encoded results.
    * @param datasetSize The number of strings in the input dataset.
-   * @param * (maxNumTokens) The maximum number of tokens in the strings of the
-   *                     input dataset (not used).
+   * @param size_t (maxNumTokens) The maximum number of tokens in the strings of the
+   *     input dataset (not used).
    * @param dictionarySize The size of the dictionary.
    */
   template<typename ElemType>
@@ -97,7 +97,7 @@ class BagOfWordsEncodingPolicy
    * @param output Output matrix to store the encoded results (sp_mat or mat).
    * @param value The encoded token.
    * @param line The line number at which the encoding is performed.
-   * @param * (index) The token index in the line.
+   * @param size_t (index) The token index in the line.
    */
   template<typename MatType>
   static void Encode(MatType& output,
@@ -122,7 +122,7 @@ class BagOfWordsEncodingPolicy
    * @param output Output matrix to store the encoded results.
    * @param value The encoded token.
    * @param line The line number at which the encoding is performed.
-   * @param * (index) The line token number at which the encoding is performed.
+   * @param size_t (index) The line token number at which the encoding is performed.
    */
   template<typename ElemType>
   static void Encode(std::vector<std::vector<ElemType>>& output,

--- a/src/mlpack/core/data/string_encoding_policies/dictionary_encoding_policy.hpp
+++ b/src/mlpack/core/data/string_encoding_policies/dictionary_encoding_policy.hpp
@@ -50,7 +50,7 @@ class DictionaryEncodingPolicy
    * @param datasetSize The number of strings in the input dataset.
    * @param maxNumTokens The maximum number of tokens in the strings of the
    *                     input dataset.
-   * @param * (dictionarySize) The size of the dictionary (not used).
+   * @param size_t (dictionarySize) The size of the dictionary (not used).
    */
   template<typename MatType>
   static void InitMatrix(MatType& output,
@@ -102,7 +102,7 @@ class DictionaryEncodingPolicy
   /**
    * The function is not used by the dictionary encoding policy.
    *
-   * @param * (line) The line number at which the encoding is performed.
+   * @param size_t (line) The line number at which the encoding is performed.
    * @param * (index) The token sequence number in the line.
    * @param * (value) The encoded token.
    */

--- a/src/mlpack/core/data/string_encoding_policies/tf_idf_encoding_policy.hpp
+++ b/src/mlpack/core/data/string_encoding_policies/tf_idf_encoding_policy.hpp
@@ -96,7 +96,7 @@ class TfIdfEncodingPolicy
    *
    * @param output Output matrix to store the encoded results (sp_mat or mat).
    * @param datasetSize The number of strings in the input dataset.
-   * @param * (maxNumTokens) The maximum number of tokens in the strings of the
+   * @param size_t (maxNumTokens) The maximum number of tokens in the strings of the
    *                     input dataset (not used).
    * @param dictionarySize The size of the dictionary.
    */
@@ -119,7 +119,7 @@ class TfIdfEncodingPolicy
    *
    * @param output Output matrix to store the encoded results.
    * @param datasetSize The number of strings in the input dataset.
-   * @param * (maxNumTokens) The maximum number of tokens in the strings of the
+   * @param size_t (maxNumTokens) The maximum number of tokens in the strings of the
    *                     input dataset (not used).
    * @param dictionarySize The size of the dictionary.
    */
@@ -142,7 +142,7 @@ class TfIdfEncodingPolicy
    * @param output Output matrix to store the encoded results (sp_mat or mat).
    * @param value The encoded token.
    * @param line The line number at which the encoding is performed.
-   * @param * (index) The token index in the line.
+   * @param size_t (index) The token index in the line.
    */
   template<typename MatType>
   void Encode(MatType& output,
@@ -174,7 +174,7 @@ class TfIdfEncodingPolicy
    * @param output Output matrix to store the encoded results.
    * @param value The encoded token.
    * @param line The line number at which the encoding is performed.
-   * @param * (index) The token index in the line.
+   * @param size_t (index) The token index in the line.
    */
   template<typename ElemType>
   void Encode(std::vector<std::vector<ElemType>>& output,

--- a/src/mlpack/core/tree/rectangle_tree/no_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/no_auxiliary_information.hpp
@@ -45,7 +45,7 @@ class NoAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node in which the point is being inserted.
-   * @param * (point) The global number of the point being inserted.
+   * @param size_t (point) The global number of the point being inserted.
    */
   bool HandlePointInsertion(TreeType* /* node */, const size_t /* point */)
   {
@@ -79,7 +79,7 @@ class NoAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node from which the point is being deleted.
-   * @param * (localIndex) The local index of the point being deleted.
+   * @param size_t (localIndex) The local index of the point being deleted.
    */
   bool HandlePointDeletion(TreeType* /* node */, const size_t /* localIndex */)
   {
@@ -94,7 +94,7 @@ class NoAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node from which the node is being deleted.
-   * @param * (nodeIndex) The local index of the node being deleted.
+   * @param size_t (nodeIndex) The local index of the node being deleted.
    */
   bool HandleNodeRemoval(TreeType* /* node */, const size_t /* nodeIndex */)
   {

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information.hpp
@@ -69,7 +69,7 @@ class RPlusPlusTreeAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node in which the point is being inserted.
-   * @param * (point) The global number of the point being inserted.
+   * @param size_t (point) The global number of the point being inserted.
    */
   bool HandlePointInsertion(TreeType* /* node */, const size_t /* point */);
 
@@ -97,7 +97,7 @@ class RPlusPlusTreeAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node from which the point is being deleted.
-   * @param * (localIndex) The local index of the point being deleted.
+   * @param size_t (localIndex) The local index of the point being deleted.
    */
   bool HandlePointDeletion(TreeType* /* node */, const size_t /* localIndex */);
 
@@ -109,7 +109,7 @@ class RPlusPlusTreeAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node from which the node is being deleted.
-   * @param * (nodeIndex) The local index of the node being deleted.
+   * @param size_t (nodeIndex) The local index of the node being deleted.
    */
   bool HandleNodeRemoval(TreeType* /* node */, const size_t /* nodeIndex */);
 

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_auxiliary_information.hpp
@@ -91,7 +91,7 @@ class XTreeAuxiliaryInformation
    * returns false the RectangleTree performs its default behavior.
    *
    * @param * (node) The node in which the point is being inserted.
-   * @param * (point) The global number of the point being inserted.
+   * @param size_t (point) The global number of the point being inserted.
    */
   bool HandlePointInsertion(TreeType* /* node */, const size_t /* point */)
   {
@@ -124,7 +124,7 @@ class XTreeAuxiliaryInformation
    * information does that, then the method should return true; if the method
    * returns false the RectangleTree performs its default behavior.
    * @param * (node) The node from which the point is being deleted.
-   * @param * (localIndex) The local index of the point being deleted.
+   * @param size_t (localIndex) The local index of the point being deleted.
    */
   bool HandlePointDeletion(TreeType* /* node */ , const size_t /* localIndex */)
   {
@@ -138,7 +138,7 @@ class XTreeAuxiliaryInformation
    * information does that, then the method should return true; if the method
    * returns false the RectangleTree performs its default behavior.
    * @param * (node) The node from which the node is being deleted.
-   * @param * (nodeIndex) The local index of the node being deleted.
+   * @param size_t (nodeIndex) The local index of the node being deleted.
    */
   bool HandleNodeRemoval(TreeType* /* node */ , const size_t /* nodeIndex */)
   {

--- a/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
@@ -67,7 +67,7 @@ class SVDCompleteIncrementalLearning
    * are unnecessary; we are only setting the current element index to 0.
    *
    * @param * (dataset) Input matrix to be factorized.
-   * @param * (rank) Rank of factorization.
+   * @param size_t (rank) Rank of factorization.
    */
   void Initialize(const MatType& /* dataset */, const size_t /* rank */)
   {

--- a/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
@@ -64,7 +64,7 @@ class SVDIncompleteIncrementalLearning
    * to 0, so the input matrix and rank are not used.
    *
    * @param * (dataset) Input matrix to be factorized.
-   * @param * (rank) of factorization
+   * @param size_t (rank) of factorization
    */
   template<typename MatType>
   void Initialize(const MatType& /* dataset */, const size_t /* rank */)

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
@@ -21,30 +21,30 @@ namespace mlpack {
 namespace regression {
 
 /**
- * A Bayesian approach to the maximum likelihood estimation of the parameters 
- * \f$ \omega \f$ of the linear regression model. The Complexity is governed by 
- * the addition of a gaussian isotropic prior of precision \f$ \alpha \f$ over 
- * \f$ \omega \f$:  
+ * A Bayesian approach to the maximum likelihood estimation of the parameters
+ * \f$ \omega \f$ of the linear regression model. The Complexity is governed by
+ * the addition of a gaussian isotropic prior of precision \f$ \alpha \f$ over
+ * \f$ \omega \f$:
  *
  * \f[
  * p(\omega|\alpha) = \mathcal{N}(\omega|0, \alpha^{-1}I)
  * \f]
- * 
- * The optimization procedure calculates the posterior distribution of 
- * \f$ \omega \f$ knowing the data by maximizing an approximation of the log 
- * marginal likelihood derived from a type II maximum likelihood approximation. 
+ *
+ * The optimization procedure calculates the posterior distribution of
+ * \f$ \omega \f$ knowing the data by maximizing an approximation of the log
+ * marginal likelihood derived from a type II maximum likelihood approximation.
  * The determination of \f$ alpha \f$ and of the noise precision \f$ beta \f$
- * is part of the optimization process, leading to an automatic determination of 
- * w. The model being entirely based on probabilty distributions, uncertainties 
+ * is part of the optimization process, leading to an automatic determination of
+ * w. The model being entirely based on probabilty distributions, uncertainties
  * are available and easly computed for both the parameters and the predictions.
  *
- * The advantage over linear regression and ridge regression is that the 
+ * The advantage over linear regression and ridge regression is that the
  * regularization is determined from all the training data alone without any
- * require to an hold out method. 
+ * require to an hold out method.
  *
- * The code below is an implementation of the maximization of the evidence 
+ * The code below is an implementation of the maximization of the evidence
  * function described in the section 3.5.2 of the C.Bishop book, Pattern
- * Recognition and Machine Learning.  
+ * Recognition and Machine Learning.
  *
  * @code
  * @article{MacKay91bayesianinterpolation,
@@ -60,36 +60,36 @@ namespace regression {
  * @code
  * @book{Bishop:2006:PRM:1162264,
  *   author = {Bishop, Christopher M.},
- *   title = {Pattern Recognition and Machine Learning (Information Science 
+ *   title = {Pattern Recognition and Machine Learning (Information Science
  *            and Statistics)},
  *   chapter = {3}
  *   year = {2006},
  *   isbn = {0387310738},
  *   publisher = {Springer-Verlag},
  *   address = {Berlin, Heidelberg},
- * } 
+ * }
  * @endcode
- *   
+ *
  * Example of use:
  *
  * @code
  * arma::mat xTrain; // Train data matrix. Column-major.
  * arma::rowvec yTrain; // Train target values.
- 
+
  * // Train the model. Regularization strength is optimally tunned with the
  * // training data alone by applying the Train method.
  * BayesianLinearRegression estimator(); // Instanciate the estimator with default option.
  * estimator.Train(xTrain, yTrain);
- 
+
  * // Prediction on test points.
  * arma::mat xTest; // Test data matrix. Column-major.
  * arma::rowvec predictions;
- 
+
  * estimator.Predict(xTest, prediction);
- 
+
  * arma::rowvec yTest; // Test target values.
  * estimator.RMSE(xTest, yTest); // Evaluate using the RMSE score.
- 
+
  * // Compute the standard deviations of the predictions.
  * arma::rowvec stds;
  * estimator.Predict(xTest, responses, stds)
@@ -108,8 +108,8 @@ class BayesianLinearRegression
    * @param scaleData Whether or not scale the data according to the
    *    standard deviation of each feature.
    * @param nIterMax Maximum number of iterations for convergency.
-   * @param tol Level from which the solution is considered sufficientlly 
-   *    stable.  
+   * @param tol Level from which the solution is considered sufficientlly
+   *    stable.
    */
   BayesianLinearRegression(const bool centerData = true,
                            const bool scaleData = false,
@@ -119,7 +119,7 @@ class BayesianLinearRegression
   /**
    * Run BayesianLinearRegression. The input matrix (like all mlpack matrices) should be
    * column-major -- each column is an observation and each row is a dimension.
-   * 
+   *
    * @param data Column-major input data, dim(P, N).
    * @param responses A vector of targets, dim(N).
    * @return Root mean squared error.
@@ -133,13 +133,12 @@ class BayesianLinearRegression
    *
    * @param points The data points to apply the model.
    * @param predictions y, Contains the  predicted values on completion.
-   * @return Root mean squared error computed on the train set.
    */
   void Predict(const arma::mat& points,
                arma::rowvec& predictions) const;
 
   /**
-   * Predict \f$y_{i}\f$ and the standard deviation of the predictive posterior 
+   * Predict \f$y_{i}\f$ and the standard deviation of the predictive posterior
    * distribution for each data point in the given data matrix, using the
    * currently-trained Bayesian Ridge estimator.
    *
@@ -163,7 +162,7 @@ class BayesianLinearRegression
               const arma::rowvec& responses) const;
 
   /**
-   * Get the solution vector. 
+   * Get the solution vector.
    *
    * @return omega Solution vector.
    */
@@ -187,7 +186,7 @@ class BayesianLinearRegression
 
   /**
    * Get the estimated variance. Train() must be called before.
-   *   
+   *
    * @return 1.0 / \f$ \beta \f$
    */
   double Variance() const { return 1.0 / Beta(); }
@@ -200,7 +199,7 @@ class BayesianLinearRegression
   const arma::colvec& DataOffset() const { return dataOffset; }
 
   /**
-   * Get the vector of standard deviations computed on the features over the 
+   * Get the vector of standard deviations computed on the features over the
    * training points.
    *
    * @return dataOffset

--- a/src/mlpack/methods/cf/interpolation_policies/average_interpolation.hpp
+++ b/src/mlpack/methods/cf/interpolation_policies/average_interpolation.hpp
@@ -55,7 +55,7 @@ class AverageInterpolation
    * @param weights Resulting interpolation weights. The size of weights should
    *     be set to the number of neighbors before calling GetWeights().
    * @param * (decomposition) Decomposition object.
-   * @param * (queryUser) Queried user.
+   * @param size_t (queryUser) Queried user.
    * @param neighbors Neighbors of queried user.
    * @param * (similarities) Similarites between query user and neighbors.
    * @param * (cleanedData) Sparse rating matrix.

--- a/src/mlpack/methods/cf/interpolation_policies/similarity_interpolation.hpp
+++ b/src/mlpack/methods/cf/interpolation_policies/similarity_interpolation.hpp
@@ -57,7 +57,7 @@ class SimilarityInterpolation
    * @param weights Resulting interpolation weights. The size of weights should
    *     be set to the number of neighbors before calling GetWeights().
    * @param * (decomposition) Decomposition object.
-   * @param * (queryUser) Queried user.
+   * @param size_t (queryUser) Queried user.
    * @param neighbors Neighbors of queried user.
    * @param similarities Similarities between query user and neighbors.
    * @param * (cleanedData) Sparse rating matrix.

--- a/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/item_mean_normalization.hpp
@@ -123,7 +123,7 @@ class ItemMeanNormalization
   /**
    * Denormalize computed rating by adding item mean.
    *
-   * @param * (user) User ID.
+   * @param size_t (user) User ID.
    * @param item Item ID.
    * @param rating Computed rating before denormalization.
    */

--- a/src/mlpack/methods/cf/normalization/no_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/no_normalization.hpp
@@ -39,7 +39,7 @@ class NoNormalization
   /**
    * Do nothing.
    *
-   * @param * (user) User ID.
+   * @param size_t (user) User ID.
    * @param * (item) Item ID.
    * @param rating Computed rating before denormalization.
    */

--- a/src/mlpack/methods/cf/normalization/overall_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/overall_mean_normalization.hpp
@@ -96,7 +96,7 @@ class OverallMeanNormalization
   /**
    * Denormalize computed rating by adding mean.
    *
-   * @param * (user) User ID.
+   * @param size_t (user) User ID.
    * @param * (item) Item ID.
    * @param rating Computed rating before denormalization.
    */

--- a/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/user_mean_normalization.hpp
@@ -124,7 +124,7 @@ class UserMeanNormalization
    * Denormalize computed rating by adding user mean.
    *
    * @param user User ID.
-   * @param * (item) Item ID.
+   * @param size_t (item) Item ID.
    * @param rating Computed rating before denormalization.
    */
   double Denormalize(const size_t user,

--- a/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
+++ b/src/mlpack/methods/cf/normalization/z_score_normalization.hpp
@@ -108,7 +108,7 @@ class ZScoreNormalization
   /**
    * Denormalize computed rating by adding mean and multiplying stddev.
    *
-   * @param * (user) User ID.
+   * @param size_t (user) User ID.
    * @param * (item) Item ID.
    * @param rating Computed rating before denormalization.
    */

--- a/src/mlpack/methods/dbscan/random_point_selection.hpp
+++ b/src/mlpack/methods/dbscan/random_point_selection.hpp
@@ -26,7 +26,7 @@ class RandomPointSelection
   /**
    * Select the next point to use, randomly.
    *
-   * @param * (point) Unused data.
+   * @param size_t (point) Unused data.
    * @param data Dataset to cluster.
    */
   template<typename MatType>

--- a/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
+++ b/src/mlpack/methods/kernel_pca/kernel_rules/naive_method.hpp
@@ -29,7 +29,7 @@ class NaiveKernelRule
    * @param transformedData Matrix to output results into.
    * @param eigval KPCA eigenvalues will be written to this vector.
    * @param eigvec KPCA eigenvectors will be written to this matrix.
-   * @param * (rank) Rank to be used for matrix approximation.
+   * @param size_t (rank) Rank to be used for matrix approximation.
    * @param kernel Kernel to be used for computation.
    */
   static void ApplyKernelMatrix(const arma::mat& data,

--- a/src/mlpack/methods/kmeans/allow_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/allow_empty_clusters.hpp
@@ -41,7 +41,7 @@ class AllowEmptyClusters
    *      of the iteration.
    * @param * (clusterCounts) Number of points in each cluster.
    * @param * (metric) The Metric to use.
-   * @param * (iteration) Number of iteration.
+   * @param size_t (iteration) Number of iteration.
    *
    * @return Number of points changed (0).
    */

--- a/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
+++ b/src/mlpack/methods/kmeans/kill_empty_clusters.hpp
@@ -41,7 +41,7 @@ class KillEmptyClusters
    *      of the iteration.
    * @param clusterCounts Number of points in each cluster.
    * @param * (metric) The Metric to use.
-   * @param * (iteration) Number of iteration.
+   * @param size_t (iteration) Number of iteration.
    *
    * @return Number of points changed (0).
    */

--- a/src/mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp
@@ -36,7 +36,7 @@ class ExactSVDPolicy
    * @param transformedData Matrix to put results of PCA into.
    * @param eigVal Vector to put eigenvalues into.
    * @param eigvec Matrix to put eigenvectors (loadings) into.
-   * @param * (rank) Rank of the decomposition.
+   * @param size_t (rank) Rank of the decomposition.
    */
   void Apply(const arma::mat& data,
              const arma::mat& centeredData,

--- a/src/mlpack/methods/pca/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/quic_svd_method.hpp
@@ -48,7 +48,7 @@ class QUICSVDPolicy
    * @param transformedData Matrix to put results of PCA into.
    * @param eigVal Vector to put eigenvalues into.
    * @param eigvec Matrix to put eigenvectors (loadings) into.
-   * @param * (rank) Rank of the decomposition.
+   * @param size_t (rank) Rank of the decomposition.
    */
   void Apply(const arma::mat& data,
              const arma::mat& centeredData,


### PR DESCRIPTION
The recent doxygen version(s) fail to build the documentation because it reports `size_t` as an undocumented parameter. @birm already reported the issue (https://github.com/doxygen/doxygen/issues/7818). I figured it would be better to apply the workaround he suggested instead of breaking the build.