### PR TITLE
Fix LazyData Note in R-bindings.

### DIFF
--- a/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
+++ b/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
@@ -20,6 +20,5 @@ Suggests: testthat (>= 2.1.0)
 URL: https://www.mlpack.org/doc/mlpack-@PACKAGE_VERSION@/r_documentation.html,
      https://github.com/mlpack/mlpack
 BugReports: https://github.com/mlpack/mlpack/issues
-LazyData: true
 RoxygenNote: 7.1.0
 Encoding: UTF-8


### PR DESCRIPTION
I had notice a `LazyData` [NOTE](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/mlpack-00check.html) at CRAN mlpack result. Hence I have tired to fix this Note in this PR.