### PR TITLE
storing size of matrix in cli bindings

### DIFF
--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -48,7 +48,7 @@ void AddToCLI11(const std::string& cliName,
       {
         using TupleType = std::tuple<T, typename ParameterType<T>::type>;
         TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
-        std::get<1>(tuple) = boost::any_cast<std::string>(value);
+        std::get<0>(std::get<1>(tuple)) = boost::any_cast<std::string>(value);
         param.wasPassed = true;
       },
       param.desc.c_str());
@@ -110,7 +110,7 @@ void AddToCLI11(const std::string& cliName,
       {
         using TupleType = std::tuple<T, typename ParameterType<T>::type>;
         TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
-        std::get<1>(tuple) = boost::any_cast<std::string>(value);
+        std::get<0>(std::get<1>(tuple)) = boost::any_cast<std::string>(value);
         param.wasPassed = true;
       },
       param.desc.c_str());

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -46,7 +46,7 @@ void AddToCLI11(const std::string& cliName,
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
       {
-        using TupleType = std::tuple<T, typename ParameterType<T>::type, size_t, size_t>;
+        using TupleType = std::tuple<T, typename ParameterType<T>::type>;
         TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
         std::get<1>(tuple) = boost::any_cast<std::string>(value);
         param.wasPassed = true;
@@ -108,7 +108,7 @@ void AddToCLI11(const std::string& cliName,
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
       {
-        using TupleType = std::tuple<T, typename ParameterType<T>::type, size_t, size_t>;
+        using TupleType = std::tuple<T, typename ParameterType<T>::type>;
         TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
         std::get<1>(tuple) = boost::any_cast<std::string>(value);
         param.wasPassed = true;

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -46,7 +46,7 @@ void AddToCLI11(const std::string& cliName,
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
       {
-        using TupleType = std::tuple<T, typename ParameterType<T>::type>;
+        using TupleType = std::tuple<T, typename ParameterType<T>::type, size_t, size_t>;
         TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
         std::get<1>(tuple) = boost::any_cast<std::string>(value);
         param.wasPassed = true;
@@ -108,7 +108,7 @@ void AddToCLI11(const std::string& cliName,
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
       {
-        using TupleType = std::tuple<T, typename ParameterType<T>::type>;
+        using TupleType = std::tuple<T, typename ParameterType<T>::type, size_t, size_t>;
         TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
         std::get<1>(tuple) = boost::any_cast<std::string>(value);
         param.wasPassed = true;

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -100,11 +100,7 @@ class CLIOption
     else
     {
       typename ParameterType<typename std::remove_pointer<N>::type>::type tmp;
-      if(arma::is_arma_type<N>::value || 
-          std::is_same<N, std::tuple<data::DatasetInfo, arma::mat>>::value)
-      	data.value = boost::any(std::tuple<N, decltype(tmp), size_t, size_t>(defaultValue, tmp, 0, 0));
-      else
-      	data.value = boost::any(std::tuple<N, decltype(tmp)>(defaultValue, tmp));
+      data.value = boost::any(std::tuple<N, decltype(tmp)>(defaultValue, tmp));
     }
 
     const std::string tname = data.tname;

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -100,7 +100,8 @@ class CLIOption
     else
     {
       typename ParameterType<typename std::remove_pointer<N>::type>::type tmp;
-      if(arma::is_arma_type<N>::value)
+      if(arma::is_arma_type<N>::value || 
+          std::is_same<N, std::tuple<data::DatasetInfo, arma::mat>>::value)
       	data.value = boost::any(std::tuple<N, decltype(tmp), size_t, size_t>(defaultValue, tmp, 0, 0));
       else
       	data.value = boost::any(std::tuple<N, decltype(tmp)>(defaultValue, tmp));

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -100,7 +100,10 @@ class CLIOption
     else
     {
       typename ParameterType<typename std::remove_pointer<N>::type>::type tmp;
-      data.value = boost::any(std::tuple<N, decltype(tmp)>(defaultValue, tmp));
+      if(arma::is_arma_type<N>::value)
+      	data.value = boost::any(std::tuple<N, decltype(tmp), size_t, size_t>(defaultValue, tmp, 0, 0));
+      else
+      	data.value = boost::any(std::tuple<N, decltype(tmp)>(defaultValue, tmp));
     }
 
     const std::string tname = data.tname;

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -51,12 +51,10 @@ T& GetParam(
   // contains the filename.  It's possible we could load empty matrices many
   // times, but I am not bothered by that---it shouldn't be something that
   // happens.
-  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<1>(tuple);
   T& matrix = std::get<0>(tuple);
-  size_t& n_rows = std::get<2>(tuple);
-  size_t& n_cols = std::get<3>(tuple);
   if (d.input && !d.loaded)
   {
     // Call correct data::Load() function.
@@ -64,8 +62,6 @@ T& GetParam(
       data::Load(value, matrix, true);
     else
       data::Load(value, matrix, true, !d.noTranspose);
-    n_rows = matrix.n_rows;
-    n_cols = matrix.n_cols;
     d.loaded = true;
   }
 
@@ -85,17 +81,13 @@ T& GetParam(
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
-  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
+  typedef std::tuple<T, std::string> TupleType;
   TupleType* tuple = boost::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<1>(*tuple);
   T& t = std::get<0>(*tuple);
-  size_t& n_rows = std::get<2>(*tuple);
-  size_t& n_cols = std::get<3>(*tuple);
   if (d.input && !d.loaded)
   {
     data::Load(value, std::get<1>(t), std::get<0>(t), true, !d.noTranspose);
-    n_rows = std::get<1>(t).n_rows;
-    n_cols = std::get<1>(t).n_cols;
     d.loaded = true;
   }
 

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -53,8 +53,10 @@ T& GetParam(
   // happens.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
-  const std::string& value = std::get<1>(tuple);
+  const std::string& value = std::get<0>(std::get<1>(tuple));
   T& matrix = std::get<0>(tuple);
+  size_t& n_rows = std::get<1>(std::get<1>(tuple));
+  size_t& n_cols = std::get<2>(std::get<1>(tuple));
   if (d.input && !d.loaded)
   {
     // Call correct data::Load() function.
@@ -62,6 +64,8 @@ T& GetParam(
       data::Load(value, matrix, true);
     else
       data::Load(value, matrix, true, !d.noTranspose);
+    n_rows = matrix.n_rows;
+    n_cols = matrix.n_cols;
     d.loaded = true;
   }
 
@@ -81,13 +85,17 @@ T& GetParam(
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   TupleType* tuple = boost::any_cast<TupleType>(&d.value);
-  const std::string& value = std::get<1>(*tuple);
+  const std::string& value = std::get<0>(std::get<1>(*tuple));
   T& t = std::get<0>(*tuple);
+  size_t& n_rows = std::get<1>(std::get<1>(*tuple));
+  size_t& n_cols = std::get<2>(std::get<1>(*tuple));
   if (d.input && !d.loaded)
   {
     data::Load(value, std::get<1>(t), std::get<0>(t), true, !d.noTranspose);
+    n_rows = std::get<1>(t).n_rows;
+    n_cols = std::get<1>(t).n_cols;
     d.loaded = true;
   }
 

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -51,10 +51,12 @@ T& GetParam(
   // contains the filename.  It's possible we could load empty matrices many
   // times, but I am not bothered by that---it shouldn't be something that
   // happens.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<1>(tuple);
   T& matrix = std::get<0>(tuple);
+  size_t& n_rows = std::get<2>(tuple);
+  size_t& n_cols = std::get<3>(tuple);
   if (d.input && !d.loaded)
   {
     // Call correct data::Load() function.
@@ -62,6 +64,8 @@ T& GetParam(
       data::Load(value, matrix, true);
     else
       data::Load(value, matrix, true, !d.noTranspose);
+    n_rows = matrix.n_rows;
+    n_cols = matrix.n_cols;
     d.loaded = true;
   }
 
@@ -81,13 +85,17 @@ T& GetParam(
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
   TupleType* tuple = boost::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<1>(*tuple);
   T& t = std::get<0>(*tuple);
+  size_t& n_rows = std::get<2>(*tuple);
+  size_t& n_cols = std::get<3>(*tuple);
   if (d.input && !d.loaded)
   {
     data::Load(value, std::get<1>(t), std::get<0>(t), true, !d.noTranspose);
+    n_rows = std::get<1>(t).n_rows;
+    n_cols = std::get<1>(t).n_cols;
     d.loaded = true;
   }
 

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -87,6 +87,8 @@ std::string GetPrintableParam(
 
   if (std::get<1>(*tuple) != "")
   {
+    // make sure that the matrix is loaded, so that we can print its size.
+    GetParam<T>(const_cast<util::ParamData&>(data));
     std::string matDescription = std::to_string(std::get<2>(*tuple)) + "x";
                 matDescription += std::to_string(std::get<3>(*tuple)) + " matrix";
     oss << " (" << matDescription << ")";

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -89,8 +89,9 @@ std::string GetPrintableParam(
   {
     // Make sure the matrix is loaded so that we can print its size.
     GetParam<T>(const_cast<util::ParamData&>(data));
-    std::string matDescription = std::to_string(std::get<1>(std::get<1>(*tuple))) + "x";
-                matDescription += std::to_string(std::get<2>(std::get<1>(*tuple))) + " matrix";
+    std::string matDescription =
+        std::to_string(std::get<2>(std::get<1>(*tuple))) + "x" +
+        std::to_string(std::get<1>(std::get<1>(*tuple))) + " matrix";
 
     oss << " (" << matDescription << ")";
   }

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -83,13 +83,14 @@ std::string GetPrintableParam(
   const TupleType* tuple = boost::any_cast<TupleType>(&data.value);
 
   std::ostringstream oss;
-  oss << "'" << std::get<1>(*tuple) << "'";
+  oss << "'" << std::get<0>(std::get<1>(*tuple)) << "'";
 
-  if (std::get<1>(*tuple) != "")
+  if (std::get<0>(std::get<1>(*tuple)) != "")
   {
     // Make sure the matrix is loaded so that we can print its size.
-    T& mat = GetParam<T>(const_cast<util::ParamData&>(data));
-    std::string matDescription = GetMatrixSize(mat);
+    GetParam<T>(const_cast<util::ParamData&>(data));
+    std::string matDescription = std::to_string(std::get<1>(std::get<1>(*tuple))) + "x";
+                matDescription += std::to_string(std::get<2>(std::get<1>(*tuple))) + " matrix";
 
     oss << " (" << matDescription << ")";
   }

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -79,7 +79,7 @@ std::string GetPrintableParam(
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   // Extract the string from the tuple that's being held.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
   const TupleType* tuple = boost::any_cast<TupleType>(&data.value);
 
   std::ostringstream oss;
@@ -87,10 +87,8 @@ std::string GetPrintableParam(
 
   if (std::get<1>(*tuple) != "")
   {
-    // Make sure the matrix is loaded so that we can print its size.
-    T& mat = GetParam<T>(const_cast<util::ParamData&>(data));
-    std::string matDescription = GetMatrixSize(mat);
-
+    std::string matDescription = std::to_string(std::get<2>(*tuple)) + "x";
+                matDescription += std::to_string(std::get<3>(*tuple)) + " matrix";
     oss << " (" << matDescription << ")";
   }
 

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -79,7 +79,7 @@ std::string GetPrintableParam(
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   // Extract the string from the tuple that's being held.
-  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
   const TupleType* tuple = boost::any_cast<TupleType>(&data.value);
 
   std::ostringstream oss;
@@ -87,10 +87,10 @@ std::string GetPrintableParam(
 
   if (std::get<1>(*tuple) != "")
   {
-    // make sure that the matrix is loaded, so that we can print its size.
-    GetParam<T>(const_cast<util::ParamData&>(data));
-    std::string matDescription = std::to_string(std::get<2>(*tuple)) + "x";
-                matDescription += std::to_string(std::get<3>(*tuple)) + " matrix";
+    // Make sure the matrix is loaded so that we can print its size.
+    T& mat = GetParam<T>(const_cast<util::ParamData&>(data));
+    std::string matDescription = GetMatrixSize(mat);
+
     oss << " (" << matDescription << ")";
   }
 

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -48,7 +48,7 @@ T& GetRawParam(
                                    arma::mat>>::value>::type* = 0)
 {
   // Don't load the matrix.
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
   T& value = std::get<0>(*boost::any_cast<TupleType>(&d.value));
   return value;
 }

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -48,7 +48,7 @@ T& GetRawParam(
                                    arma::mat>>::value>::type* = 0)
 {
   // Don't load the matrix.
-  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
+  typedef std::tuple<T, std::string> TupleType;
   T& value = std::get<0>(*boost::any_cast<TupleType>(&d.value));
   return value;
 }

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -48,7 +48,7 @@ T& GetRawParam(
                                    arma::mat>>::value>::type* = 0)
 {
   // Don't load the matrix.
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   T& value = std::get<0>(*boost::any_cast<TupleType>(&d.value));
   return value;
 }

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -53,7 +53,8 @@ void InPlaceCopyInternal(
     const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T,
-                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value
+                 >::type* = 0)
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -67,7 +67,7 @@ void InPlaceCopyInternal(
 
 /**
  * Modify the filename for any type that needs to be loaded from disk to match
- * the filename of the input parameter. For Serializable object.
+ * the filename of the input parameter. For serializable objects.
  *
  * @param d ParamData object we want to make into an in-place copy.
  * @param input ParamData object whose filename we should copy.

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -41,7 +41,7 @@ void InPlaceCopyInternal(
 
 /**
  * Modify the filename for any type that needs to be loaded from disk to match
- * the filename of the input parameter. For matrix/dataset info.
+ * the filename of the input parameter.
  *
  * @param d ParamData object we want to make into an in-place copy.
  * @param input ParamData object whose filename we should copy.
@@ -50,34 +50,14 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& d,
     util::ParamData& input,
-    const typename std::enable_if<arma::is_arma_type<T>::value ||
-                                  std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const typename std::enable_if<
+        arma::is_arma_type<T>::value ||
+        std::is_same<T,
+                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value ||
+        data::HasSerialize<T>::value>::type* = 0)
 {
   // Make the output filename the same as the input filename.
-  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
-  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
-  std::string& value = std::get<1>(tuple);
-
-  const TupleType& inputTuple = *boost::any_cast<TupleType>(&input.value);
-  value = std::get<1>(inputTuple);
-}
-
-/**
- * Modify the filename for any type that needs to be loaded from disk to match
- * the filename of the input parameter. For serializable object.
- *
- * @param d ParamData object we want to make into an in-place copy.
- * @param input ParamData object whose filename we should copy.
- */
-template<typename T>
-void InPlaceCopyInternal(
-    util::ParamData& d,
-    util::ParamData& input,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
-{
-  // Make the output filename the same as the input filename.
-  typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   std::string& value = std::get<1>(tuple);
 

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -41,7 +41,7 @@ void InPlaceCopyInternal(
 
 /**
  * Modify the filename for any type that needs to be loaded from disk to match
- * the filename of the input parameter.
+ * the filename of the input parameter. For matrix/dataset info.
  *
  * @param d ParamData object we want to make into an in-place copy.
  * @param input ParamData object whose filename we should copy.
@@ -50,14 +50,34 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& d,
     util::ParamData& input,
-    const typename std::enable_if<
-        arma::is_arma_type<T>::value ||
-        std::is_same<T,
-                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value ||
-        data::HasSerialize<T>::value>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value ||
+                                  std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Make the output filename the same as the input filename.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
+  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
+  std::string& value = std::get<1>(tuple);
+
+  const TupleType& inputTuple = *boost::any_cast<TupleType>(&input.value);
+  value = std::get<1>(inputTuple);
+}
+
+/**
+ * Modify the filename for any type that needs to be loaded from disk to match
+ * the filename of the input parameter. For serializable object.
+ *
+ * @param d ParamData object we want to make into an in-place copy.
+ * @param input ParamData object whose filename we should copy.
+ */
+template<typename T>
+void InPlaceCopyInternal(
+    util::ParamData& d,
+    util::ParamData& input,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+{
+  // Make the output filename the same as the input filename.
+  typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   std::string& value = std::get<1>(tuple);
 

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -41,7 +41,7 @@ void InPlaceCopyInternal(
 
 /**
  * Modify the filename for any type that needs to be loaded from disk to match
- * the filename of the input parameter.
+ * the filename of the input parameter. For matrix/datasetinfo parameter.
  *
  * @param d ParamData object we want to make into an in-place copy.
  * @param input ParamData object whose filename we should copy.
@@ -53,11 +53,33 @@ void InPlaceCopyInternal(
     const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T,
-                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value ||
-        data::HasSerialize<T>::value>::type* = 0)
+                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
+  std::string& value = std::get<0>(std::get<1>(tuple));
+
+  const TupleType& inputTuple = *boost::any_cast<TupleType>(&input.value);
+  value = std::get<0>(std::get<1>(inputTuple));
+}
+
+/**
+ * Modify the filename for any type that needs to be loaded from disk to match
+ * the filename of the input parameter. For Serializable object.
+ *
+ * @param d ParamData object we want to make into an in-place copy.
+ * @param input ParamData object whose filename we should copy.
+ */
+template<typename T>
+void InPlaceCopyInternal(
+    util::ParamData& d,
+    util::ParamData& input,
+    const typename std::enable_if<
+        data::HasSerialize<T>::value>::type* = 0)
+{
+  // Make the output filename the same as the input filename.
+  typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   std::string& value = std::get<1>(tuple);
 

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -41,7 +41,7 @@ void InPlaceCopyInternal(
 
 /**
  * Modify the filename for any type that needs to be loaded from disk to match
- * the filename of the input parameter. For matrix/datasetinfo parameter.
+ * the filename of the input parameter, for a matrix/DatasetInfo parameter.
  *
  * @param d ParamData object we want to make into an in-place copy.
  * @param input ParamData object whose filename we should copy.

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -53,7 +53,7 @@ void OutputParamImpl(
     util::ParamData& data,
     const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
 {
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
   const T& output = std::get<0>(*boost::any_cast<TupleType>(&data.value));
   const std::string& filename =
       std::get<1>(*boost::any_cast<TupleType>(&data.value));
@@ -95,7 +95,7 @@ void OutputParamImpl(
         std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
 {
   // Output the matrix with the mappings.
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
   const T& tuple = std::get<0>(*boost::any_cast<TupleType>(&data.value));
   const std::string& filename =
       std::get<1>(*boost::any_cast<TupleType>(&data.value));

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -53,10 +53,10 @@ void OutputParamImpl(
     util::ParamData& data,
     const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
 {
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   const T& output = std::get<0>(*boost::any_cast<TupleType>(&data.value));
   const std::string& filename =
-      std::get<1>(*boost::any_cast<TupleType>(&data.value));
+      std::get<0>(std::get<1>(*boost::any_cast<TupleType>(&data.value)));
 
   if (output.n_elem > 0 && filename != "")
   {
@@ -95,10 +95,10 @@ void OutputParamImpl(
         std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
 {
   // Output the matrix with the mappings.
-  typedef std::tuple<T, std::string> TupleType;
+  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   const T& tuple = std::get<0>(*boost::any_cast<TupleType>(&data.value));
   const std::string& filename =
-      std::get<1>(*boost::any_cast<TupleType>(&data.value));
+      std::get<0>(std::get<1>(*boost::any_cast<TupleType>(&data.value)));
   const arma::mat& matrix = std::get<1>(tuple);
 
   // The mapping isn't taken into account.  We should write a data::Save()

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -53,7 +53,7 @@ void OutputParamImpl(
     util::ParamData& data,
     const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
 {
-  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
+  typedef std::tuple<T, std::string> TupleType;
   const T& output = std::get<0>(*boost::any_cast<TupleType>(&data.value));
   const std::string& filename =
       std::get<1>(*boost::any_cast<TupleType>(&data.value));
@@ -95,7 +95,7 @@ void OutputParamImpl(
         std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
 {
   // Output the matrix with the mappings.
-  typedef std::tuple<T, std::string, size_t, size_t> TupleType;
+  typedef std::tuple<T, std::string> TupleType;
   const T& tuple = std::get<0>(*boost::any_cast<TupleType>(&data.value));
   const std::string& filename =
       std::get<1>(*boost::any_cast<TupleType>(&data.value));

--- a/src/mlpack/bindings/cli/parameter_type.hpp
+++ b/src/mlpack/bindings/cli/parameter_type.hpp
@@ -53,7 +53,7 @@ struct ParameterType
 template<typename eT>
 struct ParameterType<arma::Col<eT>>
 {
-  typedef std::string type;
+  typedef std::tuple<std::string, size_t, size_t> type;
 };
 
 /**
@@ -65,7 +65,7 @@ struct ParameterType<arma::Col<eT>>
 template<typename eT>
 struct ParameterType<arma::Row<eT>>
 {
-  typedef std::string type;
+  typedef std::tuple<std::string, size_t, size_t> type;
 };
 
 /**
@@ -76,7 +76,7 @@ struct ParameterType<arma::Row<eT>>
 template<typename eT>
 struct ParameterType<arma::Mat<eT>>
 {
-  typedef std::string type;
+  typedef std::tuple<std::string, size_t, size_t> type;
 };
 
 /**
@@ -86,7 +86,7 @@ template<typename eT, typename PolicyType>
 struct ParameterType<std::tuple<mlpack::data::DatasetMapper<PolicyType,
                          std::string>, arma::Mat<eT>>>
 {
-  typedef std::string type;
+  typedef std::tuple<std::string, size_t, size_t> type;
 };
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -51,8 +51,8 @@ void SetParam(
 }
 
 /**
- * Set a matrix parameter, a matrix/dataset info parameter.
- * These set the filename referring to the parameter.
+ * Set a matrix parameter, a matrix/dataset info parameter, or a serializable
+ * object.  These set the filename referring to the parameter.
  */
 template<typename T>
 void SetParam(
@@ -63,7 +63,7 @@ void SetParam(
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // We're setting the string filename.
-  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   std::get<1>(tuple) = boost::any_cast<std::string>(value);
 }

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -51,8 +51,8 @@ void SetParam(
 }
 
 /**
- * Set a matrix parameter, a matrix/dataset info parameter, or a serializable
- * object.  These set the filename referring to the parameter.
+ * Set a matrix parameter, a matrix/dataset info parameter.
+ * These set the filename referring to the parameter.
  */
 template<typename T>
 void SetParam(
@@ -65,7 +65,7 @@ void SetParam(
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
-  std::get<1>(tuple) = boost::any_cast<std::string>(value);
+  std::get<0>(std::get<1>(tuple)) = boost::any_cast<std::string>(value);
 }
 
 /**

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -51,8 +51,8 @@ void SetParam(
 }
 
 /**
- * Set a matrix parameter, a matrix/dataset info parameter, or a serializable
- * object.  These set the filename referring to the parameter.
+ * Set a matrix parameter, a matrix/dataset info parameter.
+ * These set the filename referring to the parameter.
  */
 template<typename T>
 void SetParam(

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -63,7 +63,7 @@ void SetParam(
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // We're setting the string filename.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  typedef std::tuple<T, typename ParameterType<T>::type, size_t, size_t> TupleType;
   TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
   std::get<1>(tuple) = boost::any_cast<std::string>(value);
 }

--- a/src/mlpack/tests/cli_binding_test.cpp
+++ b/src/mlpack/tests/cli_binding_test.cpp
@@ -82,7 +82,7 @@ TEST_CASE("GetParamLoadedMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  tuple<arma::mat, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
+  tuple<arma::mat, string> tuple = make_tuple(m, filename);
   d.value = boost::any(tuple);
   // Mark it as already loaded.
   d.input = true;
@@ -106,7 +106,7 @@ TEST_CASE("GetParamUnloadedMatTest", "[CLIOptionTest]")
   arma::mat test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::mat m;
-  tuple<arma::mat, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
+  tuple<arma::mat, string> tuple = make_tuple(m, filename);
   d.value = boost::any(tuple);
   // Make sure it is not loaded yet.
   d.input = true;
@@ -132,7 +132,7 @@ TEST_CASE("GetParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::Mat<size_t> m(5, 5, arma::fill::ones);
-  tuple<arma::Mat<size_t>, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
+  tuple<arma::Mat<size_t>, string> tuple = make_tuple(m, filename);
   d.value = boost::any(tuple);
   // Mark it as already loaded.
   d.input = true;
@@ -157,7 +157,7 @@ TEST_CASE("GetParamUnloadedUmatTest", "[CLIOptionTest]")
   arma::Mat<size_t> test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::Mat<size_t> m;
-  tuple<arma::Mat<size_t>, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
+  tuple<arma::Mat<size_t>, string> tuple = make_tuple(m, filename);
   d.value = boost::any(tuple);
   // Make sure it is not loaded yet.
   d.input = true;
@@ -200,7 +200,7 @@ TEST_CASE("GetParamDatasetInfoMatTest", "[CLIOptionTest]")
   arma::mat m;
 
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
-  tuple<decltype(tuple1), string, size_t, size_t> tuple2 = make_tuple(tuple1, filename, 0, 0);
+  tuple<decltype(tuple1), string> tuple2 = make_tuple(tuple1, filename);
 
   d.value = boost::any(tuple2);
   // Make sure it is not loaded yet.
@@ -274,7 +274,7 @@ TEST_CASE("RawParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  tuple<arma::mat, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
+  tuple<arma::mat, string> tuple = make_tuple(m, filename);
   d.value = boost::any(tuple);
   d.input = true;
   d.loaded = false;
@@ -324,7 +324,7 @@ TEST_CASE("GetRawParamDatasetInfoTest", "[CLIOptionTest]")
   arma::mat m(3, 3, arma::fill::randu);
 
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
-  tuple<decltype(tuple1), string, size_t, size_t> tuple2 = make_tuple(tuple1, filename, 0, 0);
+  tuple<decltype(tuple1), string> tuple2 = make_tuple(tuple1, filename);
 
   d.value = boost::any(tuple2);
   // Make sure it is not loaded yet.
@@ -350,7 +350,7 @@ TEST_CASE("OutputParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::mat m(3, 3, arma::fill::randu);
-  tuple<arma::mat, string, size_t, size_t> t = make_tuple(m, filename, 0, 0);
+  tuple<arma::mat, string> t = make_tuple(m, filename);
 
   d.value = boost::any(t);
   d.input = false;
@@ -376,7 +376,7 @@ TEST_CASE("OutputParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::Mat<size_t> m(3, 3, arma::fill::randu);
-  tuple<arma::Mat<size_t>, string, size_t, size_t> t = make_tuple(m, filename, 0, 0);
+  tuple<arma::Mat<size_t>, string> t = make_tuple(m, filename);
 
   d.value = boost::any(t);
   d.input = false;
@@ -467,7 +467,7 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
   // Create initial value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::randu);
-  d.value = boost::any(make_tuple(m, filename, size_t(0), size_t(0)));
+  d.value = boost::any(make_tuple(m, filename));
 
   // Get a new string.
   string newFilename = "new.csv";
@@ -475,9 +475,10 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
 
   SetParam<arma::mat>((util::ParamData&) d, (const void*) &a2,
       (void*) NULL);
+
   // Make sure the change went through.
-  tuple<arma::mat, string, size_t, size_t>& t =
-      *boost::any_cast<tuple<arma::mat, string, size_t, size_t>>(&d.value);
+  tuple<arma::mat, string>& t =
+      *boost::any_cast<tuple<arma::mat, string>>(&d.value);
   REQUIRE(get<1>(t) == "new.csv");
 }
 
@@ -517,8 +518,7 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
   arma::mat m(3, 3, arma::fill::randu);
   DatasetInfo di(3);
   tuple<DatasetInfo, arma::mat> t1 = make_tuple(di, m);
-  tuple<tuple<DatasetInfo, arma::mat>, string, size_t, size_t> t2 = make_tuple(t1, filename, 
-      size_t(0), size_t(0));
+  tuple<tuple<DatasetInfo, arma::mat>, string> t2 = make_tuple(t1, filename);
   d.value = boost::any(t2);
   d.noTranspose = false;
 
@@ -530,8 +530,8 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
       (const void*) &a2, (void*) NULL);
 
   // Check that the name is right.
-  tuple<tuple<DatasetInfo, arma::mat>, string, size_t, size_t>& t3 =
-      *boost::any_cast<tuple<tuple<DatasetInfo, arma::mat>, string, size_t, size_t>>(&d.value);
+  tuple<tuple<DatasetInfo, arma::mat>, string>& t3 =
+      *boost::any_cast<tuple<tuple<DatasetInfo, arma::mat>, string>>(&d.value);
 
   REQUIRE(get<1>(t3) == "new_filename.csv");
 }
@@ -556,7 +556,7 @@ TEST_CASE("GetAllocatedMemoryNonModelTest", "[CLIOptionTest]")
   // Also test with a matrix type.
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  tuple<arma::mat, string, size_t, size_t> t = make_tuple(test, filename, 0, 0);
+  tuple<arma::mat, string> t = make_tuple(test, filename);
   d.value = boost::any(t);
 
   result = (void*) 1;
@@ -602,7 +602,7 @@ TEST_CASE("DeleteAllocatedMemoryNonModelTest", "[CLIOptionTest]")
 
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  tuple<arma::mat, string, size_t, size_t> t = make_tuple(test, filename, 0, 0);
+  tuple<arma::mat, string> t = make_tuple(test, filename);
   d.value = boost::any(t);
 
   DeleteAllocatedMemory<arma::mat>((util::ParamData&) d,

--- a/src/mlpack/tests/cli_binding_test.cpp
+++ b/src/mlpack/tests/cli_binding_test.cpp
@@ -82,7 +82,7 @@ TEST_CASE("GetParamLoadedMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  tuple<arma::mat, string> tuple = make_tuple(m, filename);
+  tuple<arma::mat, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
   d.value = boost::any(tuple);
   // Mark it as already loaded.
   d.input = true;
@@ -106,7 +106,7 @@ TEST_CASE("GetParamUnloadedMatTest", "[CLIOptionTest]")
   arma::mat test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::mat m;
-  tuple<arma::mat, string> tuple = make_tuple(m, filename);
+  tuple<arma::mat, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
   d.value = boost::any(tuple);
   // Make sure it is not loaded yet.
   d.input = true;
@@ -132,7 +132,7 @@ TEST_CASE("GetParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::Mat<size_t> m(5, 5, arma::fill::ones);
-  tuple<arma::Mat<size_t>, string> tuple = make_tuple(m, filename);
+  tuple<arma::Mat<size_t>, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
   d.value = boost::any(tuple);
   // Mark it as already loaded.
   d.input = true;
@@ -157,7 +157,7 @@ TEST_CASE("GetParamUnloadedUmatTest", "[CLIOptionTest]")
   arma::Mat<size_t> test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::Mat<size_t> m;
-  tuple<arma::Mat<size_t>, string> tuple = make_tuple(m, filename);
+  tuple<arma::Mat<size_t>, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
   d.value = boost::any(tuple);
   // Make sure it is not loaded yet.
   d.input = true;
@@ -200,7 +200,7 @@ TEST_CASE("GetParamDatasetInfoMatTest", "[CLIOptionTest]")
   arma::mat m;
 
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
-  tuple<decltype(tuple1), string> tuple2 = make_tuple(tuple1, filename);
+  tuple<decltype(tuple1), string, size_t, size_t> tuple2 = make_tuple(tuple1, filename, 0, 0);
 
   d.value = boost::any(tuple2);
   // Make sure it is not loaded yet.
@@ -274,7 +274,7 @@ TEST_CASE("RawParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  tuple<arma::mat, string> tuple = make_tuple(m, filename);
+  tuple<arma::mat, string, size_t, size_t> tuple = make_tuple(m, filename, 0, 0);
   d.value = boost::any(tuple);
   d.input = true;
   d.loaded = false;
@@ -324,7 +324,7 @@ TEST_CASE("GetRawParamDatasetInfoTest", "[CLIOptionTest]")
   arma::mat m(3, 3, arma::fill::randu);
 
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
-  tuple<decltype(tuple1), string> tuple2 = make_tuple(tuple1, filename);
+  tuple<decltype(tuple1), string, size_t, size_t> tuple2 = make_tuple(tuple1, filename, 0, 0);
 
   d.value = boost::any(tuple2);
   // Make sure it is not loaded yet.
@@ -350,7 +350,7 @@ TEST_CASE("OutputParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::mat m(3, 3, arma::fill::randu);
-  tuple<arma::mat, string> t = make_tuple(m, filename);
+  tuple<arma::mat, string, size_t, size_t> t = make_tuple(m, filename, 0, 0);
 
   d.value = boost::any(t);
   d.input = false;
@@ -376,7 +376,7 @@ TEST_CASE("OutputParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::Mat<size_t> m(3, 3, arma::fill::randu);
-  tuple<arma::Mat<size_t>, string> t = make_tuple(m, filename);
+  tuple<arma::Mat<size_t>, string, size_t, size_t> t = make_tuple(m, filename, 0, 0);
 
   d.value = boost::any(t);
   d.input = false;
@@ -467,7 +467,7 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
   // Create initial value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::randu);
-  d.value = boost::any(make_tuple(m, filename));
+  d.value = boost::any(make_tuple(m, filename, size_t(0), size_t(0)));
 
   // Get a new string.
   string newFilename = "new.csv";
@@ -475,10 +475,9 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
 
   SetParam<arma::mat>((util::ParamData&) d, (const void*) &a2,
       (void*) NULL);
-
   // Make sure the change went through.
-  tuple<arma::mat, string>& t =
-      *boost::any_cast<tuple<arma::mat, string>>(&d.value);
+  tuple<arma::mat, string, size_t, size_t>& t =
+      *boost::any_cast<tuple<arma::mat, string, size_t, size_t>>(&d.value);
   REQUIRE(get<1>(t) == "new.csv");
 }
 
@@ -518,7 +517,8 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
   arma::mat m(3, 3, arma::fill::randu);
   DatasetInfo di(3);
   tuple<DatasetInfo, arma::mat> t1 = make_tuple(di, m);
-  tuple<tuple<DatasetInfo, arma::mat>, string> t2 = make_tuple(t1, filename);
+  tuple<tuple<DatasetInfo, arma::mat>, string, size_t, size_t> t2 = make_tuple(t1, filename, 
+      size_t(0), size_t(0));
   d.value = boost::any(t2);
   d.noTranspose = false;
 
@@ -530,8 +530,8 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
       (const void*) &a2, (void*) NULL);
 
   // Check that the name is right.
-  tuple<tuple<DatasetInfo, arma::mat>, string>& t3 =
-      *boost::any_cast<tuple<tuple<DatasetInfo, arma::mat>, string>>(&d.value);
+  tuple<tuple<DatasetInfo, arma::mat>, string, size_t, size_t>& t3 =
+      *boost::any_cast<tuple<tuple<DatasetInfo, arma::mat>, string, size_t, size_t>>(&d.value);
 
   REQUIRE(get<1>(t3) == "new_filename.csv");
 }
@@ -556,7 +556,7 @@ TEST_CASE("GetAllocatedMemoryNonModelTest", "[CLIOptionTest]")
   // Also test with a matrix type.
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  tuple<arma::mat, string> t = make_tuple(test, filename);
+  tuple<arma::mat, string, size_t, size_t> t = make_tuple(test, filename, 0, 0);
   d.value = boost::any(t);
 
   result = (void*) 1;
@@ -602,7 +602,7 @@ TEST_CASE("DeleteAllocatedMemoryNonModelTest", "[CLIOptionTest]")
 
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  tuple<arma::mat, string> t = make_tuple(test, filename);
+  tuple<arma::mat, string, size_t, size_t> t = make_tuple(test, filename, 0, 0);
   d.value = boost::any(t);
 
   DeleteAllocatedMemory<arma::mat>((util::ParamData&) d,

--- a/src/mlpack/tests/cli_binding_test.cpp
+++ b/src/mlpack/tests/cli_binding_test.cpp
@@ -82,7 +82,9 @@ TEST_CASE("GetParamLoadedMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  tuple<arma::mat, string> tuple = make_tuple(m, filename);
+  typedef std::tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::mat, TupleType> tuple = make_tuple(m, testTuple);
   d.value = boost::any(tuple);
   // Mark it as already loaded.
   d.input = true;
@@ -106,7 +108,9 @@ TEST_CASE("GetParamUnloadedMatTest", "[CLIOptionTest]")
   arma::mat test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::mat m;
-  tuple<arma::mat, string> tuple = make_tuple(m, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::mat, TupleType> tuple = make_tuple(m, testTuple);
   d.value = boost::any(tuple);
   // Make sure it is not loaded yet.
   d.input = true;
@@ -132,7 +136,9 @@ TEST_CASE("GetParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::Mat<size_t> m(5, 5, arma::fill::ones);
-  tuple<arma::Mat<size_t>, string> tuple = make_tuple(m, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::Mat<size_t>, TupleType> tuple = make_tuple(m, testTuple);
   d.value = boost::any(tuple);
   // Mark it as already loaded.
   d.input = true;
@@ -157,7 +163,9 @@ TEST_CASE("GetParamUnloadedUmatTest", "[CLIOptionTest]")
   arma::Mat<size_t> test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::Mat<size_t> m;
-  tuple<arma::Mat<size_t>, string> tuple = make_tuple(m, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::Mat<size_t>, TupleType> tuple = make_tuple(m, testTuple);
   d.value = boost::any(tuple);
   // Make sure it is not loaded yet.
   d.input = true;
@@ -199,8 +207,10 @@ TEST_CASE("GetParamDatasetInfoMatTest", "[CLIOptionTest]")
   data::DatasetInfo dd;
   arma::mat m;
 
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
-  tuple<decltype(tuple1), string> tuple2 = make_tuple(tuple1, filename);
+  tuple<decltype(tuple1), TupleType> tuple2 = make_tuple(tuple1, testTuple);
 
   d.value = boost::any(tuple2);
   // Make sure it is not loaded yet.
@@ -274,7 +284,9 @@ TEST_CASE("RawParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  tuple<arma::mat, string> tuple = make_tuple(m, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::mat, TupleType> tuple = make_tuple(m, testTuple);
   d.value = boost::any(tuple);
   d.input = true;
   d.loaded = false;
@@ -322,9 +334,10 @@ TEST_CASE("GetRawParamDatasetInfoTest", "[CLIOptionTest]")
   // Create tuples.
   data::DatasetInfo dd(3);
   arma::mat m(3, 3, arma::fill::randu);
-
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
-  tuple<decltype(tuple1), string> tuple2 = make_tuple(tuple1, filename);
+  tuple<decltype(tuple1), TupleType> tuple2 = make_tuple(tuple1, testTuple);
 
   d.value = boost::any(tuple2);
   // Make sure it is not loaded yet.
@@ -350,7 +363,9 @@ TEST_CASE("OutputParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::mat m(3, 3, arma::fill::randu);
-  tuple<arma::mat, string> t = make_tuple(m, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::mat, TupleType> t = make_tuple(m, testTuple);
 
   d.value = boost::any(t);
   d.input = false;
@@ -376,7 +391,9 @@ TEST_CASE("OutputParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::Mat<size_t> m(3, 3, arma::fill::randu);
-  tuple<arma::Mat<size_t>, string> t = make_tuple(m, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::Mat<size_t>, TupleType> t = make_tuple(m, testTuple);
 
   d.value = boost::any(t);
   d.input = false;
@@ -467,7 +484,9 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
   // Create initial value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::randu);
-  d.value = boost::any(make_tuple(m, filename));
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  d.value = boost::any(make_tuple(m, testTuple));
 
   // Get a new string.
   string newFilename = "new.csv";
@@ -477,9 +496,9 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
       (void*) NULL);
 
   // Make sure the change went through.
-  tuple<arma::mat, string>& t =
-      *boost::any_cast<tuple<arma::mat, string>>(&d.value);
-  REQUIRE(get<1>(t) == "new.csv");
+  tuple<arma::mat, TupleType>& t =
+      *boost::any_cast<tuple<arma::mat, TupleType>>(&d.value);
+  REQUIRE(get<0>(get<1>(t)) == "new.csv");
 }
 
 // Test that calling SetParam on a model sets the string correctly.
@@ -517,8 +536,10 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
   string filename = "test.csv";
   arma::mat m(3, 3, arma::fill::randu);
   DatasetInfo di(3);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
   tuple<DatasetInfo, arma::mat> t1 = make_tuple(di, m);
-  tuple<tuple<DatasetInfo, arma::mat>, string> t2 = make_tuple(t1, filename);
+  tuple<tuple<DatasetInfo, arma::mat>, TupleType> t2 = make_tuple(t1, testTuple);
   d.value = boost::any(t2);
   d.noTranspose = false;
 
@@ -530,10 +551,10 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
       (const void*) &a2, (void*) NULL);
 
   // Check that the name is right.
-  tuple<tuple<DatasetInfo, arma::mat>, string>& t3 =
-      *boost::any_cast<tuple<tuple<DatasetInfo, arma::mat>, string>>(&d.value);
+  tuple<tuple<DatasetInfo, arma::mat>, TupleType>& t3 =
+      *boost::any_cast<tuple<tuple<DatasetInfo, arma::mat>, TupleType>>(&d.value);
 
-  REQUIRE(get<1>(t3) == "new_filename.csv");
+  REQUIRE(get<0>(get<1>(t3)) == "new_filename.csv");
 }
 
 // Test that GetAllocatedMemory() will properly return NULL for a non-model
@@ -556,7 +577,9 @@ TEST_CASE("GetAllocatedMemoryNonModelTest", "[CLIOptionTest]")
   // Also test with a matrix type.
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  tuple<arma::mat, string> t = make_tuple(test, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::mat, TupleType> t = make_tuple(test, testTuple);
   d.value = boost::any(t);
 
   result = (void*) 1;
@@ -602,7 +625,9 @@ TEST_CASE("DeleteAllocatedMemoryNonModelTest", "[CLIOptionTest]")
 
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  tuple<arma::mat, string> t = make_tuple(test, filename);
+  typedef tuple<string, size_t, size_t> TupleType;
+  TupleType testTuple{filename, 0, 0};
+  tuple<arma::mat, TupleType> t = make_tuple(test, testTuple);
   d.value = boost::any(t);
 
   DeleteAllocatedMemory<arma::mat>((util::ParamData&) d,

--- a/src/mlpack/tests/io_test.cpp
+++ b/src/mlpack/tests/io_test.cpp
@@ -974,7 +974,7 @@ TEST_CASE_METHOD(IOTestDestroyer, "UnmappedParamTest",
 
   // Now check that we can get unmapped parameters.
   REQUIRE(IO::GetPrintableParam<arma::mat>("matrix") ==
-      "'test_data_3_1000.csv' (3x1000 matrix)");
+      "'test_data_3_1000.csv' (1000x3 matrix)");
   // This will have size 0x0 since it's an output parameter, and it hasn't been
   // set since ParseCommandLine() was called.
   REQUIRE(IO::GetPrintableParam<arma::mat>("matrix2") ==


### PR DESCRIPTION
Solves #2817.

As recommended by @rcurtin, I have added extra elements to `TupleType` of type `size_t` that store the number of rows and number of columns for the matrix parameters. So, `TupleType` for matrix is now `std::tuple<arma::mat, std::string, size_t, size_t>`.
I have also changed corresponding files in `bindings/cli` to account for the added elements.

Now, we get the correct matrix size for CLI:

```bash
./mlpack_adaboost -t data.csv -l classes.csv -M model.bin -v 
[DEBUG] Compiled with debugging symbols.
[INFO ] Loading 'data.csv' as CSV data.  Size is 4 x 4.
[INFO ] Loading 'classes.csv' as raw ASCII formatted data.  Size is 4 x 1.
[INFO ] 2 classes in dataset.
[INFO ] 
[INFO ] Execution parameters:
[INFO ]   help: 0
[INFO ]   info: 
[INFO ]   input_model_file: 
[INFO ]   iterations: 1000
[INFO ]   labels_file: 'classes.csv' (1x4 matrix)
[INFO ]   output_file: ''
[INFO ]   output_model_file: model.bin
[INFO ]   predictions_file: ''
[INFO ]   probabilities_file: ''
[INFO ]   test_file: ''
[INFO ]   tolerance: 1e-10
[INFO ]   training_file: 'data.csv' (4x4 matrix)
[INFO ]   verbose: 1
[INFO ]   version: 0
[INFO ]   weak_learner: decision_stump
[INFO ] Program timers:
[INFO ]   adaboost_training: 0.000307s
[INFO ]   loading_data: 0.000519s
[INFO ]   total_time: 0.001305s
```