### PR TITLE
Include string header to resolve undefined type error

### DIFF
--- a/src/mlpack/tests/main_tests/gmm_generate_test.cpp
+++ b/src/mlpack/tests/main_tests/gmm_generate_test.cpp
@@ -9,6 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
+#include <string>
+
 #define BINDING_TYPE BINDING_TYPE_TEST
 static const std::string testName = "GmmGenerate";
 

--- a/src/mlpack/tests/main_tests/gmm_probability_test.cpp
+++ b/src/mlpack/tests/main_tests/gmm_probability_test.cpp
@@ -9,9 +9,9 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
+#include <string>
 
 #define BINDING_TYPE BINDING_TYPE_TEST
-
 static const std::string testName = "GmmProbability";
 
 #include <mlpack/core.hpp>

--- a/src/mlpack/tests/main_tests/range_search_test.cpp
+++ b/src/mlpack/tests/main_tests/range_search_test.cpp
@@ -9,6 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
+#include <string>
+
 #define BINDING_TYPE BINDING_TYPE_TEST
 static const std::string testName = "RangeSearchMain";
 


### PR DESCRIPTION
I guess you only run into the issue if you don't use cotire.