### PR TITLE
Add a link to the vision document in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ older versions of mlpack:
   - [Development Site (Github)](https://www.github.com/mlpack/mlpack/)
   - [API documentation (Doxygen)](https://www.mlpack.org/doc/mlpack-git/doxygen/index.html)
 
+To learn about the development goals of mlpack in the short- and medium-term
+future, see the [vision document](https://www.mlpack.org/papers/vision.pdf).
+
 ### 8. Bug reporting
 
    (see also [mlpack help](https://www.mlpack.org/questions.html))


### PR DESCRIPTION
This comes from #2524, and just adds a link to the vision document PDF to the README.  It should wait to be merged until once mlpack/mlpack.org#48 is also merged.