### PR TITLE
Move initialization of static environment members into a cpp file

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/environment/CMakeLists.txt
+++ b/src/mlpack/methods/reinforcement_learning/environment/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Anything not in this list will not be compiled into mlpack.
 set(SOURCES
   env_type.hpp
+  env_type.cpp
   mountain_car.hpp
   cart_pole.hpp
   continuous_mountain_car.hpp

--- a/src/mlpack/methods/reinforcement_learning/environment/env_type.cpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/env_type.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file methods/reinforcement_learning/environment/env_type.cpp
+ * @author Nishant Kumar
+ *
+ * This file defines the static variables used by the discrete and continuous
+ * environments.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include "env_type.hpp"
+
+namespace mlpack {
+namespace rl {
+
+// Instantiate static members.
+
+size_t DiscreteActionEnv::State::dimension = 0;
+size_t DiscreteActionEnv::Action::size = 0;
+
+size_t ContinuousActionEnv::State::dimension = 0;
+size_t ContinuousActionEnv::Action::size = 0;
+
+} // namespace rl
+} // namespace mlpack

--- a/src/mlpack/methods/reinforcement_learning/environment/env_type.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/env_type.hpp
@@ -105,8 +105,6 @@ class DiscreteActionEnv
    */
   bool IsTerminal(const State& /* state */) const { return false; }
 };
-size_t DiscreteActionEnv::State::dimension = 0;
-size_t DiscreteActionEnv::Action::size = 0;
 
 /**
  * To use the dummy environment, one may start by specifying the state and
@@ -201,8 +199,6 @@ class ContinuousActionEnv
    */
   bool IsTerminal(const State& /* state */) const { return false; }
 };
-size_t ContinuousActionEnv::State::dimension = 0;
-size_t ContinuousActionEnv::Action::size = 0;
 
 } // namespace rl
 } // namespace mlpack


### PR DESCRIPTION
This fixes #2854.

`env_type.hpp` previously initialized some static members, but initializing a static member in a header file means that if that header is included in multiple different places, the member will be multiply defined.  In this PR I've fixed the issue by simply moving the initialization of static members into a .cpp file, which will then be compiled into `libmlpack.so`.

As a result, now those static members will live in `libmlpack.so` and not in any downstream application compiled by the user.

@nishantkr18 if you don't mind taking a look and making sure I'm not unintentionally breaking something, it would be great. :)  Thanks!