### PR TITLE
[WIP] Add DDPG reinforcement learning method

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -1,9 +1,9 @@
 #ifndef MLPACK_METHODS_RL_DDPG_HPP
 #define MLPACK_METHODS_RL_DDPG_HPP
 
-#include <vector>
-#include "ra_util.hpp"
-#include <training_config.hpp>
+#include <mlpack/prereqs.hpp>
+#include <mlpack/methods/ann/loss_functions/mean_squared_error.hpp>
+
 #include "training_config.hpp"
 #include "replay/random_replay.hpp"
 
@@ -51,7 +51,16 @@ class DDPG
   ReplayType& replayMethod;
 
   UpdaterType qNetworkUpdater;
+  #if ENS_VERSION_MAJOR >= 2
+  typename UpdaterType::template Policy<arma::mat, arma::mat>*
+    qNetworkUpdatePolicy;
+  #endif
+
   UpdaterType policyNetworkUpdater;
+  #if ENS_VERSION_MAJOR >= 2
+  typename UpdaterType::template Policy<arma::mat, arma::mat>*
+    policyNetworkUpdatePolicy;
+  #endif
 
   EnvironmentType environment;
   

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -59,6 +59,8 @@ class DDPG
   ActionType action;
 
   size_t totalSteps;
+
+  mlpack::ann::MeanSquaredError<> lossFunction;
 };
 
 } // namespace rl

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -1,0 +1,69 @@
+#ifndef MLPACK_METHODS_RL_DDPG_HPP
+#define MLPACK_METHODS_RL_DDPG_HPP
+
+#include <vector>
+#include "ra_util.hpp"
+#include <training_config.hpp>
+#include "training_config.hpp"
+#include "replay/random_replay.hpp"
+
+namespace mlpack {
+namespace rl {
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType = RandomReplay<EnvironmentType>
+>
+class DDPG
+{
+ public:
+  using StateType = typename EnvironmentType::State;
+  using ActionType = typename EnvironmentType::Action;
+
+  DDPG(TrainingConfig& config,
+       QNetworkType& qNetwork,
+       PolicyNetworkType& policyNetwork,
+       ReplayType& replayMethod,
+       UpdaterType qNetworkUpdater = UpdaterType(),
+       UpdaterType policyNetworkUpdater = UpdaterType(),
+       EnvironmentType environment = EnvironmentType());
+  
+  void SelectAction();
+
+  void SoftUpdateTargetNetwork(double tau);
+
+  void TrainAgent();
+  
+  double Episode();
+
+ private:
+  TrainingConfig& config;
+
+  PolicyNetworkType& policyNetwork;
+  PolicyNetworkType targetPolicyNetwork;
+  
+  QNetworkType& qNetwork;
+  QNetworkType targetQNetwork;
+  
+  ReplayType& replayMethod;
+
+  UpdaterType qNetworkUpdater;
+  UpdaterType policyNetworkUpdater;
+
+  EnvironmentType environment;
+  
+  StateType state;
+  ActionType action;
+
+  size_t totalSteps;
+};
+
+} // namespace rl
+} // namespace mlpack
+
+// Include implementation
+#include "ddpg_impl.hpp"
+#endif

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -41,8 +41,8 @@ class DDPG
   
   double Episode();
 
-  bool& Deterministic() { return &deterministic; }
-  const bool& Deterministic() { return deterministic; }
+  bool& Deterministic() { return deterministic; }
+  const bool& Deterministic() const { return deterministic; }
 
  private:
   TrainingConfig& config;

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -39,6 +39,9 @@ class DDPG
   
   double Episode();
 
+  bool& Deterministic() { return &deterministic; }
+  const bool& Deterministic() { return deterministic; }
+
  private:
   TrainingConfig& config;
 
@@ -68,6 +71,7 @@ class DDPG
   ActionType action;
 
   size_t totalSteps;
+  bool deterministic;
 
   mlpack::ann::MeanSquaredError<> lossFunction;
 };

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -1,3 +1,15 @@
+/**
+ * @file methods/reinforcement_learning/ddpg.hpp
+ * @author Tri Wahyu Guntara
+ *
+ * This file is the definition of DDPG class, which implements the
+ * Deep Deterministic Policy Gradient algorithm.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
 #ifndef MLPACK_METHODS_RL_DDPG_HPP
 #define MLPACK_METHODS_RL_DDPG_HPP
 
@@ -10,6 +22,35 @@
 namespace mlpack {
 namespace rl {
 
+/**
+ * @brief Implementation of Deep Deterministic Policy Gradient, a model-free
+ * off-policy actor-critic based deep reinforcement learning algorithm for
+ * continuous action spaces. DDPG can be thought of as being deep Q-learning
+ * for continous action spaces.
+ *
+ * For more details, see the following:
+ * @code
+ * @misc{lillicrap2015continuous,
+ *  author    = {Timothy P. Lillicrap and
+ *               Jonathan J. Hunt and
+ *               Alexander Pritzel and
+ *               Nicolas Heess and
+ *               Tom Erez and
+ *               Yuval Tassa and
+ *               David Silver and
+ *               Daan Wierstra},
+ *  title     = {Continuous control with deep reinforcement learning},
+ *  year      = {2015},
+ *  url       = {https://arxiv.org/abs/1509.02971}
+ * }
+ * @endcode
+ *
+ * @tparam EnvironmentType The environment of the reinforcement learning task.
+ * @tparam QNetworkType The network to compute action value.
+ * @tparam PolicyNetworkType The network to compute action given state.
+ * @tparam UpdaterType How to apply gradients when training.
+ * @tparam ReplayType Experience replay method.
+ */
 template <
   typename EnvironmentType,
   typename QNetworkType,
@@ -20,9 +61,25 @@ template <
 class DDPG
 {
  public:
+  //! Convenient typedef for state.
   using StateType = typename EnvironmentType::State;
+
+  //! Convenient typedef for action.
   using ActionType = typename EnvironmentType::Action;
 
+  /**
+   * @brief Create the DDPG object given settings.
+   * 
+   * @param config Hyper-parameter for training of type
+   *        `mlpack::rl::TrainingConfig`.
+   * @param qNetwork The network to compute action value.
+   * @param policyNetwork The network to compute action given state.
+   * @param replayMethod Experience replay method.
+   * @param qNetworkUpdater How to apply gradients when training Q network.
+   * @param policyNetworkUpdater How to apply gradients when training
+   *        policy network
+   * @param environment The environment of the reinforcement learning task.
+   */
   DDPG(TrainingConfig& config,
        QNetworkType& qNetwork,
        PolicyNetworkType& policyNetwork,
@@ -31,50 +88,96 @@ class DDPG
        UpdaterType policyNetworkUpdater = UpdaterType(),
        EnvironmentType environment = EnvironmentType());
   
+  /**
+   * @brief Destroy the DDPG object and clean memory.
+   */
   ~DDPG();
   
+  /**
+   * @brief Select action by passing state to policy network.
+   */
   void SelectAction();
 
-  void SoftUpdateTargetNetwork(double tau);
+  /**
+   * @brief Update the target networks by Polyak Averaging.
+   * 
+   * @param rho Weight of the current networks for averaging (0 <= rho <= 1).
+   */
+  void SoftUpdateTargetNetwork(double rho);
 
+  /**
+   * @brief Update the Q and policy networks.
+   */
   void TrainAgent();
   
+  /**
+   * @brief Execute an episode.
+   * 
+   * @return Return of the episode.
+   */
   double Episode();
 
+  //! Modify the total steps from the beginning.
+  size_t& TotalSteps() { return totalSteps; }
+  //! Get the total steps from the beginning.
+  const size_t& TotalSteps() const { return totalSteps; }
+
+  //! Modify the state of the agent.
+  StateType& State() { return state; }
+  //! Get the state of the agent.
+  const StateType& State() const { return state; }
+
+  //! Get the action of the agent.
+  const ActionType& Action() const { return action; }
+
+  //! Modify the training mode / test mode indicator.
   bool& Deterministic() { return deterministic; }
+  //! Get the indicator of training mode / test mode.
   const bool& Deterministic() const { return deterministic; }
 
  private:
+  //! Locally-stored hyper-parameters.
   TrainingConfig& config;
 
+  //! Locally-stored actual and target policy network.
   PolicyNetworkType& policyNetwork;
   PolicyNetworkType targetPolicyNetwork;
   
+  //! Locally-stored actual and target Q network.
   QNetworkType& qNetwork;
   QNetworkType targetQNetwork;
   
+  //! Locally-stored experience replay method.
   ReplayType& replayMethod;
 
+  //! Locally-stored updater for Q network.
   UpdaterType qNetworkUpdater;
   #if ENS_VERSION_MAJOR >= 2
   typename UpdaterType::template Policy<arma::mat, arma::mat>*
     qNetworkUpdatePolicy;
   #endif
 
+  //! Locally-stored updater for policy network.
   UpdaterType policyNetworkUpdater;
   #if ENS_VERSION_MAJOR >= 2
   typename UpdaterType::template Policy<arma::mat, arma::mat>*
     policyNetworkUpdatePolicy;
   #endif
 
+  //! Locally-stored environment of the reinforcement learning task.
   EnvironmentType environment;
   
+  //! Locally-stored current state and action of the agent.
   StateType state;
   ActionType action;
 
+  //! Locally-stored total steps from the beginning of the task.
   size_t totalSteps;
+
+  //! Locally-stored flag indicating training mode / test mode.
   bool deterministic;
 
+  //! Locally-stored loss function for Q network.
   mlpack::ann::MeanSquaredError<> lossFunction;
 };
 

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -31,6 +31,8 @@ class DDPG
        UpdaterType policyNetworkUpdater = UpdaterType(),
        EnvironmentType environment = EnvironmentType());
   
+  ~DDPG();
+  
   void SelectAction();
 
   void SoftUpdateTargetNetwork(double tau);

--- a/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
@@ -1,0 +1,157 @@
+#ifndef MLPACK_METHODS_RL_DDPG_IMPL_HPP
+#define MLPACK_METHODS_RL_DDPG_IMPL_HPP
+
+#include "ddpg.hpp"
+
+namespace mlpack {
+namespace rl {
+
+template <
+  typename EnvironmentType,
+  typename NetworkType,
+  typename UpdaterType,
+  typename PolicyType,
+  typename ReplayType
+>
+DDPG<
+  EnvironmentType,
+  NetworkType,
+  UpdaterType,
+  PolicyType,
+  ReplayType
+>::DDPG(TrainingConfig& config,
+        QNetworkType& qNetwork,
+        PolicyNetworkType& policyNetwork,
+        ReplayType& replayMethod,
+        UpdaterType qNetworkUpdater,
+        UpdaterType policyNetworkUpdater,
+        EnvironmentType environment):
+    config(config),
+    qNetwork(qNetwork),
+    policyNetwork(policyNetwork),
+    replayMethod(replayMethod),
+    qNetworkUpdater(std::move(qNetworkUpdater)),
+    policyNetworkUpdater(std::move(policyNetworkUpdater)),
+    environment(std::move(environment))
+{
+  if (qNetwork.Parameters().is_empty())
+    qNetwork.ResetParameters();
+  if (policyNetwork.Parameters().is_empty())
+    policyNetwork.ResetParameters();
+  
+  targetQNetwork = qNetwork;
+  targetPolicyNetwork = policyNetwork;
+
+  qNetworkUpdater.Initialize(qNetwork.Parameters().n_rows,
+                             qNetwork.Parameters().n_cols);
+  policyNetworkUpdater.Initialize(policyNetwork.Parameters().n_rows,
+                                  policyNetwork.Parameters().n_cols);
+}
+
+template <
+  typename EnvironmentType,
+  typename NetworkType,
+  typename UpdaterType,
+  typename PolicyType,
+  typename ReplayType
+>
+void DDPG<
+  EnvironmentType,
+  NetworkType,
+  UpdaterType,
+  PolicyType,
+  ReplayType
+>::SelectAction()
+{
+  arma::colvec outputAction;
+  policyNetwork.Predict(state.Encode(), outputAction);
+}
+
+template <
+  typename EnvironmentType,
+  typename NetworkType,
+  typename UpdaterType,
+  typename PolicyType,
+  typename ReplayType
+>
+void DDPG<
+  EnvironmentType,
+  NetworkType,
+  UpdaterType,
+  PolicyType,
+  ReplayType
+>::SoftUpdateTargetNetwork(double tau)
+{
+  targetQNetwork.Parameters() = tau * qNetwork.Parameters() + 
+      (1 - tau) * targetQNetwork.Parameters();
+  targetPolicyNetwork.Parameters() = tau * policyNetwork.Parameters() +
+      (1 - tau) * targetPolicyNetwork.Parameters();
+}
+
+template <
+  typename EnvironmentType,
+  typename NetworkType,
+  typename UpdaterType,
+  typename PolicyType,
+  typename ReplayType
+>
+void DDPG<
+  EnvironmentType,
+  NetworkType,
+  UpdaterType,
+  PolicyType,
+  ReplayType
+>::TrainAgent()
+{
+
+}
+
+template <
+  typename EnvironmentType,
+  typename NetworkType,
+  typename UpdaterType,
+  typename PolicyType,
+  typename ReplayType
+>
+double DDPG<
+  EnvironmentType,
+  NetworkType,
+  UpdaterType,
+  PolicyType,
+  ReplayType
+>::Episode()
+{
+  state = environment.InitialSample();
+  size_t steps= 0;
+  double totalReturn = 0.;
+
+  while (!environment.IsTerminal(state)) {
+    if (config.StepLimit() && steps >= config.StepLimit())
+      break;
+    
+    this->SelectAction();
+
+    StateType nextState;
+    double reward = environment.Sample(state, action, nextState);
+
+    totalReturn += reward;
+    steps++;
+    totalSteps++;
+
+    replayMethod.Store(state, action, reward, nextState,
+      environment.IsTerminal(nextState), config.Discount());
+
+    state = nextState;
+
+    // Make sure to populate the replay buffer before sampling.
+    if (totalSteps < config.ExplorationSteps())
+      continue;
+    
+    this->TrainAgent();
+  }
+}
+
+} // namespace rl
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
@@ -1,6 +1,8 @@
 #ifndef MLPACK_METHODS_RL_DDPG_IMPL_HPP
 #define MLPACK_METHODS_RL_DDPG_IMPL_HPP
 
+#include <mlpack/prereqs.hpp>
+
 #include "ddpg.hpp"
 
 namespace mlpack {
@@ -63,8 +65,16 @@ void DDPG<
   ReplayType
 >::SelectAction()
 {
+  // Get the deterministic action at current state from policy
   arma::colvec outputAction;
   policyNetwork.Predict(state.Encode(), outputAction);
+
+  // Add noise to convert the deterministic policy into exploration policy
+  arma::colvec noise = arma::randn<arma::colvec>(outputAction.n_rows) * 0.1;
+  noise = arma::clamp(noise, -0.25, 0.25);
+  outputAction = outputAction + noise;
+
+  action.action = arma::conv_to<decltype(action.action)>::from(outputAction);
 }
 
 template <
@@ -103,7 +113,81 @@ void DDPG<
   ReplayType
 >::TrainAgent()
 {
+  // Sample from previous experience.
+  arma::mat sampledStates;
+  std::vector<ActionType> sampledActionsVector;
+  arma::rowvec sampledRewards;
+  arma::mat sampledNextStates;
+  arma::irowvec isTerminal;
 
+  replayMethod.Sample(sampledStates, sampledActions, sampledRewards,
+      sampledNextStates, isTerminal);
+
+  /*
+    Critic network update.
+  */
+
+  // Predict next actions using target policy given sampled next states.
+  arma::mat predictedNextActions;
+  targetPolicyNetwork.Predict(sampledNextStates, predictedNextActions);
+
+  // Compute Q target values given sampled next states and predicted next actions.
+  arma::rowvec qTarget;
+  arma::mat qTargetInput = arma::join_vert(predictedNextActions, sampledNextStates);
+  targetQNetwork.Predict(qTargetInput, qTarget);
+
+  // Compute TD target.
+  arma::rowvec tdTarget = sampledRewards + config.Discount() * (
+      (1 - isTerminal) * qTarget);
+
+  // Compute Q values given sampled current states and sampled current actions.
+  arma::mat sampledActions(action.size, sampledActionsVector.size());
+  for (auto& a: sampledActionsVector)
+    sampledActions.col(i) = arma::conv_to<arma::colvec>::from(a.action);
+  
+  arma::mat Q;
+  arma::mat qInput = arma::join_vert(sampledActions, sampledStates);
+  qNetwork.Forward(qInput, Q);
+
+  // Compute gradient.
+  arma::mat gradLoss, gradQ;
+  lossFunction.Backward(Q, tdTarget, gradLoss);
+  qNetwork.Backward(qInput, gradLoss, gradQ);
+
+  // Update by applying gradient.
+  qNetworkUpdater.Update(qNetwork.Parameters(), config.StepSize(), gradQ);
+
+  /*
+    Actor network update.
+  */
+
+  // Compute gradient for each samples and then take the average.
+  arma::mat gradient;
+  for (size_t i = 0; i < sampledStates.n_cols; i++)
+  {
+    arma::colvec state = sampledStates.col(i);
+
+    // Predict action using true policy given sampled current state.
+    arma::colvec predictedAction;
+    policyNetwork.Forward(state, predictedAction);
+
+    // Compute Q value given sampled current state and predicted action.
+    qInput = arma::join_vert(predictedAction, state);
+    qNetwork.Forward(qInput, Q);
+
+    // Compute gradient.
+    qNetwork.Backward()
+    policyNetwork.Backward(state, )
+
+    if (i == 0)
+    {
+      gradient.copy_size(grad);
+      gradient.fill(0.0);
+    }
+
+    gradient += grad;
+  }
+  gradient /= sampledStates.n_cols;
 }
 
 template <

--- a/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
@@ -80,6 +80,27 @@ template <
   typename UpdaterType,
   typename ReplayType
 >
+DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::~DDPG()
+{
+  #if ENS_VERSION_MAJOR >= 2
+  delete qNetworkUpdatePolicy;
+  delete policyNetworkUpdatePolicy;
+  #endif
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
 void DDPG<
   EnvironmentType,
   QNetworkType,

--- a/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
@@ -55,7 +55,7 @@ DDPG<
                              qNetwork.Parameters().n_cols);
   #else
   qNetworkUpdatePolicy = new typename UpdaterType::template
-      Policy<arma::mat, arma::mat>(qNetworkUpdater,
+      Policy<arma::mat, arma::mat>(this->qNetworkUpdater,
                                    qNetwork.Parameters().n_rows,
                                    qNetwork.Parameters().n_cols);
   #endif
@@ -65,7 +65,7 @@ DDPG<
                                   policyNetwork.Parameters().n_cols);
   #else
   policyNetworkUpdatePolicy = new typename UpdaterType::template
-      Policy<arma::mat, arma::mat>(policyNetworkUpdater,
+      Policy<arma::mat, arma::mat>(this->policyNetworkUpdater,
                                    policyNetwork.Parameters().n_rows,
                                    policyNetwork.Parameters().n_cols);
   #endif


### PR DESCRIPTION
An implementation of **Deep Deterministic Policy Gradient** ([Lillicrap et al., 2015](https://arxiv.org/abs/1509.02971)). Square bracket [ ] denotes reference to the paper.

### To do
- [x] [ERROR] Fix actor update because there's still error in **derivative of Q with respect to action** [_Eq (6)_].
- [x] Add destructor for memory cleanup.
- [x] Add `Deterministic()` mode.
- [x] Add documentation.
- [ ] Add tests.

### Assumption made
- Noise used for exploratory policy is `Gaussian` with fixed `standard_deviation` and `clipping_threshold`, while the original paper used `Ornstein-Uhlenbeck` [_Eq (7)_]. `CustomNoiseType`, `standard_deviation`, and `clipping threshold` can be added as a parameter to the constructor later **if needed**.

### Question
What is the structure of the gradient matrix? As an example, see the following code snippet:
```
ann::FFN<ann::EmptyLoss<>, ann::GaussianInitialization> qNetwork(
  ann::EmptyLoss<>(), ann::GaussianInitialization(0, 0.1));
qNetwork.Add(new ann::Linear<>(2, 3));
qNetwork.Add(new ann::ReLULayer<>());
qNetwork.Add(new ann::Linear<>(3, 1));

arma::mat Q, gradQ;
arma::mat qInput = arma::join_vert(predictedAction, state); // assume only 1 sample i.e. qInput is 2x1
qNetwork.Forward(qInput, Q); // Q will be 1x1
qNetwork.Backward(qInput, -1, gradQ); // gradQ will be 13x1
```
`gradQ` has a shape of `13x1` because `first_layer + second_layer = (2x3 + 3) + (3x1 + 1) = 13`. What is the structure of `gradQ`? I need to take the **gradient of the parameters of the second layer** only in order to compute the **derivative of Q with respect to action** (right?).

**Edit** : turns out the answer to my question is the matrix is ordered in column-major order.