### PR TITLE
changed comments in convolution.hpp

### DIFF
--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -207,10 +207,10 @@ class Convolution
   //! Modify the output height.
   size_t& OutputHeight() { return outputHeight; }
 
-  //! Get the input size.
+  //! Get the number of input maps.
   size_t InputSize() const { return inSize; }
 
-  //! Get the output size.
+  //! Get the number of output maps.
   size_t OutputSize() const { return outSize; }
 
   //! Get the kernel width.


### PR DESCRIPTION
As discussed with @zoq in gitter. I have changed the comments to prevent possible confusion between number of input maps and size of the input and between number of output maps and size of output.