### PR TITLE
added no_sanity_checks option to python bindings

### DIFF
--- a/src/mlpack/bindings/python/mlpack/io.pxd
+++ b/src/mlpack/bindings/python/mlpack/io.pxd
@@ -50,3 +50,4 @@ cdef extern from "<mlpack/bindings/python/mlpack/io_util.hpp>" \
   void DisableBacktrace() nogil except +
   void ResetTimers() nogil except +
   void EnableTimers() nogil except +
+  void SanityCheck[T](T&) nogil except +

--- a/src/mlpack/bindings/python/mlpack/io_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/io_util.hpp
@@ -163,6 +163,16 @@ inline void EnableTimers()
   Timer::EnableTiming();
 }
 
+/**
+ * Sanity Check.
+ */
+template<typename T>
+inline void SanityCheck(T& matrix)
+{
+  if (matrix.has_nan())
+    Log::Fatal << "The input matrix has nan values" << std::endl;
+}
+
 } // namespace util
 } // namespace mlpack
 

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -78,7 +78,7 @@ void PrintPYX(const util::BindingDetails& doc,
   cout << "from io cimport SetParam, SetParamPtr, SetParamWithInfo, "
       << "GetParamPtr" << endl;
   cout << "from io cimport EnableVerbose, DisableVerbose, DisableBacktrace, "
-      << "ResetTimers, EnableTimers" << endl;
+      << "ResetTimers, EnableTimers, SanityCheck" << endl;
   cout << "from matrix_utils import to_matrix, to_matrix_with_info" << endl;
   cout << "from serialization cimport SerializeIn, SerializeOut" << endl;
   cout << endl;
@@ -206,6 +206,17 @@ void PrintPYX(const util::BindingDetails& doc,
       << "\'bool'!\")" << endl;
   cout << endl;
 
+  // Determine whether or not we have to do a sanity check.
+  cout << "  if isinstance(no_sanity_checks, bool):" << endl;
+  cout << "    if no_sanity_checks:" << endl;
+  cout << "      SetParam[cbool](<const string> 'no_sanity_checks', "
+      << "no_sanity_checks)" << endl;
+  cout << "      IO.SetPassed(<const string> 'no_sanity_checks')" << endl;
+  cout << "  else:" << endl;
+  cout << "    raise TypeError(" <<"\"'no_sanity_checks\' must have type "
+      << "\'bool'!\")" << endl;
+  cout << endl;
+
   // Do any input processing.
   for (size_t i = 0; i < inputOptions.size(); ++i)
   {
@@ -223,6 +234,10 @@ void PrintPYX(const util::BindingDetails& doc,
     util::ParamData& d = parameters.at(outputOptions[i]);
     cout << "  IO.SetPassed(<const string> '" << d.name << "')" << endl;
   }
+
+  // Before calling mlpackMain(), we do a sanity check if needed.
+  cout << "  if not IO.GetParam[cbool](<const string> 'no_sanity_checks'):" << endl;
+  cout << "    SanityCheck[arma.Mat[double]](IO.GetParam[arma.Mat[double]](<const string> 'training'))" << endl;
 
   // Call the method.
   cout << "  # Call the mlpack program." << endl;

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -64,8 +64,8 @@ class PyOption
     data.required = required;
     data.input = input;
     data.loaded = false;
-    // Only "verbose" and "copy_all_inputs" will be persistent.
-    if (identifier == "verbose" || identifier == "copy_all_inputs")
+    // Only "verbose", "copy_all_inputs" and "no_sanity_checks" will be persistent.
+    if (identifier == "verbose" || identifier == "copy_all_inputs" || identifier == "no_sanity_checks")
       data.persistent = true;
     else
       data.persistent = false;

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -230,6 +230,8 @@ PARAM_FLAG("copy_all_inputs", "If specified, all input parameters will be deep"
     " copied before the method is run.  This is useful for debugging problems "
     "where the input parameters are being modified by the algorithm, but can "
     "slow down the code.", "");
+PARAM_FLAG("no_sanity_checks", "If specified, the input matrix is checked for"
+    " nan values.", "");
 
 // Nothing else needs to be defined---the binding will use mlpackMain() as-is.
 


### PR DESCRIPTION
This is in reference to #2679 .
I have added `no_sanity_checks` option for the python bindings in this PR. I am working on adding this option inside other bindings as well for which I will open separate PR's.
Since this is my first PR on the automatic binding system please forgive any silly mistakes.

To test the added option I ran the following test script:

test.py

    from mlpack import linear_regression
    import pandas as pd
    import numpy as np

    df = pd.read_csv("data.csv")
    x_train = df[["col1", "col2"]].values
    y_train = df["y"].values
    
    print("Training data")
    print(x_train)
    
    d = linear_regression(input_model=None, lambda_=0., test=np.array([[0, 0]]),
                          training=x_train, training_responses=y_train)
    
    output_model = d["output_model"]
    output_preds = d["output_predictions"]
    
    print("Test predictions")
    print(output_preds)

when 'data.csv' has no `nan` values:

output:

    $ python test.py
    Training data
    [[1 2]
     [2 3]
     [4 5]
     [7 8]]
    Test predictions
    [1.]

when 'data.csv' has `nan` values:

output:

    $ python test.py
    Training data
    [[nan  2.]
     [ 2.  3.]
     [ 4.  5.]
     [ 7.  8.]]
    [FATAL] The input matrix has nan values
    
    Traceback (most recent call last):
      File "test.py", line 12, in <module>
        d = linear_regression(input_model=None, lambda_=0., test=np.array([[0, 0]]),
      File "mlpack/linear_regression.pyx", line 208, in mlpack.linear_regression.linear_regression
    RuntimeError: fatal error; see Log::Fatal output

when `no_sanity_checks=True` and the 'data.csv' has `nan` values:

test.py:

    from mlpack import linear_regression
    import pandas as pd
    import numpy as np
    
    df = pd.read_csv("data.csv")
    x_train = df[["col1", "col2"]].values
    y_train = df["y"].values
    
    print("Training data")
    print(x_train)
    
    d = linear_regression(input_model=None, lambda_=0., test=np.array([[0, 0]]),
                          training=x_train, training_responses=y_train, no_sanity_checks=True)
    
    output_model = d["output_model"]
    output_preds = d["output_predictions"]
    
    print("Test predictions")
    print(output_preds)

output (no error is thrown): 

    $ python test.py
    Training data
    [[nan  2.]
     [ 2.  3.]
     [ 4.  5.]
     [ 7.  8.]]
    Test predictions
    [nan]

