### PR TITLE
Adding Copy and Move Constructors for RNN and FastLSTM layer.

### DIFF
--- a/src/mlpack/methods/ann/layer/fast_lstm.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm.hpp
@@ -73,6 +73,18 @@ class FastLSTM
   //! Create the Fast LSTM object.
   FastLSTM();
 
+  //! Copy Constructor
+  FastLSTM(const FastLSTM& layer);
+
+  //! Move Constructor
+  FastLSTM(FastLSTM&& layer);
+
+  //! Copy assignment operator
+  FastLSTM& operator=(const FastLSTM& layer);
+
+  //! Move assignment operator
+  FastLSTM& operator=(FastLSTM&& layer);
+
   /**
    * Create the Fast LSTM layer object using the specified parameters.
    *

--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -50,7 +50,16 @@ FastLSTM<InputDataType, OutputDataType>::FastLSTM(const FastLSTM& layer) :
     inSize(layer.inSize),
     outSize(layer.outSize),
     rho(layer.rho),
-    weights(layer.weights)
+    forwardStep(layer.forwardStep),
+    backwardStep(layer.backwardStep),
+    gradientStep(layer.gradientStep),
+    weights(layer.weights),
+    batchSize(layer.batchSize),
+    batchStep(layer.batchStep),
+    gradientStepIdx(layer.gradientStepIdx),
+    grad(layer.grad),
+    rhoSize(layer.rho),
+    bpttSteps(layer.bpttSteps)
 {
   // Nothing to do here.
 }
@@ -60,7 +69,16 @@ FastLSTM<InputDataType, OutputDataType>::FastLSTM(FastLSTM&& layer) :
     inSize(std::move(layer.inSize)),
     outSize(std::move(layer.outSize)),
     rho(std::move(layer.rho)),
-    weights(std::move(layer.weights))
+    forwardStep(std::move(layer.forwardStep)),
+    backwardStep(std::move(layer.backwardStep)),
+    gradientStep(std::move(layer.gradientStep)),
+    weights(std::move(layer.weights)),
+    batchSize(std::move(layer.batchSize)),
+    batchStep(std::move(layer.batchStep)),
+    gradientStepIdx(std::move(layer.gradientStepIdx)),
+    grad(std::move(layer.grad)),
+    rhoSize(std::move(layer.rho)),
+    bpttSteps(std::move(layer.bpttSteps))
 {
   // Nothing to do here.
 }
@@ -74,7 +92,16 @@ FastLSTM<InputDataType, OutputDataType>::operator=(const FastLSTM& layer)
     inSize = layer.inSize;
     outSize = layer.outSize;
     rho = layer.rho;
+    forwardStep = layer.forwardStep;
+    backwardStep = layer.backwardStep;
+    gradientStep = layer.gradientStep;
     weights = layer.weights;
+    batchSize = layer.batchSize;
+    batchStep = layer.batchStep;
+    gradientStepIdx = layer.gradientStepIdx;
+    grad = layer.grad;
+    rhoSize = layer.rho;
+    bpttSteps = layer.bpttSteps;
   }
   return *this;
 }
@@ -88,7 +115,16 @@ FastLSTM<InputDataType, OutputDataType>::operator=(FastLSTM&& layer)
     inSize = std::move(layer.inSize);
     outSize = std::move(layer.outSize);
     rho = std::move(layer.rho);
+    forwardStep = std::move(layer.forwardStep);
+    backwardStep = std::move(layer.backwardStep);
+    gradientStep = std::move(layer.gradientStep);
     weights = std::move(layer.weights);
+    batchSize = std::move(layer.batchSize);
+    batchStep = std::move(layer.batchStep);
+    gradientStepIdx = std::move(layer.gradientStepIdx);
+    grad = std::move(layer.grad);
+    rhoSize = std::move(layer.rho);
+    bpttSteps = std::move(layer.bpttSteps);
   }
   return *this;
 }

--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -46,6 +46,60 @@ FastLSTM<InputDataType, OutputDataType>::FastLSTM(
 }
 
 template<typename InputDataType, typename OutputDataType>
+FastLSTM<InputDataType, OutputDataType>::FastLSTM(const FastLSTM& layer) :
+    inSize(layer.inSize),
+    outSize(layer.outSize),
+    rho(layer.rho),
+    weights(layer.weights)
+{
+  // Nothing to do here.
+  std::cout << "Trying to copy fast LSTM layer" << std::endl;
+}
+
+template<typename InputDataType, typename OutputDataType>
+FastLSTM<InputDataType, OutputDataType>::FastLSTM(FastLSTM&& layer) :
+    inSize(std::move(layer.inSize)),
+    outSize(std::move(layer.outSize)),
+    rho(std::move(layer.rho)),
+    weights(std::move(layer.weights))
+{
+  // Nothing to do here.
+  std::cout << "Trying to move fast LSTM layer" << std::endl;
+}
+
+template<typename InputDataType, typename OutputDataType>
+FastLSTM<InputDataType, OutputDataType>&
+FastLSTM<InputDataType, OutputDataType>::operator=(const FastLSTM& layer)
+{
+  std::cout << "Trying to copy fast LSTM layer" << std::endl;
+  if (this != &layer)
+  {
+    inSize = layer.inSize;
+    outSize = layer.outSize;
+    rho = layer.rho;
+    weights = layer.weights;
+  }
+  std::cout << "Copied layer and returned" << std::endl;
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType>
+FastLSTM<InputDataType, OutputDataType>&
+FastLSTM<InputDataType, OutputDataType>::operator=(FastLSTM&& layer)
+{
+  std::cout << "Trying to move fast LSTM layer" << std::endl;
+  if (this != &layer)
+  {
+    inSize = std::move(layer.inSize);
+    outSize = std::move(layer.outSize);
+    rho = std::move(layer.rho);
+    weights = std::move(layer.weights);
+  }
+  std::cout << "Moved and returned" << std::endl;
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType>
 void FastLSTM<InputDataType, OutputDataType>::Reset()
 {
   // Set the weight parameter for the input to gate layer (linear layer) using

--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -53,7 +53,6 @@ FastLSTM<InputDataType, OutputDataType>::FastLSTM(const FastLSTM& layer) :
     weights(layer.weights)
 {
   // Nothing to do here.
-  std::cout << "Trying to copy fast LSTM layer" << std::endl;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -64,14 +63,12 @@ FastLSTM<InputDataType, OutputDataType>::FastLSTM(FastLSTM&& layer) :
     weights(std::move(layer.weights))
 {
   // Nothing to do here.
-  std::cout << "Trying to move fast LSTM layer" << std::endl;
 }
 
 template<typename InputDataType, typename OutputDataType>
 FastLSTM<InputDataType, OutputDataType>&
 FastLSTM<InputDataType, OutputDataType>::operator=(const FastLSTM& layer)
 {
-  std::cout << "Trying to copy fast LSTM layer" << std::endl;
   if (this != &layer)
   {
     inSize = layer.inSize;
@@ -79,7 +76,6 @@ FastLSTM<InputDataType, OutputDataType>::operator=(const FastLSTM& layer)
     rho = layer.rho;
     weights = layer.weights;
   }
-  std::cout << "Copied layer and returned" << std::endl;
   return *this;
 }
 
@@ -87,7 +83,6 @@ template<typename InputDataType, typename OutputDataType>
 FastLSTM<InputDataType, OutputDataType>&
 FastLSTM<InputDataType, OutputDataType>::operator=(FastLSTM&& layer)
 {
-  std::cout << "Trying to move fast LSTM layer" << std::endl;
   if (this != &layer)
   {
     inSize = std::move(layer.inSize);
@@ -95,7 +90,6 @@ FastLSTM<InputDataType, OutputDataType>::operator=(FastLSTM&& layer)
     rho = std::move(layer.rho);
     weights = std::move(layer.weights);
   }
-  std::cout << "Moved and returned" << std::endl;
   return *this;
 }
 

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -70,6 +70,15 @@ class RNN
       OutputLayerType outputLayer = OutputLayerType(),
       InitializationRuleType initializeRule = InitializationRuleType());
 
+  //! Copy constructor.
+  RNN(const RNN&);
+
+  //! Move constructor.
+  RNN(RNN&&);
+
+  //! Copy/move assignment operator.
+  RNN& operator = (RNN);
+
   //! Destructor to release allocated memory.
   ~RNN();
 
@@ -411,6 +420,9 @@ class RNN
 
   //! Locally-stored weight size visitor.
   WeightSizeVisitor weightSizeVisitor;
+
+  //! Locally-stored copy visitor
+  CopyVisitor<CustomLayers...> copyVisitor;
 
   //! Locally-stored reset visitor.
   ResetVisitor resetVisitor;

--- a/src/mlpack/methods/ann/rnn.hpp
+++ b/src/mlpack/methods/ann/rnn.hpp
@@ -76,8 +76,11 @@ class RNN
   //! Move constructor.
   RNN(RNN&&);
 
-  //! Copy/move assignment operator.
-  RNN& operator = (RNN);
+  //! Copy assignment operator.
+  RNN& operator=(const RNN&);
+
+  //! Move assignment operator
+  RNN& operator=(RNN&&);
 
   //! Destructor to release allocated memory.
   ~RNN();

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -51,6 +51,49 @@ RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
 
 template<typename OutputLayerType, typename InitializationRuleType,
          typename... CustomLayers>
+RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
+    const RNN& network) :
+    rho(network.rho),
+    initializeRule(network.initializeRule),
+    inputSize(network.inputSize),
+    outputLayer(network.outputLayer),
+    outputSize(network.outputSize),
+    targetSize(network.targetSize),
+    reset(network.reset),
+    single(network.single),
+    numFunctions(network.numFunctions),
+    deterministic(network.deterministic),
+    parameter(network.parameter)
+{
+  for (size_t i = 0; i < network.network.size(); ++i)
+  {
+    this->network.push_back(boost::apply_visitor(copyVisitor,
+        network.network[i]));
+    boost::apply_visitor(resetVisitor, this->network[i]);
+  }
+}
+
+template<typename OutputLayerType, typename InitializationRuleType,
+         typename... CustomLayers>
+RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
+    RNN&& network) :
+    rho(std::move(network.rho)),
+    initializeRule(std::move(network.initializeRule)),
+    inputSize(std::move(network.inputSize)),
+    outputLayer(std::move(network.outputLayer)),
+    outputSize(std::move(network.outputSize)),
+    targetSize(std::move(network.targetSize)),
+    reset(std::move(network.reset)),
+    single(std::move(network.single)),
+    numFunctions(std::move(network.numFunctions)),
+    deterministic(std::move(network.deterministic)),
+    parameter(std::move(network.parameter))
+{
+  this->network = std::move(network.network);
+}
+
+template<typename OutputLayerType, typename InitializationRuleType,
+         typename... CustomLayers>
 RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::~RNN()
 {
   for (LayerTypes<CustomLayers...>& layer : network)

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -54,22 +54,27 @@ template<typename OutputLayerType, typename InitializationRuleType,
 RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
     const RNN& network) :
     rho(network.rho),
+    outputLayer(network.outputLayer),
     initializeRule(network.initializeRule),
     inputSize(network.inputSize),
-    outputLayer(network.outputLayer),
     outputSize(network.outputSize),
     targetSize(network.targetSize),
     reset(network.reset),
     single(network.single),
+    parameter(network.parameter),
     numFunctions(network.numFunctions),
-    deterministic(network.deterministic),
-    parameter(network.parameter)
+    deterministic(network.deterministic)
 {
   for (size_t i = 0; i < network.network.size(); ++i)
   {
     this->network.push_back(boost::apply_visitor(copyVisitor,
         network.network[i]));
-    boost::apply_visitor(resetVisitor, this->network[i]);
+    boost::apply_visitor(resetVisitor, this->network.back());
+  }
+  ResetCells();
+  if (parameter.is_empty())
+  {
+    ResetParameters();
   }
 }
 
@@ -78,16 +83,16 @@ template<typename OutputLayerType, typename InitializationRuleType,
 RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
     RNN&& network) :
     rho(std::move(network.rho)),
+    outputLayer(std::move(network.outputLayer)),
     initializeRule(std::move(network.initializeRule)),
     inputSize(std::move(network.inputSize)),
-    outputLayer(std::move(network.outputLayer)),
     outputSize(std::move(network.outputSize)),
     targetSize(std::move(network.targetSize)),
     reset(std::move(network.reset)),
     single(std::move(network.single)),
+    parameter(std::move(network.parameter)),
     numFunctions(std::move(network.numFunctions)),
-    deterministic(std::move(network.deterministic)),
-    parameter(std::move(network.parameter))
+    deterministic(std::move(network.deterministic))
 {
   this->network = std::move(network.network);
 }

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -71,11 +71,6 @@ RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
         network.network[i]));
     boost::apply_visitor(resetVisitor, this->network.back());
   }
-  ResetCells();
-  if (parameter.is_empty())
-  {
-    ResetParameters();
-  }
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -87,9 +87,10 @@ RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
     single(std::move(network.single)),
     parameter(std::move(network.parameter)),
     numFunctions(std::move(network.numFunctions)),
-    deterministic(std::move(network.deterministic))
+    deterministic(std::move(network.deterministic)),
+    network(std::move(network.network))
 {
-  this->network = std::move(network.network);
+  // Nothing to do here.
 }
 
 template<typename OutputLayerType, typename InitializationRuleType,

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -1184,6 +1184,65 @@ TEST_CASE("FastLSTMLayerParametersTest", "[ANNLayerTest]")
 }
 
 /**
+ * Check whether copying and moving network with FastLSTM is working or not.
+ */
+ TEST_CASE("CheckCopyFastLSTMTest", "[ANNLayerTest]")
+ {
+   std::cout << "Starting copy test" << std::endl;
+   arma::cube input = arma::randu(1, 1, 5);
+   arma::cube target = arma::ones(1, 1, 5);
+   const size_t rho = 5;
+
+   RNN<NegativeLogLikelihood<> > *model1 = new RNN<NegativeLogLikelihood<> >(rho);
+   model1->Predictors() = input;
+   model1->Responses() = target;
+   model1->Add<Linear<> >(1, 10);
+   model1->Add<FastLSTM<> >(10, 3, rho);
+   model1->Add<LogSoftMax<> >();
+
+   ens::StandardSGD opt(0.1, 1, 5, -100, false);
+   std::cout << "Before Training Model" << std::endl;
+   model1->Train(input, target, opt);
+   std::cout << "After Training" << std::endl;
+
+   arma::cube predictions1;
+   model1->Predict(input, predictions1);
+
+   std::cout << "After model1 predict" << std::endl;
+
+   RNN<> model2(rho);
+   model2 = *model1;
+   delete model1;
+
+   arma::cube predictions2;
+   std::cout << "After model1 delete" << std::endl;
+   model2.Predict(input, predictions2);
+   std::cout << "After model2 predictions" << std::endl;
+   CheckMatrices(predictions1, predictions2);
+   // FastLSTM<> *layer1 = new FastLSTM<>(1,2,3);
+   // FastLSTM<> layer2();
+   //
+   // // Provide input of all ones.
+   // arma::mat input = arma::ones(3, 1);
+   //
+   // // Declaring two ouput matrices for each layer.
+   // arma::mat output1;
+   // arma::mat output2;
+   //
+   // // Forward pass through layer1.
+   // layer1->Forward(input, output1);
+   // layer2 = *layer1;
+   //
+   // // Freeing up layer1 to prevent memory leaks.
+   // delete layer1;
+   //
+   // // Forward pass through layer2.
+   // layer2.Forward(input, output2);
+   //
+   // CheckMatrices(output1, output2);
+ }
+
+/**
  * Testing the overloaded Forward() of the LSTM layer, for retrieving the cell
  * state. Besides output, the overloaded function provides read access to cell
  * state of the LSTM layer.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -31,51 +31,6 @@
 using namespace mlpack;
 using namespace mlpack::ann;
 
-// network1 should be allocated with `new`, and trained on some data.
-template<typename MatType = arma::mat, typename ModelType>
-void CheckCopyFunction(ModelType* network1,
-                       MatType& trainData,
-                       MatType& trainLabels,
-                       const size_t maxEpochs)
-{
-  ens::RMSProp opt(0.01, 32, 0.88, 1e-8, maxEpochs * trainData.n_cols, -1);
-  network1->Train(trainData, trainLabels, opt);
-
-  arma::mat predictions1;
-  network1->Predict(trainData, predictions1);
-  FFN<> network2;
-  network2 = *network1;
-  delete network1;
-
-  // Deallocating all of network1's memory, so that
-  // if network2 is trying to use any of that memory.
-  arma::mat predictions2;
-  network2.Predict(trainData, predictions2);
-  CheckMatrices(predictions1, predictions2);
-}
-
-// network1 should be allocated with `new`, and trained on some data.
-template<typename MatType = arma::mat, typename ModelType>
-void CheckMoveFunction(ModelType* network1,
-                       MatType& trainData,
-                       MatType& trainLabels,
-                       const size_t maxEpochs)
-{
-  ens::RMSProp opt(0.01, 32, 0.88, 1e-8, maxEpochs * trainData.n_cols, -1);
-  network1->Train(trainData, trainLabels, opt);
-
-  arma::mat predictions1;
-  network1->Predict(trainData, predictions1);
-  FFN<> network2(std::move(*network1));
-  delete network1;
-
-  // Deallocating all of network1's memory, so that
-  // if network2 is trying to use any of that memory.
-  arma::mat predictions2;
-  network2.Predict(trainData, predictions2);
-  CheckMatrices(predictions1, predictions2);
-}
-
 /**
  * Simple add module test.
  */

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -40,7 +40,7 @@ void CheckRNNCopyFunction(ModelType* network1,
 {
   arma::cube predictions1;
   arma::cube predictions2;
-  ens::StandardSGD opt(0.1, 1, 5, -100, false);
+  ens::StandardSGD opt(0.1, 1, maxEpochs * trainData.n_cols, -100, false);
 
   network1->Train(trainData, trainLabels, opt);
   network1->Predict(trainData, predictions1);
@@ -63,7 +63,7 @@ void CheckRNNMoveFunction(ModelType* network1,
 {
   arma::cube predictions1;
   arma::cube predictions2;
-  ens::StandardSGD opt(0.1, 1, 5, -100, false);
+  ens::StandardSGD opt(0.1, 1, maxEpochs * trainData.n_cols, -100, false);
 
   network1->Train(trainData, trainLabels, opt);
   network1->Predict(trainData, predictions1);
@@ -1242,21 +1242,23 @@ TEST_CASE("CheckCopyMoveFastLSTMTest", "[ANNLayerTest]")
     new RNN<NegativeLogLikelihood<> >(rho);
   model1->Predictors() = input;
   model1->Responses() = target;
+  model1->Add<IdentityLayer<> >();
   model1->Add<Linear<> >(1, 10);
   model1->Add<FastLSTM<> >(10, 3, rho);
   model1->Add<LogSoftMax<> >();
+
+  // Check whether copy constructor is working or not.
+  CheckRNNCopyFunction<>(model1, input, target, 1);
 
   RNN<NegativeLogLikelihood<> > *model2 =
      new RNN<NegativeLogLikelihood<> >(rho);
   model2->Predictors() = input;
   model2->Responses() = target;
+  model2->Add<IdentityLayer<> >();
   model2->Add<Linear<> >(1, 10);
   model2->Add<FastLSTM<> >(10, 3, rho);
   model2->Add<LogSoftMax<> >();
 
-  // Check whether copy constructor is working or not.
-  CheckRNNCopyFunction<>(model1, input, target, 1);
-  
   // Check whether move constructor is working or not.
   CheckRNNMoveFunction<>(model2, input, target, 1);
 }

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -71,8 +71,8 @@ void CheckCopyFunction(ModelType* network1,
   network2 = *network1;
   delete network1;
 
-  // Deallocating all of network1's memory, so that
-  // if network2 is trying to use any of that memory.
+  // Deallocating all of network1's memory, so that network2 does not use any
+  // of that memory.
   arma::mat predictions2;
   network2.Predict(trainData, predictions2);
   CheckMatrices(predictions1, predictions2);
@@ -93,8 +93,8 @@ void CheckMoveFunction(ModelType* network1,
   FFN<> network2(std::move(*network1));
   delete network1;
 
-  // Deallocating all of network1's memory, so that
-  // if network2 is trying to use any of that memory.
+  // Deallocating all of network1's memory, so that network2 does not use any
+  // of that memory.
   arma::mat predictions2;
   network2.Predict(trainData, predictions2);
   CheckMatrices(predictions1, predictions2);
@@ -171,7 +171,7 @@ TEST_CASE("CheckCopyMovingNoisyLinearTest", "[FeedForwardNetworkTest]")
   model1->Add<NoisyLinear<>>(10, 5);
   model1->Add<Linear<> >(5, 1);
   model1->Add<LogSoftMax<>>();
-  
+
   // Check whether copy constructor is working or not.
   CheckCopyFunction<>(model1, input, output, 1);
 


### PR DESCRIPTION
Reference #2625 
This PR attempts to add the copy and move constructors to RNN and FastLSTM layers.