### PR TITLE
brew cask instal is no longer supported

### DIFF
--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -22,7 +22,7 @@ steps:
     fi
 
     if [ "a$(julia.version)" != "a" ]; then
-      brew cask install julia
+      brew install --cask julia
     fi
 
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf


### PR DESCRIPTION
`brew cask install` is no longer supported, use `brew install --cask` instead.