### PR TITLE
Disabling bindings by default in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (BUILD_JULIA_BINDINGS)
 else()
   set(FORCE_BUILD_JULIA_BINDINGS OFF)
 endif()
-option(BUILD_JULIA_BINDINGS "Build Julia bindings." ON)
+option(BUILD_JULIA_BINDINGS "Build Julia bindings." OFF)
 
 # Detect whether the user passed BUILD_GO_BINDINGS in order to determine if
 # we should fail if Go isn't found.
@@ -61,7 +61,7 @@ if (BUILD_GO_BINDINGS)
 else()
   set(FORCE_BUILD_GO_BINDINGS OFF)
 endif()
-option(BUILD_GO_BINDINGS "Build Go bindings." ON)
+option(BUILD_GO_BINDINGS "Build Go bindings." OFF)
 
 # If building Go bindings then build go shared libraries.
 if (BUILD_GO_BINDINGS)
@@ -75,7 +75,7 @@ if (BUILD_R_BINDINGS)
 else()
   set(FORCE_BUILD_R_BINDINGS OFF)
 endif()
-option(BUILD_R_BINDINGS "Build R bindings." ON)
+option(BUILD_R_BINDINGS "Build R bindings." OFF)
 # Build Markdown bindings for documentation.  This is used as part of website
 # generation.
 option(BUILD_MARKDOWN_BINDINGS "Build Markdown bindings for website documentation." OFF)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Disabled all the bindings by default in cmake (#2782).
   * Added an implementation to Stratify Data (#2671).
 
   * Add `BUILD_DOCS` CMake option to control whether Doxygen documentation is

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ### mlpack ?.?.?
 ###### ????-??-??
   * Disabled all the bindings by default in cmake (#2782).
+
   * Added an implementation to Stratify Data (#2671).
 
   * Add `BUILD_DOCS` CMake option to control whether Doxygen documentation is


### PR DESCRIPTION
This PR tries to solve #2773 .
The default options for all bindings are set to "OFF" in this.