### PR TITLE
Adding copy and move constructors for "Select" layer.

### DIFF
--- a/src/mlpack/methods/ann/layer/select.hpp
+++ b/src/mlpack/methods/ann/layer/select.hpp
@@ -40,6 +40,18 @@ class Select
    */
   Select(const size_t index = 0, const size_t elements = 0);
 
+  //! Copy Constructor.
+  Select(const Select& layer);
+
+  //! Move Constructor.
+  Select(Select&& layer);
+
+  //! Copy assignment operator.
+  Select& operator=(const Select& layer);
+
+  //! Move assignment operator. 
+  Select& operator=(Select&& layer);
+
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
    * f(x) by propagating the activity forward through f.

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -28,6 +28,50 @@ Select<InputDataType, OutputDataType>::Select(
     // Nothing to do here.
   }
 
+template <typename InputDataType, typename OutputDataType>
+Select<InputDataType, OutputDataType>::Select(
+    const Select& layer) :
+    index(layer.index),
+    elements(layer.elements)
+{
+   //Nothing to do here     
+}
+
+template <typename InputDataType, typename OutputDataType>
+Select<InputDataType, OutputDataType>::Select(
+    Select&& layer) :
+    index(std::move(layer.index)),
+    elements(std::move(layer.elements))
+{
+   //Nothing to do here     
+}
+
+template <typename InputDataType, typename OutputDataType>
+Select<InputDataType, OutputDataType>&
+Select<InputDataType, OutputDataType>::
+operator=(const Select& layer) 
+{
+       if (this != &layer)
+       {
+         index = layer.index;
+         elements = layer.elements;
+       }
+       return *this;
+}
+
+template <typename InputDataType, typename OutputDataType>
+Select<InputDataType, OutputDataType>&
+Select<InputDataType, OutputDataType>::
+operator=(Select&& layer) 
+{
+       if (this != &layer)
+       {
+         index = std::move(layer.index);
+         elements = std::move(layer.elements);
+       }
+       return *this;
+}
+    
 template<typename InputDataType, typename OutputDataType>
 template<typename eT>
 void Select<InputDataType, OutputDataType>::Forward(

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -43,7 +43,7 @@ Select<InputDataType, OutputDataType>::Select(
     index(std::move(layer.index)),
     elements(std::move(layer.elements))
 {
-   //Nothing to do here     
+   // Nothing to do here     
 }
 
 template <typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -34,7 +34,7 @@ Select<InputDataType, OutputDataType>::Select(
     index(layer.index),
     elements(layer.elements)
 {
-   //Nothing to do here     
+   // Nothing to do here     
 }
 
 template <typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/select_impl.hpp
+++ b/src/mlpack/methods/ann/layer/select_impl.hpp
@@ -51,12 +51,12 @@ Select<InputDataType, OutputDataType>&
 Select<InputDataType, OutputDataType>::
 operator=(const Select& layer) 
 {
-       if (this != &layer)
-       {
-         index = layer.index;
-         elements = layer.elements;
-       }
-       return *this;
+  if (this != &layer)
+  {
+    index = layer.index;
+    elements = layer.elements;
+  }
+  return *this;
 }
 
 template <typename InputDataType, typename OutputDataType>
@@ -64,12 +64,12 @@ Select<InputDataType, OutputDataType>&
 Select<InputDataType, OutputDataType>::
 operator=(Select&& layer) 
 {
-       if (this != &layer)
-       {
-         index = std::move(layer.index);
-         elements = std::move(layer.elements);
-       }
-       return *this;
+  if (this != &layer)
+  {
+    index = std::move(layer.index);
+    elements = std::move(layer.elements);
+  }
+  return *this;
 }
     
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/tests/feedforward_network_test.cpp
+++ b/src/mlpack/tests/feedforward_network_test.cpp
@@ -200,17 +200,16 @@ TEST_CASE("CheckCopyMovingSelectNetworkTest", "[FeedForwardNetworkTest]")
 
   arma::mat trainLabels = trainData.row(trainData.n_rows - 1);
   trainData.shed_row(trainData.n_rows - 1);
-  arma::mat SelectedLabel = trainLabels.submat(0,0,trainData.n_rows/2,0);
-  trainLabels=SelectedLabel;
+  trainLabels=trainLabels.col(0);
   FFN<NegativeLogLikelihood<> > *model = new FFN<NegativeLogLikelihood<> >;
-  model->Add<Select<> >(0, trainData.n_rows/2);
+  model->Add<Select<> >(0, 0);
   //model->Add<Linear<> >(trainData.n_rows , 8);
   model->Add<SigmoidLayer<> >();
   //model->Add<Linear<> >(8, 3);
   model->Add<LogSoftMax<> >();
 
   FFN<NegativeLogLikelihood<> > *model1 = new FFN<NegativeLogLikelihood<> >;
-  model->Add<Select<> >(0, trainData.n_rows/2);
+  model->Add<Select<> >(0, 0);
   //model1->Add<Linear<> >(trainData.n_rows , 8);
   model1->Add<SigmoidLayer<> >();
   //model1->Add<Linear<> >(8, 3);


### PR DESCRIPTION
I have implemented Copy and Move constructors for `Select` layer in reference to issue #2625  . The purpose of this layer is to select a column(first few elements) from input matrix and output it.