### PR TITLE
Fix edge case for similarly-correlated LARS dimensions.

### DIFF
--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -366,13 +366,16 @@ double LARS::Train(const arma::mat& matX,
         if (isActive[ind] || isIgnored[ind])
           continue;
 
-        double dirCorr = dot(dataRef.col(ind), yHatDirection);
-        double val1 = (maxCorr - corr(ind)) / (normalization - dirCorr);
-        double val2 = (maxCorr + corr(ind)) / (normalization + dirCorr);
-        if ((val1 > 0) && (val1 < gamma))
-          gamma = val1;
-        if ((val2 > 0) && (val2 < gamma))
-          gamma = val2;
+        const double dirCorr = dot(dataRef.col(ind), yHatDirection);
+        const double val1 = (maxCorr - corr(ind)) / (normalization - dirCorr);
+        const double val2 = (maxCorr + corr(ind)) / (normalization + dirCorr);
+        if ((val1 > 0.0) && (val1 < gamma))
+           gamma = val1;
+        if ((val2 > 0.0) && (val2 < gamma))
+           gamma = val2;
+        // Handle edge case where the largest actually is equal to 0.
+        if (std::max(val1, val2) == 0.0)
+          gamma = 0.0;
       }
     }
 


### PR DESCRIPTION
This PR fixes a very unexpected edge case that arises in the LARS algorithm.  Even describing the situation is not particularly easy, and I am not sure I have accurately described it here.

LARS is a regression algorithm that proceeds by adding one feature at a time to the model.  It's a super clever algorithm that actually manages to recover *all* models of the form

```
argminᵦ ∥ Xβ - Y ∥² + λ ∥ β ‖₁
```

for all possible values of `λ`.

Super loosely summarized, the algorithm works like this:

 - Pick the next feature `i` that isn't already in the model that is maximally correlated with the responses `Y`.

 - Compute the maximum weight `βᵢ` is before another feature needs to be added to the model.

 - Repeat until all features are added to the model.

The situation reported in #2749 is a very strange one where two features in the matrix `X` are *not* linearly dependent (that is already accounted for in the code), but instead there exists a situation where two features have exactly the same correlations with the responses `Y`.  This means that the maximum weight `βᵢ` for whichever of those features is chosen should be 0 (since we actually need to add both those features at the same time).

So, this edge case manifests itself in a way that the max of `val1` and `val2` when computing the step size is 0, but the code does not handle this and actually choose a step size of 0.  I've therefore just added an `if` to handle this situation, and now the example code in #2749 appears to work.

I tried for a while to make a minimum reproducible example, but I wasn't able to come up with a standalone test case.
