### PR TITLE
Add methods to `BayesianLinearRegression` to change training parameters

### DIFF
--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.cpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.cpp
@@ -18,12 +18,12 @@ using namespace mlpack::regression;
 
 BayesianLinearRegression::BayesianLinearRegression(const bool centerData,
                                                    const bool scaleData,
-                                                   const size_t nIterMax,
-                                                   const double tol) :
+                                                   const size_t maxIterations,
+                                                   const double tolerance) :
   centerData(centerData),
   scaleData(scaleData),
-  nIterMax(nIterMax),
-  tol(tol),
+  maxIterations(maxIterations),
+  tolerance(tolerance),
   responsesOffset(0.0),
   alpha(0.0),
   beta(0.0),
@@ -60,7 +60,7 @@ double BayesianLinearRegression::Train(const arma::mat& data,
   unsigned short i = 0;
   double deltaAlpha = 1.0, deltaBeta = 1.0, crit = 1.0;
 
-  while ((crit > tol) && (i < nIterMax))
+  while ((crit > tolerance) && (i < maxIterations))
   {
     deltaAlpha = -alpha;
     deltaBeta = -beta;

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
@@ -21,30 +21,30 @@ namespace mlpack {
 namespace regression {
 
 /**
- * A Bayesian approach to the maximum likelihood estimation of the parameters 
- * \f$ \omega \f$ of the linear regression model. The Complexity is governed by 
- * the addition of a gaussian isotropic prior of precision \f$ \alpha \f$ over 
- * \f$ \omega \f$:  
+ * A Bayesian approach to the maximum likelihood estimation of the parameters
+ * \f$ \omega \f$ of the linear regression model. The Complexity is governed by
+ * the addition of a gaussian isotropic prior of precision \f$ \alpha \f$ over
+ * \f$ \omega \f$:
  *
  * \f[
  * p(\omega|\alpha) = \mathcal{N}(\omega|0, \alpha^{-1}I)
  * \f]
- * 
- * The optimization procedure calculates the posterior distribution of 
- * \f$ \omega \f$ knowing the data by maximizing an approximation of the log 
- * marginal likelihood derived from a type II maximum likelihood approximation. 
+ *
+ * The optimization procedure calculates the posterior distribution of
+ * \f$ \omega \f$ knowing the data by maximizing an approximation of the log
+ * marginal likelihood derived from a type II maximum likelihood approximation.
  * The determination of \f$ alpha \f$ and of the noise precision \f$ beta \f$
- * is part of the optimization process, leading to an automatic determination of 
- * w. The model being entirely based on probabilty distributions, uncertainties 
+ * is part of the optimization process, leading to an automatic determination of
+ * w. The model being entirely based on probabilty distributions, uncertainties
  * are available and easly computed for both the parameters and the predictions.
  *
- * The advantage over linear regression and ridge regression is that the 
+ * The advantage over linear regression and ridge regression is that the
  * regularization is determined from all the training data alone without any
- * require to an hold out method. 
+ * require to an hold out method.
  *
- * The code below is an implementation of the maximization of the evidence 
+ * The code below is an implementation of the maximization of the evidence
  * function described in the section 3.5.2 of the C.Bishop book, Pattern
- * Recognition and Machine Learning.  
+ * Recognition and Machine Learning.
  *
  * @code
  * @article{MacKay91bayesianinterpolation,
@@ -60,36 +60,37 @@ namespace regression {
  * @code
  * @book{Bishop:2006:PRM:1162264,
  *   author = {Bishop, Christopher M.},
- *   title = {Pattern Recognition and Machine Learning (Information Science 
+ *   title = {Pattern Recognition and Machine Learning (Information Science
  *            and Statistics)},
  *   chapter = {3}
  *   year = {2006},
  *   isbn = {0387310738},
  *   publisher = {Springer-Verlag},
  *   address = {Berlin, Heidelberg},
- * } 
+ * }
  * @endcode
- *   
+ *
  * Example of use:
  *
  * @code
  * arma::mat xTrain; // Train data matrix. Column-major.
  * arma::rowvec yTrain; // Train target values.
- 
+ *
  * // Train the model. Regularization strength is optimally tunned with the
  * // training data alone by applying the Train method.
- * BayesianLinearRegression estimator(); // Instanciate the estimator with default option.
+ * // Instantiate the estimator with default option.
+ * BayesianLinearRegression estimator;
  * estimator.Train(xTrain, yTrain);
- 
+ *
  * // Prediction on test points.
  * arma::mat xTest; // Test data matrix. Column-major.
  * arma::rowvec predictions;
- 
+ *
  * estimator.Predict(xTest, prediction);
- 
+ *
  * arma::rowvec yTest; // Test target values.
  * estimator.RMSE(xTest, yTest); // Evaluate using the RMSE score.
- 
+ *
  * // Compute the standard deviations of the predictions.
  * arma::rowvec stds;
  * estimator.Predict(xTest, responses, stds)
@@ -107,19 +108,20 @@ class BayesianLinearRegression
    *    examples.
    * @param scaleData Whether or not scale the data according to the
    *    standard deviation of each feature.
-   * @param nIterMax Maximum number of iterations for convergency.
-   * @param tol Level from which the solution is considered sufficientlly 
-   *    stable.  
+   * @param maxIterations Maximum number of iterations for convergency.
+   * @param tolerance Level from which the solution is considered sufficientlly
+   *    stable.
    */
   BayesianLinearRegression(const bool centerData = true,
                            const bool scaleData = false,
-                           const size_t nIterMax = 50,
-                           const double tol = 1e-4);
+                           const size_t maxIterations = 50,
+                           const double tolerance = 1e-4);
 
   /**
-   * Run BayesianLinearRegression. The input matrix (like all mlpack matrices) should be
-   * column-major -- each column is an observation and each row is a dimension.
-   * 
+   * Run BayesianLinearRegression. The input matrix (like all mlpack matrices)
+   * should be column-major -- each column is an observation and each row is a
+   * dimension.
+   *
    * @param data Column-major input data, dim(P, N).
    * @param responses A vector of targets, dim(N).
    * @return Root mean squared error.
@@ -139,12 +141,13 @@ class BayesianLinearRegression
                arma::rowvec& predictions) const;
 
   /**
-   * Predict \f$y_{i}\f$ and the standard deviation of the predictive posterior 
+   * Predict \f$y_{i}\f$ and the standard deviation of the predictive posterior
    * distribution for each data point in the given data matrix, using the
    * currently-trained Bayesian Ridge estimator.
    *
    * @param points The data point to apply the model.
-   * @param predictions Vector which will contain calculated values on completion.
+   * @param predictions Vector which will contain calculated values on
+   *     completion.
    * @param std Standard deviations of the predictions.
    */
   void Predict(const arma::mat& points,
@@ -163,7 +166,7 @@ class BayesianLinearRegression
               const arma::rowvec& responses) const;
 
   /**
-   * Get the solution vector. 
+   * Get the solution vector.
    *
    * @return omega Solution vector.
    */
@@ -187,7 +190,7 @@ class BayesianLinearRegression
 
   /**
    * Get the estimated variance. Train() must be called before.
-   *   
+   *
    * @return 1.0 / \f$ \beta \f$
    */
   double Variance() const { return 1.0 / Beta(); }
@@ -200,7 +203,7 @@ class BayesianLinearRegression
   const arma::colvec& DataOffset() const { return dataOffset; }
 
   /**
-   * Get the vector of standard deviations computed on the features over the 
+   * Get the vector of standard deviations computed on the features over the
    * training points.
    *
    * @return dataOffset
@@ -214,9 +217,31 @@ class BayesianLinearRegression
    */
   double ResponsesOffset() const { return responsesOffset; }
 
+  //! Get whether the data will be centered during training.
+  bool CenterData() const { return centerData; }
+  //! Modify whether the data will be centered during training.
+  bool& CenterData() { return centerData; }
+
+  //! Get whether the data will be scaled by standard deviations during
+  //! training.
+  bool ScaleData() const { return scaleData; }
+  //! Modify whether the data will be scaled by standard deviations during
+  //! training.
+  bool& ScaleData() { return scaleData; }
+
+  //! Get the maximum number of iterations for training.
+  size_t MaxIterations() const { return maxIterations; }
+  //! Modify the maximum number of iterations for training.
+  size_t& MaxIterations() { return maxIterations; }
+
+  //! Get the tolerance for training to converge.
+  double Tolerance() const { return tolerance; }
+  //! Modify the tolerance for training to converge.
+  double& Tolerance() { return tolerance; }
+
   /**
    * Serialize the BayesianLinearRegression model.
-   **/
+   */
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t version);
 
@@ -227,11 +252,11 @@ class BayesianLinearRegression
   //! Scale the data by standard deviations if true.
   bool scaleData;
 
-  //! Maximum number of iterations for convergency.
-  size_t nIterMax;
+  //! Maximum number of iterations for convergence.
+  size_t maxIterations;
 
   //! Level from which the solution is considered sufficientlly stable.
-  double tol;
+  double tolerance;
 
   //! Mean vector computed over the points.
   arma::colvec dataOffset;
@@ -251,7 +276,7 @@ class BayesianLinearRegression
   //! Effective number of parameters.
   double gamma;
 
-  //! Solution vector
+  //! Solution vector.
   arma::colvec omega;
 
   //! Covariance matrix of the solution vector omega.

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression_impl.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression_impl.hpp
@@ -26,8 +26,8 @@ void BayesianLinearRegression::serialize(Archive& ar,
 {
   ar(CEREAL_NVP(centerData));
   ar(CEREAL_NVP(scaleData));
-  ar(CEREAL_NVP(nIterMax));
-  ar(CEREAL_NVP(tol));
+  ar(CEREAL_NVP(maxIterations));
+  ar(CEREAL_NVP(tolerance));
   ar(CEREAL_NVP(dataOffset));
   ar(CEREAL_NVP(dataScale));
   ar(CEREAL_NVP(responsesOffset));


### PR DESCRIPTION
This fixes #2879.

I added the `CenterData()`, `ScaleData()`, `MaxIterations()`, and `Tolerance()` functions to change the training parameters of `BayesianLinearRegression`.

I also changed the variable name `nIterMax` to `maxIterations` to better match other parts of the codebase, and similarly for `tol` -> `tolerance`.

@mercierc you originally wrote this code, so please let me know if this breaks anything unintentionally that I overlooked.  It seems to pass the tests just fine. :)