### PR TITLE
Adding another overload member function of PCA::Apply() 

### DIFF
--- a/src/mlpack/methods/pca/pca.hpp
+++ b/src/mlpack/methods/pca/pca.hpp
@@ -68,6 +68,14 @@ class PCA
   void Apply(const arma::mat& data,
              arma::mat& transformedData,
              arma::vec& eigVal);
+/**
+   * Apply Principal Component Analysis to the provided data set. It is safe
+   * to pass the same matrix reference for both data and transformedData.
+   * @param data Data matrix.
+   * @param transformedData Matrix to store results of PCA in.
+   */
+  void Apply(const arma::mat& data,
+             arma::mat& transformedData);
 
   /**
    * Use PCA for dimensionality reduction on the given dataset. This will save

--- a/src/mlpack/methods/pca/pca.hpp
+++ b/src/mlpack/methods/pca/pca.hpp
@@ -68,7 +68,7 @@ class PCA
   void Apply(const arma::mat& data,
              arma::mat& transformedData,
              arma::vec& eigVal);
-/**
+  /**
    * Apply Principal Component Analysis to the provided data set. It is safe
    * to pass the same matrix reference for both data and transformedData.
    * @param data Data matrix.

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -61,7 +61,8 @@ void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
 
 /**
  * Apply Principal Component Analysis to the provided data set.
- *
+ * It creates matrix to store eigenvectors and 
+   that matrix need not to be passed in paramteres
  * @param data - Data matrix
  * @param transformedData - Data with PCA applied
  * @param eigVal - contains eigen values in a column vector
@@ -72,6 +73,20 @@ void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
                                      arma::vec& eigVal)
 {
   arma::mat eigvec;
+  Apply(data, transformedData, eigVal, eigvec);
+}
+ /*This is another Overload of apply with only 2 parameteres(data & transformed data)
+ and it will create eigval and eigvec and store the corresponding values  in them
+ as the source of information are first 2 parameters only.
+ * @param data - Data matrix
+ * @param transformedData - Data with PCA applied
+ */
+template<typename DecompositionPolicy>
+void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
+                                     arma::mat& transformedData)
+{
+  arma::mat eigvec;
+  arma::vec eigVal;
   Apply(data, transformedData, eigVal, eigvec);
 }
 

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -61,8 +61,7 @@ void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
 
 /**
  * Apply Principal Component Analysis to the provided data set.
- * It creates matrix to store eigenvectors and 
-   that matrix need not to be passed in paramteres
+ *
  * @param data - Data matrix
  * @param transformedData - Data with PCA applied
  * @param eigVal - contains eigen values in a column vector
@@ -75,9 +74,12 @@ void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
   arma::mat eigvec;
   Apply(data, transformedData, eigVal, eigvec);
 }
- /*This is another Overload of apply with only 2 parameteres(data & transformed data)
- and it will create eigval and eigvec and store the corresponding values  in them
- as the source of information are first 2 parameters only.
+    
+/**
+ * This is another Overload of apply with only 2 parameteres(data & transformed data)
+ * and it will create eigval and eigvec and store the corresponding values  in them
+ * as the source of information are first 2 parameters only.
+ *
  * @param data - Data matrix
  * @param transformedData - Data with PCA applied
  */

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -76,9 +76,7 @@ void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
 }
     
 /**
- * This is another Overload of apply with only 2 parameteres(data & transformed data)
- * and it will create eigval and eigvec and store the corresponding values  in them
- * as the source of information are first 2 parameters only.
+ * Apply Principal Component Analysis to the provided data set.
  *
  * @param data - Data matrix
  * @param transformedData - Data with PCA applied

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -78,8 +78,8 @@ void PCA<DecompositionPolicy>::Apply(const arma::mat& data,
 /**
  * Apply Principal Component Analysis to the provided data set.
  *
- * @param data - Data matrix
- * @param transformedData - Data with PCA applied
+ * @param data - Data matrix.
+ * @param transformedData Data with PCA applied.
  */
 template<typename DecompositionPolicy>
 void PCA<DecompositionPolicy>::Apply(const arma::mat& data,


### PR DESCRIPTION
This added member  function(in PCA class) takes 2 parameters the data(source) and the transformed data matrices and gives the user an option to pass 2 parameters only and  this function will create the variables to store eigenvalues and eigenvectors and perform PCA as usual.

I have also documented another overload just  above this one which was doing similar task.