### PR TITLE
 faster forward pass of mean pool layer

### DIFF
--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -162,10 +162,10 @@ class MeanPooling
   {
     arma::Mat<eT> inputPre = input;
 
-    for(size_t i = 1; i < input.n_cols; ++i)
+    for (size_t i = 1; i < input.n_cols; ++i)
       inputPre.col(i) += inputPre.col(i - 1);
   
-    for(size_t i = 1; i < input.n_rows; ++i)
+    for (size_t i = 1; i < input.n_rows; ++i)
       inputPre.row(i) += inputPre.row(i - 1);
 
     for (size_t j = 0, colidx = 0; j < output.n_cols;

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -160,12 +160,23 @@ class MeanPooling
   template<typename eT>
   void Pooling(const arma::Mat<eT>& input, arma::Mat<eT>& output)
   {
+    arma::mat inputPre = input;
+    size_t inRow = input.n_rows;
+    size_t inCol = input.n_cols;
+
+    for(int i = 1; i < inCol; i++)
+      inputPre.col(i) += inputPre.col(i - 1);
+  
+    for(int i = 1; i < inRow; i++)
+      inputPre.row(i) += inputPre.row(i - 1);
+
     for (size_t j = 0, colidx = 0; j < output.n_cols;
          ++j, colidx += strideHeight)
     {
       for (size_t i = 0, rowidx = 0; i < output.n_rows;
            ++i, rowidx += strideWidth)
       {
+        double val = 0.0;
         size_t rowEnd = rowidx + kernelWidth - 1;
         size_t colEnd = colidx + kernelHeight - 1;
 
@@ -174,11 +185,17 @@ class MeanPooling
         if (colEnd > input.n_cols - 1)
           colEnd = input.n_cols - 1;
 
-        arma::mat subInput = input(
-            arma::span(rowidx, rowEnd),
-            arma::span(colidx, colEnd));
+        val += inputPre(rowEnd, colEnd);
+        if(rowidx >= 1)
+        {
+          if(colidx >= 1)
+            val += inputPre(rowidx - 1, colidx - 1);
+          val -= inputPre(rowidx - 1, colEnd);
+        }
+        if(colidx >= 1)
+          val -= inputPre(rowEnd, colidx - 1);
 
-        output(i, j) = arma::mean(arma::mean(subInput));
+        output(i, j) = val / input.n_elem;
       }
     }
   }

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -163,6 +163,7 @@ class MeanPooling
     arma::mat inputPre = input;
     size_t inRow = input.n_rows;
     size_t inCol = input.n_cols;
+    size_t kernalArea = kernelWidth * kernelHeight;
 
     for(int i = 1; i < inCol; i++)
       inputPre.col(i) += inputPre.col(i - 1);
@@ -195,7 +196,7 @@ class MeanPooling
         if(colidx >= 1)
           val -= inputPre(rowEnd, colidx - 1);
 
-        output(i, j) = val / input.n_elem;
+        output(i, j) = val / kernalArea;
       }
     }
   }

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -160,14 +160,12 @@ class MeanPooling
   template<typename eT>
   void Pooling(const arma::Mat<eT>& input, arma::Mat<eT>& output)
   {
-    arma::mat inputPre = input;
-    size_t inRow = input.n_rows;
-    size_t inCol = input.n_cols;
+    arma::Mt<eT> inputPre = input;
 
-    for(int i = 1; i < inCol; i++)
+    for(size_t i = 1; i < input.n_cols; ++i)
       inputPre.col(i) += inputPre.col(i - 1);
   
-    for(int i = 1; i < inRow; i++)
+    for(size_t i = 1; i < input.n_rows; ++i)
       inputPre.row(i) += inputPre.row(i - 1);
 
     for (size_t j = 0, colidx = 0; j < output.n_cols;
@@ -185,15 +183,15 @@ class MeanPooling
         if (colEnd > input.n_cols - 1)
           colEnd = input.n_cols - 1;
 
-        size_t kernalArea = (rowEnd - rowidx + 1) * (colEnd - colidx + 1);
+        const kernalArea = (rowEnd - rowidx + 1) * (colEnd - colidx + 1);
         val += inputPre(rowEnd, colEnd);
-        if(rowidx >= 1)
+        if (rowidx >= 1)
         {
-          if(colidx >= 1)
+          if (colidx >= 1)
             val += inputPre(rowidx - 1, colidx - 1);
           val -= inputPre(rowidx - 1, colEnd);
         }
-        if(colidx >= 1)
+        if (colidx >= 1)
           val -= inputPre(rowEnd, colidx - 1);
 
         output(i, j) = val / kernalArea;

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -163,7 +163,6 @@ class MeanPooling
     arma::mat inputPre = input;
     size_t inRow = input.n_rows;
     size_t inCol = input.n_cols;
-    size_t kernalArea = kernelWidth * kernelHeight;
 
     for(int i = 1; i < inCol; i++)
       inputPre.col(i) += inputPre.col(i - 1);
@@ -186,6 +185,7 @@ class MeanPooling
         if (colEnd > input.n_cols - 1)
           colEnd = input.n_cols - 1;
 
+        size_t kernalArea = (rowEnd - rowidx + 1) * (colEnd - colidx + 1);
         val += inputPre(rowEnd, colEnd);
         if(rowidx >= 1)
         {

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -160,7 +160,7 @@ class MeanPooling
   template<typename eT>
   void Pooling(const arma::Mat<eT>& input, arma::Mat<eT>& output)
   {
-    arma::Mt<eT> inputPre = input;
+    arma::Mat<eT> inputPre = input;
 
     for(size_t i = 1; i < input.n_cols; ++i)
       inputPre.col(i) += inputPre.col(i - 1);

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -183,7 +183,7 @@ class MeanPooling
         if (colEnd > input.n_cols - 1)
           colEnd = input.n_cols - 1;
 
-        const kernalArea = (rowEnd - rowidx + 1) * (colEnd - colidx + 1);
+        const size_t kernalArea = (rowEnd - rowidx + 1) * (colEnd - colidx + 1);
         val += inputPre(rowEnd, colEnd);
         if (rowidx >= 1)
         {


### PR DESCRIPTION
 When inputmatrix size is greater than approx 20 * 20, this new method is faster, but then input is    less than 20*20  this  method is around 5~10  microseconds slower.
https://colab.research.google.com/drive/1MmJoeJfFaJ--ugz8VAViHsHTjssYCn3L?usp=sharing 