### PR TITLE
Fix uwp build error C4146

### DIFF
--- a/src/mlpack/core/data/is_naninf.hpp
+++ b/src/mlpack/core/data/is_naninf.hpp
@@ -41,12 +41,12 @@ inline bool IsNaNInf(T& val, const std::string& token)
       if (std::numeric_limits<T>::has_infinity)
       {
         val = (!neg) ? std::numeric_limits<T>::infinity() :
-            -std::numeric_limits<T>::infinity();
+            -1 * std::numeric_limits<T>::infinity();
       }
       else
       {
         val = (!neg) ? std::numeric_limits<T>::max() :
-            -std::numeric_limits<T>::max();
+            -1 * std::numeric_limits<T>::max();
       }
 
       return true;


### PR DESCRIPTION
Fix build error when building x64-uwp:
```
     5>D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\is_naninf.hpp(44,13): error C4146: unary minus operator applied to unsigned type, result still unsigned (compiling source file D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load.cpp) [D:\buildtrees\mlpack\x64-uwp-dbg\src\mlpack\mlpack.vcxproj]
       D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load_arff_impl.hpp(270): message : see reference to function template instantiation 'bool mlpack::data::IsNaNInf<eT>(T &,const std::string &)' being compiled [D:\buildtrees\mlpack\x64-uwp-dbg\src\mlpack\mlpack.vcxproj]
                 with
                 [
                     eT=arma::u32,
                     T=arma::u32
                 ] (compiling source file D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load.cpp)
       D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load_impl.hpp(254): message : see reference to function template instantiation 'void mlpack::data::LoadARFF<arma::u32,mlpack::data::IncrementPolicy>(const std::string &,arma::Mat<arma::u32> &,mlpack::data::DatasetMapper<mlpack::data::IncrementPolicy,std::string> &)' being compiled (compiling source file D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load.cpp) [D:\buildtrees\mlpack\x64-uwp-dbg\src\mlpack\mlpack.vcxproj]
       D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load.cpp(95): message : see reference to function template instantiation 'bool mlpack::data::Load<arma::u32,mlpack::data::IncrementPolicy>(const std::string &,arma::Mat<arma::u32> &,mlpack::data::DatasetMapper<mlpack::data::IncrementPolicy,std::string> &,const bool,const bool)' being compiled [D:\buildtrees\mlpack\x64-uwp-dbg\src\mlpack\mlpack.vcxproj]
     5>D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\is_naninf.hpp(49,13): error C4146: unary minus operator applied to unsigned type, result still unsigned (compiling source file D:\buildtrees\mlpack\src\82feaae439-1a0b09363c.clean\src\mlpack\core\data\load.cpp) [D:\buildtrees\mlpack\x64-uwp-dbg\src\mlpack\mlpack.vcxproj]
```

Related: https://github.com/microsoft/vcpkg/pull/17983.