### PR TITLE
Add functions to modify parameters for LARS

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,6 +34,9 @@
   * `NegativeLogLikelihood<>` now expects classes in the range `0` to
     `numClasses - 1` (#2534).
 
+  * Add `Lambda1()`, `Lambda2()`, `UseCholesky()`, and `Tolerance()` members to
+    `LARS` so parameters for training can be modified (#2861).
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/src/mlpack/methods/lars/lars.cpp
+++ b/src/mlpack/methods/lars/lars.cpp
@@ -178,6 +178,10 @@ double LARS::Train(const arma::mat& matX,
   isIgnored.clear();
   matUtriCholFactor.reset();
 
+  // Update values in case lambda1 or lambda2 changed.
+  lasso = (lambda1 != 0);
+  elasticNet = (lambda1 != 0 && lambda2 != 0);
+
   // This matrix may end up holding the transpose -- if necessary.
   arma::mat dataTrans;
   // dataRef is row-major.

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -249,6 +249,26 @@ class LARS
                arma::rowvec& predictions,
                const bool rowMajor = false) const;
 
+  //! Get the L1 regularization coefficient.
+  double Lambda1() const { return lambda1; }
+  //! Modify the L1 regularization coefficient.
+  double& Lambda1() { return lambda1; }
+
+  //! Get the L2 regularization coefficient.
+  double Lambda2() const { return lambda2; }
+  //! Modify the L2 regularization coefficient.
+  double& Lambda2() { return lambda2; }
+
+  //! Get whether to use the Cholesky decomposition.
+  bool UseCholesky() const { return useCholesky; }
+  //! Modify whether to use the Cholesky decomposition.
+  bool& UseCholesky() { return useCholesky; }
+
+  //! Get the tolerance for maximum correlation during training.
+  double Tolerance() const { return tolerance; }
+  //! Modify the tolerance for maximum correlation during training.
+  double& Tolerance() { return tolerance; }
+
   //! Access the set of active dimensions.
   const std::vector<size_t>& ActiveSet() const { return activeSet; }
 


### PR DESCRIPTION
This fixes #2857.

The PR adds `Lambda1()`, `Lambda2()`, `UseCholesky()`, and `Tolerance()` members so that the parameters of LARS training can be modified after creating the object.  The only "trickiness" is that we now must recompute `elasticNet` and `lasso` (internal members) when we start training, since the user may have modified the `lambda1` or `lambda2` values.

Should be an easy review, I think. :)