### PR TITLE
Auto-detect a CSV header in `data::Load()`

### DIFF
--- a/src/mlpack/bindings/cli/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc_impl.hpp
@@ -98,8 +98,10 @@ std::string PrintTypeDoc(
         "of the data is detected by the extension of the filename.  The storage"
         " should be such that one row corresponds to one point, and one column "
         "corresponds to one dimension (this is the typical storage format for "
-        "on-disk data).  All values of the matrix will be loaded as double-"
-        "precision floating point data.";
+        "on-disk data).  CSV files will be checked for a header; if no header "
+        "is found, the first row will be loaded as a data point.  All values of"
+        " the matrix will be loaded as double-" "precision floating point "
+        "data.";
   }
   else if (std::is_same<T, arma::Mat<size_t>>::value)
   {
@@ -111,8 +113,10 @@ std::string PrintTypeDoc(
         "compiled with HDF5 support.  The type of the data is detected by the "
         "extension of the filename.  The storage should be such that one row "
         "corresponds to one point, and one column corresponds to one dimension "
-        "(this is the typical storage format for on-disk data).  All values of "
-        "the matrix will be loaded as unsigned integers.";
+        "(this is the typical storage format for on-disk data).  CSV files will"
+        " be checked for a header; if no header is found, the first row will be"
+        " loaded as a data point.  All values of the matrix will be loaded as "
+        "unsigned integers.";
   }
   else if (std::is_same<T, arma::rowvec>::value ||
            std::is_same<T, arma::vec>::value)

--- a/src/mlpack/bindings/cli/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc_impl.hpp
@@ -100,8 +100,7 @@ std::string PrintTypeDoc(
         "corresponds to one dimension (this is the typical storage format for "
         "on-disk data).  CSV files will be checked for a header; if no header "
         "is found, the first row will be loaded as a data point.  All values of"
-        " the matrix will be loaded as double-" "precision floating point "
-        "data.";
+        " the matrix will be loaded as double-precision floating point data.";
   }
   else if (std::is_same<T, arma::Mat<size_t>>::value)
   {

--- a/src/mlpack/core/data/detect_file_type.cpp
+++ b/src/mlpack/core/data/detect_file_type.cpp
@@ -54,7 +54,7 @@ std::string GetStringType(const arma::file_type& type)
  * @param f Opened istream to look into to guess the file type.
  * @param filename Name of file, for output purposes.
  */
-arma::file_type GuessFileType(std::istream& f, const std::string filename)
+arma::file_type GuessFileType(std::istream& f)
 {
   f.clear();
   const std::fstream::pos_type pos1 = f.tellg();
@@ -187,7 +187,7 @@ arma::file_type AutoDetect(std::fstream& stream, const std::string& filename)
 
   if (extension == "csv" || extension == "tsv")
   {
-    detectedLoadType = GuessFileType(stream, filename);
+    detectedLoadType = GuessFileType(stream);
     if (detectedLoadType == arma::csv_ascii)
     {
       if (extension == "tsv")
@@ -245,7 +245,7 @@ arma::file_type AutoDetect(std::fstream& stream, const std::string& filename)
     }
     else // It's not arma_ascii.  Now we let Armadillo guess.
     {
-      detectedLoadType = GuessFileType(stream, filename);
+      detectedLoadType = GuessFileType(stream);
 
       if (detectedLoadType != arma::raw_ascii &&
           detectedLoadType != arma::csv_ascii)

--- a/src/mlpack/core/data/detect_file_type.cpp
+++ b/src/mlpack/core/data/detect_file_type.cpp
@@ -137,11 +137,22 @@ arma::file_type GuessFileType(std::istream& f)
     while (std::getline(str, token, ','))
     {
       // Let's see if we can parse the token into a number.
-      try
+      double num;
+      std::string rest;
+
+      // Try to parse into a number.
+      std::stringstream s(token);
+      s >> num;
+      if (s.fail())
       {
-        (void) std::stod(token);
+        allNumeric = false;
+        break;
       }
-      catch (std::invalid_argument& s)
+
+      // Now check to see there isn't anything else.  (This catches cases like,
+      // e.g., "1a".)
+      s >> rest;
+      if (rest.length() > 0)
       {
         allNumeric = false;
         break;

--- a/src/mlpack/core/data/detect_file_type.cpp
+++ b/src/mlpack/core/data/detect_file_type.cpp
@@ -52,7 +52,6 @@ std::string GetStringType(const arma::file_type& type)
  * file.
  *
  * @param f Opened istream to look into to guess the file type.
- * @param filename Name of file, for output purposes.
  */
 arma::file_type GuessFileType(std::istream& f)
 {

--- a/src/mlpack/core/data/detect_file_type.hpp
+++ b/src/mlpack/core/data/detect_file_type.hpp
@@ -30,15 +30,23 @@ std::string GetStringType(const arma::file_type& type);
  * from Armadillo's function guess_file_type_internal(), but we avoid using
  * internal Armadillo functionality.
  *
+ * If the file is detected as a CSV, and the CSV is detected to have a header
+ * row, the stream `f` will be fast-forwarded to point at the second line of the
+ * file.
+ *
  * @param f Opened istream to look into to guess the file type.
+ * @param filename Name of file, for output purposes.
  */
-arma::file_type GuessFileType(std::istream& f);
+arma::file_type GuessFileType(std::istream& f, const std::string& filename);
 
 /**
  * Attempt to auto-detect the type of a file given its extension, and by
  * inspecting the parts of the file to disambiguate between types when
  * necessary.  (For instance, a .csv file could be delimited by spaces, commas,
  * or tabs.)  This is meant to be used during loading.
+ *
+ * If the file is detected as a CSV, and the CSV is detected to have a header
+ * row, `stream` will be fast-forwarded to point at the second line of the file.
  *
  * @param stream Opened file stream to look into for autodetection.
  * @param filename Name of the file.

--- a/src/mlpack/core/data/detect_file_type.hpp
+++ b/src/mlpack/core/data/detect_file_type.hpp
@@ -35,9 +35,8 @@ std::string GetStringType(const arma::file_type& type);
  * file.
  *
  * @param f Opened istream to look into to guess the file type.
- * @param filename Name of file, for output purposes.
  */
-arma::file_type GuessFileType(std::istream& f, const std::string& filename);
+arma::file_type GuessFileType(std::istream& f);
 
 /**
  * Attempt to auto-detect the type of a file given its extension, and by

--- a/src/mlpack/core/data/load.hpp
+++ b/src/mlpack/core/data/load.hpp
@@ -48,6 +48,10 @@ namespace data /** Functions to load and save matrices and models. */ {
  * `inputLoadType` parameter with the correct type above (e.g.
  * `arma::csv_ascii`.)
  *
+ * If the detected file type is CSV (`arma::csv_ascii`), the first row will be
+ * checked for a CSV header.  If a CSV header is not detected, the first row
+ * will be treated as data; otherwise, the first row will be skipped.
+ *
  * If the parameter 'fatal' is set to true, a std::runtime_error exception will
  * be thrown if the matrix does not load successfully.  The parameter
  * 'transpose' controls whether or not the matrix is transposed after loading.

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -2485,3 +2485,22 @@ TEST_CASE("DatasetMapperNonUniqueTest", "[LoadSaveTest]")
   REQUIRE(dm.UnmapString(nan, 0, 1) == "goodbye");
   REQUIRE(dm.UnmapString(nan, 0, 2) == "cheese");
 }
+
+/**
+ * Make sure if we load a CSV with a header, that that header doesn't get loaded
+ * as a point.
+ */
+TEST_CASE("LoadCSVHeaderTest", "[LoadSaveTest]")
+{
+  fstream f;
+  f.open("test.csv", fstream::out);
+  f << "a, b, c, d" << endl;
+  f << "1, 2, 3, 4" << endl;
+  f << "5, 6, 7, 8" << endl;
+
+  arma::mat dataset;
+  data::Load("test.csv", dataset);
+
+  REQUIRE(dataset.n_rows == 4);
+  REQUIRE(dataset.n_cols == 2);
+}


### PR DESCRIPTION
This changes the behavior of CSV loading in `data::Load()` (the overload that does not take a `DatasetInfo`).

Specifically, before this PR, if you had a CSV of this form:

```
a,b,c,d
1,2,3,4
5,6,7,8
```

it would actually be loaded as a matrix with *three* columns, treating the CSV row `a,b,c,d` as `0,0,0,0`.  This turned out to be part of a user issue in #2889.  Therefore, I wrote a patch for `data::Load()` to try and parse the first row of a CSV as `double`s.  If it succeeds, then we assume that the CSV file does not have a header row, and we load the first row as data.  If we cannot parse the first row of a CSV as `double`s, then we assume the CSV file does have a header, and we skip the first row.

I also updated documentation accordingly.