### PR TITLE
Don't build mlpack_test as part of make.

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -56,12 +56,12 @@ steps:
   displayName: 'CMake'
 
 # Build mlpack
-- script: cd build && make
+- script: cd build && make && make mlpack_test
   condition: eq(variables['CMakeArgs'], '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF')
   displayName: 'Build'
 
 # Build mlpack
-- script: cd build && make -j2
+- script: cd build && make -j2 && make -j2 mlpack_test
   condition: ne(variables['CMakeArgs'], '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF')
   displayName: 'Build'
 

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -45,7 +45,7 @@ steps:
   displayName: 'CMake'
 
 # Build mlpack
-- script: cd build && make -j2
+- script: cd build && make -j2 && make -j2 mlpack_test
   displayName: 'Build'
 
 # Run tests via ctest.

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -88,6 +88,7 @@ steps:
 # Run tests via ctest.
 - bash: |
     cd build
+    cmake --build . --target mlpack_test -C Release
     CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test -C Release . -j1
   displayName: 'Run tests via ctest'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
         - name: Build
           run: |
-            cd build && make -j2
+            cd build && make -j2 && make -j2 mlpack_test
 
         - name: Run tests via ctest
           run: |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -46,6 +46,9 @@
   * Fix Python binding build when the CMake variable `USE_OPENMP` is set to
     `OFF` (#2884).
 
+  * The `mlpack_test` target is no longer built as part of `make all`.  Use
+    `make mlpack_test` to build the tests.
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ also be built.  OpenMP will be used for parallelization when possible by
 default.
 
 Once CMake is configured, building the library is as simple as typing 'make'.
-This will build all library components as well as 'mlpack_test'.
+This will build all library components and bindings.
 
     $ make
 
@@ -242,6 +242,12 @@ If you do not want to build everything in the library, individual components
 of the build can be specified:
 
     $ make mlpack_pca mlpack_knn mlpack_kfn
+
+If you want to build the tests, just make the `mlpack_test` target, and use
+`ctest` to run the tests:
+
+    $ make mlpack_test
+    $ ctest .
 
 If the build fails and you cannot figure out why, register an account on Github
 and submit an issue. The mlpack developers will quickly help you figure it out:

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -170,7 +170,8 @@ The full list of options mlpack allows:
  - PROFILE=(ON/OFF): compile with profiling symbols (default OFF)
  - ARMA_EXTRA_DEBUG=(ON/OFF): compile with extra Armadillo debugging symbols
        (default OFF)
- - BUILD_TESTS=(ON/OFF): compile the \c mlpack_test program (default ON)
+ - BUILD_TESTS=(ON/OFF): compile the \c mlpack_test program when `make` is run
+       (default ON)
  - BUILD_CLI_EXECUTABLES=(ON/OFF): compile the mlpack command-line executables
        (i.e. \c mlpack_knn, \c mlpack_kfn, \c mlpack_logistic_regression, etc.)
        (default ON)
@@ -225,14 +226,10 @@ and libraries. These also use the '-D' flag.
 @section build_build Building mlpack
 
 Once CMake is configured, building the library is as simple as typing 'make'.
-This will build all library components as well as 'mlpack_test'.
+This will build all library components.
 
 @code
 $ make
-Scanning dependencies of target mlpack
-[  1%] Building CXX object
-src/mlpack/CMakeFiles/mlpack.dir/core/optimizers/aug_lagrangian/aug_lagrangian_test_functions.cpp.o
-<...>
 @endcode
 
 It's often useful to specify \c -jN to the \c make command, which will build on
@@ -247,17 +244,24 @@ $ make mlpack_pca mlpack_knn mlpack_kfn
 @endcode
 
 One particular component of interest is mlpack_test, which runs the mlpack test
-suite.  You can build this component with
+suite.  This is not built when @c make is run.  You can build this component
+with
 
 @code
 $ make mlpack_test
 @endcode
 
 We use <a href="https://github.com/catchorg/Catch2">Catch2</a> to write our tests.
-To run all tests, you can simply run:
+To run all tests, you can simply use CTest:
 
 @code
-$ ./bin/mlpack_test
+$ ctest .
+@endcode
+
+Or, you can run the test suite manually:
+
+@code
+$ bin/mlpack_test
 @endcode
 
 To run all tests in a particular file you can run:
@@ -266,7 +270,7 @@ To run all tests in a particular file you can run:
 $ ./bin/mlpack_test "[testname]"
 @endcode
 
-where testname is the name of the test suite. 
+where testname is the name of the test suite.
 For example to run all collaborative filtering tests implemented in cf_test.cpp you can run:
 
 @code

--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 # mlpack test executable.
 add_executable(mlpack_test
+  EXCLUDE_FROM_ALL
   activation_functions_test.cpp
   adaboost_test.cpp
   akfn_test.cpp


### PR DESCRIPTION
This is a follow-up to a suggestion by @conradsnicta in #2524.

Currently, users who download and build mlpack from source will *always* build `mlpack_test`, unless the user manually sets `BUILD_TESTS` to `OFF` when they configure with CMake.  But users are different than developers, and users are primarily interested in using the software for their own ends, not building and running the tests.  Especially given how memory- and compute-hungry the compilation process for `mlpack_test` is, I agree that it would be a good idea to disable this by default.

So, now, `mlpack_test` is not a part of the `all` target.  This means that a user who builds mlpack with `make` will not need to sit through the process of waiting for the tests to build.  (Or, more likely, waiting for their compilation to crash after it runs out of memory, or their system to start swapping and become unusable, etc., etc. :))

Users can still build the tests if they want to, if they do `make mlpack_test`.  I updated the documentation to point this out.