### PR TITLE
Refactor tests to use approx_equal() 

### DIFF
--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -76,7 +76,8 @@ TEST_CASE("JacobianBernoulliDistributionTest", "[ANNDistTest]")
     }
 
     module.LogProbBackward(target, jacobianB);
-    REQUIRE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))) <= 1e-5);
+      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 1e-5,1e-5));
+
   }
 }
 
@@ -121,7 +122,7 @@ TEST_CASE("JacobianBernoulliDistributionLogisticTest", "[ANNDistTest]")
     }
 
     module.LogProbBackward(target, jacobianB);
-    REQUIRE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))) <= 3e-5);
+      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 5e-3,5e-3));
   }
 }
 
@@ -222,7 +223,7 @@ TEST_CASE("JacobianNormalDistributionMeanTest", "[ANNDistTest]")
       jacobianB.col(k) = deltaMu % deriv;
     }
 
-    REQUIRE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))) <= 5e-3);
+      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 5e-3,5e-3));
   }
 }
 
@@ -288,6 +289,6 @@ TEST_CASE("JacobianNormalDistributionStandardDeviationTest", "[ANNDistTest]")
       jacobianB.col(k) = deltaSigma % deriv;
     }
 
-    REQUIRE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))) <= 5e-3);
+      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 5e-3,5e-3));
   }
 }

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -77,7 +77,6 @@ TEST_CASE("JacobianBernoulliDistributionTest", "[ANNDistTest]")
 
     module.LogProbBackward(target, jacobianB);
     REQUIRE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))) <= 1e-5);
-
   }
 }
 
@@ -122,7 +121,7 @@ TEST_CASE("JacobianBernoulliDistributionLogisticTest", "[ANNDistTest]")
     }
 
     module.LogProbBackward(target, jacobianB);
-    REQUIRE(arma::approx_equal(jacobianA, jacobianB, "both", 5e-3, 5e-3));
+    REQUIRE(arma::approx_equal(jacobianA, jacobianB, "both", 3e-5, 3e-5));
   }
 }
 

--- a/src/mlpack/tests/ann_dist_test.cpp
+++ b/src/mlpack/tests/ann_dist_test.cpp
@@ -76,7 +76,7 @@ TEST_CASE("JacobianBernoulliDistributionTest", "[ANNDistTest]")
     }
 
     module.LogProbBackward(target, jacobianB);
-      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 1e-5,1e-5));
+    REQUIRE(arma::max(arma::max(arma::abs(jacobianA - jacobianB))) <= 1e-5);
 
   }
 }
@@ -122,7 +122,7 @@ TEST_CASE("JacobianBernoulliDistributionLogisticTest", "[ANNDistTest]")
     }
 
     module.LogProbBackward(target, jacobianB);
-      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 5e-3,5e-3));
+    REQUIRE(arma::approx_equal(jacobianA, jacobianB, "both", 5e-3, 5e-3));
   }
 }
 
@@ -223,7 +223,7 @@ TEST_CASE("JacobianNormalDistributionMeanTest", "[ANNDistTest]")
       jacobianB.col(k) = deltaMu % deriv;
     }
 
-      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 5e-3,5e-3));
+    REQUIRE(arma::approx_equal(jacobianA, jacobianB, "both", 5e-3, 5e-3));
   }
 }
 
@@ -289,6 +289,6 @@ TEST_CASE("JacobianNormalDistributionStandardDeviationTest", "[ANNDistTest]")
       jacobianB.col(k) = deltaSigma % deriv;
     }
 
-      REQUIRE(arma::approx_equal(jacobianA, jacobianB,"both", 5e-3,5e-3));
+    REQUIRE(arma::approx_equal(jacobianA, jacobianB, "both", 5e-3, 5e-3));
   }
 }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -351,7 +351,6 @@ TEST_CASE("SimpleAlphaDropoutLayerTest", "[ANNLayerTest]")
   module.Backward(input, input, delta);
   REQUIRE(arma::as_scalar(arma::max(arma::abs(arma::mean(delta) - 0) <= 0.05)));
 
-
   // Test the Forward function when testing phase.
   module.Deterministic() = true;
   module.Forward(input, output);

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -256,7 +256,8 @@ TEST_CASE("SimpleDropoutLayerTest", "[ANNLayerTest]")
   // Test the Forward function.
   arma::mat output;
   module.Forward(input, output);
-  REQUIRE(arma::as_scalar(arma::abs(arma::mean(output) - (1 - p))) <= 0.05);
+  REQUIRE(arma::as_scalar(arma::abs(arma::mean(output) - (1 - p))) <= 0.05); 
+ // REQUIRE(arma::as_scalar(arma::approx_equal(mean(output), (1-p), "both", 0.05, 0.05 )));
 
   // Test the Backward function.
   arma::mat delta;
@@ -349,7 +350,8 @@ TEST_CASE("SimpleAlphaDropoutLayerTest", "[ANNLayerTest]")
   // Test the Backward function when training phase.
   arma::mat delta;
   module.Backward(input, input, delta);
-  REQUIRE(arma::as_scalar(arma::abs(arma::mean(delta) - 0)) <= 0.05);
+  REQUIRE(arma::as_scalar(arma::max(arma::abs(arma::mean(delta) - 0) <= 0.05)));
+
 
   // Test the Forward function when testing phase.
   module.Deterministic() = true;

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -257,7 +257,6 @@ TEST_CASE("SimpleDropoutLayerTest", "[ANNLayerTest]")
   arma::mat output;
   module.Forward(input, output);
   REQUIRE(arma::as_scalar(arma::abs(arma::mean(output) - (1 - p))) <= 0.05); 
- // REQUIRE(arma::as_scalar(arma::approx_equal(mean(output), (1-p), "both", 0.05, 0.05 )));
 
   // Test the Backward function.
   arma::mat delta;

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -256,7 +256,7 @@ TEST_CASE("SimpleDropoutLayerTest", "[ANNLayerTest]")
   // Test the Forward function.
   arma::mat output;
   module.Forward(input, output);
-  REQUIRE(arma::as_scalar(arma::abs(arma::mean(output) - (1 - p))) <= 0.05); 
+  REQUIRE(arma::as_scalar(arma::abs(arma::mean(output) - (1 - p))) <= 0.05);
 
   // Test the Backward function.
   arma::mat delta;
@@ -349,7 +349,7 @@ TEST_CASE("SimpleAlphaDropoutLayerTest", "[ANNLayerTest]")
   // Test the Backward function when training phase.
   arma::mat delta;
   module.Backward(input, input, delta);
-  REQUIRE(arma::as_scalar(arma::max(arma::abs(arma::mean(delta) - 0) <= 0.05)));
+  REQUIRE(arma::as_scalar(arma::abs(arma::mean(delta) - 0)) <= 0.05);
 
   // Test the Forward function when testing phase.
   module.Deterministic() = true;


### PR DESCRIPTION
I refactored tests for file 'ann_dist_test.cpp' in location  mlpack/tests/ . I am also still searching to see if there are any similar issues in other tests.
The link to the issue : https://github.com/mlpack/mlpack/issues/2897

The current one used abs(x-y) to check if values are almost equal. I refactored it with approx_value() funciton provided by armadillo.
