### PR TITLE
Julia: compute number of categories in categorical data

### DIFF
--- a/src/mlpack/bindings/julia/julia_util.cpp
+++ b/src/mlpack/bindings/julia/julia_util.cpp
@@ -193,13 +193,37 @@ void IO_SetParamMatWithInfo(const char* paramName,
                             const bool pointsAreRows)
 {
   data::DatasetInfo d(pointsAreRows ? cols : rows);
+  bool hasCategoricals = false;
   for (size_t i = 0; i < d.Dimensionality(); ++i)
   {
     d.Type(i) = (dimensions[i]) ? data::Datatype::categorical :
         data::Datatype::numeric;
+    if (dimensions[i])
+      hasCategoricals = true;
   }
 
   arma::mat m(memptr, arma::uword(rows), arma::uword(cols), false, true);
+
+  // Do we need to find how many categories we have?
+  if (hasCategoricals)
+  {
+    arma::vec maxs = arma::max(m, 1);
+
+    for (size_t i = 0; i < d.Dimensionality(); ++i)
+    {
+      if (dimensions[i])
+      {
+        // Map the right number of objects.
+        for (size_t j = 0; j < (size_t) maxs[i]; ++j)
+        {
+          std::ostringstream oss;
+          oss << j;
+          d.MapString<double>(oss.str(), i);
+        }
+      }
+    }
+  }
+
   std::get<0>(IO::GetParam<std::tuple<data::DatasetInfo, arma::mat>>(
       paramName)) = std::move(d);
   std::get<1>(IO::GetParam<std::tuple<data::DatasetInfo, arma::mat>>(


### PR DESCRIPTION
While playing with the Julia bindings (after fixing the error in #2970 :)), I next noticed that categorical data can't be properly passed!  Here is an example where I try to learn a decision tree on random data, where the second dimension is a categorical dimension:

```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.1 (2021-04-23)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using mlpack

julia> dims = [true, false]
2-element Vector{Bool}:
 1
 0

julia> dims = [false, true]
2-element Vector{Bool}:
 0
 1

julia> x = collect(hcat(rand(100), rand(1:4, 100))');

julia> y = rand(1:3, 100);

julia> mlpack.decision_tree(training=(dims, x), labels=y, verbose=true, points_are_rows=false)

signal (11): Segmentation fault
in expression starting at REPL[6]:1
_ZN6mlpack4tree19AllCategoricalSplitINS0_8GiniGainEE13SplitIfBetterILb0EN4arma11subview_rowIdEENS5_3RowIdEEEEddRKT0_mRKNS8_ImEEmRKT1_mdRNS5_3ColINSA_9elem_typeEEERNS3_18AuxiliarySplitInfoISK_EE at /home/ryan/work/relationalai/raicode/.julia/artifacts/334cd17b4ac7a21d703cbaf56307a1815492be54/lib/libmlpack_julia_decision_tree.so (unknown line)
_ZN6mlpack4tree12DecisionTreeINS0_8GiniGainENS0_22BestBinaryNumericSplitENS0_19AllCategoricalSplitENS0_18AllDimensionSelectEdLb0EE5TrainILb0EN4arma3MatIdEEEEdRT0_mmRKNS_4data13DatasetMapperINSD_15IncrementPolicyENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEERNS8_3RowImEEmRNSP_IdEEmdmRS5_ at /home/ryan/work/relationalai/raicode/.julia/artifacts/334cd17b4ac7a21d703cbaf56307a1815492be54/lib/libmlpack_julia_decision_tree.so (unknown line)
_ZN6mlpack4tree12DecisionTreeINS0_8GiniGainENS0_22BestBinaryNumericSplitENS0_19AllCategoricalSplitENS0_18AllDimensionSelectEdLb0EEC1IN4arma3MatIdEENS8_3RowImEEEET_RKNS_4data13DatasetMapperINSE_15IncrementPolicyENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEET0_mmdmS5_ at /home/ryan/work/relationalai/raicode/.julia/artifacts/334cd17b4ac7a21d703cbaf56307a1815492be54/lib/libmlpack_julia_decision_tree.so (unknown line)
_ZL10mlpackMainv at /home/ryan/work/relationalai/raicode/.julia/artifacts/334cd17b4ac7a21d703cbaf56307a1815492be54/lib/libmlpack_julia_decision_tree.so (unknown line)
decision_tree at /home/ryan/work/relationalai/raicode/.julia/artifacts/334cd17b4ac7a21d703cbaf56307a1815492be54/lib/libmlpack_julia_decision_tree.so (unknown line)
decision_tree_mlpackMain at /home/ryan/work/relationalai/raicode/.julia/packages/mlpack/QI2zj/src/decision_tree.jl:12 [inlined]
#decision_tree#7 at /home/ryan/work/relationalai/raicode/.julia/packages/mlpack/QI2zj/src/decision_tree.jl:202 [inlined]
decision_tree##kw at /home/ryan/work/relationalai/raicode/.julia/packages/mlpack/QI2zj/src/decision_tree.jl:154
unknown function (ip: 0x7fdd43c7a871)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2237 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2419
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1703 [inlined]
do_call at /buildworker/worker/package_linux64/build/src/interpreter.c:115
eval_value at /buildworker/worker/package_linux64/build/src/interpreter.c:204
eval_stmt_value at /buildworker/worker/package_linux64/build/src/interpreter.c:155 [inlined]
eval_body at /buildworker/worker/package_linux64/build/src/interpreter.c:562
jl_interpret_toplevel_thunk at /buildworker/worker/package_linux64/build/src/interpreter.c:670
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:877
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:825
jl_toplevel_eval_in at /buildworker/worker/package_linux64/build/src/toplevel.c:929
eval at ./boot.jl:360 [inlined]
eval_user_input at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:139
repl_backend_loop at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:200
start_repl_backend at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:185
#run_repl#42 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:317
run_repl at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:305
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2237 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2419
#874 at ./client.jl:387
jfptr_YY.874_41532.clone_1 at /opt/julia-1.6.1/lib/julia/sys.so (unknown line)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2237 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2419
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1703 [inlined]
jl_f__call_latest at /buildworker/worker/package_linux64/build/src/builtins.c:714
...
```

Not a great time!

Anyway, it turns out the reason for this is that when we pass a matrix with a `DatasetInfo` to mlpack, we actually are not populating that `DatasetInfo` with the number of categories.  That means that when, e.g., the decision tree calls `datasetInfo.NumMappings(dim)`, this returns 0, which doesn't make sense and leads to a later error.

The solution to this is just to modify `SetParamMatWithInfo()` to compute these mappings, just like the Python bindings do.

I will need to release a patched version of mlpack 3.4.2 with this included for the Julia package, so that `Pkg.add("mlpack")` will result in a correctly working binding.