### PR TITLE
Try to fix CI with CMake 3.20

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -35,8 +35,12 @@ steps:
     fi
 
     # Install armadillo.
-    curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
-    cmake . && make && sudo make install && cd ..
+    curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && \
+        cd armadillo* && \
+        cmake . && \
+        make && \
+        sudo make install && \
+        cd ..
 
     # Install cereal.
     wget https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz

--- a/src/mlpack/methods/ann/gan/metrics/CMakeLists.txt
+++ b/src/mlpack/methods/ann/gan/metrics/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Define the files we need to compile.
 # Anything not in this list will not be compiled into mlpack.
 set(SOURCES
-  inception_score
-  inception_score_impl
+  inception_score.hpp
+  inception_score_impl.hpp
 )
 
 # Add directory name to sources.


### PR DESCRIPTION
It looks like the CI builds have started failing, and this might be a factor of the Linux CI systems now using CMake 3.20.  Let's see if this simple fix fixes things... (it's kind of a shot in the dark).