### PR TITLE
Include ensmallen so ENS_VERSION_MAJOR is defined.

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/q_learning.hpp
+++ b/src/mlpack/methods/reinforcement_learning/q_learning.hpp
@@ -14,6 +14,7 @@
 #define MLPACK_METHODS_RL_Q_LEARNING_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <ensmallen.hpp>
 
 #include "replay/random_replay.hpp"
 #include "replay/prioritized_replay.hpp"

--- a/src/mlpack/methods/reinforcement_learning/sac.hpp
+++ b/src/mlpack/methods/reinforcement_learning/sac.hpp
@@ -14,6 +14,7 @@
 #define MLPACK_METHODS_RL_SAC_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <ensmallen.hpp>
 
 #include "replay/random_replay.hpp"
 #include <mlpack/methods/ann/activation_functions/tanh_function.hpp>

--- a/src/mlpack/methods/reinforcement_learning/worker/n_step_q_learning_worker.hpp
+++ b/src/mlpack/methods/reinforcement_learning/worker/n_step_q_learning_worker.hpp
@@ -13,6 +13,7 @@
 #ifndef MLPACK_METHODS_RL_WORKER_N_STEP_Q_LEARNING_WORKER_HPP
 #define MLPACK_METHODS_RL_WORKER_N_STEP_Q_LEARNING_WORKER_HPP
 
+#include <ensmallen.hpp>
 #include <mlpack/methods/reinforcement_learning/training_config.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/reinforcement_learning/worker/one_step_q_learning_worker.hpp
+++ b/src/mlpack/methods/reinforcement_learning/worker/one_step_q_learning_worker.hpp
@@ -13,6 +13,7 @@
 #ifndef MLPACK_METHODS_RL_WORKER_ONE_STEP_Q_LEARNING_WORKER_HPP
 #define MLPACK_METHODS_RL_WORKER_ONE_STEP_Q_LEARNING_WORKER_HPP
 
+#include <ensmallen.hpp>
 #include <mlpack/methods/reinforcement_learning/training_config.hpp>
 
 namespace mlpack {

--- a/src/mlpack/methods/reinforcement_learning/worker/one_step_sarsa_worker.hpp
+++ b/src/mlpack/methods/reinforcement_learning/worker/one_step_sarsa_worker.hpp
@@ -13,6 +13,7 @@
 #ifndef MLPACK_METHODS_RL_WORKER_ONE_STEP_SARSA_WORKER_HPP
 #define MLPACK_METHODS_RL_WORKER_ONE_STEP_SARSA_WORKER_HPP
 
+#include <ensmallen.hpp>
 #include <mlpack/methods/reinforcement_learning/training_config.hpp>
 
 namespace mlpack {


### PR DESCRIPTION
Some of the reinforcement learning structs are defined using the `ENS_VERSION_MAJOR` macro---but there is no guarantee that ensmallen has been included first!  So this PR fixes that by simply including ensmallen.hpp in all files that use `ENS_VERSION_MAJOR`.

This should fix @JackMBenson's issue in #2987.