### PR TITLE
Dual Optimizer for GAN class

### DIFF
--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -112,6 +112,27 @@ class FFN
       ::value, void>::type
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
+   /**
+   * Train the feedforward network on the given input data using the given
+   * optimizer in unsupervised mode.
+   *
+   * This will use the existing model parameters as a starting point for the
+   * optimization. If this is not what you want, then you should access the
+   * parameters vector directly with Parameters() and modify it as desired.
+   *
+   * If you want to pass in a parameter and discard the original parameter
+   * object, be sure to use std::move to avoid unnecessary copy.
+   *
+   * @tparam OptimizerType Type of optimizer to use to train the model.
+   * @param predictors Input training variables.
+   * @param optimizer Instantiated optimizer used to train the model.
+   * @return The final objective of the trained model (NaN or Inf on error).
+   */
+  template<typename OptimizerType, typename... CallbackTypes>
+  double Train(arma::mat predictors,
+               OptimizerType& optimizer,
+               CallbackTypes&&... callbacks);
+
   /**
    * Train the feedforward network on the given input data using the given
    * optimizer.
@@ -402,6 +423,14 @@ class FFN
    */
   void ResetData(arma::mat predictors, arma::mat responses);
 
+   /**
+   * Prepare the network for the given data.
+   * This function won't actually trigger training process.
+   *
+   * @param predictors Input data variables.
+   */
+  void ResetData(arma::mat predictors);
+
   /**
    * The Backward algorithm (part of the Forward-Backward algorithm). Computes
    * backward pass for module.
@@ -464,6 +493,10 @@ class FFN
   //! The number of separable functions (the number of predictor points).
   size_t numFunctions;
 
+  //! Flag that checks whether the given network is trained in supervised
+  //! mode or not.
+  bool supervised;
+
   //! The current error for the backward pass.
   arma::mat error;
 
@@ -514,7 +547,9 @@ class FFN
     typename Model,
     typename InitializerType,
     typename NoiseType,
-    typename PolicyType
+    typename PolicyType,
+    typename InputType,
+    typename OutputType
   >
   friend class GAN;
 }; // class FFN

--- a/src/mlpack/methods/ann/gan/CMakeLists.txt
+++ b/src/mlpack/methods/ann/gan/CMakeLists.txt
@@ -4,8 +4,8 @@ set(SOURCES
   gan.hpp
   gan_impl.hpp
   gan_policies.hpp
-  wgan_impl.hpp
-  wgangp_impl.hpp
+  # wgan_impl.hpp
+  #wgangp_impl.hpp
 )
 
 add_subdirectory(metrics)

--- a/src/mlpack/methods/ann/gan/wgan_impl.hpp
+++ b/src/mlpack/methods/ann/gan/wgan_impl.hpp
@@ -7,195 +7,195 @@
  * 3-clause BSD license along with mlpack. If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_METHODS_ANN_GAN_WGAN_IMPL_HPP
-#define MLPACK_METHODS_ANN_GAN_WGAN_IMPL_HPP
-
-#include "gan.hpp"
-
-#include <mlpack/core.hpp>
-
-#include <mlpack/methods/ann/ffn.hpp>
-#include <mlpack/methods/ann/init_rules/network_init.hpp>
-#include <mlpack/methods/ann/visitor/output_parameter_visitor.hpp>
-#include <mlpack/methods/ann/activation_functions/softplus_function.hpp>
-
-namespace mlpack {
-namespace ann /** Artifical Neural Network.  */ {
-template<
-  typename Model,
-  typename InitializationRuleType,
-  typename Noise,
-  typename PolicyType
->
-template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGAN>::value, double>::type
-GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
-    const arma::mat& /* parameters */,
-    const size_t i,
-    const size_t /* batchSize */)
-{
-  if (parameter.is_empty())
-  {
-    Reset();
-  }
-
-  if (!deterministic)
-  {
-    deterministic = true;
-    ResetDeterministic();
-  }
-
-  currentInput = arma::mat(predictors.memptr() + (i * predictors.n_rows),
-      predictors.n_rows, batchSize, false, false);
-  currentTarget = arma::mat(responses.memptr() + i, 1, batchSize, false,
-      false);
-
-  discriminator.Forward(currentInput);
-  double res = discriminator.outputLayer.Forward(
-      boost::apply_visitor(
-      outputParameterVisitor,
-      discriminator.network.back()), currentTarget);
-
-  noise.imbue( [&]() { return noiseFunction();} );
-  generator.Forward(noise);
-
-  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
-      boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  discriminator.Forward(predictors.cols(numFunctions,
-      numFunctions + batchSize - 1));
-  responses.cols(numFunctions, numFunctions + batchSize - 1) =
-      -arma::ones(1, batchSize);
-
-  currentTarget = arma::mat(responses.memptr() + numFunctions,
-      1, batchSize, false, false);
-  res += discriminator.outputLayer.Forward(
-      boost::apply_visitor(
-      outputParameterVisitor,
-      discriminator.network.back()), currentTarget);
-
-  return res;
-}
-
-template<
-  typename Model,
-  typename InitializationRuleType,
-  typename Noise,
-  typename PolicyType
->
-template<typename GradType, typename Policy>
-typename std::enable_if<std::is_same<Policy, WGAN>::value, double>::type
-GAN<Model, InitializationRuleType, Noise, PolicyType>::
-EvaluateWithGradient(const arma::mat& /* parameters */,
-                     const size_t i,
-                     GradType& gradient,
-                     const size_t /* batchSize */)
-{
-  if (parameter.is_empty())
-  {
-    Reset();
-  }
-
-  if (gradient.is_empty())
-  {
-    if (parameter.is_empty())
-      Reset();
-    gradient = arma::zeros<arma::mat>(parameter.n_elem, 1);
-  }
-  else
-    gradient.zeros();
-
-  if (this->deterministic)
-  {
-    this->deterministic = false;
-    ResetDeterministic();
-  }
-
-  if (noiseGradientDiscriminator.is_empty())
-  {
-    noiseGradientDiscriminator = arma::zeros<arma::mat>(
-        gradientDiscriminator.n_elem, 1);
-  }
-  else
-  {
-    noiseGradientDiscriminator.zeros();
-  }
-
-  gradientGenerator = arma::mat(gradient.memptr(),
-      generator.Parameters().n_elem, 1, false, false);
-
-  gradientDiscriminator = arma::mat(gradient.memptr() +
-      gradientGenerator.n_elem,
-      discriminator.Parameters().n_elem, 1, false, false);
-
-  // Get the gradients of the Discriminator.
-  double res = discriminator.EvaluateWithGradient(discriminator.parameter,
-      i, gradientDiscriminator, batchSize);
-
-  noise.imbue( [&]() { return noiseFunction();} );
-  generator.Forward(noise);
-  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
-      boost::apply_visitor(outputParameterVisitor, generator.network.back());
-  responses.cols(numFunctions, numFunctions + batchSize - 1) =
-      -arma::ones(1, batchSize);
-
-  // Get the gradients of the Generator.
-  res += discriminator.EvaluateWithGradient(discriminator.parameter,
-      numFunctions, noiseGradientDiscriminator, batchSize);
-  gradientDiscriminator += noiseGradientDiscriminator;
-  gradientDiscriminator = arma::clamp(gradientDiscriminator,
-      -clippingParameter, clippingParameter);
-
-  if (currentBatch % generatorUpdateStep == 0 && preTrainSize == 0)
-  {
-    // Minimize -D(G(noise)).
-    // Pass the error from Discriminator to Generator.
-    responses.cols(numFunctions, numFunctions + batchSize - 1) =
-        arma::ones(1, batchSize);
-
-    discriminator.outputLayer.Backward(
-        boost::apply_visitor(outputParameterVisitor,
-        discriminator.network.back()), discriminator.responses.cols(
-        numFunctions, numFunctions + batchSize - 1), discriminator.error);
-    discriminator.Backward();
-
-    generator.error = boost::apply_visitor(deltaVisitor,
-        discriminator.network[1]);
-
-    generator.Predictors() = noise;
-    generator.Backward();
-    generator.ResetGradients(gradientGenerator);
-    generator.Gradient(generator.Predictors().cols(0, batchSize - 1));
-
-    gradientGenerator *= multiplier;
-  }
-
-  currentBatch++;
-
-  if (preTrainSize > 0)
-  {
-    preTrainSize--;
-  }
-
-  return res;
-}
-
-template<
-  typename Model,
-  typename InitializationRuleType,
-  typename Noise,
-  typename PolicyType
->
-template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGAN>::value, void>::type
-GAN<Model, InitializationRuleType, Noise, PolicyType>::
-Gradient(const arma::mat& parameters,
-         const size_t i,
-         arma::mat& gradient,
-         const size_t batchSize)
-{
-  this->EvaluateWithGradient(parameters, i, gradient, batchSize);
-}
-
-} // namespace ann
-} // namespace mlpack
-# endif
+//#ifndef MLPACK_METHODS_ANN_GAN_WGAN_IMPL_HPP
+//#define MLPACK_METHODS_ANN_GAN_WGAN_IMPL_HPP
+//
+//#include "gan.hpp"
+//
+//#include <mlpack/core.hpp>
+//
+//#include <mlpack/methods/ann/ffn.hpp>
+//#include <mlpack/methods/ann/init_rules/network_init.hpp>
+//#include <mlpack/methods/ann/visitor/output_parameter_visitor.hpp>
+//#include <mlpack/methods/ann/activation_functions/softplus_function.hpp>
+//
+//namespace mlpack {
+//namespace ann /** Artifical Neural Network.  */ {
+//template<
+//  typename Model,
+//  typename InitializationRuleType,
+//  typename Noise,
+//  typename PolicyType
+//>
+//template<typename Policy>
+//typename std::enable_if<std::is_same<Policy, WGAN>::value, double>::type
+//GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
+//    const arma::mat& /* parameters */,
+//    const size_t i,
+//    const size_t /* batchSize */)
+//{
+//  if (parameter.is_empty())
+//  {
+//    Reset();
+//  }
+//
+//  if (!deterministic)
+//  {
+//    deterministic = true;
+//    ResetDeterministic();
+//  }
+//
+//  currentInput = arma::mat(predictors.memptr() + (i * predictors.n_rows),
+//      predictors.n_rows, batchSize, false, false);
+//  currentTarget = arma::mat(responses.memptr() + i, 1, batchSize, false,
+//      false);
+//
+//  discriminator.Forward(currentInput);
+//  double res = discriminator.outputLayer.Forward(
+//      boost::apply_visitor(
+//      outputParameterVisitor,
+//      discriminator.network.back()), currentTarget);
+//
+//  noise.imbue( [&]() { return noiseFunction();} );
+//  generator.Forward(noise);
+//
+//  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+//      boost::apply_visitor(outputParameterVisitor, generator.network.back());
+//  discriminator.Forward(predictors.cols(numFunctions,
+//      numFunctions + batchSize - 1));
+//  responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//      -arma::ones(1, batchSize);
+//
+//  currentTarget = arma::mat(responses.memptr() + numFunctions,
+//      1, batchSize, false, false);
+//  res += discriminator.outputLayer.Forward(
+//      boost::apply_visitor(
+//      outputParameterVisitor,
+//      discriminator.network.back()), currentTarget);
+//
+//  return res;
+//}
+//
+//template<
+//  typename Model,
+//  typename InitializationRuleType,
+//  typename Noise,
+//  typename PolicyType
+//>
+//template<typename GradType, typename Policy>
+//typename std::enable_if<std::is_same<Policy, WGAN>::value, double>::type
+//GAN<Model, InitializationRuleType, Noise, PolicyType>::
+//EvaluateWithGradient(const arma::mat& /* parameters */,
+//                     const size_t i,
+//                     GradType& gradient,
+//                     const size_t /* batchSize */)
+//{
+//  if (parameter.is_empty())
+//  {
+//    Reset();
+//  }
+//
+//  if (gradient.is_empty())
+//  {
+//    if (parameter.is_empty())
+//      Reset();
+//    gradient = arma::zeros<arma::mat>(parameter.n_elem, 1);
+//  }
+//  else
+//    gradient.zeros();
+//
+//  if (this->deterministic)
+//  {
+//    this->deterministic = false;
+//    ResetDeterministic();
+//  }
+//
+//  if (noiseGradientDiscriminator.is_empty())
+//  {
+//    noiseGradientDiscriminator = arma::zeros<arma::mat>(
+//        gradientDiscriminator.n_elem, 1);
+//  }
+//  else
+//  {
+//    noiseGradientDiscriminator.zeros();
+//  }
+//
+//  gradientGenerator = arma::mat(gradient.memptr(),
+//      generator.Parameters().n_elem, 1, false, false);
+//
+//  gradientDiscriminator = arma::mat(gradient.memptr() +
+//      gradientGenerator.n_elem,
+//      discriminator.Parameters().n_elem, 1, false, false);
+//
+//  // Get the gradients of the Discriminator.
+//  double res = discriminator.EvaluateWithGradient(discriminator.parameter,
+//      i, gradientDiscriminator, batchSize);
+//
+//  noise.imbue( [&]() { return noiseFunction();} );
+//  generator.Forward(noise);
+//  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+//      boost::apply_visitor(outputParameterVisitor, generator.network.back());
+//  responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//      -arma::ones(1, batchSize);
+//
+//  // Get the gradients of the Generator.
+//  res += discriminator.EvaluateWithGradient(discriminator.parameter,
+//      numFunctions, noiseGradientDiscriminator, batchSize);
+//  gradientDiscriminator += noiseGradientDiscriminator;
+//  gradientDiscriminator = arma::clamp(gradientDiscriminator,
+//      -clippingParameter, clippingParameter);
+//
+//  if (currentBatch % generatorUpdateStep == 0 && preTrainSize == 0)
+//  {
+//    // Minimize -D(G(noise)).
+//    // Pass the error from Discriminator to Generator.
+//    responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//        arma::ones(1, batchSize);
+//
+//    discriminator.outputLayer.Backward(
+//        boost::apply_visitor(outputParameterVisitor,
+//        discriminator.network.back()), discriminator.responses.cols(
+//        numFunctions, numFunctions + batchSize - 1), discriminator.error);
+//    discriminator.Backward();
+//
+//    generator.error = boost::apply_visitor(deltaVisitor,
+//        discriminator.network[1]);
+//
+//    generator.Predictors() = noise;
+//    generator.Backward();
+//    generator.ResetGradients(gradientGenerator);
+//    generator.Gradient(generator.Predictors().cols(0, batchSize - 1));
+//
+//    gradientGenerator *= multiplier;
+//  }
+//
+//  currentBatch++;
+//
+//  if (preTrainSize > 0)
+//  {
+//    preTrainSize--;
+//  }
+//
+//  return res;
+//}
+//
+//template<
+//  typename Model,
+//  typename InitializationRuleType,
+//  typename Noise,
+//  typename PolicyType
+//>
+//template<typename Policy>
+//typename std::enable_if<std::is_same<Policy, WGAN>::value, void>::type
+//GAN<Model, InitializationRuleType, Noise, PolicyType>::
+//Gradient(const arma::mat& parameters,
+//         const size_t i,
+//         arma::mat& gradient,
+//         const size_t batchSize)
+//{
+//  this->EvaluateWithGradient(parameters, i, gradient, batchSize);
+//}
+//
+//} // namespace ann
+//} // namespace mlpack
+//# endif

--- a/src/mlpack/methods/ann/gan/wgangp_impl.hpp
+++ b/src/mlpack/methods/ann/gan/wgangp_impl.hpp
@@ -7,220 +7,220 @@
  * 3-clause BSD license along with mlpack. If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_METHODS_ANN_GAN_WGANGP_IMPL_HPP
-#define MLPACK_METHODS_ANN_GAN_WGANGP_IMPL_HPP
-
-#include "gan.hpp"
-
-#include <mlpack/core.hpp>
-
-#include <mlpack/methods/ann/ffn.hpp>
-#include <mlpack/methods/ann/init_rules/network_init.hpp>
-#include <mlpack/methods/ann/visitor/output_parameter_visitor.hpp>
-#include <mlpack/methods/ann/activation_functions/softplus_function.hpp>
-
-namespace mlpack {
-namespace ann /** Artifical Neural Network.  */ {
-template<
-  typename Model,
-  typename InitializationRuleType,
-  typename Noise,
-  typename PolicyType
->
-template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                        double>::type
-GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
-    const arma::mat& /* parameters */,
-    const size_t i,
-    const size_t /* batchSize */)
-{
-  if ((parameter.is_empty()))
-  {
-    Reset();
-  }
-
-  if (!deterministic)
-  {
-    deterministic = true;
-    ResetDeterministic();
-  }
-
-  currentInput = arma::mat(predictors.memptr() + (i * predictors.n_rows),
-      predictors.n_rows, batchSize, false, false);
-  currentTarget = arma::mat(responses.memptr() + i, 1, batchSize, false,
-      false);
-
-  discriminator.Forward(std::move(currentInput));
-  double res = discriminator.outputLayer.Forward(
-      std::move(boost::apply_visitor(
-      outputParameterVisitor,
-      discriminator.network.back())), std::move(currentTarget));
-
-  noise.imbue( [&]() { return noiseFunction();} );
-  generator.Forward(std::move(noise));
-
-  arma::mat generatedData = boost::apply_visitor(outputParameterVisitor,
-      generator.network.back());
-  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
-      generatedData;
-  discriminator.Forward(std::move(predictors.cols(numFunctions,
-      numFunctions + batchSize - 1)));
-  responses.cols(numFunctions, numFunctions + batchSize - 1) =
-      -arma::ones(1, batchSize);
-
-  currentTarget = arma::mat(responses.memptr() + numFunctions,
-      1, batchSize, false, false);
-  res += discriminator.outputLayer.Forward(
-      std::move(boost::apply_visitor(
-      outputParameterVisitor,
-      discriminator.network.back())), std::move(currentTarget));
-
-  // Gradient Penalty is calculated here.
-  double epsilon = math::Random();
-  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
-      (epsilon * currentInput) + ((1.0 - epsilon) * generatedData);
-  responses.cols(numFunctions, numFunctions + batchSize - 1) =
-      -arma::ones(1, batchSize);
-  discriminator.Gradient(discriminator.parameter, numFunctions,
-      normGradientDiscriminator, batchSize);
-  res += lambda * std::pow(arma::norm(normGradientDiscriminator, 2) - 1, 2);
-
-  return res;
-}
-
-template<
-  typename Model,
-  typename InitializationRuleType,
-  typename Noise,
-  typename PolicyType
->
-template<typename GradType, typename Policy>
-typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                        double>::type
-GAN<Model, InitializationRuleType, Noise, PolicyType>::
-EvaluateWithGradient(const arma::mat& /* parameters */,
-                     const size_t i,
-                     GradType& gradient,
-                     const size_t /* batchSize */)
-{
-  if (parameter.is_empty())
-  {
-    Reset();
-  }
-
-  if (gradient.is_empty())
-  {
-    if (parameter.is_empty())
-      Reset();
-    gradient = arma::zeros<arma::mat>(parameter.n_elem, 1);
-  }
-  else
-    gradient.zeros();
-
-  if (this->deterministic)
-  {
-    this->deterministic = false;
-    ResetDeterministic();
-  }
-
-  if (noiseGradientDiscriminator.is_empty())
-  {
-    noiseGradientDiscriminator = arma::zeros<arma::mat>(
-        gradientDiscriminator.n_elem, 1);
-  }
-  else
-  {
-    noiseGradientDiscriminator.zeros();
-  }
-
-  gradientGenerator = arma::mat(gradient.memptr(),
-      generator.Parameters().n_elem, 1, false, false);
-
-  gradientDiscriminator = arma::mat(gradient.memptr() +
-      gradientGenerator.n_elem,
-      discriminator.Parameters().n_elem, 1, false, false);
-
-  currentInput = arma::mat(predictors.memptr() + (i * predictors.n_rows),
-      predictors.n_rows, batchSize, false, false);
-
-  // Get the gradients of the Discriminator.
-  double res = discriminator.EvaluateWithGradient(discriminator.parameter,
-      i, gradientDiscriminator, batchSize);
-
-  noise.imbue( [&]() { return noiseFunction();} );
-  generator.Forward(std::move(noise));
-  arma::mat generatedData = boost::apply_visitor(outputParameterVisitor,
-      generator.network.back());
-
-  // Gradient Penalty is calculated here.
-  double epsilon = math::Random();
-  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
-      (epsilon * currentInput) + ((1.0 - epsilon) * generatedData);
-  responses.cols(numFunctions, numFunctions + batchSize - 1) =
-      -arma::ones(1, batchSize);
-  discriminator.Gradient(discriminator.parameter, numFunctions,
-      normGradientDiscriminator, batchSize);
-  res += lambda * std::pow(arma::norm(normGradientDiscriminator, 2) - 1, 2);
-
-  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
-      generatedData;
-  res += discriminator.EvaluateWithGradient(discriminator.parameter,
-      numFunctions, noiseGradientDiscriminator, batchSize);
-  gradientDiscriminator += noiseGradientDiscriminator;
-
-  if (currentBatch % generatorUpdateStep == 0 && preTrainSize == 0)
-  {
-    // Minimize -D(G(noise)).
-    // Pass the error from Discriminator to Generator.
-    responses.cols(numFunctions, numFunctions + batchSize - 1) =
-        arma::ones(1, batchSize);
-
-    discriminator.outputLayer.Backward(
-        boost::apply_visitor(outputParameterVisitor,
-        discriminator.network.back()), discriminator.responses.cols(
-        numFunctions, numFunctions + batchSize - 1), discriminator.error);
-    discriminator.Backward();
-
-    generator.error = boost::apply_visitor(deltaVisitor,
-        discriminator.network[1]);
-
-    generator.Predictors() = noise;
-    generator.Backward();
-    generator.ResetGradients(gradientGenerator);
-    generator.Gradient(generator.Predictors().cols(0, batchSize - 1));
-
-    gradientGenerator *= multiplier;
-  }
-
-  currentBatch++;
-
-  if (preTrainSize > 0)
-  {
-    preTrainSize--;
-  }
-
-  return res;
-}
-
-template<
-  typename Model,
-  typename InitializationRuleType,
-  typename Noise,
-  typename PolicyType
->
-template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                        void>::type
-GAN<Model, InitializationRuleType, Noise, PolicyType>::
-Gradient(const arma::mat& parameters,
-         const size_t i,
-         arma::mat& gradient,
-         const size_t batchSize)
-{
-  this->EvaluateWithGradient(parameters, i, gradient, batchSize);
-}
-
-} // namespace ann
-} // namespace mlpack
-# endif
+//#ifndef MLPACK_METHODS_ANN_GAN_WGANGP_IMPL_HPP
+//#define MLPACK_METHODS_ANN_GAN_WGANGP_IMPL_HPP
+//
+//#include "gan.hpp"
+//
+//#include <mlpack/core.hpp>
+//
+//#include <mlpack/methods/ann/ffn.hpp>
+//#include <mlpack/methods/ann/init_rules/network_init.hpp>
+//#include <mlpack/methods/ann/visitor/output_parameter_visitor.hpp>
+//#include <mlpack/methods/ann/activation_functions/softplus_function.hpp>
+//
+//namespace mlpack {
+//namespace ann /** Artifical Neural Network.  */ {
+//template<
+//  typename Model,
+//  typename InitializationRuleType,
+//  typename Noise,
+//  typename PolicyType
+//>
+//template<typename Policy>
+//typename std::enable_if<std::is_same<Policy, WGANGP>::value,
+//                        double>::type
+//GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
+//    const arma::mat& /* parameters */,
+//    const size_t i,
+//    const size_t /* batchSize */)
+//{
+//  if ((parameter.is_empty()))
+//  {
+//    Reset();
+//  }
+//
+//  if (!deterministic)
+//  {
+//    deterministic = true;
+//    ResetDeterministic();
+//  }
+//
+//  currentInput = arma::mat(predictors.memptr() + (i * predictors.n_rows),
+//      predictors.n_rows, batchSize, false, false);
+//  currentTarget = arma::mat(responses.memptr() + i, 1, batchSize, false,
+//      false);
+//
+//  discriminator.Forward(std::move(currentInput));
+//  double res = discriminator.outputLayer.Forward(
+//      std::move(boost::apply_visitor(
+//      outputParameterVisitor,
+//      discriminator.network.back())), std::move(currentTarget));
+//
+//  noise.imbue( [&]() { return noiseFunction();} );
+//  generator.Forward(std::move(noise));
+//
+//  arma::mat generatedData = boost::apply_visitor(outputParameterVisitor,
+//      generator.network.back());
+//  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+//      generatedData;
+//  discriminator.Forward(std::move(predictors.cols(numFunctions,
+//      numFunctions + batchSize - 1)));
+//  responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//      -arma::ones(1, batchSize);
+//
+//  currentTarget = arma::mat(responses.memptr() + numFunctions,
+//      1, batchSize, false, false);
+//  res += discriminator.outputLayer.Forward(
+//      std::move(boost::apply_visitor(
+//      outputParameterVisitor,
+//      discriminator.network.back())), std::move(currentTarget));
+//
+//  // Gradient Penalty is calculated here.
+//  double epsilon = math::Random();
+//  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+//      (epsilon * currentInput) + ((1.0 - epsilon) * generatedData);
+//  responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//      -arma::ones(1, batchSize);
+//  discriminator.Gradient(discriminator.parameter, numFunctions,
+//      normGradientDiscriminator, batchSize);
+//  res += lambda * std::pow(arma::norm(normGradientDiscriminator, 2) - 1, 2);
+//
+//  return res;
+//}
+//
+//template<
+//  typename Model,
+//  typename InitializationRuleType,
+//  typename Noise,
+//  typename PolicyType
+//>
+//template<typename GradType, typename Policy>
+//typename std::enable_if<std::is_same<Policy, WGANGP>::value,
+//                        double>::type
+//GAN<Model, InitializationRuleType, Noise, PolicyType>::
+//EvaluateWithGradient(const arma::mat& /* parameters */,
+//                     const size_t i,
+//                     GradType& gradient,
+//                     const size_t /* batchSize */)
+//{
+//  if (parameter.is_empty())
+//  {
+//    Reset();
+//  }
+//
+//  if (gradient.is_empty())
+//  {
+//    if (parameter.is_empty())
+//      Reset();
+//    gradient = arma::zeros<arma::mat>(parameter.n_elem, 1);
+//  }
+//  else
+//    gradient.zeros();
+//
+//  if (this->deterministic)
+//  {
+//    this->deterministic = false;
+//    ResetDeterministic();
+//  }
+//
+//  if (noiseGradientDiscriminator.is_empty())
+//  {
+//    noiseGradientDiscriminator = arma::zeros<arma::mat>(
+//        gradientDiscriminator.n_elem, 1);
+//  }
+//  else
+//  {
+//    noiseGradientDiscriminator.zeros();
+//  }
+//
+//  gradientGenerator = arma::mat(gradient.memptr(),
+//      generator.Parameters().n_elem, 1, false, false);
+//
+//  gradientDiscriminator = arma::mat(gradient.memptr() +
+//      gradientGenerator.n_elem,
+//      discriminator.Parameters().n_elem, 1, false, false);
+//
+//  currentInput = arma::mat(predictors.memptr() + (i * predictors.n_rows),
+//      predictors.n_rows, batchSize, false, false);
+//
+//  // Get the gradients of the Discriminator.
+//  double res = discriminator.EvaluateWithGradient(discriminator.parameter,
+//      i, gradientDiscriminator, batchSize);
+//
+//  noise.imbue( [&]() { return noiseFunction();} );
+//  generator.Forward(std::move(noise));
+//  arma::mat generatedData = boost::apply_visitor(outputParameterVisitor,
+//      generator.network.back());
+//
+//  // Gradient Penalty is calculated here.
+//  double epsilon = math::Random();
+//  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+//      (epsilon * currentInput) + ((1.0 - epsilon) * generatedData);
+//  responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//      -arma::ones(1, batchSize);
+//  discriminator.Gradient(discriminator.parameter, numFunctions,
+//      normGradientDiscriminator, batchSize);
+//  res += lambda * std::pow(arma::norm(normGradientDiscriminator, 2) - 1, 2);
+//
+//  predictors.cols(numFunctions, numFunctions + batchSize - 1) =
+//      generatedData;
+//  res += discriminator.EvaluateWithGradient(discriminator.parameter,
+//      numFunctions, noiseGradientDiscriminator, batchSize);
+//  gradientDiscriminator += noiseGradientDiscriminator;
+//
+//  if (currentBatch % generatorUpdateStep == 0 && preTrainSize == 0)
+//  {
+//    // Minimize -D(G(noise)).
+//    // Pass the error from Discriminator to Generator.
+//    responses.cols(numFunctions, numFunctions + batchSize - 1) =
+//        arma::ones(1, batchSize);
+//
+//    discriminator.outputLayer.Backward(
+//        boost::apply_visitor(outputParameterVisitor,
+//        discriminator.network.back()), discriminator.responses.cols(
+//        numFunctions, numFunctions + batchSize - 1), discriminator.error);
+//    discriminator.Backward();
+//
+//    generator.error = boost::apply_visitor(deltaVisitor,
+//        discriminator.network[1]);
+//
+//    generator.Predictors() = noise;
+//    generator.Backward();
+//    generator.ResetGradients(gradientGenerator);
+//    generator.Gradient(generator.Predictors().cols(0, batchSize - 1));
+//
+//    gradientGenerator *= multiplier;
+//  }
+//
+//  currentBatch++;
+//
+//  if (preTrainSize > 0)
+//  {
+//    preTrainSize--;
+//  }
+//
+//  return res;
+//}
+//
+//template<
+//  typename Model,
+//  typename InitializationRuleType,
+//  typename Noise,
+//  typename PolicyType
+//>
+//template<typename Policy>
+//typename std::enable_if<std::is_same<Policy, WGANGP>::value,
+//                        void>::type
+//GAN<Model, InitializationRuleType, Noise, PolicyType>::
+//Gradient(const arma::mat& parameters,
+//         const size_t i,
+//         arma::mat& gradient,
+//         const size_t batchSize)
+//{
+//  this->EvaluateWithGradient(parameters, i, gradient, batchSize);
+//}
+//
+//} // namespace ann
+//} // namespace mlpack
+//# endif


### PR DESCRIPTION
This PR is an attempt to finish the pending work in #1888. I've made the following TODOs list:

- [x] Dual Optimizer Train function for StandardGAN and DCGAN.
- [x] Update Tests for StandardGAN and DCGAN. 
- [ ] Dual Optimizer Train function for WGAN and WGAN-GP.
- [ ] Update Tests for WGAN and WGAN-GP.
- [ ] Remove boost visitor methods.
- [ ] Current implementation overrides shuffle parameter of the optimizer as false. Figure out a way to sync shuffling between discriminator and generator.