### PR TITLE
Julia: serialize the length of the model

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -59,6 +59,8 @@
   * Fixes to `HoeffdingTree`: ensure that training still works when empty
     constructor is used (#2964).
 
+  * Fix Julia model serialization bug (#2970).
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/src/mlpack/bindings/julia/print_param_defn.hpp
+++ b/src/mlpack/bindings/julia/print_param_defn.hpp
@@ -79,12 +79,14 @@ void PrintParamDefn(
   //   buffer = ccall((:Serialize<Type>Ptr, <programName>Library),
   //       Vector{UInt8}, (Ptr{Nothing}, Ptr{UInt8}), model.ptr,
   //       Base.pointer(buf_len))
-  //   buf = Base.unsafe_wrap(buf_ptr, buf_len[0]; own=true)
+  //   buf = Base.unsafe_wrap(buf_ptr, buf_len[1]; own=true)
+  //   write(stream, buf_len[1])
   //   write(stream, buf)
   // end
   //
   // function deserialize<Type>(stream::IO)::<Type>
-  //   buffer = read(stream)
+  //   buf_len = read(stream, UInt)
+  //   buffer = read(stream, buf_len)
   //   <Type>(ccall((:Deserialize<Type>Ptr, <programName>Library),
   //       Ptr{Nothing}, (Vector{UInt8}, UInt), buffer, length(buffer)))
   // end
@@ -138,6 +140,7 @@ void PrintParamDefn(
       << "Base.pointer(buf_len))" << std::endl;
   std::cout << "  buf = Base.unsafe_wrap(Vector{UInt8}, buf_ptr, buf_len[1]; "
       << "own=true)" << std::endl;
+  std::cout << "  write(stream, buf_len[1])" << std::endl;
   std::cout << "  write(stream, buf)" << std::endl;
   std::cout << "end" << std::endl;
 
@@ -145,7 +148,8 @@ void PrintParamDefn(
   std::cout << "# Deserialize a model from the given stream." << std::endl;
   std::cout << "function deserialize" << type << "(stream::IO)::" << type
       << std::endl;
-  std::cout << "  buffer = read(stream)" << std::endl;
+  std::cout << "  buf_len = read(stream, UInt)" << std::endl;
+  std::cout << "  buffer = read(stream, buf_len)" << std::endl;
   std::cout << "  " << type << "(ccall((:Deserialize" << type << "Ptr, "
       << programName << "Library), Ptr{Nothing}, (Ptr{UInt8}, UInt), "
       << "Base.pointer(buffer), length(buffer)))" << std::endl;

--- a/src/mlpack/bindings/julia/tests/runtests.jl
+++ b/src/mlpack/bindings/julia/tests/runtests.jl
@@ -342,6 +342,27 @@ end
                          model_in=newModel)
 end
 
+# Test that we can serialize a model as part of a larger tuple.
+@testset "TestStreamTupleSerialization" begin
+  _, _, _, _, _, _, modelOut, _, _, _, _, _, _, _ =
+      test_julia_binding(4.0, 12, "hello",
+                         build_model=true)
+
+  stream = IOBuffer()
+  serialize(stream, (modelOut, 3, 4, 5))
+
+  newStream = IOBuffer(copy(stream.data))
+  (newModel, a, b, c) = deserialize(newStream)
+
+  _, _, _, _, _, bwOut, _, _, _, _, _, _, _, _ =
+      test_julia_binding(4.0, 12, "hello",
+                         model_in=newModel)
+
+  @test a == 3
+  @test b == 4
+  @test c == 5
+end
+
 @testset "TestFileSerialization" begin
   _, _, _, _, _, _, modelOut, _, _, _, _, _, _, _ =
       test_julia_binding(4.0, 12, "hello",


### PR DESCRIPTION
While playing with the mlpack Julia bindings, I noticed that there is a bug in serialization that only happens in some niche cases.

Specifically, we serialize and deserialize the model directly to an IO stream, but we don't take the length of the serialized model into account.  This means that at deserialization time, we eat everything in the stream---this screws up deserialization of anything that comes *after* the mlpack model.

Here's an example of a badly-behaved deserialization function:

```
function deserializeDecisionTreeModel(stream::IO)::DecisionTreeModel
          buffer = read(stream)
          DecisionTreeModel(ccall((:DeserializeDecisionTreeModelPtr, decision_treeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
end
```

The solution here is, luckily, pretty easy: we just also serialize a `UInt` containing the length of the serialized model, and then deserialize that first to limit our `read()` to the appropriate length:

```
function deserializeDecisionTreeModel(stream::IO)::DecisionTreeModel
          buf_len = read(stream, UInt)
          buffer = read(stream, buf_len)
          DecisionTreeModel(ccall((:DeserializeDecisionTreeModelPtr, decision_treeLibrary), Ptr{Nothing}, (Ptr{UInt8}, UInt), Base.pointer(buffer), length(buffer)))
end
```

I added a test case for this situation also.