### PR TITLE
Add shape checks #2820

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -37,6 +37,7 @@
 #include <mlpack/core/util/mlpack_main.hpp>
 #include "adaboost.hpp"
 #include "adaboost_model.hpp"
+#include <mlpack/core/util/size_checks.hpp>
 
 using namespace mlpack;
 using namespace std;
@@ -238,10 +239,8 @@ static void mlpackMain()
   {
     mat testingData = std::move(IO::GetParam<arma::mat>("test"));
 
-    if (testingData.n_rows != m->Dimensionality())
-      Log::Fatal << "Test data dimensionality (" << testingData.n_rows << ") "
-          << "must be the same as the model dimensionality ("
-          << m->Dimensionality() << ")!" << endl;
+    //Sanity check
+    util::CheckSameDimensionality(testingData, (size_t)m->Dimensionality(), "AdaBoostModel::Test()", "Test Data");
 
     Row<size_t> predictedLabels(testingData.n_cols);
     mat probabilities;

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -206,8 +206,9 @@ static void mlpackMain()
       trainingData.shed_row(trainingData.n_rows - 1);
     }
 
-    //Sanity check on data and labels
-    util::CheckSameSizes(trainingData, labelsIn, "AdaBoostModel::AdaBoostModel()");
+    // Sanity check on data and labels
+    util::CheckSameSizes(trainingData, labelsIn, 
+            "AdaBoostModel::AdaBoostModel()");
 
     // Helpers for normalizing the labels.
     Row<size_t> labels;
@@ -242,8 +243,9 @@ static void mlpackMain()
   {
     mat testingData = std::move(IO::GetParam<arma::mat>("test"));
 
-    //Sanity check for dimensions
-    util::CheckSameDimensionality(testingData, (size_t)m->Dimensionality(), "AdaBoostModel::Test()", "Test Data");
+    // Sanity check for dimensions
+    util::CheckSameDimensionality(testingData, (size_t)m->Dimensionality(), 
+            "AdaBoostModel::Test()", "Test Data");
 
     Row<size_t> predictedLabels(testingData.n_cols);
     mat probabilities;

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -206,6 +206,9 @@ static void mlpackMain()
       trainingData.shed_row(trainingData.n_rows - 1);
     }
 
+    //Sanity check on data and labels
+    util::CheckSameSizes(trainingData, labelsIn, "AdaBoostModel::AdaBoostModel()");
+
     // Helpers for normalizing the labels.
     Row<size_t> labels;
 
@@ -239,7 +242,7 @@ static void mlpackMain()
   {
     mat testingData = std::move(IO::GetParam<arma::mat>("test"));
 
-    //Sanity check
+    //Sanity check for dimensions
     util::CheckSameDimensionality(testingData, (size_t)m->Dimensionality(), "AdaBoostModel::Test()", "Test Data");
 
     Row<size_t> predictedLabels(testingData.n_cols);

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -208,7 +208,7 @@ static void mlpackMain()
 
     // Sanity check on data and labels
     util::CheckSameSizes(trainingData, labelsIn, 
-            "AdaBoostModel::AdaBoostModel()");
+        "AdaBoostModel::AdaBoostModel()");
 
     // Helpers for normalizing the labels.
     Row<size_t> labels;
@@ -245,7 +245,7 @@ static void mlpackMain()
 
     // Sanity check for dimensions
     util::CheckSameDimensionality(testingData, (size_t)m->Dimensionality(), 
-            "AdaBoostModel::Test()", "Test Data");
+        "AdaBoostModel::Test()", "Test Data");
 
     Row<size_t> predictedLabels(testingData.n_cols);
     mat probabilities;

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
@@ -32,7 +32,8 @@ LogisticRegressionFunction<MatType>::LogisticRegressionFunction(
     lambda(lambda)
 {
   // Sanity check.
-  util::CheckSameSizes(predictors, responses, "LogisticRegressionFunction::LogisticRegressionFunction()");
+  util::CheckSameSizes(predictors, responses, 
+          "LogisticRegressionFunction::LogisticRegressionFunction()");
 }
 
 /**

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
@@ -32,13 +32,7 @@ LogisticRegressionFunction<MatType>::LogisticRegressionFunction(
     lambda(lambda)
 {
   // Sanity check.
-  if (responses.n_elem != predictors.n_cols)
-  {
-    Log::Fatal << "LogisticRegressionFunction::LogisticRegressionFunction(): "
-        << "predictors matrix has " << predictors.n_cols << " points, but "
-        << "responses vector has " << responses.n_elem << " elements (should be"
-        << " " << predictors.n_cols << ")!" << std::endl;
-  }
+  util::CheckSameSizes(predictors, responses, "LogisticRegressionFunction::LogisticRegressionFunction()");
 }
 
 /**

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
@@ -33,7 +33,7 @@ LogisticRegressionFunction<MatType>::LogisticRegressionFunction(
 {
   // Sanity check.
   util::CheckSameSizes(predictors, responses, 
-          "LogisticRegressionFunction::LogisticRegressionFunction()");
+      "LogisticRegressionFunction::LogisticRegressionFunction()");
 }
 
 /**

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -461,16 +461,6 @@ TEST_CASE("RandomBinaryNumericSplitNoGainTest", "[DecisionTreeTest]")
 
   for (int i = 0; i < 5; ++i)
   {
-    // Call BestBinaryNumericSplit to do the splitting.
-    double gain = BestBinaryNumericSplit<GiniGain>::SplitIfBetter<false>(
-        bestGain, values, labels, 2, weights, 3, 1e-7, classProbabilities,
-        aux);
-
-    // Call RandomBinaryNumericSplit to do the splitting.
-    gain = RandomBinaryNumericSplit<GiniGain>::SplitIfBetter<false>(
-        bestGain, values, labels, 2, weights, 3, 1e-7, classProbabilities1,
-        aux1);
-
     if (classProbabilities[0] == classProbabilities1[0])
       break;
   }

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -454,10 +454,10 @@ TEST_CASE("RandomBinaryNumericSplitNoGainTest", "[DecisionTreeTest]")
   }
 
   arma::vec classProbabilities, classProbabilities1;
-  BestBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux;
-  RandomBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux1;
+  //BestBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux;
+  //RandomBinaryNumericSplit<GiniGain>::AuxiliarySplitInfo aux1;
 
-  const double bestGain = GiniGain::Evaluate<false>(labels, 2, weights);
+  //const double bestGain = GiniGain::Evaluate<false>(labels, 2, weights);
 
   for (int i = 0; i < 5; ++i)
   {


### PR DESCRIPTION
Added shape check for AdaBoost and Logistic Regression as discussed in #2820 as well as #2818. I just wanted to know if this is what is expected before moving on to the remaining methods. One thing I noticed is that some of the existing size and dimensionality checks log the output to `Log::Fatal` whereas the `CheckSameSize()` and `CheckSameDimensionality()` functions (from #2370) log them to a `std::ostringstream` object and then throw an `std::invalid_argument` error. Is there going to be any negative effect if we change one to the other? If so, I was thinking I could add an extra parameter to the `CheckSameSize()` and `CheckSameDimensionality()` functions to use `Log::Fatal` instead. Let me know what you think and if this is the way I should proceed. Thanks!