### PR TITLE
Corrects wrong serialization for BatchNorm and Virtual BN

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -234,7 +234,7 @@ void BatchNorm<InputDataType, OutputDataType>::serialize(
   if (cereal::is_loading<Archive>())
   {
     weights.set_size(size + size, 1);
-    loading = false;
+    loading = true;
   }
 
   ar(CEREAL_NVP(eps));

--- a/src/mlpack/methods/ann/layer/virtual_batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/virtual_batch_norm_impl.hpp
@@ -142,7 +142,7 @@ void VirtualBatchNorm<InputDataType, OutputDataType>::serialize(
   if (cereal::is_loading<Archive>())
   {
     weights.set_size(size + size, 1);
-    loading = false;
+    loading = true;
   }
 
   ar(CEREAL_NVP(eps));


### PR DESCRIPTION
While loading models which were using any of these two layer the weights param were not properly initialized because loading was set to false, setting it to true does the trick. 

Thanks to @zoq and @kartikdutt18 for helping find it out.

Closes #2561  