### PR TITLE
Added Copy and Move constructors to Multiply Layers

### DIFF
--- a/src/mlpack/methods/ann/layer/multiply_constant.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant.hpp
@@ -39,6 +39,18 @@ class MultiplyConstant
    */
   MultiplyConstant(const double scalar = 1.0);
 
+  //! Copy Constructor
+  MultiplyConstant(const MultiplyConstant& layer);
+
+  //! Move Constructor
+  MultiplyConstant(MultiplyConstant&& layer);
+
+  //! Copy assignment operator
+  MultiplyConstant& operator=(const MultiplyConstant& layer);
+
+  //! Move assignment operator
+  MultiplyConstant& operator=(MultiplyConstant&& layer);
+
   /**
    * Ordinary feed forward pass of a neural network. Multiply the input with the
    * specified constant scalar value.

--- a/src/mlpack/methods/ann/layer/multiply_constant.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant.hpp
@@ -39,16 +39,16 @@ class MultiplyConstant
    */
   MultiplyConstant(const double scalar = 1.0);
 
-  //! Copy Constructor
+  //! Copy Constructor.
   MultiplyConstant(const MultiplyConstant& layer);
 
-  //! Move Constructor
+  //! Move Constructor.
   MultiplyConstant(MultiplyConstant&& layer);
 
-  //! Copy assignment operator
+  //! Copy assignment operator.
   MultiplyConstant& operator=(const MultiplyConstant& layer);
 
-  //! Move assignment operator
+  //! Move assignment operator.
   MultiplyConstant& operator=(MultiplyConstant&& layer);
 
   /**

--- a/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_constant_impl.hpp
@@ -27,6 +27,46 @@ MultiplyConstant<InputDataType, OutputDataType>::MultiplyConstant(
 }
 
 template<typename InputDataType, typename OutputDataType>
+MultiplyConstant<InputDataType, OutputDataType>::MultiplyConstant(
+    const MultiplyConstant& layer) :
+    scalar(layer.scalar)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+MultiplyConstant<InputDataType, OutputDataType>::MultiplyConstant(
+    MultiplyConstant&& layer) :
+    scalar(std::move(layer.scalar))
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+MultiplyConstant<InputDataType, OutputDataType>&
+MultiplyConstant<InputDataType, OutputDataType>::operator=(
+    const MultiplyConstant& layer)
+{
+  if (this != &layer)
+  {
+    scalar = layer.scalar;
+  }
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType>
+MultiplyConstant<InputDataType, OutputDataType>&
+MultiplyConstant<InputDataType, OutputDataType>::operator=(
+    MultiplyConstant&& layer)
+{
+  if (this != &layer)
+  {
+    scalar = std::move(layer.scalar);
+  }
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
 void MultiplyConstant<InputDataType, OutputDataType>::Forward(
     const InputType& input, OutputType& output)

--- a/src/mlpack/methods/ann/layer/multiply_merge.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_merge.hpp
@@ -50,6 +50,18 @@ class MultiplyMerge
    */
   MultiplyMerge(const bool model = false, const bool run = true);
 
+  //! Copy Constructor
+  MultiplyMerge(const MultiplyMerge& layer);
+
+  //! Move Constructor
+  MultiplyMerge(MultiplyMerge&& layer);
+
+  //! Copy assignment operator
+  MultiplyMerge& operator=(const MultiplyMerge& layer);
+
+  //! Move assignment operator
+  MultiplyMerge& operator=(MultiplyMerge&& layer);
+
   //! Destructor to release allocated memory.
   ~MultiplyMerge();
 

--- a/src/mlpack/methods/ann/layer/multiply_merge.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_merge.hpp
@@ -50,16 +50,16 @@ class MultiplyMerge
    */
   MultiplyMerge(const bool model = false, const bool run = true);
 
-  //! Copy Constructor
+  //! Copy Constructor.
   MultiplyMerge(const MultiplyMerge& layer);
 
-  //! Move Constructor
+  //! Move Constructor.
   MultiplyMerge(MultiplyMerge&& layer);
 
-  //! Copy assignment operator
+  //! Copy assignment operator.
   MultiplyMerge& operator=(const MultiplyMerge& layer);
 
-  //! Move assignment operator
+  //! Move assignment operator.
   MultiplyMerge& operator=(MultiplyMerge&& layer);
 
   //! Destructor to release allocated memory.

--- a/src/mlpack/methods/ann/layer/multiply_merge_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multiply_merge_impl.hpp
@@ -34,6 +34,66 @@ MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::MultiplyMerge(
 
 template<typename InputDataType, typename OutputDataType,
          typename... CustomLayers>
+MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::MultiplyMerge(
+    const MultiplyMerge& layer) :
+    model(layer.model),
+    run(layer.run),
+    ownsLayer(layer.ownsLayer),
+    network(layer.network),
+    weights(layer.weights)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType,
+         typename... CustomLayers>
+MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::MultiplyMerge(
+    MultiplyMerge&& layer) :
+    model(std::move(layer.model)),
+    run(std::move(layer.run)),
+    ownsLayer(std::move(layer.ownsLayer)),
+    network(std::move(layer.network)),
+    weights(std::move(layer.weights))
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType,
+         typename... CustomLayers>
+MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>&
+MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::operator=(
+    const MultiplyMerge& layer)
+{
+  if (this != &layer)
+  {
+    model = layer.model;
+    run = layer.run;
+    ownsLayer = layer.ownsLayer;
+    network = layer.network;
+    weights = layer.weights;
+  }
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType,
+         typename... CustomLayers>
+MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>&
+MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::operator=(
+    MultiplyMerge&& layer)
+{
+  if (this != &layer)
+  {
+    model = std::move(layer.model);
+    run = std::move(layer.run);
+    ownsLayer = std::move(layer.ownsLayer);
+    network = std::move(layer.network);
+    weights = std::move(layer.weights);
+  }
+  return *this;
+}
+
+template<typename InputDataType, typename OutputDataType,
+         typename... CustomLayers>
 MultiplyMerge<InputDataType, OutputDataType, CustomLayers...>::~MultiplyMerge()
 {
   if (ownsLayer)

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -85,10 +85,10 @@ RNN<OutputLayerType, InitializationRuleType, CustomLayers...>::RNN(
     targetSize(std::move(network.targetSize)),
     reset(std::move(network.reset)),
     single(std::move(network.single)),
+    network(std::move(network.network)),
     parameter(std::move(network.parameter)),
     numFunctions(std::move(network.numFunctions)),
-    deterministic(std::move(network.deterministic)),
-    network(std::move(network.network))
+    deterministic(std::move(network.deterministic))
 {
   // Nothing to do here.
 }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -898,6 +898,39 @@ TEST_CASE("JacobianMultiplyConstantLayerTest", "[ANNLayerTest]")
 }
 
 /**
+ * Check whether copying and moving network with MultiplyConstant is working or
+ * not.
+ */
+TEST_CASE("CheckCopyMoveMultiplyConstantTest", "[ANNLayerTest]")
+{
+  arma::mat input(2, 1000);
+  input.randu();
+
+  arma::mat output1;
+  arma::mat output2;
+  arma::mat output3;
+  arma::mat output4;
+
+  MultiplyConstant<> *module1 = new MultiplyConstant<>(3.0);
+  module1->Forward(input, output1);
+
+  MultiplyConstant<> module2 = *module1;
+  delete module1;
+
+  module2.Forward(input, output2);
+  CheckMatrices(output1, output2);
+
+  MultiplyConstant<> *module3 = new MultiplyConstant<>(3.0);
+  module3->Forward(input, output3);
+
+  MultiplyConstant<> module4(std::move(*module3));
+  delete module3;
+
+  module4.Forward(input, output4);
+  CheckMatrices(output3, output4);
+}
+
+/**
  * Jacobian HardTanH module test.
  */
 TEST_CASE("JacobianHardTanHLayerTest", "[ANNLayerTest]")
@@ -2598,6 +2631,56 @@ TEST_CASE("SimpleMultiplyMergeLayerTest", "[ANNLayerTest]")
     module.Backward(input, output, delta);
     REQUIRE(arma::accu(output) == arma::accu(delta));
   }
+}
+
+/**
+ * Check whether copying and moving network with MultiplyMerge is working or
+ * not.
+ */
+TEST_CASE("CheckCopyMoveMultiplyMergeTest", "[ANNLayerTest]")
+{
+  arma::mat input(10, 1);
+  input.randu();
+
+  arma::mat output1;
+  arma::mat output2;
+  arma::mat output3;
+  arma::mat output4;
+
+  const size_t numMergeModules = math::RandInt(2, 10);
+
+  MultiplyMerge<> *module1 = new MultiplyMerge<>(true, false);
+  for (size_t m = 0; m < numMergeModules; ++m)
+  {
+    IdentityLayer<> identityLayer;
+    identityLayer.Forward(input, identityLayer.OutputParameter());
+
+    module1->Add<IdentityLayer<> >(identityLayer);
+  }
+
+  module1->Forward(input, output1);
+
+  MultiplyMerge<> module2 = *module1;
+  delete module1;
+
+  module2.Forward(input, output2);
+  CheckMatrices(output1, output2);
+
+  MultiplyMerge<> *module3 = new MultiplyMerge<>(true, false);
+  for (size_t m = 0; m < numMergeModules; ++m)
+  {
+    IdentityLayer<> identityLayer;
+    identityLayer.Forward(input, identityLayer.OutputParameter());
+
+    module3->Add<IdentityLayer<> >(identityLayer);
+  }
+  module3->Forward(input, output3);
+
+  MultiplyMerge<> module4(std::move(*module3));
+  delete module3;
+
+  module4.Forward(input, output4);
+  CheckMatrices(output3, output4);
 }
 
 /**


### PR DESCRIPTION
Reference Issue #2625.
Changes to file ```rnn_impl.hpp``` remove the warning ```x will be initialised after y``` during ```make```.