### PR TITLE
LoadCSV: only reset the DatasetMapper if the dimensionality is wrong

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -61,6 +61,8 @@
 
   * Fix Julia model serialization bug (#2970).
 
+  * Fix `LoadCSV()` to use pre-populated `DatasetInfo` objects (#2980).
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/src/mlpack/core/data/load.hpp
+++ b/src/mlpack/core/data/load.hpp
@@ -273,8 +273,12 @@ bool Load(const std::string& filename,
  * mlpack requires column-major matrices, this should be left at its default
  * value of 'true'.
  *
- * The DatasetMapper object passed to this function will be re-created, so any
- * mappings from previous loads will be lost.
+ * If the given `info` has already been used with a different `data::Load()`
+ * call where the dataset has the same dimensionality, then the mappings and
+ * dimension types inside of `info` will be *re-used*.  If the given `info` is a
+ * new `DatasetMapper` object (e.g. its dimensionality is 0), then new mappings
+ * will be created.  If the given `info` has a different dimensionality of data
+ * than what is present in `filename`, an exception will be thrown.
  *
  * @param filename Name of file to load.
  * @param matrix Matrix to load contents of file into.

--- a/src/mlpack/core/data/load_csv.hpp
+++ b/src/mlpack/core/data/load_csv.hpp
@@ -100,7 +100,7 @@ class LoadCSV
     // Reset the DatasetInfo object, if needed.
     if (info.Dimensionality() == 0)
     {
-      info = DatasetMapper<MapPolicy>(rows);
+      info.SetDimensionality(rows);
     }
     else if (info.Dimensionality() != rows)
     {
@@ -195,7 +195,7 @@ class LoadCSV
         // Reset the DatasetInfo object, if needed.
         if (info.Dimensionality() == 0)
         {
-          info = DatasetMapper<MapPolicy>(rows);
+          info.SetDimensionality(rows);
         }
         else if (info.Dimensionality() != rows)
         {

--- a/src/mlpack/core/data/load_csv.hpp
+++ b/src/mlpack/core/data/load_csv.hpp
@@ -96,7 +96,20 @@ class LoadCSV
     {
       ++rows;
     }
-    info = DatasetMapper<MapPolicy>(rows);
+
+    // Reset the DatasetInfo object, if needed.
+    if (info.Dimensionality() == 0)
+    {
+      info = DatasetMapper<MapPolicy>(rows);
+    }
+    else if (info.Dimensionality() != rows)
+    {
+      std::ostringstream oss;
+      oss << "data::LoadCSV(): given DatasetInfo has dimensionality "
+          << info.Dimensionality() << ", but data has dimensionality "
+          << rows;
+      throw std::invalid_argument(oss.str());
+    }
 
     // Now, jump back to the beginning of the file.
     inFile.clear();
@@ -179,8 +192,19 @@ class LoadCSV
         qi::parse(line.begin(), line.end(),
             stringRule[findRowSize] % delimiterRule);
 
-        // Now that we know the dimensionality, initialize the DatasetMapper.
-        info.SetDimensionality(rows);
+        // Reset the DatasetInfo object, if needed.
+        if (info.Dimensionality() == 0)
+        {
+          info = DatasetMapper<MapPolicy>(rows);
+        }
+        else if (info.Dimensionality() != rows)
+        {
+          std::ostringstream oss;
+          oss << "data::LoadCSV(): given DatasetInfo has dimensionality "
+              << info.Dimensionality() << ", but data has dimensionality "
+              << rows;
+          throw std::invalid_argument(oss.str());
+        }
       }
 
       // If we need to do a first pass for the DatasetMapper, do it.


### PR DESCRIPTION
I was trying to put together an example for @RishabhGarg108 of how to use a pre-populated `DatasetInfo` object to load categorical data.  Here's the code I wrote:

```c++
#include <mlpack/core.hpp>

using namespace arma;
using namespace mlpack;
using namespace mlpack::data;

int main()
{
  // Load the iris dataset, but mark the 2nd and 3rd dimensions as categorical.
  DatasetInfo di(4);
  di.Type(1) = Datatype::categorical;
  di.Type(2) = Datatype::categorical;

  mat m;
  data::Load("iris.csv", m, di);

  std::cout << "Loaded 'iris.csv':\n";
  for (size_t i = 0; i < 4; ++i)
  {
    std::cout << " - Dimension " << i << ": " << di.Type(i) << ", " << di.NumMappings(i)
        << " mappings." << std::endl;
  }

  m.print("m:");
}
```

But, much to my surprise, this did not work, and the data was continually loaded as numeric!

As I dug into the issue, I noticed that `LoadARFF()` only resets the `DatasetInfo` if the given `DatasetInfo` has dimensionality 0 (and throws an exception if the given `DatasetInfo` has some dimensionality other than the dimensionality of the data being loaded).  But, `LoadCSV()` behaves differently, *always* resetting the `DatasetInfo`!

So, I changed `LoadCSV()` to match `LoadARFF()`, and updated the documentation for `data::Load()` to match how it actually behaves.

Now, `data::Load()` will always behave as described in this tutorial: https://www.mlpack.org/doc/mlpack-git/doxygen/formatdoc.html#formatcatcpp

CC/FYI: @RishabhGarg108, @gmanlan, @shrit, @heisenbuug