### PR TITLE
Handle empty OpenMP_CXX_FLAGS correctly

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,9 @@
   * Remove unused `ElemType` template parameter from `DecisionTree` and
     `RandomForest` (#2874).
 
+  * Fix Python binding build when the CMake variable `USE_OPENMP` is set to
+    `OFF` (#2884).
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -52,18 +52,15 @@ if os.getenv('NO_BUILD') == '1':
 else:
   cxx_flags = '${CMAKE_CXX_FLAGS}'.strip()
   cxx_flags = re.sub(' +', ' ', cxx_flags)
+  extra_args = ['-DBINDING_TYPE=BINDING_TYPE_PYX', '-std=c++11']
+  if '${OpenMP_CXX_FLAGS}' != '':
+    extra_args.append('${OpenMP_CXX_FLAGS}')
   if cxx_flags:
-    extra_args = ['-DBINDING_TYPE=BINDING_TYPE_PYX',
-                  '-std=c++11',
-                  '${OpenMP_CXX_FLAGS}'] + cxx_flags.split(' ')
-  else:
-    extra_args = ['-DBINDING_TYPE=BINDING_TYPE_PYX',
-                  '-std=c++11',
-                  '${OpenMP_CXX_FLAGS}']
+    extra_args.extend(cxx_flags.split(' '))
 
   # Extra options for MSVC compiler.
   if platform.system() == 'Windows':
-    extra_args = extra_args + ['/MD', '/O2', '/Ob2', '/DNDEBUG']
+    extra_args.extend(['/MD', '/O2', '/Ob2', '/DNDEBUG'])
 
   # This is used for parallel builds; CMake will set PYX_TO_BUILD accordingly.
   if module is not None:


### PR DESCRIPTION
@zoq reported yesterday that a build with Python and `-DUSE_OPENMP=OFF` fails.  As it turns out, the reason for this is that an empty argument gets appended to the list of compilation flags, and then when those are joined with a space, we end up with two spaces in the compilation command.  For whatever reason, setuptools/cython does not like this, and it causes a compilation failure with a strange error message:

https://gist.github.com/zoq/8d65e3caf0a58ef9772e8466caeaf3cc

I fixed the issue by only adding `${OpenMP_CXX_FLAGS}` to the list of compilation arguments if it isn't empty.