### PR TITLE
Added copy and move constructors in Reparametrization layer

### DIFF
--- a/src/mlpack/methods/ann/layer/reparametrization.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization.hpp
@@ -71,6 +71,18 @@ class Reparametrization
                     const bool stochastic = true,
                     const bool includeKl = true,
                     const double beta = 1);
+    
+  //! Copy Constructor 
+  Reparametrization(const Reparametrization& layer);
+    
+  //! Move Constructor 
+  Reparametrization(Reparametrization&& layer);
+    
+  //! Copy assignment operator 
+  Reparametrization& operator=(const Reparametrization& layer);
+    
+  //! Move assignment operator 
+  Reparametrization& operator=(Reparametrization&& layer);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/reparametrization.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization.hpp
@@ -72,13 +72,13 @@ class Reparametrization
                     const bool includeKl = true,
                     const double beta = 1);
     
-  //! Copy Constructor 
+  //! Copy Constructor.
   Reparametrization(const Reparametrization& layer);
     
-  //! Move Constructor 
+  //! Move Constructor.
   Reparametrization(Reparametrization&& layer);
     
-  //! Copy assignment operator 
+  //! Copy assignment operator.
   Reparametrization& operator=(const Reparametrization& layer);
     
   //! Move assignment operator 

--- a/src/mlpack/methods/ann/layer/reparametrization.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization.hpp
@@ -81,7 +81,7 @@ class Reparametrization
   //! Copy assignment operator.
   Reparametrization& operator=(const Reparametrization& layer);
     
-  //! Move assignment operator 
+  //! Move assignment operator.
   Reparametrization& operator=(Reparametrization&& layer);
 
   /**

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -74,14 +74,14 @@ Reparametrization<InputDataType, OutputDataType>&
 Reparametrization<InputDataType, OutputDataType>::
 operator=(const Reparametrization& layer) 
 {
-       if (this != &layer)
-       {
-         latentSize = layer.latentSize;
-         stochastic = layer.stochastic;
-         includeKl = layer.includeKl;
-         beta = layer.beta;
-       }
-       return *this;
+  if (this != &layer)
+  {
+    latentSize = layer.latentSize;
+    stochastic = layer.stochastic;
+    includeKl = layer.includeKl;
+    beta = layer.beta;
+  }
+  return *this;
 }
     
 template <typename InputDataType, typename OutputDataType>
@@ -89,14 +89,14 @@ Reparametrization<InputDataType, OutputDataType>&
 Reparametrization<InputDataType, OutputDataType>::
 operator=(Reparametrization&& layer) 
 {
-       if (this != &layer)
-       {
-         latentSize = std::move(layer.latentSize);
-         stochastic = std::move(layer.stochastic);
-         includeKl = std::move(layer.includeKl);
-         beta = std::move(layer.beta);
-       }
-       return *this;
+  if (this != &layer)
+  {
+    latentSize = std::move(layer.latentSize);
+    stochastic = std::move(layer.stochastic);
+    includeKl = std::move(layer.includeKl);
+    beta = std::move(layer.beta);
+  }
+  return *this;
 }
   
     

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -55,7 +55,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
     includeKl(layer.includeKl),
     beta(layer.beta)
 {
-   //Nothing to do here     
+   // Nothing to do here.
 }
 
 template <typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -87,7 +87,7 @@ opertaor=(const Reparametrization& layer)
 template <typename InputDataType, typename OutputDataType>
 Reparametrization<InputDataType, OutputDataType>&
 Reparametrization<InputDataType, OutputDataType>::
-opertaor=(Reparametrization&& layer) 
+operator=(Reparametrization&& layer) 
 {
        if (this != &layer)
        {

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -72,7 +72,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
 template <typename InputDataType, typename OutputDataType>
 Reparametrization<InputDataType, OutputDataType>&
 Reparametrization<InputDataType, OutputDataType>::
-opertaor=(const Reparametrization& layer) 
+operator=(const Reparametrization& layer) 
 {
        if (this != &layer)
        {

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -46,7 +46,60 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
         << "included." << std::endl;
   }
 }
+    
+template <typename InputDataType, typename OutputDataType>
+Reparametrization<InputDataType, OutputDataType>::Reparametrization(
+    const Reparamterization& layer) :
+    latentSize(layer.latentSize),
+    stochastic(layer.stochastic),
+    includeKl(layer.includeKl),
+    beta(layer.beta)
+{
+   //Nothing to do here     
+}
 
+template <typename InputDataType, typename OutputDataType>
+Reparametrization<InputDataType, OutputDataType>::Reparametrization(
+    Reparamterization&& layer) :
+    latentSize(std::move(layer.latentSize)),
+    stochastic(std::move(layer.stochastic)),
+    includeKl(std::move(layer.includeKl)),
+    beta(std::move(layer.beta))
+{
+   //Nothing to do here     
+}
+    
+template <typename InputDataType, typename OutputDataType>
+Reparametrization<InputDataType, OutputDataType>&
+Reparametrization<InputDataType, OutputDataType>::
+opertaor=(const Reparamterization& layer) 
+{
+       if (this != &layer)
+       {
+         latentSize = layer.latentSize;
+         stochastic = layer.stochastic;
+         includeKl = layer.includeKl;
+         beta = layer.beta;
+       }
+       return *this;
+}
+    
+template <typename InputDataType, typename OutputDataType>
+Reparametrization<InputDataType, OutputDataType>&
+Reparametrization<InputDataType, OutputDataType>::
+opertaor=(Reparamterization&& layer) 
+{
+       if (this != &layer)
+       {
+         latentSize = std::move(layer.latentSize);
+         stochastic = std::move(layer.stochastic);
+         includeKl = std::move(layer.includeKl);
+         beta = std::move(layer.beta);
+       }
+       return *this;
+}
+  
+    
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Reparametrization<InputDataType, OutputDataType>::Forward(

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -49,7 +49,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
     
 template <typename InputDataType, typename OutputDataType>
 Reparametrization<InputDataType, OutputDataType>::Reparametrization(
-    const Reparamterization& layer) :
+    const Reparametrization& layer) :
     latentSize(layer.latentSize),
     stochastic(layer.stochastic),
     includeKl(layer.includeKl),
@@ -60,7 +60,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
 
 template <typename InputDataType, typename OutputDataType>
 Reparametrization<InputDataType, OutputDataType>::Reparametrization(
-    Reparamterization&& layer) :
+    Reparametrization&& layer) :
     latentSize(std::move(layer.latentSize)),
     stochastic(std::move(layer.stochastic)),
     includeKl(std::move(layer.includeKl)),
@@ -72,7 +72,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
 template <typename InputDataType, typename OutputDataType>
 Reparametrization<InputDataType, OutputDataType>&
 Reparametrization<InputDataType, OutputDataType>::
-opertaor=(const Reparamterization& layer) 
+opertaor=(const Reparametrization& layer) 
 {
        if (this != &layer)
        {
@@ -87,7 +87,7 @@ opertaor=(const Reparamterization& layer)
 template <typename InputDataType, typename OutputDataType>
 Reparametrization<InputDataType, OutputDataType>&
 Reparametrization<InputDataType, OutputDataType>::
-opertaor=(Reparamterization&& layer) 
+opertaor=(Reparametrization&& layer) 
 {
        if (this != &layer)
        {

--- a/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
+++ b/src/mlpack/methods/ann/layer/reparametrization_impl.hpp
@@ -66,7 +66,7 @@ Reparametrization<InputDataType, OutputDataType>::Reparametrization(
     includeKl(std::move(layer.includeKl)),
     beta(std::move(layer.beta))
 {
-   //Nothing to do here     
+   // Nothing to do here.
 }
     
 template <typename InputDataType, typename OutputDataType>

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -154,6 +154,59 @@ TEST_CASE("CheckCopyMovingVanillaNetworkTest", "[FeedForwardNetworkTest]")
 }
 
 /**
+ * Check whether copying and moving network with Reparametrization is working or not.
+ */
+TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTest]")
+{
+  // Load the dataset.
+  arma::mat trainData;
+  data::Load("thyroid_train.csv", trainData, true);
+
+  arma::mat trainLabels = trainData.row(trainData.n_rows - 1);
+  trainData.shed_row(trainData.n_rows - 1);
+
+  /*
+   * Construct a feed forward network with trainData.n_rows input nodes,
+   * hiddenLayerSize hidden nodes and trainLabels.n_rows output nodes. The
+   * network structure looks like:
+   *
+   *  Input         Hidden        Output
+   *  Layer         Layer         Layer
+   * +-----+       +-----+       +-----+
+   * |     |       |     |       |     |
+   * |     +------>|     +------>|     |
+   * |     |     +>|     |     +>|     |
+   * +-----+     | +--+--+     | +-----+
+   *             |             |
+   *  Bias       |  Bias       |
+   *  Layer      |  Layer      |
+   * +-----+     | +-----+     |
+   * |     |     | |     |     |
+   * |     +-----+ |     +-----+
+   * |     |       |     |
+   * +-----+       +-----+
+   */
+
+  FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
+  model->Add<Linear<> >(trainData.n_rows, 8);
+  model->Add<SigmoidLayer<> >();
+  model->Add<Reparametrization<> >(8, 3);
+  model->Add<LogSoftMax<> >();
+
+  FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;
+  model1->Add<Linear<> >(trainData.n_rows, 8);
+  model1->Add<SigmoidLayer<> >();
+  model1->Add<Reparametrization<> >(8, 3);
+  model1->Add<LogSoftMax<> >();
+
+  // Check whether copy constructor is working or not.
+  CheckCopyFunction<>(model, trainData, trainLabels, 1);
+
+  // Check whether move constructor is working or not.
+  CheckMoveFunction<>(model1, trainData, trainLabels, 1);
+}
+
+/**
  * Check whether copying and moving network with linear3d is working or not.
  */
 TEST_CASE("CheckCopyMovingLinear3DNetworkTest", "[FeedForwardNetworkTest]")

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -190,13 +190,13 @@ TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTes
   FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
   model->Add<Linear<> >(trainData.n_rows, 8);
   model->Add<SigmoidLayer<> >();
-  model->Add<Reparametrization<> >(8, 3);
+  model->Add<Reparametrization<> >();
   model->Add<LogSoftMax<> >();
 
   FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;
   model1->Add<Linear<> >(trainData.n_rows, 8);
   model1->Add<SigmoidLayer<> >();
-  model1->Add<Reparametrization<> >(8, 3);
+  model1->Add<Reparametrization<> >();
   model1->Add<LogSoftMax<> >();
 
   // Check whether copy constructor is working or not.

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -167,36 +167,17 @@ TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTes
 
   /*
    * Construct a feed forward network with trainData.n_rows input nodes,
-   * hiddenLayerSize hidden nodes and trainLabels.n_rows output nodes. The
-   * network structure looks like:
-   *
-   *  Input         Hidden        Output
-   *  Layer         Layer         Layer
-   * +-----+       +-----+       +-----+
-   * |     |       |     |       |     |
-   * |     +------>|     +------>|     |
-   * |     |     +>|     |     +>|     |
-   * +-----+     | +--+--+     | +-----+
-   *             |             |
-   *  Bias       |  Bias       |
-   *  Layer      |  Layer      |
-   * +-----+     | +-----+     |
-   * |     |     | |     |     |
-   * |     +-----+ |     +-----+
-   * |     |       |     |
-   * +-----+       +-----+
+   * followed by a linear layer and then a reparametrization layer
    */
 
   FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
-  model->Add<Linear<> >(trainData.n_rows, 8);
-  model->Add<SigmoidLayer<> >();
-  model->Add<Reparametrization<> >();
+  model1->Add<Linear<> >(trainData.n_rows, 8);
+  model1->Add<Reparametrization<> >(4,false,true,1);
   model->Add<LogSoftMax<> >();
 
   FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;
   model1->Add<Linear<> >(trainData.n_rows, 8);
-  model1->Add<SigmoidLayer<> >();
-  model1->Add<Reparametrization<> >();
+  model1->Add<Reparametrization<> >(4,false,true,1);
   model1->Add<LogSoftMax<> >();
 
   // Check whether copy constructor is working or not.

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -167,7 +167,7 @@ TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTes
 
   /*
    * Construct a feed forward network with trainData.n_rows input nodes,
-   * followed by a linear layer and then a reparametrization layer
+   * followed by a linear layer and then a reparametrization layer.
    */
 
   FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -177,7 +177,7 @@ TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTes
 
   FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;
   model1->Add<Linear<> >(trainData.n_rows, 8);
-  model1->Add<Reparametrization<> >(4,false,true,1);
+  model1->Add<Reparametrization<> >(4, false, true, 1);
   model1->Add<LogSoftMax<> >();
 
   // Check whether copy constructor is working or not.

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -171,8 +171,8 @@ TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTes
    */
 
   FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
-  model1->Add<Linear<> >(trainData.n_rows, 8);
-  model1->Add<Reparametrization<> >(4,false,true,1);
+  model->Add<Linear<> >(trainData.n_rows, 8);
+  model->Add<Reparametrization<> >(4,false,true,1);
   model->Add<LogSoftMax<> >();
 
   FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -172,7 +172,7 @@ TEST_CASE("CheckCopyMovingReparametrizationNetworkTest", "[FeedForwardNetworkTes
 
   FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
   model->Add<Linear<> >(trainData.n_rows, 8);
-  model->Add<Reparametrization<> >(4,false,true,1);
+  model->Add<Reparametrization<> >(4, false, true, 1);
   model->Add<LogSoftMax<> >();
 
   FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;


### PR DESCRIPTION
This PR is regarding the issue #2625 and I have added copy and move constructors for `Reparametrization`  layer and also added the corresponding tests.