### PR TITLE
Use `std::back_inserter()` for `util::ToLower()`

### DIFF
--- a/src/mlpack/core/util/to_lower.hpp
+++ b/src/mlpack/core/util/to_lower.hpp
@@ -19,12 +19,13 @@ namespace util {
  * Convert a string to lowercase letters.
  *
  * @param input The string to convert.
- * @param output The string to be converted.
  */
-inline void ToLower(const std::string& input, std::string& output)
+inline std::string ToLower(const std::string& input)
 {
+  std::string output;
   std::transform(input.begin(), input.end(), output.begin(),
       [](unsigned char c){ return std::tolower(c); });
+  return output;
 }
 
 } // namespace util

--- a/src/mlpack/core/util/to_lower.hpp
+++ b/src/mlpack/core/util/to_lower.hpp
@@ -23,7 +23,7 @@ namespace util {
 inline std::string ToLower(const std::string& input)
 {
   std::string output;
-  std::transform(input.begin(), input.end(), output.begin(),
+  std::transform(input.begin(), input.end(), std::back_inserter(output),
       [](unsigned char c){ return std::tolower(c); });
   return output;
 }

--- a/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
@@ -125,8 +125,7 @@ AtrousConvolution<
   weights.set_size(WeightSize(), 1);
 
   // Transform paddingType to lowercase.
-  std::string paddingTypeLow = paddingType;
-  util::ToLower(paddingType, paddingTypeLow);
+  const std::string paddingTypeLow = util::ToLower(paddingType);
 
   size_t padWLeft = std::get<0>(padW);
   size_t padWRight = std::get<1>(padW);

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -120,8 +120,7 @@ Convolution<
   weights.set_size(WeightSize(), 1);
 
   // Transform paddingType to lowercase.
-  std::string paddingTypeLow = paddingType;
-  util::ToLower(paddingType, paddingTypeLow);
+  const std::string paddingTypeLow = util::ToLower(paddingType);
 
   if (paddingTypeLow == "valid")
   {

--- a/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/transposed_convolution_impl.hpp
@@ -126,8 +126,7 @@ TransposedConvolution<
 {
   weights.set_size(WeightSize(), 1);
   // Transform paddingType to lowercase.
-  std::string paddingTypeLow = paddingType;
-  util::ToLower(paddingType, paddingTypeLow);
+  const std::string paddingTypeLow = util::ToLower(paddingType);
 
   if (paddingTypeLow == "valid")
   {


### PR DESCRIPTION
The previous implementation did not correctly iterate over the output string.  Specifically, if the `output` parameter was empty when the function was called, no transformation would be done.  So, using `std::back_inserter()` instead seems to fix the behavior and solve #2838.