### PR TITLE
Move Sequential layers to LayerTypes

### DIFF
--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -299,7 +299,6 @@ using LayerTypes = boost::variant<
     Sequential<arma::mat, arma::mat, false>*,
     Sequential<arma::mat, arma::mat, true>*,
     Softmax<arma::mat, arma::mat>*,
-
     TransposedConvolution<NaiveConvolution<ValidConvolution>,
             NaiveConvolution<ValidConvolution>,
             NaiveConvolution<ValidConvolution>, arma::mat, arma::mat>*,

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -222,6 +222,7 @@ template <typename InputDataType,
 class AdaptiveMeanPooling;
 
 using MoreTypes = boost::variant<
+        FlexibleReLU<arma::mat, arma::mat>*,
         Linear3D<arma::mat, arma::mat, NoRegularizer>*,
         LpPooling<arma::mat, arma::mat>*,
         PixelShuffle<arma::mat, arma::mat>*,
@@ -234,8 +235,7 @@ using MoreTypes = boost::variant<
         ReinforceNormal<arma::mat, arma::mat>*,
         Reparametrization<arma::mat, arma::mat>*,
         Select<arma::mat, arma::mat>*,
-        Sequential<arma::mat, arma::mat, false>*,
-        Sequential<arma::mat, arma::mat, true>*,
+        SpatialDropout<arma::mat, arma::mat>*,
         Subview<arma::mat, arma::mat>*,
         VRClassReward<arma::mat, arma::mat>*,
         VirtualBatchNorm<arma::mat, arma::mat>*,
@@ -277,7 +277,6 @@ using LayerTypes = boost::variant<
     Dropout<arma::mat, arma::mat>*,
     ELU<arma::mat, arma::mat>*,
     FastLSTM<arma::mat, arma::mat>*,
-    FlexibleReLU<arma::mat, arma::mat>*,
     GRU<arma::mat, arma::mat>*,
     HardTanH<arma::mat, arma::mat>*,
     Join<arma::mat, arma::mat>*,
@@ -297,8 +296,10 @@ using LayerTypes = boost::variant<
     NoisyLinear<arma::mat, arma::mat>*,
     Padding<arma::mat, arma::mat>*,
     PReLU<arma::mat, arma::mat>*,
+    Sequential<arma::mat, arma::mat, false>*,
+    Sequential<arma::mat, arma::mat, true>*,
     Softmax<arma::mat, arma::mat>*,
-    SpatialDropout<arma::mat, arma::mat>*,
+
     TransposedConvolution<NaiveConvolution<ValidConvolution>,
             NaiveConvolution<ValidConvolution>,
             NaiveConvolution<ValidConvolution>, arma::mat, arma::mat>*,


### PR DESCRIPTION
Moving the `sequential` Layers from `MoreTypes` to `LayerTypes` because preTrained models created with these required us to move these layers to make it work and while deserializing it requires that both the layers still be in `LayerTypes` which is currently not the case so the tests in models repo fail and any user who would try to use them would face a similar error in deserialization 

More Info on this [commnet](https://github.com/mlpack/models/pull/63#issuecomment-870899105) 
Related to the [Addtition of resnet Module](https://github.com/mlpack/models/pull/63)

cc: @kartikdutt18, @zoq 