### PR TITLE
Adding Constructors for Convolution and Adaptive mean pooling

### DIFF
--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling.hpp
@@ -45,6 +45,18 @@ class AdaptiveMaxPooling
   AdaptiveMaxPooling(const size_t outputWidth,
                      const size_t outputHeight);
 
+  //! Copy constructor.
+  AdaptiveMaxPooling(const AdaptiveMaxPooling& layer);
+
+  //! Move constructor.
+  AdaptiveMaxPooling(AdaptiveMaxPooling&&);
+
+  //! Copy assignment operator.
+  AdaptiveMaxPooling& operator=(const AdaptiveMaxPooling& layer);
+
+  //! Move assignment operator.
+  AdaptiveMaxPooling& operator=(AdaptiveMaxPooling&& layer);
+
   /**
    * Create the AdaptiveMaxPooling object.
    *

--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
@@ -75,7 +75,8 @@ AdaptiveMaxPooling<InputDataType, OutputDataType>::operator=(
 
 template <typename InputDataType, typename OutputDataType>
 AdaptiveMaxPooling<InputDataType, OutputDataType>& 
-AdaptiveMaxPooling<InputDataType, OutputDataType> :: operator=(AdaptiveMaxPooling&& layer)
+AdaptiveMaxPooling<InputDataType, OutputDataType>::operator=(
+  AdaptiveMaxPooling&& layer)
 {
   if (this != &layer)
   {

--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
@@ -19,7 +19,10 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling()
+AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling():
+    outputWidth(0),
+    outputHeight(0),
+    reset(false)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
@@ -60,7 +60,8 @@ AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling(
 
 template <typename InputDataType, typename OutputDataType>
 AdaptiveMaxPooling<InputDataType, OutputDataType>& 
-AdaptiveMaxPooling<InputDataType, OutputDataType> :: operator=(const AdaptiveMaxPooling& layer)
+AdaptiveMaxPooling<InputDataType, OutputDataType>::operator=(
+  const AdaptiveMaxPooling& layer)
 {
   if (this != &layer)
   {

--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
@@ -36,6 +36,56 @@ AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling(
   // Nothing to do here.
 }
 
+template<typename InputDataType, typename OutputDataType>
+AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling(
+    const AdaptiveMaxPooling& layer) : 
+    poolingLayer(layer.poolingLayer),
+    outputWidth(layer.outputWidth),
+    outputHeight(layer.outputHeight),
+    reset(layer.reset)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling(
+    AdaptiveMaxPooling&& layer) : 
+    poolingLayer(std::move(layer.poolingLayer)),
+    outputWidth(std::move(layer.outputWidth)),
+    outputHeight(std::move(layer.outputHeight)),
+    reset(std::move(layer.reset))
+{
+  // Nothing to do here.
+}
+
+template <typename InputDataType, typename OutputDataType>
+AdaptiveMaxPooling<InputDataType, OutputDataType>& 
+AdaptiveMaxPooling<InputDataType, OutputDataType> :: operator=(const AdaptiveMaxPooling& layer)
+{
+  if (this != &layer)
+  {
+    poolingLayer = layer.poolingLayer;
+    outputWidth = layer.outputWidth;
+    outputHeight = layer.outputHeight;
+    reset = layer.reset;
+  }
+  return *this; 
+}
+
+template <typename InputDataType, typename OutputDataType>
+AdaptiveMaxPooling<InputDataType, OutputDataType>& 
+AdaptiveMaxPooling<InputDataType, OutputDataType> :: operator=(AdaptiveMaxPooling&& layer)
+{
+  if (this != &layer)
+  {
+    poolingLayer = std::move(layer.poolingLayer);
+    outputWidth = std::move(layer.outputWidth);
+    outputHeight = std::move(layer.outputHeight);
+    reset = std::move(layer.reset);
+  }
+  return *this; 
+}
+
 template <typename InputDataType, typename OutputDataType>
 AdaptiveMaxPooling<InputDataType, OutputDataType>::AdaptiveMaxPooling(
     const std::tuple<size_t, size_t>& outputShape):

--- a/src/mlpack/methods/ann/layer/adaptive_mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_mean_pooling.hpp
@@ -46,6 +46,18 @@ class AdaptiveMeanPooling
   AdaptiveMeanPooling(const size_t outputWidth,
                       const size_t outputHeight);
 
+  //! Copy constructor.
+  AdaptiveMeanPooling(const AdaptiveMeanPooling& layer);
+
+  //! Move constructor.
+  AdaptiveMeanPooling(AdaptiveMeanPooling&&);
+
+  //! Copy assignment operator.
+  AdaptiveMeanPooling& operator=(const AdaptiveMeanPooling& layer);
+
+  //! Move assignment operator.
+  AdaptiveMeanPooling& operator=(AdaptiveMeanPooling&& layer);
+
   /**
    * Create the AdaptiveMeanPooling object.
    *

--- a/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
@@ -33,6 +33,56 @@ AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
   // Nothing to do here.
 }
 
+template<typename InputDataType, typename OutputDataType>
+AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
+    const AdaptiveMeanPooling& layer) : 
+    outputHeight(layer.outputHeight),
+    outputWidth(layer.outputWidth),
+    reset(layer.reset),
+    poolingLayer(layer.poolingLayer)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
+    AdaptiveMeanPooling&& layer) : 
+    outputHeight(std::move(layer.outputHeight)),
+    outputWidth(std::move(layer.outputWidth)),
+    reset(std::move(layer.reset)),
+    poolingLayer(std::move(layer.poolingLayer))
+{
+  // Nothing to do here.
+}
+
+template <typename InputDataType, typename OutputDataType>
+AdaptiveMeanPooling<InputDataType, OutputDataType>& 
+AdaptiveMeanPooling<InputDataType, OutputDataType> :: operator=(const AdaptiveMeanPooling& layer)
+{
+  if (this != &layer)
+  {
+    outputHeight = layer.outputHeight;
+    outputWidth = layer.outputWidth;
+    reset = layer.reset;
+    poolingLayer = layer.poolingLayer;
+  }
+  return *this; 
+}
+
+template <typename InputDataType, typename OutputDataType>
+AdaptiveMeanPooling<InputDataType, OutputDataType>& 
+AdaptiveMeanPooling<InputDataType, OutputDataType> :: operator=(AdaptiveMeanPooling&& layer)
+{
+  if (this != &layer)
+  {
+    outputHeight = std::move(layer.outputHeight);
+    outputWidth = std::move(layer.outputWidth);
+    reset = std::move(layer.reset);
+    poolingLayer = std::move(layer.poolingLayer);
+  }
+  return *this; 
+}
+
 template <typename InputDataType, typename OutputDataType>
 AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
     const std::tuple<size_t, size_t>& outputShape):

--- a/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
@@ -19,7 +19,10 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling()
+AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling():
+    outputWidth(0),
+    outputHeight(0),
+    reset(false)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
@@ -36,10 +36,10 @@ AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
 template<typename InputDataType, typename OutputDataType>
 AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
     const AdaptiveMeanPooling& layer) : 
-    outputHeight(layer.outputHeight),
+    poolingLayer(layer.poolingLayer),
     outputWidth(layer.outputWidth),
-    reset(layer.reset),
-    poolingLayer(layer.poolingLayer)
+    outputHeight(layer.outputHeight),
+    reset(layer.reset)
 {
   // Nothing to do here.
 }
@@ -47,10 +47,10 @@ AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
 template<typename InputDataType, typename OutputDataType>
 AdaptiveMeanPooling<InputDataType, OutputDataType>::AdaptiveMeanPooling(
     AdaptiveMeanPooling&& layer) : 
-    outputHeight(std::move(layer.outputHeight)),
+    poolingLayer(std::move(layer.poolingLayer)),
     outputWidth(std::move(layer.outputWidth)),
-    reset(std::move(layer.reset)),
-    poolingLayer(std::move(layer.poolingLayer))
+    outputHeight(std::move(layer.outputHeight)),
+    reset(std::move(layer.reset))
 {
   // Nothing to do here.
 }
@@ -61,10 +61,10 @@ AdaptiveMeanPooling<InputDataType, OutputDataType> :: operator=(const AdaptiveMe
 {
   if (this != &layer)
   {
-    outputHeight = layer.outputHeight;
-    outputWidth = layer.outputWidth;
-    reset = layer.reset;
     poolingLayer = layer.poolingLayer;
+    outputWidth = layer.outputWidth;
+    outputHeight = layer.outputHeight;
+    reset = layer.reset;
   }
   return *this; 
 }
@@ -75,10 +75,10 @@ AdaptiveMeanPooling<InputDataType, OutputDataType> :: operator=(AdaptiveMeanPool
 {
   if (this != &layer)
   {
-    outputHeight = std::move(layer.outputHeight);
-    outputWidth = std::move(layer.outputWidth);
-    reset = std::move(layer.reset);
     poolingLayer = std::move(layer.poolingLayer);
+    outputWidth = std::move(layer.outputWidth);
+    outputHeight = std::move(layer.outputHeight);
+    reset = std::move(layer.reset);
   }
   return *this; 
 }

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -111,6 +111,18 @@ class Convolution
               const size_t inputHeight = 0,
               const std::string& paddingType = "None");
 
+  //! Copy constructor.
+  Convolution(const Convolution& layer);
+
+  //! Move constructor.
+  Convolution(Convolution&&);
+
+  //! Copy assignment operator.
+  Convolution& operator=(const Convolution& layer);
+
+  //! Move assignment operator.
+  Convolution& operator=(Convolution&& layer);
+
   /*
    * Set the weight and bias term.
    */

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -155,6 +155,7 @@ Convolution<
     const Convolution& layer) : 
     inSize(layer.inSize),
     outSize(layer.outSize),
+    batchSize(layer.batchSize),
     kernelWidth(layer.kernelWidth),
     kernelHeight(layer.kernelHeight),
     strideWidth(layer.strideWidth),
@@ -191,6 +192,7 @@ Convolution<
     Convolution&& layer) : 
     inSize(std::move(layer.inSize)),
     outSize(std::move(layer.outSize)),
+    batchSize(std::move(layer.batchSize)),
     kernelWidth(std::move(layer.kernelWidth)),
     kernelHeight(std::move(layer.kernelHeight)),
     strideWidth(std::move(layer.strideWidth)),

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -225,14 +225,14 @@ Convolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
->& 
+>&
 Convolution<
     ForwardConvolutionRule,
     BackwardConvolutionRule,
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
-> :: operator=(const Convolution& layer)
+>::operator=(const Convolution& layer)
 {
   if (this != &layer)
   {

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -138,6 +138,168 @@ Convolution<
   padding = ann::Padding<>(padWLeft, padWRight, padHTop, padHBottom);
 }
 
+template<    
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>::Convolution(
+    const Convolution& layer) : 
+    inSize(layer.inSize),
+    outSize(layer.outSize),
+    kernelWidth(layer.kernelWidth),
+    kernelHeight(layer.kernelHeight),
+    strideWidth(layer.strideWidth),
+    strideHeight(layer.strideHeight),
+    padWLeft(layer.padWLeft),
+    padWRight(layer.padWRight),
+    padHBottom(layer.padHBottom),
+    padHTop(layer.padHTop),
+    weights(layer.weights),
+    inputWidth(layer.inputWidth),
+    inputHeight(layer.inputHeight),
+    outputWidth(layer.outputWidth),
+    outputHeight(layer.outputHeight),
+    padding(layer.padding)
+{
+  std::cout << "1\n"; 
+  // Nothing to do here.
+}
+
+template<    
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>::Convolution(
+    Convolution&& layer) : 
+    inSize(std::move(layer.inSize)),
+    outSize(std::move(layer.outSize)),
+    kernelWidth(std::move(layer.kernelWidth)),
+    kernelHeight(std::move(layer.kernelHeight)),
+    strideWidth(std::move(layer.strideWidth)),
+    strideHeight(std::move(layer.strideHeight)),
+    padWLeft(std::move(layer.padWLeft)),
+    padWRight(std::move(layer.padWRight)),
+    padHBottom(std::move(layer.padHBottom)),
+    padHTop(std::move(layer.padHTop)),
+    weights(std::move(layer.weights)),
+    inputWidth(std::move(layer.inputWidth)),
+    inputHeight(std::move(layer.inputHeight)),
+    outputWidth(std::move(layer.outputWidth)),
+    outputHeight(std::move(layer.outputHeight)),
+    padding(std::move(layer.padding))
+{
+  std::cout << "2\n"; 
+  // Nothing to do here.
+}
+
+template<    
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>& 
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+> :: operator=(const Convolution& layer)
+{
+  if (this != &layer)
+  {
+    inSize = layer.inSize; 
+    outSize = layer.outSize; 
+    kernelWidth = layer.kernelWidth; 
+    kernelHeight = layer.kernelHeight; 
+    strideWidth = layer.strideWidth; 
+    strideHeight = layer.strideHeight; 
+    padWLeft = layer.padWLeft; 
+    padWRight = layer.padWRight; 
+    padHBottom = layer.padHBottom; 
+    padHTop = layer.padHTop; 
+    weights = layer.weights; 
+    inputWidth = layer.inputWidth; 
+    inputHeight = layer.inputHeight; 
+    outputWidth = layer.outputWidth;
+    outputHeight = layer.outputHeight;
+    padding = layer.padding; 
+    std::cout << "3\n"; 
+  }
+  return *this; 
+}
+
+template<    
+    typename ForwardConvolutionRule,
+    typename BackwardConvolutionRule,
+    typename GradientConvolutionRule,
+    typename InputDataType,
+    typename OutputDataType
+>
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+>& 
+Convolution<
+    ForwardConvolutionRule,
+    BackwardConvolutionRule,
+    GradientConvolutionRule,
+    InputDataType,
+    OutputDataType
+> :: operator=(Convolution&& layer)
+{
+  if (this != &layer)
+  {
+    inSize = std::move(layer.inSize); 
+    outSize = std::move(layer.outSize);
+    kernelWidth = std::move(layer.kernelWidth); 
+    kernelHeight = std::move(layer.kernelHeight); 
+    strideWidth = std::move(layer.strideWidth); 
+    strideHeight = std::move(layer.strideHeight); 
+    padWLeft = std::move(layer.padWLeft); 
+    padWRight = std::move(layer.padWRight); 
+    padHBottom = std::move(layer.padHBottom); 
+    padHTop = std::move(layer.padHTop); 
+    weights = std::move(layer.weights); 
+    inputWidth = std::move(layer.inputWidth);
+    inputHeight = std::move(layer.inputHeight); 
+    outputWidth = std::move(layer.outputWidth); 
+    outputHeight = std::move(layer.outputHeight); 
+    padding = std::move(layer.padding); 
+    std::cout << "4\n"; 
+  }
+  return *this; 
+}
+
 template<
     typename ForwardConvolutionRule,
     typename BackwardConvolutionRule,

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -14,6 +14,7 @@
 
 // In case it hasn't yet been included.
 #include "convolution.hpp"
+using namespace std; 
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
@@ -164,16 +165,16 @@ Convolution<
     padHBottom(layer.padHBottom),
     padHTop(layer.padHTop),
     weights(layer.weights),
+    weight(layer.weight),
+    bias(layer.bias),
     inputWidth(layer.inputWidth),
     inputHeight(layer.inputHeight),
     outputWidth(layer.outputWidth),
-    outputHeight(layer.outputHeight),
-    padding(layer.padding)
+    outputHeight(layer.outputHeight)
 {
-  std::cout << "1\n"; 
-  // Nothing to do here.
+  padding = ann::Padding<>(padWLeft, padWRight, padHTop, padHBottom);
 }
-
+  
 template<    
     typename ForwardConvolutionRule,
     typename BackwardConvolutionRule,
@@ -200,14 +201,14 @@ Convolution<
     padHBottom(std::move(layer.padHBottom)),
     padHTop(std::move(layer.padHTop)),
     weights(std::move(layer.weights)),
+    weight(std::move(layer.weight)),
+    bias(std::move(layer.bias)),
     inputWidth(std::move(layer.inputWidth)),
     inputHeight(std::move(layer.inputHeight)),
     outputWidth(std::move(layer.outputWidth)),
-    outputHeight(std::move(layer.outputHeight)),
-    padding(std::move(layer.padding))
+    outputHeight(std::move(layer.outputHeight))
 {
-  std::cout << "2\n"; 
-  // Nothing to do here.
+  padding = ann::Padding<>(padWLeft, padWRight, padHTop, padHBottom);
 }
 
 template<    
@@ -243,14 +244,15 @@ Convolution<
     padWLeft = layer.padWLeft; 
     padWRight = layer.padWRight; 
     padHBottom = layer.padHBottom; 
-    padHTop = layer.padHTop; 
-    weights = layer.weights; 
+    padHTop = layer.padHTop;
+    weights = layer.weights;  
+    weight = layer.weight;
+    bias = layer.bias; 
     inputWidth = layer.inputWidth; 
     inputHeight = layer.inputHeight; 
     outputWidth = layer.outputWidth;
     outputHeight = layer.outputHeight;
-    padding = layer.padding; 
-    std::cout << "3\n"; 
+    padding = ann::Padding<>(padWLeft, padWRight, padHTop, padHBottom);
   }
   return *this; 
 }
@@ -288,14 +290,15 @@ Convolution<
     padWLeft = std::move(layer.padWLeft); 
     padWRight = std::move(layer.padWRight); 
     padHBottom = std::move(layer.padHBottom); 
-    padHTop = std::move(layer.padHTop); 
-    weights = std::move(layer.weights); 
+    padHTop = std::move(layer.padHTop);
+    weights = std::move(layer.weights);  
+    weight = std::move(layer.weight);
+    bias = std::move(layer.bias);
     inputWidth = std::move(layer.inputWidth);
     inputHeight = std::move(layer.inputHeight); 
     outputWidth = std::move(layer.outputWidth); 
     outputHeight = std::move(layer.outputHeight); 
-    padding = std::move(layer.padding); 
-    std::cout << "4\n"; 
+    padding = ann::Padding<>(padWLeft, padWRight, padHTop, padHBottom);
   }
   return *this; 
 }

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -278,7 +278,7 @@ Convolution<
     GradientConvolutionRule,
     InputDataType,
     OutputDataType
-> :: operator=(Convolution&& layer)
+> :operator=(Convolution&& layer)
 {
   if (this != &layer)
   {

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't yet been included.
 #include "convolution.hpp"
-using namespace std; 
 
 namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4068,6 +4068,57 @@ TEST_CASE("AdaptiveMeanPoolingTestCase", "[ANNLayerTest]")
 }
 
 /**
+ * Test for Copy and Move Adaptive Max Pooling layer.
+ */
+TEST_CASE("CheckCopyMoveAdaptiveMaxPooling", "[ANNLayerTest]")
+{
+  // For rectangular input.
+  arma::mat input = arma::mat(12, 1);
+  arma::mat output, delta;
+
+  input.zeros();
+  input(0) = 1;
+  input(1) = 2;
+  input(2) = 3;
+  input(3) = input(8) = 7;
+  input(4) = 4;
+  input(5) = 5;
+  input(6) = input(7) = 6;
+  input(10) = 8;
+  input(11) = 9;
+
+  // Output-Size should be 2 x 2.
+  // Square output.
+  AdaptiveMaxPooling<> layer1(2, 2);
+  layer1.InputHeight() = 3;
+  layer1.InputWidth() = 4;
+
+  // For copy Constructor
+  AdaptiveMaxPooling<> layer2 = layer1;
+
+  layer2.Forward(input, output);
+  layer2.Backward(input, output, delta);
+
+  // Calculated using torch.nn.AdaptiveMaxPool2d().
+  REQUIRE(arma::accu(output) == 28);
+  REQUIRE(output.n_elem == 4);
+  REQUIRE(output.n_cols == 1);
+  REQUIRE(arma::accu(delta) == 28.0);
+
+  // For move Constructor
+  AdaptiveMaxPooling<> layer3 = std::move(layer1);
+
+  layer3.Forward(input, output);
+  layer3.Backward(input, output, delta);
+
+  // Calculated using torch.nn.AdaptiveMaxPool2d().
+  REQUIRE(arma::accu(output) == 28);
+  REQUIRE(output.n_elem == 4);
+  REQUIRE(output.n_cols == 1);
+  REQUIRE(arma::accu(delta) == 28.0);
+}
+
+/**
  * Test for Copy and Move Adaptive Mean Pooling layer.
  */
 TEST_CASE("CheckCopyMoveAdaptiveMeanPooling", "[ANNLayerTest]")

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4377,6 +4377,43 @@ TEST_CASE("ConvolutionLayerTestCase", "[ANNLayerTest]")
   REQUIRE(arma::accu(output) == 4156);
 }
 
+TEST_CASE("CopyMoveConvolution", "[ANNLayerTest]")
+{
+  arma::mat input, output;
+
+  // The input test matrix is of the form 3 x 2 x 4 x 1 where
+  // number of images are 3 and number of feature maps are 2.
+  input = arma::mat(8, 3);
+  input << 1 << 446 << 42 << arma::endr
+      << 2 << 16 << 63 << arma::endr
+      << 3 << 13 << 63 << arma::endr
+      << 4 << 21 << 21 << arma::endr
+      << 1 << 13 << 11 << arma::endr
+      << 32 << 45 << 42 << arma::endr
+      << 22 << 16 << 63 << arma::endr
+      << 32 << 13 << 42 << arma::endr;
+
+  Convolution<> layer1(2, 4, 1, 1, 1, 1, 0, 0, 4, 1);
+  layer1.Reset();
+
+  // Set weights to 1.0 and bias to 0.0.
+  layer1.Parameters().zeros();
+  arma::mat weight(2 * 4, 1);
+  weight.fill(1.0);
+  layer1.Parameters().submat(arma::span(0, 2 * 4 - 1), arma::span()) = weight;
+
+  Convolution<> layer2 = layer1; 
+  Convolution<> layer3 = std::move(layer1); 
+
+  layer2.Forward(input, output);
+  // Value already calculated
+  REQUIRE(arma::accu(output) == 4108);
+  
+  layer3.Forward(input, output);
+  // Value already calculated
+  REQUIRE(arma::accu(output) == 4108);
+}
+
 TEST_CASE("BatchNormDeterministicTest", "[ANNLayerTest]")
 {
   FFN<> module;

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4067,6 +4067,57 @@ TEST_CASE("AdaptiveMeanPoolingTestCase", "[ANNLayerTest]")
   REQUIRE(arma::accu(delta) == 1.5);
 }
 
+/**
+ * Test for Copy and Move Adaptive Mean Pooling layer.
+ */
+TEST_CASE("CheckCopyMoveAdaptiveMeanPooling", "[ANNLayerTest]")
+{
+	// For rectangular input.
+	arma::mat input = arma::mat(12, 1);
+	arma::mat output, delta;
+
+	input.zeros();
+  input(0) = 1;
+  input(1) = 2;
+  input(2) = 3;
+  input(3) = input(8) = 7;
+  input(4) = 4;
+  input(5) = 5;
+  input(6) = input(7) = 6;
+  input(10) = 8;
+  input(11) = 9;
+
+  // Output-Size should be 2 x 2.
+  // Square output.  
+  AdaptiveMaxPooling<> layer1(2, 2);
+  layer1.InputHeight() = 3;
+  layer1.InputWidth() = 4;
+  
+  // For copy Constructor
+  AdaptiveMaxPooling<> layer2 = layer1;
+
+	layer2.Forward(input, output);
+	layer2.Backward(input, output, delta);
+
+  // Calculated using torch.nn.AdaptiveAvgPool2d().
+  REQUIRE(arma::accu(output) == 2.25);
+  REQUIRE(output.n_elem == 9);
+  REQUIRE(output.n_cols == 1);
+  REQUIRE(arma::accu(delta) == 1.5);
+
+	// For move Constructor
+  AdaptiveMaxPooling<> layer3 = std::move(layer1);
+
+  layer3.Forward(input, output);
+  layer3.Backward(input, output, delta);
+
+  // Calculated using torch.nn.AdaptiveAvgPool2d().
+  REQUIRE(arma::accu(output) == 2.25);
+  REQUIRE(output.n_elem == 9);
+  REQUIRE(output.n_cols == 1);
+  REQUIRE(arma::accu(delta) == 1.5);
+}
+
 TEST_CASE("TransposedConvolutionalLayerOptionalParameterTest", "[ANNLayerTest]")
 {
   Sequential<>* decoder = new Sequential<>();

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4395,23 +4395,18 @@ TEST_CASE("CopyMoveConvolution", "[ANNLayerTest]")
 
   Convolution<> layer1(2, 4, 1, 1, 1, 1, 0, 0, 4, 1);
   layer1.Reset();
-
-  // Set weights to 1.0 and bias to 0.0.
-  layer1.Parameters().zeros();
-  arma::mat weight(2 * 4, 1);
-  weight.fill(1.0);
-  layer1.Parameters().submat(arma::span(0, 2 * 4 - 1), arma::span()) = weight;
+  layer1.Parameters().fill(1.0);
 
   Convolution<> layer2 = layer1; 
   Convolution<> layer3 = std::move(layer1); 
 
   layer2.Forward(input, output);
   // Value already calculated
-  REQUIRE(arma::accu(output) == 4108);
-  
+  REQUIRE(arma::accu(output) == 4156);
+
   layer3.Forward(input, output);
   // Value already calculated
-  REQUIRE(arma::accu(output) == 4108);
+  REQUIRE(arma::accu(output) == 4156);
 }
 
 TEST_CASE("BatchNormDeterministicTest", "[ANNLayerTest]")

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4384,14 +4384,14 @@ TEST_CASE("CopyMoveConvolution", "[ANNLayerTest]")
   // The input test matrix is of the form 3 x 2 x 4 x 1 where
   // number of images are 3 and number of feature maps are 2.
   input = arma::mat(8, 3);
-  input = { {1, 446, 42}, 
-		      	{2, 16, 63}, 
-		     		{3, 13, 63}, 
-		      	{4, 21, 21},
-		      	{1, 13, 11}, 
-		      	{32, 45, 42}, 
-		      	{22, 16, 63},
-		      	{32, 13, 42} };
+  input = { {1, 446, 42},
+            {2, 16, 63},
+            {3, 13, 63},
+            {4, 21, 21},
+            {1, 13, 11},
+            {32, 45, 42},
+            {22, 16, 63},
+            {32, 13, 42} };
 
   Convolution<> layer1(2, 4, 1, 1, 1, 1, 0, 0, 4, 1);
   layer1.Reset();

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4089,33 +4089,33 @@ TEST_CASE("CheckCopyMoveAdaptiveMeanPooling", "[ANNLayerTest]")
 
   // Output-Size should be 2 x 2.
   // Square output.  
-  AdaptiveMaxPooling<> layer1(2, 2);
+  AdaptiveMeanPooling<> layer1(2, 2);
   layer1.InputHeight() = 3;
   layer1.InputWidth() = 4;
   
   // For copy Constructor
-  AdaptiveMaxPooling<> layer2 = layer1;
+  AdaptiveMeanPooling<> layer2 = layer1;
 
 	layer2.Forward(input, output);
 	layer2.Backward(input, output, delta);
 
   // Calculated using torch.nn.AdaptiveAvgPool2d().
-  REQUIRE(arma::accu(output) == 2.25);
-  REQUIRE(output.n_elem == 9);
+  REQUIRE(arma::accu(output) == 19.75);
+  REQUIRE(output.n_elem == 4);
   REQUIRE(output.n_cols == 1);
-  REQUIRE(arma::accu(delta) == 1.5);
+  REQUIRE(arma::accu(delta) == 7.0);
 
 	// For move Constructor
-  AdaptiveMaxPooling<> layer3 = std::move(layer1);
+  AdaptiveMeanPooling<> layer3 = std::move(layer1);
 
   layer3.Forward(input, output);
   layer3.Backward(input, output, delta);
 
   // Calculated using torch.nn.AdaptiveAvgPool2d().
-  REQUIRE(arma::accu(output) == 2.25);
-  REQUIRE(output.n_elem == 9);
+  REQUIRE(arma::accu(output) == 19.75);
+  REQUIRE(output.n_elem == 4);
   REQUIRE(output.n_cols == 1);
-  REQUIRE(arma::accu(delta) == 1.5);
+  REQUIRE(arma::accu(delta) == 7.0);
 }
 
 TEST_CASE("TransposedConvolutionalLayerOptionalParameterTest", "[ANNLayerTest]")

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4072,11 +4072,11 @@ TEST_CASE("AdaptiveMeanPoolingTestCase", "[ANNLayerTest]")
  */
 TEST_CASE("CheckCopyMoveAdaptiveMeanPooling", "[ANNLayerTest]")
 {
-	// For rectangular input.
-	arma::mat input = arma::mat(12, 1);
-	arma::mat output, delta;
+  // For rectangular input.
+  arma::mat input = arma::mat(12, 1);
+  arma::mat output, delta;
 
-	input.zeros();
+  input.zeros();
   input(0) = 1;
   input(1) = 2;
   input(2) = 3;
@@ -4092,12 +4092,12 @@ TEST_CASE("CheckCopyMoveAdaptiveMeanPooling", "[ANNLayerTest]")
   AdaptiveMeanPooling<> layer1(2, 2);
   layer1.InputHeight() = 3;
   layer1.InputWidth() = 4;
-  
+
   // For copy Constructor
   AdaptiveMeanPooling<> layer2 = layer1;
 
-	layer2.Forward(input, output);
-	layer2.Backward(input, output, delta);
+  layer2.Forward(input, output);
+  layer2.Backward(input, output, delta);
 
   // Calculated using torch.nn.AdaptiveAvgPool2d().
   REQUIRE(arma::accu(output) == 19.75);
@@ -4105,7 +4105,7 @@ TEST_CASE("CheckCopyMoveAdaptiveMeanPooling", "[ANNLayerTest]")
   REQUIRE(output.n_cols == 1);
   REQUIRE(arma::accu(delta) == 7.0);
 
-	// For move Constructor
+  // For move Constructor
   AdaptiveMeanPooling<> layer3 = std::move(layer1);
 
   layer3.Forward(input, output);

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4384,14 +4384,14 @@ TEST_CASE("CopyMoveConvolution", "[ANNLayerTest]")
   // The input test matrix is of the form 3 x 2 x 4 x 1 where
   // number of images are 3 and number of feature maps are 2.
   input = arma::mat(8, 3);
-  input << 1 << 446 << 42 << arma::endr
-      << 2 << 16 << 63 << arma::endr
-      << 3 << 13 << 63 << arma::endr
-      << 4 << 21 << 21 << arma::endr
-      << 1 << 13 << 11 << arma::endr
-      << 32 << 45 << 42 << arma::endr
-      << 22 << 16 << 63 << arma::endr
-      << 32 << 13 << 42 << arma::endr;
+  input = { {1, 446, 42}, 
+		      	{2, 16, 63}, 
+		     		{3, 13, 63}, 
+		      	{4, 21, 21},
+		      	{1, 13, 11}, 
+		      	{32, 45, 42}, 
+		      	{22, 16, 63},
+		      	{32, 13, 42} };
 
   Convolution<> layer1(2, 4, 1, 1, 1, 1, 0, 0, 4, 1);
   layer1.Reset();


### PR DESCRIPTION
This PR is in reference to issue [#2625](https://github.com/mlpack/mlpack/issues/2625)
Content in PR: 
- Adding Copy and move constructors for Convolution Layer with tests
- Adding Copy and move constructors for Adaptive mean pooling Layer with tests
- Adding Copy and move constructors for Adaptive max pooling Layer with tests
- initialization of outputWidth, outputHeight, reset variables in Adaptive mean and max pooling Layer constructors