### PR TITLE
Padding layer fix for multiple filters

### DIFF
--- a/src/mlpack/methods/ann/layer/padding.hpp
+++ b/src/mlpack/methods/ann/layer/padding.hpp
@@ -101,6 +101,26 @@ class Padding
   //! Modify the bottom padding width.
   size_t& PadHBottom() { return padHBottom; }
 
+  //! Get the input width.
+  size_t InputWidth() const { return inputWidth; }
+  //! Modify the input width.
+  size_t& InputWidth() { return inputWidth; }
+
+  //! Get the input height.
+  size_t InputHeight() const { return inputHeight; }
+  //! Modify the input height.
+  size_t& InputHeight() { return inputHeight; }
+
+  //! Get the output width.
+  size_t OutputWidth() const { return outputWidth; }
+  //! Modify the output width.
+  size_t& OutputWidth() { return outputWidth; }
+
+  //! Get the output height.
+  size_t OutputHeight() const { return outputHeight; }
+  //! Modify the output height.
+  size_t& OutputHeight() { return outputHeight; }
+
   /**
    * Serialize the layer.
    */
@@ -122,6 +142,27 @@ class Padding
 
   //! Locally-stored number of rows and columns of input.
   size_t nRows, nCols;
+
+  //! Locally-stored input height.
+  size_t inputHeight;
+
+  //! Locally-stored input width.
+  size_t inputWidth;
+  
+  //! Locally-stored output height.
+  size_t outputHeight;
+  
+  //! Locally-stored output width.
+  size_t outputWidth;
+
+  //! Locally-stored number of input channels.
+  size_t inSize;
+
+  //! Locally-stored cube input parameter.
+  arma::cube inputTemp;
+
+  //! Locally-stored output parameter.
+  arma::cube outputTemp;
 
   //! Locally-stored delta object.
   OutputDataType delta;

--- a/src/mlpack/methods/ann/layer/padding.hpp
+++ b/src/mlpack/methods/ann/layer/padding.hpp
@@ -45,7 +45,9 @@ class Padding
   Padding(const size_t padWLeft = 0,
           const size_t padWRight = 0,
           const size_t padHTop = 0,
-          const size_t padHBottom = 0);
+          const size_t padHBottom = 0,
+          const size_t inputWidth = 0,
+          const size_t inputHeight = 0);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/padding.hpp
+++ b/src/mlpack/methods/ann/layer/padding.hpp
@@ -41,6 +41,8 @@ class Padding
    * @param padWRight Right padding width of the input.
    * @param padHTop Top padding height of the input.
    * @param padHBottom Bottom padding height of the input.
+   * @param inputWidth Width of the input.
+   * @param inputHeight Height of the input.
    */
   Padding(const size_t padWLeft = 0,
           const size_t padWRight = 0,

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -57,12 +57,15 @@ void Padding<InputDataType, OutputDataType>::Forward(
   else
   {
     inSize = input.n_elem / (inputWidth * inputHeight * nCols);
-    inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
-        inputWidth, inputHeight, nCols * inSize, false, false);
+    inputTemp = arma::Cube<eT>(const_cast<arma::Mat<eT>&>(input).memptr(),
+        inputWidth, inputHeight, inSize * nCols, false, false);
     outputTemp = arma::zeros<arma::Cube<eT> >(inputWidth + padWLeft + padWRight,
-        inputHeight + padHTop + padHBottom, nCols * inSize);
-    outputTemp.subcube(padWLeft, padHTop, 0, padWLeft + inputWidth - 1,
-        padHTop + inputHeight - 1, inSize - 1) = inputTemp;
+        inputHeight + padHTop + padHBottom, inSize * nCols);
+    for (size_t i = 0; i < inputTemp.n_slices; ++i)
+    {   
+      outputTemp.slice(i).submat(padWLeft, padHTop, padWLeft + inputWidth - 1,
+          padHTop + inputHeight - 1) = inputTemp.slice(i);
+    }
     output = arma::Mat<eT>(outputTemp.memptr(), outputTemp.n_elem / nCols,
         nCols);
   }
@@ -91,9 +94,12 @@ void Padding<InputDataType, OutputDataType>::serialize(
   ar(CEREAL_NVP(padWRight));
   ar(CEREAL_NVP(padHTop));
   ar(CEREAL_NVP(padHBottom));
+  ar(CEREAL_NVP(inputWidth));
+  ar(CEREAL_NVP(inputHeight));
 }
 
 } // namespace ann
 } // namespace mlpack
 
 #endif
+    

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -59,13 +59,14 @@ void Padding<InputDataType, OutputDataType>::Forward(
     inSize = input.n_elem / (inputWidth * inputHeight * nCols);
     inputTemp = arma::Cube<eT>(const_cast<arma::Mat<eT>&>(input).memptr(),
         inputWidth, inputHeight, inSize * nCols, false, false);
-    outputTemp = arma::zeros<arma::Cube<eT> >(inputWidth + padWLeft + padWRight,
+    outputTemp = arma::zeros<arma::Cube<eT>>(inputWidth + padWLeft + padWRight,
         inputHeight + padHTop + padHBottom, inSize * nCols);
     for (size_t i = 0; i < inputTemp.n_slices; ++i)
     {   
       outputTemp.slice(i).submat(padWLeft, padHTop, padWLeft + inputWidth - 1,
           padHTop + inputHeight - 1) = inputTemp.slice(i);
     }
+
     output = arma::Mat<eT>(outputTemp.memptr(), outputTemp.n_elem / nCols,
         nCols);
   }

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -24,15 +24,17 @@ Padding<InputDataType, OutputDataType>::Padding(
     const size_t padWLeft,
     const size_t padWRight,
     const size_t padHTop,
-    const size_t padHBottom) :
+    const size_t padHBottom,
+    const size_t inputWidth,
+    const size_t inputHeight) :
     padWLeft(padWLeft),
     padWRight(padWRight),
     padHTop(padHTop),
     padHBottom(padHBottom),
     nRows(0),
     nCols(0),
-    inputHeight(0),
-    inputWidth(0)
+    inputHeight(inputWidth),
+    inputWidth(inputHeight)
 {
   // Nothing to do here.
 }
@@ -44,15 +46,26 @@ void Padding<InputDataType, OutputDataType>::Forward(
 {
   nRows = input.n_rows;
   nCols = input.n_cols;
-  inSize = input.n_elem / (inputWidth * inputHeight * nCols);
-  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
-      inputWidth, inputHeight, nCols * inSize, false, false);
-  outputTemp = arma::zeros<arma::Cube<eT> >(inputWidth + padWLeft + padWRight,
-      inputHeight + padHTop + padHBottom, nCols * inSize);
-  outputTemp.subcube(padWLeft, padHTop, 0, padWLeft + inputWidth - 1,
-      padHTop + inputHeight - 1, inSize - 1);
-  output = arma::Mat<eT>(outputTemp.memptr(), outputTemp.n_elem / nCols,
-      nCols);
+  
+  if (inputWidth == 0 || inputHeight == 0)
+  {
+    output = arma::zeros(nRows + padWLeft + padWRight,
+        nCols + padHTop + padHBottom);
+    output.submat(padWLeft, padHTop, padWLeft + nRows - 1,
+        padHTop + nCols - 1) = input;
+  }
+  else
+  {
+    inSize = input.n_elem / (inputWidth * inputHeight * nCols);
+    inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
+        inputWidth, inputHeight, nCols * inSize, false, false);
+    outputTemp = arma::zeros<arma::Cube<eT> >(inputWidth + padWLeft + padWRight,
+        inputHeight + padHTop + padHBottom, nCols * inSize);
+    outputTemp.subcube(padWLeft, padHTop, 0, padWLeft + inputWidth - 1,
+        padHTop + inputHeight - 1, inSize - 1);
+    output = arma::Mat<eT>(outputTemp.memptr(), outputTemp.n_elem / nCols,
+        nCols);
+  }
 
   outputHeight = output.n_cols;
   outputWidth = output.n_rows;

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -30,7 +30,9 @@ Padding<InputDataType, OutputDataType>::Padding(
     padHTop(padHTop),
     padHBottom(padHBottom),
     nRows(0),
-    nCols(0)
+    nCols(0),
+    inputHeight(0),
+    inputWidth(0)
 {
   // Nothing to do here.
 }
@@ -42,10 +44,18 @@ void Padding<InputDataType, OutputDataType>::Forward(
 {
   nRows = input.n_rows;
   nCols = input.n_cols;
-  output = arma::zeros(nRows + padWLeft + padWRight,
-      nCols + padHTop + padHBottom);
-  output.submat(padWLeft, padHTop, padWLeft + nRows - 1,
-      padHTop + nCols - 1) = input;
+  inSize = input.n_elem / (inputWidth * inputHeight * nCols);
+  inputTemp = arma::cube(const_cast<arma::Mat<eT>&>(input).memptr(),
+      inputWidth, inputHeight, nCols * inSize, false, false);
+  outputTemp = arma::zeros<arma::Cube<eT> >(inputWidth + padWLeft + padWRight,
+      inputHeight + padHTop + padHBottom, nCols * inSize);
+  outputTemp.subcube(padWLeft, padHTop, 0, padWLeft + inputWidth - 1,
+      padHTop + inputHeight - 1, inSize - 1);
+  output = arma::Mat<eT>(outputTemp.memptr(), outputTemp.n_elem / nCols,
+      nCols);
+
+  outputHeight = output.n_cols;
+  outputWidth = output.n_rows;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -71,8 +71,8 @@ void Padding<InputDataType, OutputDataType>::Forward(
         nCols);
   }
 
-  outputHeight = output.n_cols;
-  outputWidth = output.n_rows;
+  outputWidth = inputWidth + padWLeft + padWRight;
+  outputHeight = inputHeight + padHTop + padHBottom;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -62,7 +62,7 @@ void Padding<InputDataType, OutputDataType>::Forward(
     outputTemp = arma::zeros<arma::Cube<eT> >(inputWidth + padWLeft + padWRight,
         inputHeight + padHTop + padHBottom, nCols * inSize);
     outputTemp.subcube(padWLeft, padHTop, 0, padWLeft + inputWidth - 1,
-        padHTop + inputHeight - 1, inSize - 1);
+        padHTop + inputHeight - 1, inSize - 1) = inputTemp;
     output = arma::Mat<eT>(outputTemp.memptr(), outputTemp.n_elem / nCols,
         nCols);
   }

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -697,7 +697,7 @@ TEST_CASE("SimpleLinearNoBiasLayerTest", "[ANNLayerTest]")
  */
 TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
 {
-  arma::mat output, input, delta;
+  arma::mat output, input, delta, input1, output1;
   Padding<> module(1, 2, 3, 4);
 
   // Test the Forward function.
@@ -710,6 +710,16 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   // Test the Backward function.
   module.Backward(input, output, delta);
   CheckMatrices(delta, input);
+
+  // Test forward function for multiple filters.
+  // Here it's 3 filters with height = 244, width = 244
+  // the output should be 266 * 266 * 3 with 1 padding.
+  Padding<> module1(1, 1, 1, 1, 244, 244);
+  input1 = arma::randu(224 * 224 * 3, 1);
+  module1.Forward(input1, output1);
+  REQUIRE(arma::accu(input1) == arma::accu(output1));
+  REQUIRE(output.n_rows == (226 * 226 * 3));
+  REQUIRE(output.n_cols == 1);
 }
 
 /**

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -718,8 +718,8 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   input1 = arma::randu(224 * 224 * 3, 1);
   module1.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));
-  REQUIRE(output.n_rows == (226 * 226 * 3));
-  REQUIRE(output.n_cols == 1);
+  REQUIRE(output1.n_rows == (226 * 226 * 3));
+  REQUIRE(output1.n_cols == 1);
 
   // Test forward function for multiple batches with multiple filters.
   // Here it's 3 filters with height = 244, width = 244
@@ -728,8 +728,8 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   input1 = arma::randu(244 * 244 * 3, 3);
   module1.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));
-  REQUIRE(output.n_rows == (248 * 248 * 3));
-  REQUIRE(output.n_cols == 3);
+  REQUIRE(output1.n_rows == (248 * 248 * 3));
+  REQUIRE(output1.n_cols == 3);
 }
 
 /**

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -726,7 +726,7 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   // the output should be [248 * 248 * 3, 3] with 1 padding.
   Padding<> module2(1 ,1, 1, 1, 244, 244);
   input1 = arma::randu(244 * 244 * 3, 3);
-  module1.Forward(input1, output1);
+  module2.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));
   REQUIRE(output1.n_rows == (248 * 248 * 3));
   REQUIRE(output1.n_cols == 3);

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -714,7 +714,7 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   // Test forward function for multiple filters.
   // Here it's 3 filters with height = 224, width = 224
   // the output should be [226 * 226 * 3, 1] with 1 padding.
-  Padding<> module1(1, 1, 1, 1, 244, 244);
+  Padding<> module1(1, 1, 1, 1, 224, 224);
   input1 = arma::randu(224 * 224 * 3, 1);
   module1.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));
@@ -724,6 +724,7 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   // Test forward function for multiple batches with multiple filters.
   // Here it's 3 filters with height = 244, width = 244
   // the output should be [248 * 248 * 3, 3] with 1 padding.
+  Padding<> module2(1 ,1, 1, 1, 244, 244);
   input1 = arma::randu(244 * 244 * 3, 3);
   module1.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -712,14 +712,23 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
   CheckMatrices(delta, input);
 
   // Test forward function for multiple filters.
-  // Here it's 3 filters with height = 244, width = 244
-  // the output should be 266 * 266 * 3 with 1 padding.
+  // Here it's 3 filters with height = 224, width = 224
+  // the output should be [226 * 226 * 3, 1] with 1 padding.
   Padding<> module1(1, 1, 1, 1, 244, 244);
   input1 = arma::randu(224 * 224 * 3, 1);
   module1.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));
   REQUIRE(output.n_rows == (226 * 226 * 3));
   REQUIRE(output.n_cols == 1);
+
+  // Test forward function for multiple batches with multiple filters.
+  // Here it's 3 filters with height = 244, width = 244
+  // the output should be [248 * 248 * 3, 3] with 1 padding.
+  input1 = arma::randu(244 * 244 * 3, 3);
+  module1.Forward(input1, output1);
+  REQUIRE(arma::accu(input1) == arma::accu(output1));
+  REQUIRE(output.n_rows == (248 * 248 * 3));
+  REQUIRE(output.n_cols == 3);
 }
 
 /**

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -723,12 +723,12 @@ TEST_CASE("SimplePaddingLayerTest", "[ANNLayerTest]")
 
   // Test forward function for multiple batches with multiple filters.
   // Here it's 3 filters with height = 244, width = 244
-  // the output should be [248 * 248 * 3, 3] with 1 padding.
+  // the output should be [246 * 246 * 3, 3] with 1 padding.
   Padding<> module2(1 ,1, 1, 1, 244, 244);
   input1 = arma::randu(244 * 244 * 3, 3);
   module2.Forward(input1, output1);
   REQUIRE(arma::accu(input1) == arma::accu(output1));
-  REQUIRE(output1.n_rows == (248 * 248 * 3));
+  REQUIRE(output1.n_rows == (246 * 246 * 3));
   REQUIRE(output1.n_cols == 3);
 }
 


### PR DESCRIPTION
The current implementation of the padding layer only accounted for a single filter and added the padding to only a single filter even if there were multiple of them, this PR aims to account for that and the code works but there are somethings that i would like to discuss.

1. This layer was implemented by taking inspiration from the maxpool layer and in that there are two params which are `inputWidth` and `inputHeight` now i don't think those params are auto initialized in a `FFN` class and that class is used as a module rather than a direct layer because of those two params? (I might be wrong here).
2. If we want to use the padding class directly as a layer it would require that it now accepts `inputWidth` and `inputHeight`  or whever it is used as amoudle it would require that we update the internal vairables which are `inputHeight` and `inputWidth` after creating the `Padding` module and in turn so much code change that uses padding. :tired_face: 

Is there any better solution to this ? 
I might have missed something that i would have wanted to say so let me know if you feel like something is missing. 