### PR TITLE
Remove ElemType template parameter from DecisionTree

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,9 @@
   * Add `Lambda1()`, `Lambda2()`, `UseCholesky()`, and `Tolerance()` members to
     `LARS` so parameters for training can be modified (#2861).
 
+  * Remove unused `ElemType` template parameter from `DecisionTree` and
+    `RandomForest` (#2874).
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/src/mlpack/methods/decision_tree/all_categorical_split.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split.hpp
@@ -29,7 +29,6 @@ class AllCategoricalSplit
 {
  public:
   // No extra info needed for split.
-  template<typename ElemType>
   class AuxiliarySplitInfo { };
 
   /**
@@ -64,8 +63,8 @@ class AllCategoricalSplit
       const WeightVecType& weights,
       const size_t minimumLeafSize,
       const double minimumGainSplit,
-      arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux);
+      arma::vec& classProbabilities,
+      AuxiliarySplitInfo& aux);
 
   /**
    * Return the number of children in the split.
@@ -73,9 +72,8 @@ class AllCategoricalSplit
    * @param classProbabilities Auxiliary information for the split.
    * @param * (aux) Auxiliary information for the split (Unused).
    */
-  template<typename ElemType>
-  static size_t NumChildren(const arma::Col<ElemType>& classProbabilities,
-                            const AuxiliarySplitInfo<ElemType>& /* aux */);
+  static size_t NumChildren(const arma::vec& classProbabilities,
+                            const AuxiliarySplitInfo& /* aux */);
 
   /**
    * Calculate the direction a point should percolate to.
@@ -87,8 +85,8 @@ class AllCategoricalSplit
   template<typename ElemType>
   static size_t CalculateDirection(
       const ElemType& point,
-      const arma::Col<ElemType>& classProbabilities,
-      const AuxiliarySplitInfo<ElemType>& /* aux */);
+      const arma::vec& classProbabilities,
+      const AuxiliarySplitInfo& /* aux */);
 };
 
 } // namespace tree

--- a/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
@@ -26,8 +26,8 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
     const WeightVecType& weights,
     const size_t minimumLeafSize,
     const double minimumGainSplit,
-    arma::Col<typename VecType::elem_type>& classProbabilities,
-    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */)
+    arma::vec& classProbabilities,
+    AuxiliarySplitInfo& /* aux */)
 {
   // Count the number of elements in each potential child.
   const double epsilon = 1e-7; // Tolerance for floating-point errors.
@@ -110,20 +110,19 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
 }
 
 template<typename FitnessFunction>
-template<typename ElemType>
 size_t AllCategoricalSplit<FitnessFunction>::NumChildren(
-    const arma::Col<ElemType>& classProbabilities,
-    const AuxiliarySplitInfo<ElemType>& /* aux */)
+    const arma::vec& classProbabilities,
+    const AuxiliarySplitInfo& /* aux */)
 {
-  return classProbabilities[0];
+  return size_t(classProbabilities[0]);
 }
 
 template<typename FitnessFunction>
 template<typename ElemType>
 size_t AllCategoricalSplit<FitnessFunction>::CalculateDirection(
     const ElemType& point,
-    const arma::Col<ElemType>& /* classProbabilities */,
-    const AuxiliarySplitInfo<ElemType>& /* aux */)
+    const arma::vec& /* classProbabilities */,
+    const AuxiliarySplitInfo& /* aux */)
 {
   return (size_t) point;
 }

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split.hpp
@@ -28,7 +28,6 @@ class BestBinaryNumericSplit
 {
  public:
   // No extra info needed for split.
-  template<typename ElemType>
   class AuxiliarySplitInfo { };
 
   /**
@@ -36,6 +35,10 @@ class BestBinaryNumericSplit
    * improves on 'bestGain', then we return the improved gain.  Otherwise we
    * return the value 'bestGain'.  If a split is made, then classProbabilities
    * and aux may be modified.
+   *
+   * It's not necessary that `ElemType` is the same as the type of the data in
+   * `VecType`---if they are different, casting will be done to store the
+   * auxiliary information.
    *
    * @param bestGain Best gain seen so far (we'll only split if we find gain
    *      better than this).
@@ -60,15 +63,14 @@ class BestBinaryNumericSplit
       const WeightVecType& weights,
       const size_t minimumLeafSize,
       const double minimumGainSplit,
-      arma::Col<typename VecType::elem_type>& classProbabilities,
-      AuxiliarySplitInfo<typename VecType::elem_type>& aux);
+      arma::vec& classProbabilities,
+      AuxiliarySplitInfo& aux);
 
   /**
    * Returns 2, since the binary split always has two children.
    */
-  template<typename ElemType>
-  static size_t NumChildren(const arma::Col<ElemType>& /* classProbabilities */,
-                            const AuxiliarySplitInfo<ElemType>& /* aux */)
+  static size_t NumChildren(const arma::vec& /* classProbabilities */,
+                            const AuxiliarySplitInfo& /* aux */)
   {
     return 2;
   }
@@ -83,8 +85,8 @@ class BestBinaryNumericSplit
   template<typename ElemType>
   static size_t CalculateDirection(
       const ElemType& point,
-      const arma::Col<ElemType>& classProbabilities,
-      const AuxiliarySplitInfo<ElemType>& /* aux */);
+      const arma::vec& classProbabilities,
+      const AuxiliarySplitInfo& /* aux */);
 };
 
 } // namespace tree

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -25,8 +25,8 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     const WeightVecType& weights,
     const size_t minimumLeafSize,
     const double minimumGainSplit,
-    arma::Col<typename VecType::elem_type>& classProbabilities,
-    AuxiliarySplitInfo<typename VecType::elem_type>& /* aux */)
+    arma::vec& classProbabilities,
+    AuxiliarySplitInfo& /* aux */)
 {
   // First sanity check: if we don't have enough points, we can't split.
   if (data.n_elem < (minimumLeafSize * 2))
@@ -189,8 +189,8 @@ template<typename FitnessFunction>
 template<typename ElemType>
 size_t BestBinaryNumericSplit<FitnessFunction>::CalculateDirection(
     const ElemType& point,
-    const arma::Col<ElemType>& classProbabilities,
-    const AuxiliarySplitInfo<ElemType>& /* aux */)
+    const arma::vec& classProbabilities,
+    const AuxiliarySplitInfo& /* aux */)
 {
   if (point <= classProbabilities[0])
     return 0; // Go left.

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -30,18 +30,20 @@ namespace tree {
  *
  * The class inherits from the auxiliary split information in order to prevent
  * an empty auxiliary split information struct from taking any extra size.
+ *
+ * Note that `ElemType` is a template parameter controlling the type that is
+ * used to store split information.  In general, you would want to set this to
+ * be the same as the type of the data that you will be using, but it's not
+ * required to do that.
  */
 template<typename FitnessFunction = GiniGain,
          template<typename> class NumericSplitType = BestBinaryNumericSplit,
          template<typename> class CategoricalSplitType = AllCategoricalSplit,
          typename DimensionSelectionType = AllDimensionSelect,
-         typename ElemType = double,
          bool NoRecursion = false>
 class DecisionTree :
-    public NumericSplitType<FitnessFunction>::template
-        AuxiliarySplitInfo<ElemType>,
-    public CategoricalSplitType<FitnessFunction>::template
-        AuxiliarySplitInfo<ElemType>
+    public NumericSplitType<FitnessFunction>::AuxiliarySplitInfo,
+    public CategoricalSplitType<FitnessFunction>::AuxiliarySplitInfo
 {
  public:
   //! Allow access to the numeric split type.
@@ -500,9 +502,9 @@ class DecisionTree :
   //! Note that this class will also hold the members of the NumericSplit and
   //! CategoricalSplit AuxiliarySplitInfo classes, since it inherits from them.
   //! We'll define some convenience typedefs here.
-  typedef typename NumericSplit::template AuxiliarySplitInfo<ElemType>
+  typedef typename NumericSplit::AuxiliarySplitInfo
       NumericAuxiliarySplitInfo;
-  typedef typename CategoricalSplit::template AuxiliarySplitInfo<ElemType>
+  typedef typename CategoricalSplit::AuxiliarySplitInfo
       CategoricalAuxiliarySplitInfo;
 
   /**
@@ -578,13 +580,11 @@ class DecisionTree :
 template<typename FitnessFunction = GiniGain,
          template<typename> class NumericSplitType = BestBinaryNumericSplit,
          template<typename> class CategoricalSplitType = AllCategoricalSplit,
-         typename DimensionSelectType = AllDimensionSelect,
-         typename ElemType = double>
+         typename DimensionSelectType = AllDimensionSelect>
 using DecisionStump = DecisionTree<FitnessFunction,
                                    NumericSplitType,
                                    CategoricalSplitType,
                                    DimensionSelectType,
-                                   ElemType,
                                    false>;
 
 /**
@@ -595,7 +595,6 @@ typedef DecisionTree<InformationGain,
                      BestBinaryNumericSplit,
                      AllCategoricalSplit,
                      AllDimensionSelect,
-                     double,
                      true> ID3DecisionStump;
 } // namespace tree
 } // namespace mlpack

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -22,14 +22,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(
     MatType data,
     const data::DatasetInfo& datasetInfo,
@@ -62,14 +60,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(
     MatType data,
     LabelsType labels,
@@ -100,14 +96,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(
     MatType data,
     const data::DatasetInfo& datasetInfo,
@@ -144,14 +138,12 @@ template<typename FitnessFunction,
         template<typename> class NumericSplitType,
         template<typename> class CategoricalSplitType,
         typename DimensionSelectionType,
-        typename ElemType,
         bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 DecisionTree<FitnessFunction,
         NumericSplitType,
         CategoricalSplitType,
         DimensionSelectionType,
-        ElemType,
         NoRecursion>::DecisionTree(
     const DecisionTree& other,
     MatType data,
@@ -185,14 +177,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(
     MatType data,
     LabelsType labels,
@@ -229,14 +219,12 @@ template<typename FitnessFunction,
         template<typename> class NumericSplitType,
         template<typename> class CategoricalSplitType,
         typename DimensionSelectionType,
-        typename ElemType,
         bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 DecisionTree<FitnessFunction,
         NumericSplitType,
         CategoricalSplitType,
         DimensionSelectionType,
-        ElemType,
         NoRecursion>::DecisionTree(
     const DecisionTree& other,
     MatType data,
@@ -275,13 +263,11 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(const size_t numClasses) :
     splitDimension(0),
     dimensionTypeOrMajorityClass(0),
@@ -296,13 +282,11 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(const DecisionTree& other) :
     NumericAuxiliarySplitInfo(other),
     CategoricalAuxiliarySplitInfo(other),
@@ -320,13 +304,11 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::DecisionTree(DecisionTree&& other) :
     NumericAuxiliarySplitInfo(std::move(other)),
     CategoricalAuxiliarySplitInfo(std::move(other)),
@@ -344,19 +326,16 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>&
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::operator=(const DecisionTree& other)
 {
   if (this == &other)
@@ -388,19 +367,16 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>&
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::operator=(DecisionTree&& other)
 {
   if (this == &other)
@@ -432,13 +408,11 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 DecisionTree<FitnessFunction,
              NumericSplitType,
              CategoricalSplitType,
              DimensionSelectionType,
-             ElemType,
              NoRecursion>::~DecisionTree()
 {
   for (size_t i = 0; i < children.size(); ++i)
@@ -450,14 +424,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType>
 double DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Train(
     MatType data,
     const data::DatasetInfo& datasetInfo,
@@ -493,14 +465,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType>
 double DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Train(
     MatType data,
     LabelsType labels,
@@ -535,14 +505,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 double DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Train(
     MatType data,
     const data::DatasetInfo& datasetInfo,
@@ -584,14 +552,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType, typename LabelsType, typename WeightsType>
 double DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Train(
     MatType data,
     LabelsType labels,
@@ -632,14 +598,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<bool UseWeights, typename MatType>
 double DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Train(
     MatType& data,
     const size_t begin,
@@ -818,14 +782,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<bool UseWeights, typename MatType>
 double DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Train(
     MatType& data,
     const size_t begin,
@@ -976,14 +938,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename VecType>
 size_t DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::Classify(const VecType& point) const
 {
   if (children.size() == 0)
@@ -1000,14 +960,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename VecType>
 void DecisionTree<FitnessFunction,
                   NumericSplitType,
                   CategoricalSplitType,
                   DimensionSelectionType,
-                  ElemType,
                   NoRecursion>::Classify(const VecType& point,
                                          size_t& prediction,
                                          arma::vec& probabilities) const
@@ -1028,14 +986,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType>
 void DecisionTree<FitnessFunction,
                   NumericSplitType,
                   CategoricalSplitType,
                   DimensionSelectionType,
-                  ElemType,
                   NoRecursion>::Classify(const MatType& data,
                                          arma::Row<size_t>& predictions) const
 {
@@ -1056,14 +1012,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename MatType>
 void DecisionTree<FitnessFunction,
                   NumericSplitType,
                   CategoricalSplitType,
                   DimensionSelectionType,
-                  ElemType,
                   NoRecursion>::Classify(const MatType& data,
                                          arma::Row<size_t>& predictions,
                                          arma::mat& probabilities) const
@@ -1095,14 +1049,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename Archive>
 void DecisionTree<FitnessFunction,
                   NumericSplitType,
                   CategoricalSplitType,
                   DimensionSelectionType,
-                  ElemType,
                   NoRecursion>::serialize(Archive& ar,
                                           const uint32_t /* version */)
 {
@@ -1126,14 +1078,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<typename VecType>
 size_t DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::CalculateDirection(const VecType& point) const
 {
   if ((data::Datatype) dimensionTypeOrMajorityClass ==
@@ -1150,13 +1100,11 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 size_t DecisionTree<FitnessFunction,
                     NumericSplitType,
                     CategoricalSplitType,
                     DimensionSelectionType,
-                    ElemType,
                     NoRecursion>::NumClasses() const
 {
   // Recurse to the nearest child and return the number of elements in the
@@ -1171,14 +1119,12 @@ template<typename FitnessFunction,
          template<typename> class NumericSplitType,
          template<typename> class CategoricalSplitType,
          typename DimensionSelectionType,
-         typename ElemType,
          bool NoRecursion>
 template<bool UseWeights, typename RowType, typename WeightsRowType>
 void DecisionTree<FitnessFunction,
                   NumericSplitType,
                   CategoricalSplitType,
                   DimensionSelectionType,
-                  ElemType,
                   NoRecursion>::CalculateClassProbabilities(
     const RowType& labels,
     const size_t numClasses,

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -19,17 +19,33 @@
 namespace mlpack {
 namespace tree {
 
+/**
+ * The RandomForest class provides an implementation of random forests,
+ * described in Breiman's seminal paper:
+ *
+ * @code
+ * @article{breiman2001random,
+ *   title={Random forests},
+ *   author={Breiman, Leo},
+ *   journal={Machine Learning},
+ *   volume={45},
+ *   number={1},
+ *   pages={5--32},
+ *   year={2001},
+ *   publisher={Springer}
+ * }
+ * @endcode
+ */
 template<typename FitnessFunction = GiniGain,
          typename DimensionSelectionType = MultipleRandomDimensionSelect,
          template<typename> class NumericSplitType = BestBinaryNumericSplit,
-         template<typename> class CategoricalSplitType = AllCategoricalSplit,
-         typename ElemType = double>
+         template<typename> class CategoricalSplitType = AllCategoricalSplit>
 class RandomForest
 {
  public:
   //! Allow access to the underlying decision tree type.
   typedef DecisionTree<FitnessFunction, NumericSplitType, CategoricalSplitType,
-      DimensionSelectionType, ElemType> DecisionTreeType;
+      DimensionSelectionType> DecisionTreeType;
 
   /**
    * Construct the random forest without any training or specifying the number

--- a/src/mlpack/methods/random_forest/random_forest_impl.hpp
+++ b/src/mlpack/methods/random_forest/random_forest_impl.hpp
@@ -22,16 +22,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::RandomForest(const MatType& dataset,
                 const arma::Row<size_t>& labels,
                 const size_t numClasses,
@@ -52,16 +50,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::RandomForest(const MatType& dataset,
                 const data::DatasetInfo& datasetInfo,
                 const arma::Row<size_t>& labels,
@@ -83,16 +79,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::RandomForest(const MatType& dataset,
                 const arma::Row<size_t>& labels,
                 const size_t numClasses,
@@ -113,16 +107,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::RandomForest(const MatType& dataset,
                 const data::DatasetInfo& datasetInfo,
                 const arma::Row<size_t>& labels,
@@ -143,16 +135,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 double RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Train(const MatType& dataset,
          const arma::Row<size_t>& labels,
          const size_t numClasses,
@@ -174,16 +164,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 double RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Train(const MatType& dataset,
          const data::DatasetInfo& datasetInfo,
          const arma::Row<size_t>& labels,
@@ -205,16 +193,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 double RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Train(const MatType& dataset,
          const arma::Row<size_t>& labels,
          const size_t numClasses,
@@ -236,16 +222,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 double RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Train(const MatType& dataset,
          const data::DatasetInfo& datasetInfo,
          const arma::Row<size_t>& labels,
@@ -267,16 +251,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename VecType>
 size_t RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Classify(const VecType& point) const
 {
   // Pass off to another Classify() overload.
@@ -291,16 +273,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename VecType>
 void RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Classify(const VecType& point,
             size_t& prediction,
             arma::vec& probabilities) const
@@ -338,16 +318,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 void RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Classify(const MatType& data,
             arma::Row<size_t>& predictions) const
 {
@@ -373,16 +351,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename MatType>
 void RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Classify(const MatType& data,
             arma::Row<size_t>& predictions,
             arma::mat& probabilities) const
@@ -411,16 +387,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<typename Archive>
 void RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::serialize(Archive& ar, const uint32_t /* version */)
 {
   size_t numTrees;
@@ -442,16 +416,14 @@ template<
     typename FitnessFunction,
     typename DimensionSelectionType,
     template<typename> class NumericSplitType,
-    template<typename> class CategoricalSplitType,
-    typename ElemType
+    template<typename> class CategoricalSplitType
 >
 template<bool UseWeights, bool UseDatasetInfo, typename MatType>
 double RandomForest<
     FitnessFunction,
     DimensionSelectionType,
     NumericSplitType,
-    CategoricalSplitType,
-    ElemType
+    CategoricalSplitType
 >::Train(const MatType& dataset,
          const data::DatasetInfo& datasetInfo,
          const arma::Row<size_t>& labels,

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -745,7 +745,7 @@ TEST_CASE("SimpleGeneralizationFMatTest", "[DecisionTreeTest]")
 
   REQUIRE(correct > 0.75);
 
-  // reset the prediction
+  // Reset the prediction.
   predictions.zeros();
   wd.Classify(testData, predictions);
 

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -718,8 +718,8 @@ TEST_CASE("SimpleGeneralizationFMatTest", "[DecisionTreeTest]")
   arma::rowvec weights(labels.n_cols, arma::fill::ones);
 
   // Build decision tree.
-  DecisionTree<> d(inputData, labels, 3, 10); // Leaf size of 10.
-  DecisionTree<> wd(inputData, labels, 3, weights, 10); // Leaf size of 10.
+  DecisionTree<> d(inputData, labels, 3, 10 /* Leaf size of 10. */);
+  DecisionTree<> wd(inputData, labels, 3, weights, 10 /* Leaf size of 10. */);
 
   // Load testing data.
   arma::mat testData;

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -289,7 +289,7 @@ TEST_CASE("BestBinaryNumericSplitSimpleSplitTest", "[DecisionTreeTest]")
   weights.ones();
 
   arma::vec classProbabilities;
-  BestBinaryNumericSplit<GiniGain>::template AuxiliarySplitInfo<double> aux;
+  BestBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux;
 
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 2, weights);
@@ -327,7 +327,7 @@ TEST_CASE("BestBinaryNumericSplitMinSamplesTest", "[DecisionTreeTest]")
   arma::rowvec weights(labels.n_elem);
 
   arma::vec classProbabilities;
-  BestBinaryNumericSplit<GiniGain>::template AuxiliarySplitInfo<double> aux;
+  BestBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux;
 
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 2, weights);
@@ -363,7 +363,7 @@ TEST_CASE("BestBinaryNumericSplitNoGainTest", "[DecisionTreeTest]")
   }
 
   arma::vec classProbabilities;
-  BestBinaryNumericSplit<GiniGain>::template AuxiliarySplitInfo<double> aux;
+  BestBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux;
 
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 2, weights);
@@ -388,7 +388,7 @@ TEST_CASE("AllCategoricalSplitSimpleSplitTest", "[DecisionTreeTest]")
   weights.ones();
 
   arma::vec classProbabilities;
-  AllCategoricalSplit<GiniGain>::template AuxiliarySplitInfo<double> aux;
+  AllCategoricalSplit<GiniGain>::AuxiliarySplitInfo aux;
 
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 3, weights);
@@ -424,7 +424,7 @@ TEST_CASE("AllCategoricalSplitMinSamplesTest", "[DecisionTreeTest]")
   weights.ones();
 
   arma::vec classProbabilities;
-  AllCategoricalSplit<GiniGain>::template AuxiliarySplitInfo<double> aux;
+  AllCategoricalSplit<GiniGain>::AuxiliarySplitInfo aux;
 
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 3, weights);
@@ -457,7 +457,7 @@ TEST_CASE("AllCategoricalSplitNoGainTest", "[DecisionTreeTest]")
   }
 
   arma::vec classProbabilities;
-  AllCategoricalSplit<GiniGain>::template AuxiliarySplitInfo<double> aux;
+  AllCategoricalSplit<GiniGain>::AuxiliarySplitInfo aux;
 
   // Call the method to do the splitting.
   const double bestGain = GiniGain::Evaluate<false>(labels, 3, weights);
@@ -647,6 +647,66 @@ TEST_CASE("ClassProbabilityTest", "[DecisionTreeTest]")
 TEST_CASE("SimpleGeneralizationTest", "[DecisionTreeTest]")
 {
   arma::mat inputData;
+  if (!data::Load("vc2.csv", inputData))
+    FAIL("Cannot load test dataset vc2.csv!");
+
+  arma::Row<size_t> labels;
+  if (!data::Load("vc2_labels.txt", labels))
+    FAIL("Cannot load labels for vc2_labels.txt");
+
+  // Initialize an all-ones weight matrix.
+  arma::rowvec weights(labels.n_cols, arma::fill::ones);
+
+  // Build decision tree.
+  DecisionTree<> d(inputData, labels, 3, 10); // Leaf size of 10.
+  DecisionTree<> wd(inputData, labels, 3, weights, 10); // Leaf size of 10.
+
+  // Load testing data.
+  arma::mat testData;
+  if (!data::Load("vc2_test.csv", testData))
+    FAIL("Cannot load test dataset vc2_test.csv!");
+
+  arma::Mat<size_t> trueTestLabels;
+  if (!data::Load("vc2_test_labels.txt", trueTestLabels))
+    FAIL("Cannot load labels for vc2_test_labels.txt");
+
+  // Get the predicted test labels.
+  arma::Row<size_t> predictions;
+  d.Classify(testData, predictions);
+
+  REQUIRE(predictions.n_elem == testData.n_cols);
+
+  // Figure out the accuracy.
+  double correct = 0.0;
+  for (size_t i = 0; i < predictions.n_elem; ++i)
+    if (predictions[i] == trueTestLabels[i])
+      ++correct;
+  correct /= predictions.n_elem;
+
+  REQUIRE(correct > 0.75);
+
+  // reset the prediction
+  predictions.zeros();
+  wd.Classify(testData, predictions);
+
+  REQUIRE(predictions.n_elem == testData.n_cols);
+
+  // Figure out the accuracy.
+  double wdcorrect = 0.0;
+  for (size_t i = 0; i < predictions.n_elem; ++i)
+    if (predictions[i] == trueTestLabels[i])
+      ++wdcorrect;
+  wdcorrect /= predictions.n_elem;
+
+  REQUIRE(wdcorrect > 0.75);
+}
+
+/**
+ * Test that the decision tree generalizes reasonably when built on float data.
+ */
+TEST_CASE("SimpleGeneralizationFMatTest", "[DecisionTreeTest]")
+{
+  arma::fmat inputData;
   if (!data::Load("vc2.csv", inputData))
     FAIL("Cannot load test dataset vc2.csv!");
 


### PR DESCRIPTION
While fixing #2872, I noticed that there is a template parameter `ElemType` for `DecisionTree` and `RandomForest` that is currently entirely unused.  In fact, it gets in the way and is confusing a little bit, so I thought it was better to remove it.

In addition, I changed some function signatures to force `arma::vec` for the `classProbabilities` member to actually fix #2872.

This is an API change, but since the next release is 4.0.0 anyway, it should be okay to break reverse compatibility in this minor way.