### PR TITLE
Added FAIL messages to svd_batch_test and argument fix for callback_test.

### DIFF
--- a/src/mlpack/tests/callback_test.cpp
+++ b/src/mlpack/tests/callback_test.cpp
@@ -42,9 +42,9 @@ TEST_CASE("FFNCallbackTest", "[CallbackTest]")
   arma::mat data;
   arma::mat labels;
 
-  if (!data::Load("lab1.csv", data, true))
+  if (!data::Load("lab1.csv", data))
     FAIL("Cannot load test dataset lab1.csv!");
-  if (!data::Load("lab3.csv", labels, true))
+  if (!data::Load("lab3.csv", labels))
     FAIL("Cannot load test dataset lab3.csv!");
 
   FFN<MeanSquaredError<>, RandomInitialization> model;
@@ -68,9 +68,9 @@ TEST_CASE("FFNWithOptimizerCallbackTest", "[CallbackTest]")
   arma::mat data;
   arma::mat labels;
 
-  if (!data::Load("lab1.csv", data, true))
+  if (!data::Load("lab1.csv", data))
     FAIL("Cannot load test dataset lab1.csv!");
-  if (!data::Load("lab3.csv", labels, true))
+  if (!data::Load("lab3.csv", labels))
     FAIL("Cannot load test dataset lab3.csv!");
 
   FFN<MeanSquaredError<>, RandomInitialization> model;

--- a/src/mlpack/tests/svd_batch_test.cpp
+++ b/src/mlpack/tests/svd_batch_test.cpp
@@ -70,7 +70,7 @@ class SpecificRandomInitialization
 TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]")
 {
   mat dataset;
-  if (data::Load("GroupLensSmall.csv", dataset))
+  if (!data::Load("GroupLensSmall.csv", dataset))
     FAIL("Cannot load dataset GroupLensSmall.csv!");
 
   // Generate list of locations for batch insert constructor for sparse
@@ -118,7 +118,7 @@ TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]")
 TEST_CASE("SVDBatchRegularizationTest", "[SVDBatchTest]")
 {
   mat dataset;
-  if (data::Load("GroupLensSmall.csv", dataset))
+  if (!data::Load("GroupLensSmall.csv", dataset))
     FAIL("Cannot load dataset GroupLensSmall.csv!");
 
   // Generate list of locations for batch insert constructor for sparse

--- a/src/mlpack/tests/svd_batch_test.cpp
+++ b/src/mlpack/tests/svd_batch_test.cpp
@@ -70,7 +70,8 @@ class SpecificRandomInitialization
 TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]")
 {
   mat dataset;
-  data::Load("GroupLensSmall.csv", dataset);
+  if (data::Load("GroupLensSmall.csv", dataset))
+    FAIL("Cannot load dataset GroupLensSmall.csv!");
 
   // Generate list of locations for batch insert constructor for sparse
   // matrices.
@@ -117,7 +118,8 @@ TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]")
 TEST_CASE("SVDBatchRegularizationTest", "[SVDBatchTest]")
 {
   mat dataset;
-  data::Load("GroupLensSmall.csv", dataset);
+  if (data::Load("GroupLensSmall.csv", dataset))
+    FAIL("Cannot load dataset GroupLensSmall.csv!");
 
   // Generate list of locations for batch insert constructor for sparse
   // matrices.


### PR DESCRIPTION
Reference #2715 .

Changes to file ```callback_test.cpp``` made according to this [comment](https://github.com/mlpack/mlpack/pull/2717#pullrequestreview-536109228).
Missed out file ```svd_batch_test.cpp``` during the initial screening of files for the issue.