### PR TITLE
Make sure feedforward_network_2_test.cpp gets compiled and run.

### DIFF
--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(mlpack_test
   facilities_test.cpp
   fastmks_test.cpp
   feedforward_network_test.cpp
+  feedforward_network_2_test.cpp
   gan_test.cpp
   gmm_test.cpp
   hmm_test.cpp


### PR DESCRIPTION
I noticed while reviewing #2844 that this file actually isn't being compiled and run in the tests.  The PR is an easy fix. :)