### PR TITLE
Clean old no longer used download var for ensmallen and stb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ option(TEST_VERBOSE "Run test cases with verbose output." OFF)
 option(BUILD_TESTS "Build tests." ON)
 option(BUILD_CLI_EXECUTABLES "Build command-line executables." ON)
 option(DISABLE_DOWNLOADS "Disable downloads of dependencies during build." OFF)
-option(DOWNLOAD_ENSMALLEN "If ensmallen is not found, download it." ON)
-option(DOWNLOAD_STB_IMAGE "Download stb_image for image loading." ON)
 option(BUILD_GO_SHLIB "Build Go shared library." OFF)
 option(BUILD_DOCS "Build doxygen documentation (if doxygen is available)." ON)
 

--- a/README.md
+++ b/README.md
@@ -219,10 +219,8 @@ Options are specified with the -D flag.  The allowed options include:
     BUILD_SHARED_LIBS=(ON/OFF): compile shared libraries and executables as
         opposed to static libraries
     DISABLE_DOWNLOADS=(ON/OFF): whether to disable all downloads during build
-    DOWNLOAD_ENSMALLEN=(ON/OFF): If ensmallen is not found, download it
     ENSMALLEN_INCLUDE_DIR=(/path/to/ensmallen/include): path to include directory
        for ensmallen
-    DOWNLOAD_STB_IMAGE=(ON/OFF): If STB is not found, download it
     STB_IMAGE_INCLUDE_DIR=(/path/to/stb/include): path to include directory for
        STB image library
     USE_OPENMP=(ON/OFF): whether or not to use OpenMP if available

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -193,9 +193,6 @@ The full list of options mlpack allows:
        (default OFF)
  - DISABLE_DOWNLOADS=(ON/OFF): Disable downloads of dependencies during build
        (default OFF)
- - DOWNLOAD_ENSMALLEN=(ON/OFF): If ensmallen is not found, download it
-       (default ON)
- - DOWNLOAD_STB_IMAGE=(ON/OFF): If STB is not found, download it (default ON)
  - PYTHON_EXECUTABLE=(/path/to/python_version): Path to specific Python executable
  - PYTHON_INSTALL_PREFIX=(/path/to/python/): Path to root of Python installation
  - JULIA_EXECUTABLE=(/path/to/julia): Path to specific Julia executable


### PR DESCRIPTION
Both of these variables were forgotten, when we created the autodownloader.
Time to remove them.
Signed-off-by: Omar Shrit <omar@shrit.me>