### PR TITLE
Gonum can't hold ints, so remove slightly confusing documentation.

### DIFF
--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -98,17 +98,8 @@ inline std::string GetPrintableType(
         std::tuple<data::DatasetInfo, arma::mat>>>::type*)
 {
   std::string type = "*mat.Dense";
-  if (std::is_same<typename T::elem_type, double>::value)
-  {
-    if (T::is_row || T::is_col)
-      type = "*mat.Dense (1d)";
-  }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
-  {
-    type = "*mat.Dense (with ints)";
-    if (T::is_row || T::is_col)
-      type = "*mat.Dense (1d with ints)";
-  }
+  if (T::is_row || T::is_col)
+    type = "*mat.Dense (1d)";
 
   return type;
 }

--- a/src/mlpack/bindings/go/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/go/print_type_doc_impl.hpp
@@ -87,35 +87,15 @@ std::string PrintTypeDoc(
     util::ParamData& data,
     const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (T::is_col || T::is_row)
   {
-    if (T::is_col || T::is_row)
-    {
-      return "A 1-d gonum Matrix (that is, a Matrix where either the number"
-             " of rows or number of columns is 1).";
-    }
-    else
-    {
-      return "A 2-d gonum Matrix. If the type is not already `float64`, it "
-             "will be converted.";
-    }
-  }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
-  {
-    if (T::is_col || T::is_row)
-    {
-      return "A 1-d gonum Matrix (that is, a Matrix where either the number"
-             " of rows or number of columns is 1).";
-    }
-    else
-    {
-      return "A 2-d gonum Matrix. If the type is not already `int64`, it "
-             "will be converted.";
-    }
+    return "A 1-d gonum Matrix (that is, a Matrix where either the number"
+           " of rows or number of columns is 1).";
   }
   else
   {
-    throw std::invalid_argument("unknown matrix type " + data.cppType);
+    return "A 2-d gonum Matrix. If the type is not already `float64`, it "
+           "will be converted.";
   }
 }
 


### PR DESCRIPTION
This comes from a discussion in IRC:

> One thing I was suprised by, though, is that I expect assignments to be an int vector (array/slice), but its treated as a float64 array

So I took a look at the documentation, and it is true that Gonum doesn't actually support holding `int`s.  Therefore I thought it was worthwhile to remove any documentation that might cause people to think they are holding `int`s, being clear that the type is the same as when floating point values are used.

@Yashwants19 let me know what you think about this change or if you have an alternate suggestion. :+1: