### PR TITLE
Fix missing semicolon in Python type documentation

### DIFF
--- a/src/mlpack/bindings/python/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/python/print_type_doc_impl.hpp
@@ -161,7 +161,7 @@ std::string PrintTypeDoc(
       "contains all the parameters of the model.  These parameters can "
       "be inspected and changed.  To set new parameters for a model, "
       "pass the modified dictionary (without deleting any keys) to the "
-      "`set_cpp_params()` method."
+      "`set_cpp_params()` method.";
 }
 
 } // namespace python


### PR DESCRIPTION
I noticed that the Doxygen build for the website failed:

http://ci.mlpack.org/job/mlpack.org%20nightly%20rebuild/227/consoleFull

The issue is just a missing semicolon. :smile:  This didn't get noticed during CI testing, because it will only appear when building Markdown bindings (which is what the website does).