### PR TITLE
Add 'probabilities' option to softmax regression binding

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -63,6 +63,9 @@
 
   * Fix `LoadCSV()` to use pre-populated `DatasetInfo` objects (#2980).
 
+  * Add `probabilities` option to softmax regression binding, to get class
+    probabilities for test points (#3001).
+
 ### mlpack 3.4.2
 ###### 2020-10-26
   * Added Mean Absolute Percentage Error.

--- a/src/mlpack/methods/softmax_regression/softmax_regression_main.cpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_main.cpp
@@ -112,6 +112,8 @@ PARAM_MODEL_OUT(SoftmaxRegression, "output_model", "File to save trained "
 PARAM_MATRIX_IN("test", "Matrix containing test dataset.", "T");
 PARAM_UROW_OUT("predictions", "Matrix to save predictions for test dataset "
     "into.", "p");
+PARAM_MATRIX_OUT("probabilities", "Matrix to save class probabilities for test "
+    "dataset into.", "P");
 PARAM_UROW_IN("test_labels", "Matrix containing test labels.", "L");
 
 // Softmax configuration options.
@@ -250,6 +252,16 @@ void TestClassifyAcc(size_t numClasses, const Model& model)
   // Save predictions, if desired.
   if (IO::HasParam("predictions"))
     IO::GetParam<arma::Row<size_t>>("predictions") = std::move(predictLabels);
+
+  // Compute probabiltiies, if desired.
+  if (IO::HasParam("probabilities"))
+  {
+    Log::Info << "Calculating class probabilities of points in '"
+        << IO::GetPrintableParam<arma::mat>("test") << "'." << endl;
+    arma::mat probabilities;
+    model.Classify(testData, probabilities);
+    IO::GetParam<arma::mat>("probabilities") = std::move(probabilities);
+  }
 }
 
 template<typename Model>


### PR DESCRIPTION
This solves #2997 by adding a 'probabilities' option to the softmax regression binding.  This allows users to not just get class predictions via `predictions` but also the probabilities for each class.  I guess this option must have been overlooked when the original binding was written!