### PR TITLE
Fix anchor links in generated Markdown documentation

### DIFF
--- a/src/mlpack/bindings/go/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/go/print_type_doc_impl.hpp
@@ -84,7 +84,7 @@ std::string PrintTypeDoc(
  */
 template<typename T>
 std::string PrintTypeDoc(
-    util::ParamData& data,
+    util::ParamData& /* data */,
     const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   if (T::is_col || T::is_row)

--- a/src/mlpack/bindings/markdown/print_docs.cpp
+++ b/src/mlpack/bindings/markdown/print_docs.cpp
@@ -36,8 +36,18 @@ void PrintHeaders(const std::string& bindingName,
   {
     BindingInfo::Language() = languages[i];
 
-    cout << " - [" << GetBindingName(bindingName) << "](#" << languages[i]
-        << "_" << bindingName << "){: .language-link #" << languages[i] << " }"
+    // Get the name of the binding in the target language, and convert it to
+    // lowercase (since the anchor link will be in lowercase).
+    const std::string langBindingName = GetBindingName(bindingName);
+    std::string anchorName = langBindingName;
+    std::transform(anchorName.begin(), anchorName.end(), anchorName.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    // Strip '()' from the end if needed.
+    if (anchorName.substr(anchorName.size() - 2, 2) == "()")
+      anchorName = anchorName.substr(0, anchorName.size() - 2);
+
+    cout << " - [" << langBindingName << "](#" << languages[i]
+        << "_" << anchorName << "){: .language-link #" << languages[i] << " }"
         << endl;
   }
 }

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -45,9 +45,9 @@ class SimpleResidueTermination
     maxIterations(maxIterations),
     residue(0.0),
     iteration(0),
-    nm(0),
-    normOld(0)
-  { 
+    normOld(0),
+    nm(0)
+  {
     // Nothing to do here.
   }
 

--- a/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_complete_incremental_learning.hpp
@@ -172,7 +172,7 @@ class SVDCompleteIncrementalLearning<arma::sp_mat>
   SVDCompleteIncrementalLearning(double u = 0.01,
                                  double kw = 0,
                                  double kh = 0)
-            : u(u), kw(kw), kh(kh), it(NULL), m(0), n(0), isStart(false)
+            : u(u), kw(kw), kh(kh), n(0), m(0), it(NULL), isStart(false)
     {}
 
   ~SVDCompleteIncrementalLearning()


### PR DESCRIPTION
I noticed that on the binding documentation pages, sometimes the anchors in the left margin don't work:

https://www.mlpack.org/doc/mlpack-git/cli_documentation.html

So, if you click on `mlpack_adaboost`, it doesn't actually link anywhere, because the link points to the anchor `#adaboost`, but the name of the section is `#mlpack_adaboost`.

This PR just adds a little bit of processing to use the right anchor link, and also fixes a few compilation warnings that I found.