### PR TITLE
Adding assert statement to spatial dropout and virtual batch norm

### DIFF
--- a/src/mlpack/methods/ann/layer/spatial_dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/spatial_dropout_impl.hpp
@@ -51,6 +51,9 @@ template<typename eT>
 void SpatialDropout<InputDataType, OutputDataType>::Forward(
   const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
+  Log::Assert(input.n_rows % size == 0, "Input features must be divisible \
+      by feature maps.");
+
   if (!reset)
   {
     batchSize = input.n_cols;

--- a/src/mlpack/methods/ann/layer/virtual_batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/virtual_batch_norm_impl.hpp
@@ -67,6 +67,9 @@ template<typename eT>
 void VirtualBatchNorm<InputDataType, OutputDataType>::Forward(
     const arma::Mat<eT>& input, arma::Mat<eT>& output)
 {
+  Log::Assert(input.n_rows % size == 0, "Input features must be divisible \
+      by feature maps.");
+
   inputParameter = input;
   arma::mat inputMean = arma::mean(input, 1);
   arma::mat inputMeanSquared = arma::mean(arma::square(input), 1);


### PR DESCRIPTION
I have added an assert statement in `spatial_dropout_impl.hpp` and `virtual_batch_norm_impl.hpp` that asserts that the input size must be divisible by the number of input maps. Like there is one in `batch_norm_impl.hpp`.