### PR TITLE
Better handling of empty Hoeffding trees

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,6 +54,9 @@
   * The `mlpack_test` target is no longer built as part of `make all`.  Use
     `make mlpack_test` to build the tests.
 
+  * Fixes to `HoeffdingTree`: ensure that training still works when empty
+    constructor is used.
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -55,7 +55,7 @@
     `make mlpack_test` to build the tests.
 
   * Fixes to `HoeffdingTree`: ensure that training still works when empty
-    constructor is used.
+    constructor is used (#2964).
 
 ### mlpack 3.4.2
 ###### 2020-10-26

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -203,10 +203,10 @@ class DecisionTree :
           typename std::remove_reference<WeightsType>::type>::value>* = 0);
 
   /**
-   * Take ownership of another decision tree and train on the given data and labels
-   * with weights, assuming that the data is all of the numeric type. Setting
-   * minimumLeafSize and minimumGainSplit too small may cause the tree to
-   * overfit, but setting them too large may cause it to underfit.
+   * Take ownership of another decision tree and train on the given data and
+   * labels with weights, assuming that the data is all of the numeric type.
+   * Setting minimumLeafSize and minimumGainSplit too small may cause the tree
+   * to overfit, but setting them too large may cause it to underfit.
    *
    * Use std::move if data, labels or weights are no longer needed to avoid
    * copies.

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
@@ -188,18 +188,22 @@ class HoeffdingTree
    *
    * Note that the tree will be automatically reset if the dimensionality of
    * `data` does not match the dimensionality that the tree was currently
-   * trained with.
+   * trained with.  The tree will also be reset if `numClasses` is passed.
    *
    * @param data Data points to train on.
    * @param labels Labels of data points.
    * @param batchTraining If true, perform training in batch.
    * @param resetTree If true, reset the tree to an empty tree before training.
+   * @param numClasses The number of classes in `labels`.  Passing this will
+   *      reset the tree.  If not given and `resetTree` is `true`, then the
+   *      number of classes will be computed from `labels`.
    */
   template<typename MatType>
   void Train(const MatType& data,
              const arma::Row<size_t>& labels,
              const bool batchTraining = true,
-             const bool resetTree = false);
+             const bool resetTree = false,
+             const size_t numClasses = 0);
 
   /**
    * Train on a set of points, either in streaming mode or in batch mode, with
@@ -208,12 +212,20 @@ class HoeffdingTree
    * are training incrementally but have already passed the DatasetInfo once,
    * use the overload of `Train()` that does not take a `DatasetInfo` and make
    * sure `resetTree` is set to `false`.
+   *
+   * @param data Data points to train on.
+   * @param info DatasetInfo object with information about each dimension.
+   * @param labels Labels of data points.
+   * @param batchTraining If true, perform training in batch.
+   * @param numClasses Number of classes in `labels`.  If not specified, it is
+   *      computed from `labels`.
    */
   template<typename MatType>
   void Train(const MatType& data,
              const data::DatasetInfo& info,
              const arma::Row<size_t>& labels,
-             const bool batchTraining = true);
+             const bool batchTraining = true,
+             const size_t numClasses = 0);
 
   /**
    * Train on a single point in streaming mode, with the given label.  The tree

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
@@ -164,14 +164,14 @@ class HoeffdingTree
 
   /**
    * Copy assignment operator.
-   * 
+   *
    * @param other Tree to copy.
    */
   HoeffdingTree& operator=(const HoeffdingTree& other);
 
   /**
    * Move assignment operator.
-   * 
+   *
    * @param other Tree to move.
    */
   HoeffdingTree& operator=(HoeffdingTree&& other);
@@ -183,20 +183,31 @@ class HoeffdingTree
 
   /**
    * Train on a set of points, either in streaming mode or in batch mode, with
-   * the given labels.
+   * the given labels.  If `resetTree` is set to `true`, then reset the state of
+   * the tree to an empty tree before training.
+   *
+   * Note that the tree will be automatically reset if the dimensionality of
+   * `data` does not match the dimensionality that the tree was currently
+   * trained with.
    *
    * @param data Data points to train on.
    * @param labels Labels of data points.
    * @param batchTraining If true, perform training in batch.
+   * @param resetTree If true, reset the tree to an empty tree before training.
    */
   template<typename MatType>
   void Train(const MatType& data,
              const arma::Row<size_t>& labels,
-             const bool batchTraining = true);
+             const bool batchTraining = true,
+             const bool resetTree = false);
 
   /**
    * Train on a set of points, either in streaming mode or in batch mode, with
-   * the given labels and the given DatasetInfo.  This will reset the tree.
+   * the given labels and the given `DatasetInfo`.  This will reset the tree.
+   * This only needs to be called when the `DatasetInfo` has changed---if you
+   * are training incrementally but have already passed the DatasetInfo once,
+   * use the overload of `Train()` that does not take a `DatasetInfo` and make
+   * sure `resetTree` is set to `false`.
    */
   template<typename MatType>
   void Train(const MatType& data,
@@ -205,7 +216,8 @@ class HoeffdingTree
              const bool batchTraining = true);
 
   /**
-   * Train on a single point in streaming mode, with the given label.
+   * Train on a single point in streaming mode, with the given label.  The tree
+   * will not be reset before training.
    *
    * @param point Point to train on.
    * @param label Label of point to train on.
@@ -379,6 +391,24 @@ class HoeffdingTree
   typename NumericSplitType<FitnessFunction>::SplitInfo numericSplit;
   //! If the split has occurred, these are the children.
   std::vector<HoeffdingTree*> children;
+
+  /**
+   * Perform training (typically after a reset, but not necessarily).  This
+   * assumes datasetInfo and dimensionMappings are set correctly.
+   */
+  template<typename MatType>
+  void TrainInternal(const MatType& data,
+                     const arma::Row<size_t>& labels,
+                     const bool batchTraining);
+
+  /**
+   * Reset the tree.  This assumes datasetInfo is set correctly.
+   */
+  void ResetTree(
+      const CategoricalSplitType<FitnessFunction>& categoricalSplitIn =
+          CategoricalSplitType<FitnessFunction>(0, 0),
+      const NumericSplitType<FitnessFunction>& numericSplitIn =
+          NumericSplitType<FitnessFunction>(0));
 };
 
 } // namespace tree

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_impl.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_impl.hpp
@@ -28,7 +28,7 @@ HoeffdingTree<
     NumericSplitType,
     CategoricalSplitType
 >::HoeffdingTree(const MatType& data,
-                 const data::DatasetInfo& datasetInfo,
+                 const data::DatasetInfo& datasetInfoIn,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,
                  const bool batchTraining,
@@ -39,15 +39,14 @@ HoeffdingTree<
                  const CategoricalSplitType<FitnessFunction>&
                      categoricalSplitIn,
                  const NumericSplitType<FitnessFunction>& numericSplitIn) :
-    dimensionMappings(new std::unordered_map<size_t,
-        std::pair<size_t, size_t>>()),
-    ownsMappings(true),
+    dimensionMappings(NULL),
+    ownsMappings(false),
     numSamples(0),
     numClasses(numClasses),
     maxSamples((maxSamples == 0) ? size_t(-1) : maxSamples),
     checkInterval(checkInterval),
     minSamples(minSamples),
-    datasetInfo(new data::DatasetInfo(datasetInfo)),
+    datasetInfo(new data::DatasetInfo(datasetInfoIn)),
     ownsInfo(true),
     successProbability(successProbability),
     splitDimension(size_t(-1)),
@@ -56,24 +55,8 @@ HoeffdingTree<
     categoricalSplit(0),
     numericSplit()
 {
-  // Generate dimension mappings and create split objects.
-  for (size_t i = 0; i < datasetInfo.Dimensionality(); ++i)
-  {
-    if (datasetInfo.Type(i) == data::Datatype::categorical)
-    {
-      categoricalSplits.push_back(CategoricalSplitType<FitnessFunction>(
-          datasetInfo.NumMappings(i), numClasses, categoricalSplitIn));
-      (*dimensionMappings)[i] = std::make_pair(data::Datatype::categorical,
-          categoricalSplits.size() - 1);
-    }
-    else
-    {
-      numericSplits.push_back(NumericSplitType<FitnessFunction>(numClasses,
-          numericSplitIn));
-      (*dimensionMappings)[i] = std::make_pair(data::Datatype::numeric,
-          numericSplits.size() - 1);
-    }
-  }
+  // Reset the tree.
+  ResetTree(categoricalSplitIn, numericSplitIn);
 
   // Now train.
   Train(data, labels, batchTraining);
@@ -119,23 +102,7 @@ HoeffdingTree<
   // Do we need to generate the mappings too?
   if (ownsMappings)
   {
-    for (size_t i = 0; i < datasetInfo.Dimensionality(); ++i)
-    {
-      if (datasetInfo.Type(i) == data::Datatype::categorical)
-      {
-        categoricalSplits.push_back(CategoricalSplitType<FitnessFunction>(
-            datasetInfo.NumMappings(i), numClasses, categoricalSplitIn));
-        (*dimensionMappings)[i] = std::make_pair(data::Datatype::categorical,
-            categoricalSplits.size() - 1);
-      }
-      else
-      {
-        numericSplits.push_back(NumericSplitType<FitnessFunction>(numClasses,
-            numericSplitIn));
-        (*dimensionMappings)[i] = std::make_pair(data::Datatype::numeric,
-            numericSplits.size() - 1);
-      }
-    }
+    ResetTree(categoricalSplitIn, numericSplitIn);
   }
   else
   {
@@ -381,71 +348,26 @@ void HoeffdingTree<
     CategoricalSplitType
 >::Train(const MatType& data,
          const arma::Row<size_t>& labels,
-         const bool batchTraining)
+         const bool batchTraining,
+         const bool resetTree)
 {
-  if (batchTraining)
+  // We need to reset the tree either if the user asked for it, or if they
+  // passed data whose dimensionality is different than our datasetInfo object.
+  if (resetTree || data.n_rows != datasetInfo->Dimensionality())
   {
-    // Pass all the points through the nodes, and then split only after that.
-    checkInterval = data.n_cols; // Only split on the last sample.
-    // Don't split if there are fewer than five points.
-    size_t oldMaxSamples = maxSamples;
-    maxSamples = std::max(size_t(data.n_cols - 1), size_t(5));
-    for (size_t i = 0; i < data.n_cols; ++i)
-      Train(data.col(i), labels[i]);
-    maxSamples = oldMaxSamples;
+    // Create a new datasetInfo, which assumes that all features are numeric.
+    if (ownsInfo)
+      delete datasetInfo;
+    datasetInfo = new data::DatasetInfo(data.n_rows);
+    ownsInfo = true;
 
-    // Now, if we did split, find out which points go to which child, and
-    // perform the same batch training.
-    if (children.size() > 0)
-    {
-      // We need to create a vector of indices that represent the points that
-      // must go to each child, so we need children.size() vectors, but we don't
-      // know how long they will be.  Therefore, we will create vectors each of
-      // size data.n_cols, but will probably not use all the memory we
-      // allocated, and then pass subvectors to the submat() function.
-      std::vector<arma::uvec> indices(children.size(), arma::uvec(data.n_cols));
-      arma::Col<size_t> counts =
-          arma::zeros<arma::Col<size_t>>(children.size());
+    // Set the number of classes correctly.
+    numClasses = arma::max(labels) + 1;
 
-      for (size_t i = 0; i < data.n_cols; ++i)
-      {
-        size_t direction = CalculateDirection(data.col(i));
-        size_t currentIndex = counts[direction];
-        indices[direction][currentIndex] = i;
-        counts[direction]++;
-      }
-
-      // Now pass each of these submatrices to the children to perform
-      // batch-mode training.
-      for (size_t i = 0; i < children.size(); ++i)
-      {
-        // If we don't have any points that go to the child in question, don't
-        // train that child.
-        if (counts[i] == 0)
-          continue;
-
-        // The submatrix here is non-contiguous, but I think this will be faster
-        // than copying the points to an ordered state.  We still have to
-        // assemble the labels vector, though.
-        arma::Row<size_t> childLabels = labels.cols(
-            indices[i].subvec(0, counts[i] - 1));
-
-        // Unfortunately, limitations of Armadillo's non-contiguous subviews
-        // prohibits us from successfully passing the non-contiguous subview to
-        // Train(), since the col() function is not provided.  So,
-        // unfortunately, instead, we'll just extract the non-contiguous
-        // submatrix.
-        MatType childData = data.cols(indices[i].subvec(0, counts[i] - 1));
-        children[i]->Train(childData, childLabels, true);
-      }
-    }
+    ResetTree();
   }
-  else
-  {
-    // We aren't training in batch mode; loop through the points.
-    for (size_t i = 0; i < data.n_cols; ++i)
-      Train(data.col(i), labels[i]);
-  }
+
+  TrainInternal(data, labels, batchTraining);
 }
 
 //! Train on a set of points.
@@ -468,40 +390,13 @@ void HoeffdingTree<
   datasetInfo = &info;
   ownsInfo = false;
 
-  // Generate mappings.
-  if (ownsMappings)
-    delete dimensionMappings;
+  // Set the number of classes correctly.
+  numClasses = arma::max(labels) + 1;
 
-  const CategoricalSplitType<FitnessFunction> categoricalSplitIn(0, 0);
-  const NumericSplitType<FitnessFunction> numericSplitIn(0);
-
-  dimensionMappings =
-      new std::unordered_map<size_t, std::pair<size_t, size_t>>();
-  for (size_t i = 0; i < datasetInfo->Dimensionality(); ++i)
-  {
-    if (datasetInfo->Type(i) == data::Datatype::categorical)
-    {
-      categoricalSplits.push_back(CategoricalSplitType<FitnessFunction>(
-          datasetInfo->NumMappings(i), numClasses, categoricalSplitIn));
-      (*dimensionMappings)[i] = std::make_pair(data::Datatype::categorical,
-          categoricalSplits.size() - 1);
-    }
-    else
-    {
-      numericSplits.push_back(NumericSplitType<FitnessFunction>(numClasses,
-          numericSplitIn));
-      (*dimensionMappings)[i] = std::make_pair(data::Datatype::numeric,
-          numericSplits.size() - 1);
-    }
-  }
-
-  // Remove any old children.
-  for (size_t i = 0; i < children.size(); ++i)
-    delete children[i];
-  children.clear();
+  ResetTree();
 
   // Now train.
-  Train(data, labels, batchTraining);
+  TrainInternal(data, labels, batchTraining);
 }
 
 //! Train on one point.
@@ -1034,6 +929,140 @@ void HoeffdingTree<
       successProbability = 0.0;
     }
   }
+}
+
+template<
+    typename FitnessFunction,
+    template<typename> class NumericSplitType,
+    template<typename> class CategoricalSplitType
+>
+template<typename MatType>
+void HoeffdingTree<
+    FitnessFunction,
+    NumericSplitType,
+    CategoricalSplitType
+>::TrainInternal(const MatType& data,
+                 const arma::Row<size_t>& labels,
+                 const bool batchTraining)
+{
+  if (batchTraining)
+  {
+    // Pass all the points through the nodes, and then split only after that.
+    checkInterval = data.n_cols; // Only split on the last sample.
+    // Don't split if there are fewer than five points.
+    size_t oldMaxSamples = maxSamples;
+    maxSamples = std::max(size_t(data.n_cols - 1), size_t(5));
+    for (size_t i = 0; i < data.n_cols; ++i)
+      Train(data.col(i), labels[i]);
+    maxSamples = oldMaxSamples;
+
+    // Now, if we did split, find out which points go to which child, and
+    // perform the same batch training.
+    if (children.size() > 0)
+    {
+      // We need to create a vector of indices that represent the points that
+      // must go to each child, so we need children.size() vectors, but we don't
+      // know how long they will be.  Therefore, we will create vectors each of
+      // size data.n_cols, but will probably not use all the memory we
+      // allocated, and then pass subvectors to the submat() function.
+      std::vector<arma::uvec> indices(children.size(), arma::uvec(data.n_cols));
+      arma::Col<size_t> counts =
+          arma::zeros<arma::Col<size_t>>(children.size());
+
+      for (size_t i = 0; i < data.n_cols; ++i)
+      {
+        size_t direction = CalculateDirection(data.col(i));
+        size_t currentIndex = counts[direction];
+        indices[direction][currentIndex] = i;
+        counts[direction]++;
+      }
+
+      // Now pass each of these submatrices to the children to perform
+      // batch-mode training.
+      for (size_t i = 0; i < children.size(); ++i)
+      {
+        // If we don't have any points that go to the child in question, don't
+        // train that child.
+        if (counts[i] == 0)
+          continue;
+
+        // The submatrix here is non-contiguous, but I think this will be faster
+        // than copying the points to an ordered state.  We still have to
+        // assemble the labels vector, though.
+        arma::Row<size_t> childLabels = labels.cols(
+            indices[i].subvec(0, counts[i] - 1));
+
+        // Unfortunately, limitations of Armadillo's non-contiguous subviews
+        // prohibits us from successfully passing the non-contiguous subview to
+        // Train(), since the col() function is not provided.  So,
+        // unfortunately, instead, we'll just extract the non-contiguous
+        // submatrix.
+        MatType childData = data.cols(indices[i].subvec(0, counts[i] - 1));
+        children[i]->Train(childData, childLabels, true);
+      }
+    }
+  }
+  else
+  {
+    // We aren't training in batch mode; loop through the points.
+    for (size_t i = 0; i < data.n_cols; ++i)
+      Train(data.col(i), labels[i]);
+  }
+}
+
+template<
+    typename FitnessFunction,
+    template<typename> class NumericSplitType,
+    template<typename> class CategoricalSplitType
+>
+void HoeffdingTree<
+    FitnessFunction,
+    NumericSplitType,
+    CategoricalSplitType
+>::ResetTree(const CategoricalSplitType<FitnessFunction>& categoricalSplitIn,
+             const NumericSplitType<FitnessFunction>& numericSplitIn)
+{
+  // Generate mappings.
+  if (ownsMappings)
+    delete dimensionMappings;
+
+  categoricalSplits.clear();
+  numericSplits.clear();
+
+  dimensionMappings =
+      new std::unordered_map<size_t, std::pair<size_t, size_t>>();
+  ownsMappings = true;
+  for (size_t i = 0; i < datasetInfo->Dimensionality(); ++i)
+  {
+    if (datasetInfo->Type(i) == data::Datatype::categorical)
+    {
+      categoricalSplits.push_back(CategoricalSplitType<FitnessFunction>(
+          datasetInfo->NumMappings(i), numClasses, categoricalSplitIn));
+      (*dimensionMappings)[i] = std::make_pair(data::Datatype::categorical,
+          categoricalSplits.size() - 1);
+    }
+    else
+    {
+      numericSplits.push_back(NumericSplitType<FitnessFunction>(numClasses,
+          numericSplitIn));
+      (*dimensionMappings)[i] = std::make_pair(data::Datatype::numeric,
+          numericSplits.size() - 1);
+    }
+  }
+
+  // Clear children.
+  for (size_t i = 0; i < children.size(); ++i)
+    delete children[i];
+  children.clear();
+
+  // Reset statistics.
+  numSamples = 0;
+  splitDimension = size_t(-1);
+  majorityClass = 0;
+  majorityProbability = 0.0;
+  categoricalSplit =
+      typename CategoricalSplitType<FitnessFunction>::SplitInfo(0);
+  numericSplit = typename NumericSplitType<FitnessFunction>::SplitInfo();
 }
 
 } // namespace tree

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_impl.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_impl.hpp
@@ -349,11 +349,13 @@ void HoeffdingTree<
 >::Train(const MatType& data,
          const arma::Row<size_t>& labels,
          const bool batchTraining,
-         const bool resetTree)
+         const bool resetTree,
+         const size_t numClassesIn)
 {
   // We need to reset the tree either if the user asked for it, or if they
   // passed data whose dimensionality is different than our datasetInfo object.
-  if (resetTree || data.n_rows != datasetInfo->Dimensionality())
+  if (resetTree || data.n_rows != datasetInfo->Dimensionality() ||
+      numClassesIn != 0)
   {
     // Create a new datasetInfo, which assumes that all features are numeric.
     if (ownsInfo)
@@ -362,7 +364,7 @@ void HoeffdingTree<
     ownsInfo = true;
 
     // Set the number of classes correctly.
-    numClasses = arma::max(labels) + 1;
+    numClasses = (numClassesIn != 0) ? numClassesIn : arma::max(labels) + 1;
 
     ResetTree();
   }
@@ -382,7 +384,8 @@ void HoeffdingTree<
 >::Train(const MatType& data,
          const data::DatasetInfo& info,
          const arma::Row<size_t>& labels,
-         const bool batchTraining)
+         const bool batchTraining,
+         const size_t numClassesIn)
 {
   // Take over new DatasetInfo.
   if (ownsInfo)
@@ -391,7 +394,7 @@ void HoeffdingTree<
   ownsInfo = false;
 
   // Set the number of classes correctly.
-  numClasses = arma::max(labels) + 1;
+  numClasses = (numClassesIn != 0) ? numClassesIn : arma::max(labels) + 1;
 
   ResetTree();
 

--- a/src/mlpack/tests/hoeffding_tree_test.cpp
+++ b/src/mlpack/tests/hoeffding_tree_test.cpp
@@ -1044,7 +1044,7 @@ TEST_CASE("BatchTrainingTest", "[HoeffdingTreeTest]")
   // able to have enough samples to build to the same leaves.
   HoeffdingTree<> batchTree(trainingData, info, trainingLabels, 5, true,
       0.99999999);
-  HoeffdingTree<> streamTree(trainingLabels, info, trainingLabels, 5, false,
+  HoeffdingTree<> streamTree(trainingData, info, trainingLabels, 5, false,
       0.99999999);
 
   // Ensure that the performance of the batch tree is better.
@@ -1474,4 +1474,51 @@ TEST_CASE("HoeffdingTreeModelSerializationTest", "[HoeffdingTreeTest]")
       REQUIRE(probabilities[i] == Approx(probabilitiesBinary[i]).epsilon(1e-7));
     }
   }
+}
+
+TEST_CASE("HoeffdingTreeEmptyConstructorTrainTest", "[HoeffdingTreeTest]")
+{
+  // Generate data.
+  arma::mat data(5, 1000, arma::fill::randu);
+  // Generate labels.
+  arma::Row<size_t> labels(1000);
+  for (size_t i = 0; i < 500; ++i)
+    labels[i] = 0;
+  for (size_t i = 500; i < 1000; ++i)
+    labels[i] = 1;
+
+  // Create an empty tree.
+  HoeffdingTree<> ht;
+
+  // Just ensure that we can train without throwing an exception.
+  REQUIRE_NOTHROW(ht.Train(data, labels));
+
+  // Now, create a categorical dataset and retrain.
+  data = arma::mat(4, 3000);
+  labels.set_size(3000);
+  data::DatasetInfo info(4); // All features are numeric, except the fourth.
+  info.MapString<double>("0", 3);
+  for (size_t i = 0; i < 3000; i += 3)
+  {
+    data(0, i) = mlpack::math::Random();
+    data(1, i) = mlpack::math::Random();
+    data(2, i) = mlpack::math::Random();
+    data(3, i) = 0.0;
+    labels[i] = 0;
+
+    data(0, i + 1) = mlpack::math::Random();
+    data(1, i + 1) = mlpack::math::Random() - 1.0;
+    data(2, i + 1) = mlpack::math::Random() + 0.5;
+    data(3, i + 1) = 0.0;
+    labels[i + 1] = 2;
+
+    data(0, i + 2) = mlpack::math::Random();
+    data(1, i + 2) = mlpack::math::Random() + 1.0;
+    data(2, i + 2) = mlpack::math::Random() + 0.8;
+    data(3, i + 2) = 0.0;
+    labels[i + 2] = 1;
+  }
+
+  // Ensure we can train without throwing an exception.
+  REQUIRE_NOTHROW(ht.Train(data, info, labels));
 }

--- a/src/mlpack/tests/hoeffding_tree_test.cpp
+++ b/src/mlpack/tests/hoeffding_tree_test.cpp
@@ -1494,31 +1494,35 @@ TEST_CASE("HoeffdingTreeEmptyConstructorTrainTest", "[HoeffdingTreeTest]")
   REQUIRE_NOTHROW(ht.Train(data, labels));
 
   // Now, create a categorical dataset and retrain.
-  data = arma::mat(4, 3000);
-  labels.set_size(3000);
+  arma::mat data2 = arma::mat(4, 3000);
+  arma::Row<size_t> labels2(3000);
   data::DatasetInfo info(4); // All features are numeric, except the fourth.
   info.MapString<double>("0", 3);
   for (size_t i = 0; i < 3000; i += 3)
   {
-    data(0, i) = mlpack::math::Random();
-    data(1, i) = mlpack::math::Random();
-    data(2, i) = mlpack::math::Random();
-    data(3, i) = 0.0;
-    labels[i] = 0;
+    data2(0, i) = mlpack::math::Random();
+    data2(1, i) = mlpack::math::Random();
+    data2(2, i) = mlpack::math::Random();
+    data2(3, i) = 0.0;
+    labels2[i] = 0;
 
-    data(0, i + 1) = mlpack::math::Random();
-    data(1, i + 1) = mlpack::math::Random() - 1.0;
-    data(2, i + 1) = mlpack::math::Random() + 0.5;
-    data(3, i + 1) = 0.0;
-    labels[i + 1] = 2;
+    data2(0, i + 1) = mlpack::math::Random();
+    data2(1, i + 1) = mlpack::math::Random() - 1.0;
+    data2(2, i + 1) = mlpack::math::Random() + 0.5;
+    data2(3, i + 1) = 0.0;
+    labels2[i + 1] = 2;
 
-    data(0, i + 2) = mlpack::math::Random();
-    data(1, i + 2) = mlpack::math::Random() + 1.0;
-    data(2, i + 2) = mlpack::math::Random() + 0.8;
-    data(3, i + 2) = 0.0;
-    labels[i + 2] = 1;
+    data2(0, i + 2) = mlpack::math::Random();
+    data2(1, i + 2) = mlpack::math::Random() + 1.0;
+    data2(2, i + 2) = mlpack::math::Random() + 0.8;
+    data2(3, i + 2) = 0.0;
+    labels2[i + 2] = 1;
   }
 
   // Ensure we can train without throwing an exception.
-  REQUIRE_NOTHROW(ht.Train(data, info, labels));
+  REQUIRE_NOTHROW(ht.Train(data2, info, labels2));
+
+  // Train while specifying the number of classes.
+  REQUIRE_NOTHROW(ht.Train(data, labels, false, true, 2));
+  REQUIRE_NOTHROW(ht.Train(data2, info, labels2, false, 3));
 }


### PR DESCRIPTION
In #2962, @xlindo pointed out some issues when trying to train a Hoeffding tree after it was created with an empty constructor.  I went through the code and realized that there are some situations where this does not work correctly; therefore, I went through and refactored things such that the code in #2962 now works.  In essence, the problem was that a `HoeffdingTree<>` stores a `data::DatasetInfo` and a few other parameters that track how many dimensions are in the data and what type those are, but the code does not provide clear facilities for how to modify those quantities.

Specifically, I made the following changes:

 - I added a bunch of documentation to the overloads of `Train()` to be clear about when the tree will and won't be reset.
 - I added a specific parameter `resetTree` to the overload of `Train()` that doesn't take a `datasetInfo`.  This makes it possible to reset the internal state of a tree even without passing a `DatasetInfo`.
 - I refactored training and resetting into `TrainInternal()` and `ResetTree()`, which are meant to be called internally.
 - I added some new test cases to ensure that the original code works now.