### PR TITLE
Replace boost enable if by std::enable_if

### DIFF
--- a/src/mlpack/bindings/R/default_param.hpp
+++ b/src/mlpack/bindings/R/default_param.hpp
@@ -30,7 +30,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type* = 0,
+        std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/R/default_param.hpp
+++ b/src/mlpack/bindings/R/default_param.hpp
@@ -26,12 +26,12 @@ namespace r {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,7 +57,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */ = 0);
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/R/default_param.hpp
+++ b/src/mlpack/bindings/R/default_param.hpp
@@ -29,7 +29,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace r {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -132,8 +132,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "NA";
 }

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -27,7 +27,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -28,7 +28,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type*,
+        std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/R/get_printable_param.hpp
+++ b/src/mlpack/bindings/R/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace r {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/R/get_printable_type.hpp
+++ b/src/mlpack/bindings/R/get_printable_type.hpp
@@ -23,84 +23,84 @@ namespace r {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,

--- a/src/mlpack/bindings/R/get_printable_type.hpp
+++ b/src/mlpack/bindings/R/get_printable_type.hpp
@@ -50,10 +50,14 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
+    const typename std::enable_if<
+        !util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>

--- a/src/mlpack/bindings/R/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/R/get_printable_type_impl.hpp
@@ -58,11 +58,15 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const typename std::enable_if<
+        !util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !std::is_same<std::string,
+         std::tuple<data::DatasetInfo,arma::mat>>::value>::type*)
 {
   return "character";
 }

--- a/src/mlpack/bindings/R/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/R/get_printable_type_impl.hpp
@@ -22,11 +22,11 @@ namespace r {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "unknown";
 }
@@ -34,11 +34,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -46,11 +46,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "numeric";
 }
@@ -58,11 +58,11 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "character";
 }
@@ -70,11 +70,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -82,11 +82,11 @@ inline std::string GetPrintableType<size_t>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "logical";
 }
@@ -94,9 +94,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "vector of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -104,9 +104,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = "numeric matrix";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -127,8 +127,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "categorical matrix/data.frame";
 }
@@ -136,10 +136,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = util::StripType(d.cppType);
   if (type == "mlpackModel")

--- a/src/mlpack/bindings/R/get_r_type.hpp
+++ b/src/mlpack/bindings/R/get_r_type.hpp
@@ -23,11 +23,11 @@ namespace r {
 template<typename T>
 inline std::string GetRType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -35,11 +35,11 @@ inline std::string GetRType(
 template<>
 inline std::string GetRType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "logical";
 }
@@ -47,11 +47,11 @@ inline std::string GetRType<bool>(
 template<>
 inline std::string GetRType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -59,11 +59,11 @@ inline std::string GetRType<int>(
 template<>
 inline std::string GetRType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -71,11 +71,11 @@ inline std::string GetRType<size_t>(
 template<>
 inline std::string GetRType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "numeric";
 }
@@ -83,11 +83,11 @@ inline std::string GetRType<double>(
 template<>
 inline std::string GetRType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "character";
 }
@@ -95,7 +95,7 @@ inline std::string GetRType<std::string>(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return GetRType<typename T::value_type>(d) + " vector";
 }
@@ -103,9 +103,9 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   std::string elemType = GetRType<typename T::elem_type>(d);
   std::string type = "matrix";
@@ -120,8 +120,8 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "numeric matrix/data.frame with info";
 }
@@ -129,8 +129,8 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return util::StripType(d.cppType);
 }

--- a/src/mlpack/bindings/R/get_r_type.hpp
+++ b/src/mlpack/bindings/R/get_r_type.hpp
@@ -83,10 +83,14 @@ inline std::string GetRType<double>(
 template<>
 inline std::string GetRType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
+    const typename std::enable_if<
+        !util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "character";

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -73,7 +73,7 @@ template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -74,7 +74,8 @@ inline std::string GetType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -72,7 +72,8 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -76,7 +76,8 @@ inline std::string GetType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -24,11 +24,11 @@ namespace r {
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -36,11 +36,11 @@ inline std::string GetType(
 template<>
 inline std::string GetType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Int";
 }
@@ -48,11 +48,11 @@ inline std::string GetType<int>(
 template<>
 inline std::string GetType<float>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<float>>::type*,
-    const typename boost::disable_if<data::HasSerialize<float>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<float>>::type*,
-    const typename boost::disable_if<std::is_same<float,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*,
+    const typename std::enable_if<!std::is_same<float,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Float";
 }
@@ -60,11 +60,11 @@ inline std::string GetType<float>(
 template<>
 inline std::string GetType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Double";
 }
@@ -72,11 +72,11 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "String";
 }
@@ -84,11 +84,11 @@ inline std::string GetType<std::string>(
 template<>
 inline std::string GetType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Bool";
 }
@@ -96,9 +96,9 @@ inline std::string GetType<bool>(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "Vec" + GetType<typename T::value_type>(d);
 }
@@ -106,9 +106,9 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::string type = "";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -136,8 +136,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "MatWithInfo";
 }
@@ -145,8 +145,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return d.cppType;
 }

--- a/src/mlpack/bindings/R/print_input_processing.hpp
+++ b/src/mlpack/bindings/R/print_input_processing.hpp
@@ -26,10 +26,10 @@ namespace r {
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   if (!d.required)
   {
@@ -72,7 +72,7 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   if (!d.required)
   {
@@ -108,8 +108,8 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   if (!d.required)
   {
@@ -155,8 +155,8 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   if (!d.required)
   {

--- a/src/mlpack/bindings/R/print_output_processing.hpp
+++ b/src/mlpack/bindings/R/print_output_processing.hpp
@@ -26,10 +26,10 @@ namespace r {
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   /**
    * This gives us code like:
@@ -48,7 +48,7 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
@@ -69,8 +69,8 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   /**
    * This gives us code like:
@@ -89,8 +89,8 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   /**
    * This gives us code like:

--- a/src/mlpack/bindings/R/print_type_doc.hpp
+++ b/src/mlpack/bindings/R/print_type_doc.hpp
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value::value>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -54,7 +54,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0);
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a model.

--- a/src/mlpack/bindings/R/print_type_doc.hpp
+++ b/src/mlpack/bindings/R/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace r {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -54,7 +54,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/R/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/R/print_type_doc_impl.hpp
@@ -64,7 +64,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value::value>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
 {
   if (std::is_same<T, std::vector<int>>::value)
   {
@@ -86,7 +86,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   if (std::is_same<typename T::elem_type, double>::value)
   {
@@ -129,7 +129,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type*)
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "A 2-d array containing `numeric` data.  Like the regular 2-d matrices"
       ", this can be a `matrix`, or a `data.frame`. However, this type can also"

--- a/src/mlpack/bindings/R/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/R/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace r {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -64,7 +64,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value::value>::type*)
 {
   if (std::is_same<T, std::vector<int>>::value)
   {
@@ -86,7 +86,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type*)
 {
   if (std::is_same<typename T::elem_type, double>::value)
   {
@@ -129,7 +129,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type*)
 {
   return "A 2-d array containing `numeric` data.  Like the regular 2-d matrices"
       ", this can be a `matrix`, or a `data.frame`. However, this type can also"
@@ -146,8 +146,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  `<Model>` refers to the type of model that "
       "is being stored, so, e.g., for `cf()`, the type will be `CFModel`. "

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -33,15 +33,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<std::is_same<T,
-                    bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::enable_if<std::is_same<T,
+                const typename std::enable_if<!std::is_same<T,
+                    bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -65,15 +65,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<std::is_same<T,
-                    bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::enable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<!std::is_same<T,
+                    bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -97,13 +97,13 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<
-                    std::is_same<T, bool>>::type* = 0,
-                const typename boost::enable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<!
+                    std::is_same<T, bool>::value>::type* = 0,
+                const typename std::enable_if<
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                   std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -127,15 +127,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<
-                    std::is_same<T, bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<!
+                    std::is_same<T, bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<T>(cliName.c_str(),
       [&param](const T& value)
@@ -157,15 +157,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::enable_if<
-                    std::is_same<T, bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<
+                    std::is_same<T, bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_flag_function(cliName.c_str(),
       [&param](const T& value)

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -57,7 +57,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */ = 0);

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -30,7 +30,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type* = 0,
+        std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -29,7 +29,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -26,12 +26,12 @@ namespace cli {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace cli {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (!std::is_same<T, bool>::value)
@@ -44,7 +44,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -88,7 +88,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "'" + s + "'";
@@ -115,8 +115,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "''";
 }

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -27,7 +27,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -100,7 +100,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -28,7 +28,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type*,
+        std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/cli/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/delete_allocated_memory.hpp
@@ -21,8 +21,8 @@ namespace cli {
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -30,7 +30,7 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -38,8 +38,8 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
   typedef std::tuple<T*, std::string> TupleType;

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -22,8 +22,8 @@ namespace cli {
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -31,7 +31,7 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -39,8 +39,8 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Here we have a model, which is a tuple, and we need the address of the
   // memory.

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -28,10 +28,10 @@ namespace cli {
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // No mapping is needed, so just cast it directly.
   return *boost::any_cast<T>(&d.value);
@@ -45,7 +45,7 @@ T& GetParam(
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // If the matrix is an input matrix, we have to load the matrix.  'value'
   // contains the filename.  It's possible we could load empty matrices many
@@ -80,8 +80,8 @@ T& GetParam(
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
@@ -110,8 +110,8 @@ T& GetParam(
 template<typename T>
 T*& GetParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // If the model is an input model, we have to load it from file.  'value'
   // contains the filename.

--- a/src/mlpack/bindings/cli/get_printable_param.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param.hpp
@@ -27,11 +27,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Print a vector option, with spaces between it.
@@ -57,8 +57,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print an option into a std::string.  This should print a short, one-line

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -23,11 +23,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -103,8 +103,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   // Extract the string from the tuple that's being held.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/get_printable_param_name.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_name.hpp
@@ -26,10 +26,10 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -38,7 +38,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -47,8 +47,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -57,8 +57,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/cli/get_printable_param_name_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_name_impl.hpp
@@ -26,10 +26,10 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name;
 }
@@ -41,7 +41,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -53,8 +53,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -66,8 +66,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name + "_file";
 }

--- a/src/mlpack/bindings/cli/get_printable_param_value.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_value.hpp
@@ -27,10 +27,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -40,7 +40,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -50,8 +50,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -61,8 +61,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/cli/get_printable_param_value_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_value_impl.hpp
@@ -28,10 +28,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input;
 }
@@ -44,7 +44,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return input + ".csv";
 }
@@ -57,8 +57,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return input + ".bin";
 }
@@ -71,8 +71,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input + ".arff";
 }

--- a/src/mlpack/bindings/cli/get_printable_type.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type.hpp
@@ -23,11 +23,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -60,8 +60,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/cli/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type_impl.hpp
@@ -101,7 +101,7 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
     const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return data.cppType + " file";

--- a/src/mlpack/bindings/cli/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type_impl.hpp
@@ -25,11 +25,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   if (std::is_same<T, bool>::value)
     return "flag";
@@ -101,8 +101,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return data.cppType + " file";
 }

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -27,10 +27,10 @@ namespace cli {
 template<typename T>
 T& GetRawParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // No mapping is needed, so just cast it directly.
   return *boost::any_cast<T>(&d.value);
@@ -42,7 +42,7 @@ T& GetRawParam(
 template<typename T>
 T& GetRawParam(
     util::ParamData& d,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* = 0)
@@ -59,8 +59,8 @@ T& GetRawParam(
 template<typename T>
 T*& GetRawParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Don't load the model.
   typedef std::tuple<T*, std::string> TupleType;

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -31,10 +31,10 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& /* d */,
     util::ParamData& /* input */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Nothing to do.
 }

--- a/src/mlpack/bindings/cli/map_parameter_name.hpp
+++ b/src/mlpack/bindings/cli/map_parameter_name.hpp
@@ -27,10 +27,10 @@ namespace cli {
 template<typename T>
 std::string MapParameterName(
     const std::string& identifier,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return identifier;
 }
@@ -43,7 +43,7 @@ std::string MapParameterName(
 template<typename T>
 std::string MapParameterName(
     const std::string& identifier,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value ||

--- a/src/mlpack/bindings/cli/output_param.hpp
+++ b/src/mlpack/bindings/cli/output_param.hpp
@@ -26,11 +26,11 @@ namespace cli {
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Output a vector option (print to stdout).
@@ -38,7 +38,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Output a matrix option (this saves it to the given file).
@@ -46,7 +46,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Output a serializable class option (this saves it to the given file).
@@ -54,8 +54,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Output a mapped dataset.
@@ -63,8 +63,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Output an option.  This is the function that will be called by the IO

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -24,11 +24,11 @@ namespace cli {
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::cout << data.name << ": " << *boost::any_cast<T>(&data.value)
       << std::endl;
@@ -38,7 +38,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   std::cout << data.name << ": ";
   const T& t = *boost::any_cast<T>(&data.value);
@@ -51,7 +51,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* /* junk */)
 {
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   const T& output = std::get<0>(*boost::any_cast<TupleType>(&data.value));
@@ -71,8 +71,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   // The const cast is necessary here because Serialize() can't ever be marked
   // const.  In this case we can assume it though, since we will be saving and
@@ -91,8 +91,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   // Output the matrix with the mappings.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;

--- a/src/mlpack/bindings/cli/print_type_doc.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace cli {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/cli/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace cli {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -165,8 +165,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "A filename containing an mlpack model.  These can have one of three "
       "formats: binary (.bin), text (.txt), and XML (.xml).  The XML format "

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -27,11 +27,11 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const boost::any& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, bool>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, bool>::value>::type* = 0)
 {
   // No mapping is needed.
   d.value = value;
@@ -44,7 +44,7 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const boost::any& /* value */,
-    const typename boost::enable_if<std::is_same<T, bool>>::type* = 0)
+    const typename std::enable_if<std::is_same<T, bool>::value>::type* = 0)
 {
   // Force set to the value of whether or not this was passed.
   d.value = d.wasPassed;
@@ -60,7 +60,7 @@ void SetParam(
     const boost::any& value,
     const typename std::enable_if<arma::is_arma_type<T>::value ||
                                   std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
@@ -76,8 +76,8 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const boost::any& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -60,7 +60,7 @@ void SetParam(
     const boost::any& value,
     const typename std::enable_if<arma::is_arma_type<T>::value ||
                                   std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0)
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/string_type_param.hpp
+++ b/src/mlpack/bindings/cli/string_type_param.hpp
@@ -26,22 +26,22 @@ namespace cli {
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return a string containing the type of the parameter, for vector options.
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return a string containing the type of the parameter,
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return a string containing the type of a parameter.  This overload is used if

--- a/src/mlpack/bindings/cli/string_type_param_impl.hpp
+++ b/src/mlpack/bindings/cli/string_type_param_impl.hpp
@@ -23,8 +23,8 @@ namespace cli {
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */)
 {
   // Don't know what type this is.
   return "unknown";
@@ -35,7 +35,7 @@ std::string StringTypeParamImpl(
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   return "vector";
 }
@@ -45,7 +45,7 @@ std::string StringTypeParamImpl(
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "string";
 }

--- a/src/mlpack/bindings/go/default_param.hpp
+++ b/src/mlpack/bindings/go/default_param.hpp
@@ -26,12 +26,12 @@ namespace go {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,10 +57,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+                                   arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/go/default_param.hpp
+++ b/src/mlpack/bindings/go/default_param.hpp
@@ -30,7 +30,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type* = 0,
+        std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/go/default_param.hpp
+++ b/src/mlpack/bindings/go/default_param.hpp
@@ -29,7 +29,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/go/default_param_impl.hpp
+++ b/src/mlpack/bindings/go/default_param_impl.hpp
@@ -27,7 +27,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/go/default_param_impl.hpp
+++ b/src/mlpack/bindings/go/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace go {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -90,7 +90,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -134,8 +134,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "nil";
 }

--- a/src/mlpack/bindings/go/default_param_impl.hpp
+++ b/src/mlpack/bindings/go/default_param_impl.hpp
@@ -28,7 +28,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type*,
+        std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -77,7 +77,8 @@ inline std::string GetGoType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -37,11 +37,11 @@ inline std::string GetGoType(
 template<>
 inline std::string GetGoType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -49,11 +49,11 @@ inline std::string GetGoType<int>(
 template<>
 inline std::string GetGoType<float>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<float>>::type*,
-    const typename boost::disable_if<data::HasSerialize<float>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<float>>::type*,
-    const typename boost::disable_if<std::is_same<float,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*,
+    const typename std::enable_if<!std::is_same<float,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float32";
 }
@@ -61,11 +61,11 @@ inline std::string GetGoType<float>(
 template<>
 inline std::string GetGoType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float64";
 }
@@ -73,11 +73,11 @@ inline std::string GetGoType<double>(
 template<>
 inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "string";
 }
@@ -85,11 +85,11 @@ inline std::string GetGoType<std::string>(
 template<>
 inline std::string GetGoType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "bool";
 }
@@ -97,7 +97,7 @@ inline std::string GetGoType<bool>(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return "[]" + GetGoType<typename T::value_type>(d);
 }
@@ -105,9 +105,9 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   return "mat.Dense";
 }
@@ -115,8 +115,8 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "matrixWithInfo";
 }
@@ -124,8 +124,8 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::string goStrippedType, strippedType, printedType, defaultsType;
   StripType(d.cppType, goStrippedType, strippedType, printedType, defaultsType);

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -73,7 +73,8 @@ inline std::string GetGoType<double>(
 template<>
 inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -75,7 +75,8 @@ inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -74,7 +74,7 @@ template<>
 inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/go/get_printable_param.hpp
+++ b/src/mlpack/bindings/go/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -23,75 +23,75 @@ namespace go {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -50,7 +50,8 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -54,7 +54,8 @@ inline std::string GetPrintableType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -52,7 +52,8 @@ inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -51,7 +51,7 @@ template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -60,7 +60,7 @@ template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -59,7 +59,8 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -61,7 +61,8 @@ inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -63,7 +63,8 @@ inline std::string GetPrintableType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -23,11 +23,11 @@ namespace go {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "unknown";
 }
@@ -35,11 +35,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -47,11 +47,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float64";
 }
@@ -59,11 +59,11 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "string";
 }
@@ -71,11 +71,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "bool";
 }
@@ -83,9 +83,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "array of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -93,9 +93,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = "*mat.Dense";
   if (T::is_row || T::is_col)
@@ -107,8 +107,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "matrixWithInfo";
 }
@@ -116,10 +116,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string goStrippedType, strippedType, printedType, defaultsType;
   StripType(d.cppType, goStrippedType, strippedType, printedType, defaultsType);

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -24,9 +24,9 @@ namespace go {
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -34,9 +34,9 @@ inline std::string GetType(
 template<>
 inline std::string GetType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*)
 {
   return "Int";
 }
@@ -44,9 +44,9 @@ inline std::string GetType<int>(
 template<>
 inline std::string GetType<float>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<float>>::type*,
-    const typename boost::disable_if<data::HasSerialize<float>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<float>>::type*)
+    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*)
 {
   return "Float";
 }
@@ -54,9 +54,9 @@ inline std::string GetType<float>(
 template<>
 inline std::string GetType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*)
 {
   return "Double";
 }
@@ -64,9 +64,9 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {
   return "String";
 }
@@ -74,9 +74,9 @@ inline std::string GetType<std::string>(
 template<>
 inline std::string GetType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*)
 {
   return "Bool";
 }
@@ -84,7 +84,7 @@ inline std::string GetType<bool>(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return "Vec" + GetType<typename T::value_type>(d);
 }
@@ -92,7 +92,7 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   std::string type = "";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -120,8 +120,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return d.cppType + "*";
 }

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -65,7 +65,7 @@ template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -68,7 +68,8 @@ inline std::string GetType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*)
 {
   return "String";
 }

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -66,7 +66,8 @@ inline std::string GetType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {
   return "String";

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -64,7 +64,8 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {

--- a/src/mlpack/bindings/go/print_defn_input.hpp
+++ b/src/mlpack/bindings/go/print_defn_input.hpp
@@ -28,10 +28,10 @@ namespace go {
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   if (d.required)
   {
@@ -46,7 +46,7 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // param_name *mat.Dense
   if (d.required)
@@ -62,8 +62,8 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // param_name *DataWithInfo
   if (d.required)
@@ -79,8 +79,8 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_defn_output.hpp
+++ b/src/mlpack/bindings/go/print_defn_output.hpp
@@ -27,10 +27,10 @@ namespace go {
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::cout << GetGoType<T>(d);
 }
@@ -41,7 +41,7 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // *mat.Dense
   std::cout << "*" << GetGoType<T>(d);
@@ -53,8 +53,8 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // *mat.Dense
   std::cout << "*" << GetGoType<T>(d);
@@ -66,8 +66,8 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_input_processing.hpp
+++ b/src/mlpack/bindings/go/print_input_processing.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -129,7 +129,7 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -189,8 +189,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -250,8 +250,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, get the correct classparamName if needed.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_method_config.hpp
+++ b/src/mlpack/bindings/go/print_method_config.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -64,7 +64,7 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -96,8 +96,8 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -129,8 +129,8 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 

--- a/src/mlpack/bindings/go/print_method_init.hpp
+++ b/src/mlpack/bindings/go/print_method_init.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -86,7 +86,7 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -118,8 +118,8 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -151,8 +151,8 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 

--- a/src/mlpack/bindings/go/print_output_processing.hpp
+++ b/src/mlpack/bindings/go/print_output_processing.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -56,7 +56,7 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
@@ -83,8 +83,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -109,8 +109,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_type_doc.hpp
+++ b/src/mlpack/bindings/go/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/go/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/go/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace go {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -122,8 +122,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  This type holds a pointer to C++ memory "
       "containing the mlpack model.  Note that this means the mlpack model "

--- a/src/mlpack/bindings/julia/default_param.hpp
+++ b/src/mlpack/bindings/julia/default_param.hpp
@@ -26,12 +26,12 @@ namespace julia {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,10 +57,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+                                   arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/julia/default_param.hpp
+++ b/src/mlpack/bindings/julia/default_param.hpp
@@ -30,7 +30,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type* = 0,
+        std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/julia/default_param.hpp
+++ b/src/mlpack/bindings/julia/default_param.hpp
@@ -29,7 +29,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/julia/default_param_impl.hpp
+++ b/src/mlpack/bindings/julia/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace julia {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -134,8 +134,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "nothing";
 }

--- a/src/mlpack/bindings/julia/default_param_impl.hpp
+++ b/src/mlpack/bindings/julia/default_param_impl.hpp
@@ -27,7 +27,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/julia/default_param_impl.hpp
+++ b/src/mlpack/bindings/julia/default_param_impl.hpp
@@ -28,7 +28,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type*,
+        std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/julia/get_printable_param.hpp
+++ b/src/mlpack/bindings/julia/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/julia/get_printable_type.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type.hpp
@@ -23,11 +23,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -60,8 +60,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/julia/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type_impl.hpp
@@ -26,11 +26,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   if (std::is_same<T, bool>::value)
     return "Bool";
@@ -102,8 +102,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   std::string type = util::StripType(data.cppType);
   if (type == "mlpackModel")

--- a/src/mlpack/bindings/julia/print_type_doc.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace julia {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/julia/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace julia {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -153,8 +153,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  `<Model>` refers to the type of model that "
       "is being stored, so, e.g., for `CF()`, the type will be `CFModel`. "

--- a/src/mlpack/bindings/markdown/get_printable_param.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/markdown/get_printable_param_name.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_name.hpp
@@ -26,10 +26,10 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -38,7 +38,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -47,8 +47,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -57,8 +57,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/markdown/get_printable_param_name_impl.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_name_impl.hpp
@@ -26,10 +26,10 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name;
 }
@@ -41,7 +41,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -53,8 +53,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -66,8 +66,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name + "_file";
 }

--- a/src/mlpack/bindings/markdown/get_printable_param_value.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_value.hpp
@@ -27,10 +27,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -40,7 +40,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -50,8 +50,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -61,8 +61,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/markdown/get_printable_param_value_impl.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_value_impl.hpp
@@ -28,10 +28,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input;
 }
@@ -44,7 +44,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return input + ".csv";
 }
@@ -57,8 +57,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return input + ".bin";
 }
@@ -71,8 +71,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input + ".arff";
 }

--- a/src/mlpack/bindings/markdown/is_serializable.hpp
+++ b/src/mlpack/bindings/markdown/is_serializable.hpp
@@ -25,7 +25,7 @@ namespace markdown {
  */
 template<typename T>
 bool IsSerializable(
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
 {
   return false;
 }
@@ -35,8 +35,8 @@ bool IsSerializable(
  */
 template<typename T>
 bool IsSerializable(
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return true;
 }

--- a/src/mlpack/bindings/python/default_param.hpp
+++ b/src/mlpack/bindings/python/default_param.hpp
@@ -30,7 +30,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type* = 0,
+        std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/python/default_param.hpp
+++ b/src/mlpack/bindings/python/default_param.hpp
@@ -29,7 +29,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 

--- a/src/mlpack/bindings/python/default_param.hpp
+++ b/src/mlpack/bindings/python/default_param.hpp
@@ -26,12 +26,12 @@ namespace python {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,10 +57,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+                                   arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/python/default_param_impl.hpp
+++ b/src/mlpack/bindings/python/default_param_impl.hpp
@@ -27,7 +27,8 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        !std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/python/default_param_impl.hpp
+++ b/src/mlpack/bindings/python/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace python {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "'" + s + "'";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -134,8 +134,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "None";
 }

--- a/src/mlpack/bindings/python/default_param_impl.hpp
+++ b/src/mlpack/bindings/python/default_param_impl.hpp
@@ -28,7 +28,7 @@ std::string DefaultParamImpl(
     const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
     const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
     const typename std::enable_if<!std::is_same<T,
-        !std::string>::value>::type*,
+        std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -55,7 +55,8 @@ inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {
   return "string";

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -53,7 +53,8 @@ inline std::string GetCythonType<double>(
 template<>
 inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -54,7 +54,7 @@ template<>
 inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -57,7 +57,8 @@ inline std::string GetCythonType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*)
 {
   return "string";
 }

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -23,9 +23,9 @@ namespace python {
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -33,9 +33,9 @@ inline std::string GetCythonType(
 template<>
 inline std::string GetCythonType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*)
 {
   return "int";
 }
@@ -43,9 +43,9 @@ inline std::string GetCythonType<int>(
 template<>
 inline std::string GetCythonType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*)
 {
   return "double";
 }
@@ -53,9 +53,9 @@ inline std::string GetCythonType<double>(
 template<>
 inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {
   return "string";
 }
@@ -63,9 +63,9 @@ inline std::string GetCythonType<std::string>(
 template<>
 inline std::string GetCythonType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*)
 {
   return "size_t";
 }
@@ -73,9 +73,9 @@ inline std::string GetCythonType<size_t>(
 template<>
 inline std::string GetCythonType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*)
 {
   return "cbool";
 }
@@ -83,7 +83,7 @@ inline std::string GetCythonType<bool>(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return "vector[" + GetCythonType<typename T::value_type>(d) + "]";
 }
@@ -91,7 +91,7 @@ inline std::string GetCythonType(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   std::string type = "Mat";
   if (T::is_row)
@@ -105,8 +105,8 @@ inline std::string GetCythonType(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return d.cppType + "*";
 }

--- a/src/mlpack/bindings/python/get_printable_param.hpp
+++ b/src/mlpack/bindings/python/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace python {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -23,84 +23,84 @@ namespace python {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -50,7 +50,8 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -54,7 +54,8 @@ inline std::string GetPrintableType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -52,7 +52,8 @@ inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -51,7 +51,7 @@ template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -60,7 +60,8 @@ inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
         !util::isStdVector<std::string>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<
+        !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -58,7 +58,8 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<
+        !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -62,7 +62,8 @@ inline std::string GetPrintableType<std::string>(
         !util::isStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<
+        !arma::is_arma_type<std::string>::value>::type*,
     const typename std::enable_if<!std::is_same<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -22,11 +22,11 @@ namespace python {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "unknown";
 }
@@ -34,11 +34,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -46,11 +46,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float";
 }
@@ -58,11 +58,11 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "str";
 }
@@ -70,11 +70,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -82,11 +82,11 @@ inline std::string GetPrintableType<size_t>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "bool";
 }
@@ -94,9 +94,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "list of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -104,9 +104,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = "matrix";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -127,8 +127,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "categorical matrix";
 }
@@ -136,10 +136,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return d.cppType + "Type";
 }

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -59,7 +59,7 @@ template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
     const typename std::enable_if<
-        !util::isStdVector<std::string>::value>::type*,
+        !util::IsStdVector<std::string>::value>::type*,
     const typename std::enable_if<
         !data::HasSerialize<std::string>::value>::type*,
     const typename std::enable_if<

--- a/src/mlpack/bindings/python/import_decl.hpp
+++ b/src/mlpack/bindings/python/import_decl.hpp
@@ -26,8 +26,8 @@ template<typename T>
 void ImportDecl(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, we have to parse the type.  If we have something like, e.g.,
   // 'LogisticRegression<>', we must convert this to 'LogisticRegression[T=*].'
@@ -53,8 +53,8 @@ template<typename T>
 void ImportDecl(
     util::ParamData& /* d */,
     const size_t /* indent */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
 {
   // Print nothing.
 }
@@ -66,7 +66,7 @@ template<typename T>
 void ImportDecl(
     util::ParamData& /* d */,
     const size_t /* indent */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Print nothing.
 }

--- a/src/mlpack/bindings/python/print_class_defn.hpp
+++ b/src/mlpack/bindings/python/print_class_defn.hpp
@@ -25,8 +25,8 @@ namespace python {
 template<typename T>
 void PrintClassDefn(
     util::ParamData& /* d */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -37,7 +37,7 @@ void PrintClassDefn(
 template<typename T>
 void PrintClassDefn(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -48,8 +48,8 @@ void PrintClassDefn(
 template<typename T>
 void PrintClassDefn(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, we have to parse the type.  If we have something like, e.g.,
   // 'LogisticRegression<>', we must convert this to 'LogisticRegression[].'

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -31,11 +31,11 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // The copy_all_inputs parameter must be handled first, and therefore is
   // outside the scope of this code.
@@ -164,11 +164,11 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -251,8 +251,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -372,9 +372,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, get the correct class name if needed.
   std::string strippedType, printedType, defaultsType;
@@ -445,9 +445,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // The user should pass in a matrix type of some sort.
   const std::string prefix(indent, ' ');

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -30,10 +30,10 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -86,7 +86,7 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -128,8 +128,8 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -170,8 +170,8 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/python/print_type_doc.hpp
+++ b/src/mlpack/bindings/python/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace python {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/python/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/python/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace python {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -150,8 +150,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  This type can be pickled to or from disk, "
       "and internally holds a pointer to C++ memory containing the mlpack "

--- a/src/mlpack/bindings/tests/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/delete_allocated_memory.hpp
@@ -21,8 +21,8 @@ namespace tests {
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -30,7 +30,7 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -38,8 +38,8 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
   delete *boost::any_cast<T*>(&d.value);

--- a/src/mlpack/bindings/tests/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/get_allocated_memory.hpp
@@ -22,8 +22,8 @@ namespace tests {
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -31,7 +31,7 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -39,8 +39,8 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Here we have a model; return its memory location.
   return *boost::any_cast<T*>(&d.value);

--- a/src/mlpack/bindings/tests/get_printable_param.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param.hpp
@@ -27,11 +27,11 @@ namespace tests {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Print a vector option, with spaces between it.
@@ -39,7 +39,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Print a matrix option (this just prints the filename).
@@ -47,7 +47,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Print a serializable class option (this just prints the filename).
@@ -55,8 +55,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print a mapped matrix option (this just prints the filename).
@@ -64,8 +64,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Print an option into a std::string.  This should print a short, one-line

--- a/src/mlpack/bindings/tests/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param_impl.hpp
@@ -22,11 +22,11 @@ namespace tests {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -37,7 +37,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -51,7 +51,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& /* data */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* /* junk */)
 {
   return "matrix type";
 }
@@ -60,8 +60,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   // Extract the string from the tuple that's being held.
   std::ostringstream oss;
@@ -73,8 +73,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& /* data */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   return "matrix/DatatsetInfo tuple";
 }


### PR DESCRIPTION
This replacement should cover mlpack code base entirely. Some of them are replaced by hand while others using regular expression. I have tested them locally except Go lang.
