### PR TITLE
Replace std::move by reference in async_learn

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/async_learning.hpp
+++ b/src/mlpack/methods/reinforcement_learning/async_learning.hpp
@@ -67,7 +67,7 @@ class AsyncLearning
    * @param environment The reinforcement learning task.
    */
   AsyncLearning(TrainingConfig config,
-                NetworkType network,
+                NetworkType& network,
                 PolicyType policy,
                 UpdaterType updater = UpdaterType(),
                 EnvironmentType environment = EnvironmentType());
@@ -118,7 +118,7 @@ class AsyncLearning
   TrainingConfig config;
 
   //! Locally-stored global learning network.
-  NetworkType learningNetwork;
+  NetworkType& learningNetwork;
 
   //! Locally-stored policy.
   PolicyType policy;

--- a/src/mlpack/methods/reinforcement_learning/async_learning_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/async_learning_impl.hpp
@@ -34,12 +34,12 @@ AsyncLearning<
   PolicyType
 >::AsyncLearning(
     TrainingConfig config,
-    NetworkType network,
+    NetworkType& network,
     PolicyType policy,
     UpdaterType updater,
     EnvironmentType environment):
     config(std::move(config)),
-    learningNetwork(std::move(network)),
+    learningNetwork(network),
     policy(std::move(policy)),
     updater(std::move(updater)),
     environment(std::move(environment))

--- a/src/mlpack/tests/async_learning_test.cpp
+++ b/src/mlpack/tests/async_learning_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE("OneStepQLearningTest", "[AsyncLearningTest]")
 
     OneStepQLearning<
         CartPole, decltype(model), ens::VanillaUpdate, decltype(policy)>
-        agent(std::move(config), std::move(model), std::move(policy));
+        agent(std::move(config), model, std::move(policy));
 
     arma::vec rewards(20, arma::fill::zeros);
     size_t pos = 0;
@@ -149,7 +149,7 @@ TEST_CASE("OneStepSarsaTest", "[AsyncLearningTest]")
                  decltype(model),
                  ens::VanillaUpdate,
                  decltype(policy)>
-    agent(std::move(config), std::move(model), std::move(policy));
+    agent(std::move(config), model, std::move(policy));
 
     arma::vec rewards(20, arma::fill::zeros);
     size_t pos = 0;
@@ -222,7 +222,7 @@ TEST_CASE("NStepQLearningTest", "[AsyncLearningTest]")
 
   NStepQLearning<
       CartPole, decltype(model), ens::VanillaUpdate, decltype(policy)>
-      agent(std::move(config), std::move(model), std::move(policy));
+      agent(std::move(config), model, std::move(policy));
 
   arma::vec rewards(20, arma::fill::zeros);
   size_t pos = 0;


### PR DESCRIPTION
This pull request fixes the issue of the lost weights of the models when using `std::move` inside the constructor.
This pull request should fix issue #2801 open by @MarkFischinger 

Signed-off-by: Omar Shrit <omar@shrit.me>