### PR TITLE
Loosen tolerances for AdaBoost test

### DIFF
--- a/src/mlpack/tests/adaboost_test.cpp
+++ b/src/mlpack/tests/adaboost_test.cpp
@@ -67,7 +67,7 @@ TEST_CASE("HammingLossBoundIris", "[AdaBoostTest]")
 /**
  * This test case runs the AdaBoost.mh algorithm on the UCI Iris dataset.  It
  * checks if the error returned by running a single instance of the weak learner
- * is worse than running the boosted weak learner using adaboost.
+ * close to that of the boosted weak learner using adaboost.
  */
 TEST_CASE("WeakLearnerErrorIris", "[AdaBoostTest]")
 {
@@ -105,7 +105,7 @@ TEST_CASE("WeakLearnerErrorIris", "[AdaBoostTest]")
   size_t countError = arma::accu(labels != predictedLabels);;
   double error = (double) countError / labels.n_cols;
 
-  REQUIRE(error <= weakLearnerErrorRate);
+  REQUIRE(error <= weakLearnerErrorRate + 0.03);
 }
 
 /**
@@ -151,7 +151,7 @@ TEST_CASE("HammingLossBoundVertebralColumn", "[AdaBoostTest]")
 /**
  * This test case runs the AdaBoost.mh algorithm on the UCI Vertebral Column
  * dataset.  It checks if the error returned by running a single instance of the
- * weak learner is worse than running the boosted weak learner using adaboost.
+ * weak learner is close to that of a boosted weak learner using adaboost.
  */
 TEST_CASE("WeakLearnerErrorVertebralColumn", "[AdaBoostTest]")
 {
@@ -187,7 +187,7 @@ TEST_CASE("WeakLearnerErrorVertebralColumn", "[AdaBoostTest]")
   size_t countError = arma::accu(labels != predictedLabels);
   double error = (double) countError / labels.n_cols;
 
-  REQUIRE(error <= weakLearnerErrorRate);
+  REQUIRE(error <= weakLearnerErrorRate + 0.03);
 }
 
 /**
@@ -233,7 +233,7 @@ TEST_CASE("HammingLossBoundNonLinearSepData", "[AdaBoostTest]")
 /**
  * This test case runs the AdaBoost.mh algorithm on a non-linearly separable
  * dataset.  It checks if the error returned by running a single instance of the
- * weak learner is worse than running the boosted weak learner using AdaBoost.
+ * weak learner is close to that of a boosted weak learner using AdaBoost.
  */
 TEST_CASE("WeakLearnerErrorNonLinearSepData", "[AdaBoostTest]")
 {
@@ -269,7 +269,7 @@ TEST_CASE("WeakLearnerErrorNonLinearSepData", "[AdaBoostTest]")
   size_t countError = arma::accu(labels != predictedLabels);
   double error = (double) countError / labels.n_cols;
 
-  REQUIRE(error == weakLearnerErrorRate);
+  REQUIRE(error <= weakLearnerErrorRate + 0.03);
 }
 
 /**
@@ -314,7 +314,7 @@ TEST_CASE("HammingLossIris_DS", "[AdaBoostTest]")
 /**
  * This test case runs the AdaBoost.mh algorithm on a non-linearly separable
  * dataset.  It checks if the error returned by running a single instance of the
- * weak learner is worse than running the boosted weak learner using adaboost.
+ * weak learner is close to that of a boosted weak learner using adaboost.
  * This is for the weak learner: decision stumps.
  */
 TEST_CASE("WeakLearnerErrorIris_DS", "[AdaBoostTest]")
@@ -355,13 +355,13 @@ TEST_CASE("WeakLearnerErrorIris_DS", "[AdaBoostTest]")
   size_t countError = arma::accu(labels != predictedLabels);
   double error = (double) countError / labels.n_cols;
 
-  REQUIRE(error <= weakLearnerErrorRate);
+  REQUIRE(error <= weakLearnerErrorRate + 0.03);
 }
 
 /**
  * This test case runs the AdaBoost.mh algorithm on the UCI Vertebral Column
  * dataset.  It checks if the error returned by running a single instance of the
- * weak learner is worse than running the boosted weak learner using adaboost.
+ * weak learner is close to that of a boosted weak learner using adaboost.
  * This is for the weak learner: decision stumps.
  */
 TEST_CASE("HammingLossBoundVertebralColumn_DS", "[AdaBoostTest]")
@@ -403,7 +403,7 @@ TEST_CASE("HammingLossBoundVertebralColumn_DS", "[AdaBoostTest]")
 /**
  * This test case runs the AdaBoost.mh algorithm on the UCI Vertebral Column
  * dataset.  It checks if the error returned by running a single instance of the
- * weak learner is worse than running the boosted weak learner using adaboost.
+ * weak learner is close to that of a boosted weak learner using adaboost.
  * This is for the weak learner: decision stumps.
  */
 TEST_CASE("WeakLearnerErrorVertebralColumn_DS", "[AdaBoostTest]")
@@ -440,7 +440,7 @@ TEST_CASE("WeakLearnerErrorVertebralColumn_DS", "[AdaBoostTest]")
   size_t countError = arma::accu(labels != predictedLabels);
   double error = (double) countError / labels.n_cols;
 
-  REQUIRE(error <= weakLearnerErrorRate);
+  REQUIRE(error <= weakLearnerErrorRate + 0.03);
 }
 
 /**
@@ -487,7 +487,7 @@ TEST_CASE("HammingLossBoundNonLinearSepData_DS", "[AdaBoostTest]")
 /**
  * This test case runs the AdaBoost.mh algorithm on a non-linearly separable
  * dataset.  It checks if the error returned by running a single instance of the
- * weak learner is worse than running the boosted weak learner using adaboost.
+ * weak learner is close to that of a boosted weak learner using adaboost.
  * This for the weak learner: decision stumps.
  */
 TEST_CASE("WeakLearnerErrorNonLinearSepData_DS", "[AdaBoostTest]")
@@ -526,7 +526,7 @@ TEST_CASE("WeakLearnerErrorNonLinearSepData_DS", "[AdaBoostTest]")
   size_t countError = arma::accu(labels != predictedLabels);
   double error = (double) countError / labels.n_cols;
 
-  REQUIRE(error <= weakLearnerErrorRate);
+  REQUIRE(error <= weakLearnerErrorRate + 0.03);
 }
 
 /**


### PR DESCRIPTION
Several AdaBoost tests check that a boosted learner produced by AdaBoost performs better on the training set than a single weak learner.  However, this is not actually guaranteed---in typical situations, a boosted learner _will_ do better than a single weak learner, but there is no theory to support this in all cases.  Therefore, the tests are flawed; I fixed them by instead testing that a boosted learner gets performance at least close to that of a single weak learner.  (Technically even this is not guaranteed but I would be astonished to find datasets that aren't worst-case where that condition doesn't hold.)

The route to finding this problem was very strange indeed; the problem was reported in #2827.  As it turns out, tiny handling differences in floating-point arithmetic cause the first weak learner for the `WeakLearnerErrorIris` test to classify one single point differently; this in turn causes a noticeably different AdaBoost classifier to be trained (it has ~7 weak learners as opposed to ~12 when trained on x86-64).  But there is no actual problem in how the different architectures are handling things.

Anyway, when I realized this, I went and did a bit more digging and thinking and realized the test itself is flawed.