### PR TITLE
Add PYTHON_INSTALL_PREFIX CMake option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,9 @@
 
   * Add finalizers to Julia binding model types to fix memory handling (#2756).
 
+  * Add `PYTHON_INSTALL_PREFIX` CMake option to specify installation root for
+    Python bindings.
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,7 @@
   * Add finalizers to Julia binding model types to fix memory handling (#2756).
 
   * Add `PYTHON_INSTALL_PREFIX` CMake option to specify installation root for
-    Python bindings.
+    Python bindings (#2797).
 
 ### mlpack 3.4.2
 ###### 2020-10-26

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Options are specified with the -D flag.  The allowed options include:
     BUILD_CLI_EXECUTABLES=(ON/OFF): whether or not to build command-line programs
     BUILD_PYTHON_BINDINGS=(ON/OFF): whether or not to build Python bindings
     PYTHON_EXECUTABLE=(/path/to/python_version): Path to specific Python executable
+    PYTHON_INSTALL_PREFIX=(/path/to/python/): Path to root of Python installation
     BUILD_JULIA_BINDINGS=(ON/OFF): whether or not to build Julia bindings
     JULIA_EXECUTABLE=(/path/to/julia): Path to specific Julia executable
     BUILD_GO_BINDINGS=(ON/OFF): whether or not to build Go bindings

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -190,6 +190,7 @@ The full list of options mlpack allows:
  - BUILD_WITH_COVERAGE=(ON/OFF): Build with support for code coverage tools
       (gcc only) (default OFF)
  - PYTHON_EXECUTABLE=(/path/to/python_version): Path to specific Python executable
+ - PYTHON_INSTALL_PREFIX=(/path/to/python/): Path to root of Python installation
  - JULIA_EXECUTABLE=(/path/to/julia): Path to specific Julia executable
  - BUILD_MARKDOWN_BINDINGS=(ON/OFF): Build Markdown bindings for website
        documentation (default OFF)

--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -230,7 +230,7 @@ if (BUILD_R_BINDINGS)
   install(CODE
       "execute_process(
          COMMAND R CMD INSTALL mlpack_${PACKAGE_VERSION}.tar.gz
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
   )
 
   add_dependencies(R r_build)

--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -229,7 +229,7 @@ if (BUILD_R_BINDINGS)
   # Installation script for the packagae.
   install(CODE
       "execute_process(
-         COMMAND R CMD INSTALL mlpack_${PACKAGE_VERSION}.tar.gz
+         COMMAND ${R_EXECUTABLE} CMD INSTALL mlpack_${PACKAGE_VERSION}.tar.gz
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
   )
 

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -214,14 +214,20 @@ add_custom_command(TARGET python POST_BUILD
 add_dependencies(python python_configured)
 
 # Configure installation script file.
+if (NOT PYTHON_INSTALL_PREFIX)
+  set(PYTHON_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+endif ()
+
 execute_process(COMMAND ${PYTHON_EXECUTABLE}
-    "${CMAKE_CURRENT_SOURCE_DIR}/print_python_version.py" "${CMAKE_INSTALL_PREFIX}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/print_python_version.py"
+    "${PYTHON_INSTALL_PREFIX}"
     OUTPUT_VARIABLE CMAKE_PYTHON_PATH)
 string(STRIP "${CMAKE_PYTHON_PATH}" CMAKE_PYTHON_PATH)
 install(CODE "set(ENV{PYTHONPATH} ${CMAKE_PYTHON_PATH})")
 install(CODE "set(PYTHON_EXECUTABLE \"${PYTHON_EXECUTABLE}\")")
 install(CODE "set(CMAKE_BINARY_DIR \"${CMAKE_BINARY_DIR}\")")
-install(CODE "set(CMAKE_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\")")
+
+install(CODE "set(PYTHON_INSTALL_PREFIX \"${PYTHON_INSTALL_PREFIX}\")")
 install(CODE "execute_process(COMMAND mkdir -p $ENV{DESTDIR}${CMAKE_PYTHON_PATH})")
 install(SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/PythonInstall.cmake")
 

--- a/src/mlpack/bindings/python/PythonInstall.cmake
+++ b/src/mlpack/bindings/python/PythonInstall.cmake
@@ -5,13 +5,13 @@
 if (DEFINED ENV{DESTDIR})
   execute_process(COMMAND ${PYTHON_EXECUTABLE}
       "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
-          --prefix=${CMAKE_INSTALL_PREFIX} --root=$ENV{DESTDIR}
+          --prefix=${PYTHON_INSTALL_PREFIX} --root=$ENV{DESTDIR}
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 else ()
   execute_process(COMMAND ${PYTHON_EXECUTABLE}
       "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
-          --prefix=${CMAKE_INSTALL_PREFIX}
+          --prefix=${PYTHON_INSTALL_PREFIX}
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 endif ()


### PR DESCRIPTION
This comes out of the discussion in #2775.

Right now, the Python bindings will simply be installed to `CMAKE_INSTALL_PREFIX`, even if `PYTHON_EXECUTABLE` is set to some other location.  This PR does not automatically extract the path of the Python installation from `PYTHON_EXECUTABLE`, but simply adds a `PYTHON_INSTALL_PREFIX` option so that a separate location for the Python bindings to be installed can be specified.

@BJWiley233 do you think that you could try these changes and see if they work correctly?