### PR TITLE
Added Hinge Loss to loss functions

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
+++ b/src/mlpack/methods/ann/loss_functions/CMakeLists.txt
@@ -9,24 +9,32 @@ set(SOURCES
   dice_loss_impl.hpp
   earth_mover_distance.hpp
   earth_mover_distance_impl.hpp
+  empty_loss.hpp
+  empty_loss_impl.hpp
   huber_loss.hpp
   huber_loss_impl.hpp
+  hinge_embedding_loss.hpp
+  hinge_embedding_loss_impl.hpp
+  hinge_loss.hpp
+  hinge_loss_impl.hpp
   kl_divergence.hpp
   kl_divergence_impl.hpp
-  margin_ranking_loss.hpp
-  margin_ranking_loss_impl.hpp
-  mean_bias_error.hpp
-  mean_bias_error_impl.hpp
   l1_loss.hpp
   l1_loss_impl.hpp
+  log_cosh_loss.hpp
+  log_cosh_loss_impl.hpp
+  margin_ranking_loss.hpp
+  margin_ranking_loss_impl.hpp
+  mean_absolute_percentage_error.hpp
+  mean_absolute_percentage_error_impl.hpp
+  mean_bias_error.hpp
+  mean_bias_error_impl.hpp
   mean_squared_error.hpp
   mean_squared_error_impl.hpp
   mean_squared_logarithmic_error.hpp
   mean_squared_logarithmic_error_impl.hpp
   negative_log_likelihood.hpp
   negative_log_likelihood_impl.hpp
-  log_cosh_loss.hpp
-  log_cosh_loss_impl.hpp
   poisson_nll_loss.hpp
   poisson_nll_loss_impl.hpp
   reconstruction_loss.hpp
@@ -35,12 +43,6 @@ set(SOURCES
   sigmoid_cross_entropy_error_impl.hpp
   soft_margin_loss.hpp
   soft_margin_loss_impl.hpp
-  hinge_embedding_loss.hpp
-  hinge_embedding_loss_impl.hpp
-  empty_loss.hpp
-  empty_loss_impl.hpp
-  mean_absolute_percentage_error.hpp
-  mean_absolute_percentage_error_impl.hpp
   triplet_margin_loss.hpp
   triplet_margin_loss_impl.hpp
 )

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -1,0 +1,102 @@
+/**
+ * @file methods/ann/loss_functions/hinge_loss.hpp
+ * @author Anush Kini
+ *
+ * Definition of the Hinge Loss Function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_HINGE_LOSS_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_HINGE_LOSS_HPP
+
+#include<mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * Computes the hinge loss between y_true and y_pred. Expects y_true to be
+ * either -1 or 1. If y_true is either 0 or 1, a temporary conversion is made to
+ * calculate the loss.
+ *
+ * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template <
+        typename InputDataType = arma::mat,
+        typename OutputDataType = arma::mat
+>
+class HingeLoss
+{
+ public:
+  /**
+   * Create HingeLoss object.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If
+   *                  true, 'sum' reduction is used and the output will be
+   *                  summed. It is set to true by default.
+   */
+  HingeLoss(const bool reduction = true);
+
+  /**
+   * Computes the Hinge loss function.
+   *
+   * @param prediction Prediction used for evaluating the specified loss
+   *     function.
+   * @param target Target data to compare with.
+   */
+  template<typename PredictionType, typename TargetType>
+  typename PredictionType::elem_type Forward(const PredictionType& prediction,
+                                              const TargetType& target);
+
+  /**
+   * Ordinary feed backward pass of a neural network.
+   *
+   * @param prediction Prediction used for evaluating the specified loss
+   *     function.
+   * @param target The target vector.
+   * @param loss The calculated error.
+   */
+  template<typename PredictionType, typename TargetType>
+  void Backward(const PredictionType& prediction,
+                const TargetType& target,
+                LossType& loss);
+
+  //! Get the output parameter.
+  OutputDataType& OutputParameter() const { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */);
+
+ private:
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
+
+  //! The boolean value that tells if reduction is sum or mean.
+  bool reduction;
+}; // class HingeLoss
+
+} // namespace ann
+} // namespace mlpack
+
+// include implementation
+#include "hinge_loss_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -64,7 +64,7 @@ class HingeLoss
    * @param target The target vector.
    * @param loss The calculated error.
    */
-  template<typename PredictionType, typename TargetType>
+  template<typename PredictionType, typename TargetType, typename LossType>
   void Backward(const PredictionType& prediction,
                 const TargetType& target,
                 LossType& loss);

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -22,6 +22,8 @@ namespace ann /** Artificial Neural Network. */ {
  * Computes the hinge loss between y_true and y_pred. Expects y_true to be
  * either -1 or 1. If y_true is either 0 or 1, a temporary conversion is made to
  * calculate the loss.
+ * The hinge loss \f$l(y_true, y_pred)\f$ is defined as
+ * \f$l(y_true, y_pred) = max(0, 1 - y_true*y_pred)\f$.
  *
  * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
  *         arma::sp_mat or arma::cube).
@@ -37,6 +39,7 @@ class HingeLoss
  public:
   /**
    * Create HingeLoss object.
+   *
    * @param reduction Specifies the reduction to apply to the output. If false,
    *                  'mean' reduction is used, where sum of the output will be
    *                  divided by the number of elements in the output. If
@@ -54,7 +57,7 @@ class HingeLoss
    */
   template<typename PredictionType, typename TargetType>
   typename PredictionType::elem_type Forward(const PredictionType& prediction,
-                                              const TargetType& target);
+                                             const TargetType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -19,9 +19,9 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 /**
- * Computes the hinge loss between y_true and y_pred. Expects y_true to be
- * either -1 or 1. If y_true is either 0 or 1, a temporary conversion is made to
- * calculate the loss.
+ * Computes the hinge loss between \f$y_true\f$ and \f$y_pred\f$. Expects
+ * \f$y_true\f$ to be either -1 or 1. If \f$y_true\f$ is either 0 or 1, a
+ * temporary conversion is made to calculate the loss.
  * The hinge loss \f$l(y_true, y_pred)\f$ is defined as
  * \f$l(y_true, y_pred) = max(0, 1 - y_true*y_pred)\f$.
  *

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
@@ -34,7 +34,7 @@ HingeLoss<InputDataType, OutputDataType>::Forward(
     const TargetType& target)
 {
   TargetType temp = target - (target == 0);
-  TargetType temp_zeros.zeros(target.size());
+  TargetType temp_zeros(size(target), arma::fill::zeros);
 
   PredictionType loss = arma::max(1 - prediction % temp, temp_zeros);
 
@@ -48,7 +48,7 @@ HingeLoss<InputDataType, OutputDataType>::Forward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename PredictionType, typename TargetType, typename LossType>
-void HingeEmbeddingLoss<InputDataType, OutputDataType>::Backward(
+void HingeLoss<InputDataType, OutputDataType>::Backward(
     const PredictionType& prediction,
     const TargetType& target,
     LossType& loss)
@@ -62,7 +62,7 @@ void HingeEmbeddingLoss<InputDataType, OutputDataType>::Backward(
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void HingeEmbeddingLoss<InputDataType, OutputDataType>::serialize(
+void HingeLoss<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const uint32_t /* version */)
 {

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
@@ -36,7 +36,8 @@ HingeLoss<InputDataType, OutputDataType>::Forward(
   TargetType temp = target - (target == 0);
   TargetType temp_zeros.zeros(target.size());
 
-  PredictionType loss = arma::mean(arma::max(1 - prediction % temp, temp_zeros), 1);
+  PredictionType loss = arma::max(1 - prediction % temp, temp_zeros);
+
   typename PredictionType::elem_type lossSum = arma::accu(loss);
 
   if (reduction)
@@ -53,11 +54,20 @@ void HingeEmbeddingLoss<InputDataType, OutputDataType>::Backward(
     LossType& loss)
 {
   TargetType temp = target - (target == 0);
-  loss = (prediction < 1 / temp) % -temp;
+  loss = (prediction < (1 / temp)) % -temp;
+
+  if (!reduction)
+    loss /= target.n_elem;
 }
 
-
-
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void HingeEmbeddingLoss<InputDataType, OutputDataType>::serialize(
+    Archive& ar,
+    const uint32_t /* version */)
+{
+  ar(CEREAL_NVP(reduction));
+}
 
 } // namespace ann
 } // namespace mlpack

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
@@ -36,7 +36,7 @@ HingeLoss<InputDataType, OutputDataType>::Forward(
   TargetType temp = target - (target == 0);
   TargetType temp_zeros(size(target), arma::fill::zeros);
 
-  PredictionType loss = arma::max(1 - prediction % temp, temp_zeros);
+  PredictionType loss = arma::max(temp_zeros, 1 - prediction % temp);
 
   typename PredictionType::elem_type lossSum = arma::accu(loss);
 

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss_impl.hpp
@@ -1,0 +1,65 @@
+/**
+ * @file methods/ann/loss_functions/hinge_loss_impl.hpp
+ * @author Anush Kini
+ *
+ * Implementation of the Hinge loss function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_HINGE_LOSS_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_HINGE_LOSS_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "hinge_loss.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+HingeLoss<InputDataType, OutputDataType>::HingeLoss(const bool reduction):
+  reduction(reduction)
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename PredictionType, typename TargetType>
+typename PredictionType::elem_type
+HingeLoss<InputDataType, OutputDataType>::Forward(
+    const PredictionType& prediction,
+    const TargetType& target)
+{
+  TargetType temp = target - (target == 0);
+  TargetType temp_zeros.zeros(target.size());
+
+  PredictionType loss = arma::mean(arma::max(1 - prediction % temp, temp_zeros), 1);
+  typename PredictionType::elem_type lossSum = arma::accu(loss);
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / loss.n_elem;
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename PredictionType, typename TargetType, typename LossType>
+void HingeEmbeddingLoss<InputDataType, OutputDataType>::Backward(
+    const PredictionType& prediction,
+    const TargetType& target,
+    LossType& loss)
+{
+  TargetType temp = target - (target == 0);
+  loss = (prediction < 1 / temp) % -temp;
+}
+
+
+
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -984,21 +984,23 @@ TEST_CASE("HingeLossTest", "[LossFunctionsTest]")
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
 
-  input = {{0.90599973, -0.33040298, 0.07123354},
-      {0.71988434, 0.49657596, 0.39873373},
-      {-0.57646927, 0.3951491 , -0.1003365},
-      {0.12528634, 0.68122971, 0.85448826}};
+  // Randomly generated input.
+  input = { { 0.90599973, -0.33040298, 0.07123354},
+            { 0.71988434, 0.49657596, 0.39873373},
+            { -0.57646927, 0.3951491 , -0.1003365},
+            { 0.12528634, 0.68122971, 0.85448826} };
 
-  target = {{-1, -1, 1},
-      {-1, 1, 1},
-      {1, -1, -1},
-      {1, -1, -1}};
+  // Randomly generated target.
+  target = { { -1, -1, 1},
+             { -1, 1, 1},
+             { 1, -1, -1},
+             { 1, -1, -1} };
 
-  // Binary labels for target.
-  target_b = {{0, 0, 1},
-      {0, 1, 1},
-      {1, 0, 0},
-      {1, 0, 0}};
+  // Binary target can be obtained by replacing -1 with 0 in target.
+  target_b = { { 0, 0, 1},
+               { 0, 1, 1},
+               { 1, 0, 0},
+               { 1, 0, 0} };
 
   // Test for binary labels as target.
   loss = module1.Forward(input, target);
@@ -1009,6 +1011,7 @@ TEST_CASE("HingeLossTest", "[LossFunctionsTest]")
 
   // Test for sum reduction.
   // Test the Forward function.
+  // Loss calculated by referring to implementation of tf.keras.losses.hinge.
   loss = module1.Forward(input, target);
   REQUIRE(loss == Approx(14.61065).epsilon(1e-3));
 
@@ -1020,6 +1023,7 @@ TEST_CASE("HingeLossTest", "[LossFunctionsTest]")
 
   // Test for mean reduction.
   // Test for the Forward function.
+  // Loss calculated by referring to implementation of tf.keras.losses.hinge.
   loss = module2.Forward(input, target);
   REQUIRE(loss == Approx(1.21755).epsilon(1e-3));
 

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -994,7 +994,7 @@ TEST_CASE("HingeLossTest", "[LossFunctionsTest]")
       {1, -1, -1},
       {1, -1, -1}};
 
-  // Binary labels for target
+  // Binary labels for target.
   target_b = {{0, 0, 1},
       {0, 1, 1},
       {1, 0, 0},
@@ -1019,6 +1019,7 @@ TEST_CASE("HingeLossTest", "[LossFunctionsTest]")
   REQUIRE(output.n_cols == input.n_cols);
 
   // Test for mean reduction.
+  // Test for the Forward function.
   loss = module2.Forward(input, target);
   REQUIRE(loss == Approx(1.21755).epsilon(1e-3));
 


### PR DESCRIPTION
Reasons for this PR:
1. The Hinge Loss function is currently implemented as ```Hinge Embedding Loss``` in mlpack. This implementation is only correct for 1D tensors and doesn't give the right answers for tensors that are higher than 1 dimension. This [colab notebook](https://colab.research.google.com/drive/1iA1pHNxRE9fVxB01oJUEiM2BTCACQHmK?usp=sharing) highlights this by comparing with the [tensorflow](https://www.tensorflow.org/api_docs/python/tf/keras/losses/hinge) implementation. Also, the current implementation only incorporates mean reduction. This PR adds an additional ```reduction``` parameter to choose between mean and sum reduction.

2. Issue #2444 and PR #2495 aim to change the implementation of ```Hinge Embedding Loss``` to the Hinge Embedding Loss function in [pytorch](https://pytorch.org/docs/stable/generated/torch.nn.HingeEmbeddingLoss.html). Hence, a new implementation file with the corrections implemented has been made for the Hinge Loss function.

Let me know if you have any suggestions or changes on this.