### PR TITLE
Make sure all state values are set to zero on reset.

### DIFF
--- a/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/fast_lstm_impl.hpp
@@ -163,33 +163,20 @@ void FastLSTM<InputDataType, OutputDataType>::ResetCell(const size_t size)
   gradientStep = batchSize * size - 1;
 
   const size_t rhoBatchSize = size * batchSize;
-  if (gate.is_empty() || gate.n_cols != rhoBatchSize)
-  {
-    gate.set_size(4 * outSize, rhoBatchSize);
-    gateActivation.set_size(outSize * 3, rhoBatchSize);
-    stateActivation.set_size(outSize, rhoBatchSize);
-    cellActivation.set_size(outSize, rhoBatchSize);
-    prevError.set_size(4 * outSize, batchSize);
 
-    if (prevOutput.is_empty())
-    {
-      prevOutput = arma::zeros<OutputDataType>(outSize, batchSize);
-      cell = arma::zeros(outSize, size * batchSize);
-      cellActivationError = arma::zeros<OutputDataType>(outSize, batchSize);
-      outParameter = arma::zeros<OutputDataType>(
-          outSize, (size + 1) * batchSize);
-    }
-    else
-    {
-      // To preserve the leading zeros, recreate the object according to given
-      // size specifications, while preserving the elements as well as the
-      // layout of the elements.
-      prevOutput.resize(outSize, batchSize);
-      cell.resize(outSize, size * batchSize);
-      cellActivationError.resize(outSize, batchSize);
-      outParameter.resize(outSize, (size + 1) * batchSize);
-    }
-  }
+  // Make sure all of the matrices we use to store state are at least as large
+  // as we need.
+  gate.set_size(4 * outSize, rhoBatchSize);
+  gateActivation.set_size(outSize * 3, rhoBatchSize);
+  stateActivation.set_size(outSize, rhoBatchSize);
+  cellActivation.set_size(outSize, rhoBatchSize);
+  prevError.set_size(4 * outSize, batchSize);
+
+  // Reset stored state to zeros.
+  prevOutput.zeros(outSize, batchSize);
+  cell.zeros(outSize, size * batchSize);
+  cellActivationError.zeros(outSize, batchSize);
+  outParameter.zeros(outSize, (size + 1) * batchSize);
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -145,36 +145,25 @@ void LSTM<InputDataType, OutputDataType>::ResetCell(const size_t size)
   gradientStep = batchSize * size - 1;
 
   const size_t rhoBatchSize = size * batchSize;
-  if (inputGate.is_empty() || inputGate.n_cols < rhoBatchSize)
-  {
-    inputGate.set_size(outSize, rhoBatchSize);
-    forgetGate.set_size(outSize, rhoBatchSize);
-    hiddenLayer.set_size(outSize, rhoBatchSize);
-    outputGate.set_size(outSize, rhoBatchSize);
 
-    inputGateActivation.set_size(outSize, rhoBatchSize);
-    forgetGateActivation.set_size(outSize, rhoBatchSize);
-    outputGateActivation.set_size(outSize, rhoBatchSize);
-    hiddenLayerActivation.set_size(outSize, rhoBatchSize);
+  // Make sure all of the different matrices we will use to hold parameters are
+  // at least as large as we need.
+  inputGate.set_size(outSize, rhoBatchSize);
+  forgetGate.set_size(outSize, rhoBatchSize);
+  hiddenLayer.set_size(outSize, rhoBatchSize);
+  outputGate.set_size(outSize, rhoBatchSize);
 
-    cellActivation.set_size(outSize, rhoBatchSize);
-    prevError.set_size(4 * outSize, batchSize);
+  inputGateActivation.set_size(outSize, rhoBatchSize);
+  forgetGateActivation.set_size(outSize, rhoBatchSize);
+  outputGateActivation.set_size(outSize, rhoBatchSize);
+  hiddenLayerActivation.set_size(outSize, rhoBatchSize);
 
-    if (cell.is_empty())
-    {
-      cell = arma::zeros(outSize, size * batchSize);
-      outParameter = arma::zeros<OutputDataType>(
-          outSize, (size + 1) * batchSize);
-    }
-    else
-    {
-      // To preserve the leading zeros, recreate the object according to given
-      // size specifications, while preserving the elements as well as the
-      // layout of the elements.
-      cell.resize(outSize, size * batchSize);
-      outParameter.resize(outSize, (size + 1) * batchSize);
-    }
-  }
+  cellActivation.set_size(outSize, rhoBatchSize);
+  prevError.set_size(4 * outSize, batchSize);
+
+  // Now reset recurrent values to 0.
+  cell.zeros(outSize, size * batchSize);
+  outParameter.zeros(outSize, (size + 1) * batchSize);
 }
 
 template<typename InputDataType, typename OutputDataType>


### PR DESCRIPTION
This PR is an attempt to solve #2747 and possibly also #2713 (but I am not sure).  I am not confident that this is the right solution, but it at least seems to work on the example code in #2747.

I dug into the `RNN::ResetCells()` function to see if somehow there was some state that was not properly being reset.  I found that the `LSTM` and `FastLSTM` layers attempt to avoid resizing the memory used to hold the internal state when possible, but don't always set the values back to 0.  This could cause different prediction results (and, it *could* cause different serialized model results too.  But I feel like we shouldn't serialize the internal state of an LSTM?).

I replaced this by simply calling `.zeros()` with the new desired size of the object always; this is because Armadillo 10 has new functionality where if you resize a matrix to be smaller, it will reuse the larger memory.  So, as people transition to Armadillo 10, I think that this new code will function as the original code was intended to.  (But, on Armadillo 9 and older, it will make copies more than necessary.)

Anyway, I'm not 100% sure that this is the right fix for the problem, so review carefully. :)