### PR TITLE
Add some notes for usage on RHEL7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,11 @@ enable_testing()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Ensure that GCC is new enough, if the compiler is GCC.
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
+  message(FATAL_ERROR "GCC version (${CMAKE_CXX_COMPILER_VERSION}) is too old! 5.x or newer is required.")
+endif ()
+
 # Include modules in the CMake directory.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 

--- a/README.md
+++ b/README.md
@@ -153,10 +153,15 @@ mlpack_pca, mlpack_kmeans etc.) with the following command:
 On Fedora or Red Hat (EPEL):
     $ sudo dnf install mlpack-devel mlpack-bin
 
-Note: Older Ubuntu versions may not have the most recent version of mlpack
+*Note*: Older Ubuntu versions may not have the most recent version of mlpack
 available---for instance, at the time of this writing, Ubuntu 16.04 only has
 mlpack 3.4.2 available.  Options include upgrading your Ubuntu version, finding
 a PPA or other non-official sources, or installing with a manual build.
+
+*Note*: If you are using RHEL7/CentOS 7, gcc 4.8 is too old to compile mlpack.
+One option is to use `devtoolset-8`; see
+[here](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/) for more
+information.
 
 There are some useful pages to consult in addition to this section:
 

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -63,6 +63,10 @@ $ sudo make install
 If the \c cmake \c .. command fails, you are probably missing a dependency, so
 check the output and install any necessary libraries.  (See \ref build_dep.)
 
+@note If you are using RHEL7/CentOS 7, the default version of gcc is too old.
+One solution is to use \c devtoolset-8; more information is available at
+https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/ .
+
 On many Linux systems, mlpack will install by default to @c /usr/local/lib and
 you may need to set the @c LD_LIBRARY_PATH environment variable:
 


### PR DESCRIPTION
This comes from the discussion in #2939.

 * I added a check to our CMake configuration to ensure that, if GCC is used, version 5.x or newer is used.
 * I added some documentation for what to do on RHEL7/CentOS 7, where the default version of GCC is 4.8.