### PR TITLE
Remove boost any

### DIFF
--- a/src/mlpack/bindings/R/default_param.hpp
+++ b/src/mlpack/bindings/R/default_param.hpp
@@ -26,12 +26,12 @@ namespace r {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,7 +57,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */ = 0);
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace r {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -132,8 +132,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "NA";
 }

--- a/src/mlpack/bindings/R/get_printable_param.hpp
+++ b/src/mlpack/bindings/R/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace r {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/R/get_printable_type.hpp
+++ b/src/mlpack/bindings/R/get_printable_type.hpp
@@ -23,84 +23,84 @@ namespace r {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,

--- a/src/mlpack/bindings/R/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/R/get_printable_type_impl.hpp
@@ -22,11 +22,11 @@ namespace r {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "unknown";
 }
@@ -34,11 +34,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -46,11 +46,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "numeric";
 }
@@ -58,11 +58,11 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "character";
 }
@@ -70,11 +70,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -82,11 +82,11 @@ inline std::string GetPrintableType<size_t>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "logical";
 }
@@ -94,9 +94,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "vector of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -104,9 +104,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = "numeric matrix";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -127,8 +127,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "categorical matrix/data.frame";
 }
@@ -136,10 +136,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = util::StripType(d.cppType);
   if (type == "mlpackModel")

--- a/src/mlpack/bindings/R/get_r_type.hpp
+++ b/src/mlpack/bindings/R/get_r_type.hpp
@@ -23,11 +23,11 @@ namespace r {
 template<typename T>
 inline std::string GetRType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -35,11 +35,11 @@ inline std::string GetRType(
 template<>
 inline std::string GetRType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "logical";
 }
@@ -47,11 +47,11 @@ inline std::string GetRType<bool>(
 template<>
 inline std::string GetRType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -59,11 +59,11 @@ inline std::string GetRType<int>(
 template<>
 inline std::string GetRType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "integer";
 }
@@ -71,11 +71,11 @@ inline std::string GetRType<size_t>(
 template<>
 inline std::string GetRType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "numeric";
 }
@@ -83,11 +83,11 @@ inline std::string GetRType<double>(
 template<>
 inline std::string GetRType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "character";
 }
@@ -95,7 +95,7 @@ inline std::string GetRType<std::string>(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return GetRType<typename T::value_type>(d) + " vector";
 }
@@ -103,9 +103,9 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   std::string elemType = GetRType<typename T::elem_type>(d);
   std::string type = "matrix";
@@ -120,8 +120,8 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "numeric matrix/data.frame with info";
 }
@@ -129,8 +129,8 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return util::StripType(d.cppType);
 }

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -24,11 +24,11 @@ namespace r {
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -36,11 +36,11 @@ inline std::string GetType(
 template<>
 inline std::string GetType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Int";
 }
@@ -48,11 +48,11 @@ inline std::string GetType<int>(
 template<>
 inline std::string GetType<float>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<float>>::type*,
-    const typename boost::disable_if<data::HasSerialize<float>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<float>>::type*,
-    const typename boost::disable_if<std::is_same<float,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*,
+    const typename std::enable_if<!std::is_same<float,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Float";
 }
@@ -60,11 +60,11 @@ inline std::string GetType<float>(
 template<>
 inline std::string GetType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Double";
 }
@@ -72,11 +72,11 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "String";
 }
@@ -84,11 +84,11 @@ inline std::string GetType<std::string>(
 template<>
 inline std::string GetType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "Bool";
 }
@@ -96,9 +96,9 @@ inline std::string GetType<bool>(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "Vec" + GetType<typename T::value_type>(d);
 }
@@ -106,9 +106,9 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::string type = "";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -136,8 +136,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "MatWithInfo";
 }
@@ -145,8 +145,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return d.cppType;
 }

--- a/src/mlpack/bindings/R/print_input_processing.hpp
+++ b/src/mlpack/bindings/R/print_input_processing.hpp
@@ -26,10 +26,10 @@ namespace r {
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   if (!d.required)
   {
@@ -72,7 +72,7 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   if (!d.required)
   {
@@ -108,8 +108,8 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   if (!d.required)
   {
@@ -155,8 +155,8 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   if (!d.required)
   {

--- a/src/mlpack/bindings/R/print_output_processing.hpp
+++ b/src/mlpack/bindings/R/print_output_processing.hpp
@@ -26,10 +26,10 @@ namespace r {
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   /**
    * This gives us code like:
@@ -48,7 +48,7 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
@@ -69,8 +69,8 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   /**
    * This gives us code like:
@@ -89,8 +89,8 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   /**
    * This gives us code like:

--- a/src/mlpack/bindings/R/print_type_doc.hpp
+++ b/src/mlpack/bindings/R/print_type_doc.hpp
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value::value>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -54,7 +54,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0);
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a model.

--- a/src/mlpack/bindings/R/print_type_doc.hpp
+++ b/src/mlpack/bindings/R/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace r {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -54,7 +54,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/R/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/R/print_type_doc_impl.hpp
@@ -64,7 +64,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value::value>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
 {
   if (std::is_same<T, std::vector<int>>::value)
   {
@@ -86,7 +86,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   if (std::is_same<typename T::elem_type, double>::value)
   {
@@ -129,7 +129,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type*)
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "A 2-d array containing `numeric` data.  Like the regular 2-d matrices"
       ", this can be a `matrix`, or a `data.frame`. However, this type can also"

--- a/src/mlpack/bindings/R/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/R/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace r {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -64,7 +64,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value::value>::type*)
 {
   if (std::is_same<T, std::vector<int>>::value)
   {
@@ -86,7 +86,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value::value>::type*)
 {
   if (std::is_same<typename T::elem_type, double>::value)
   {
@@ -129,7 +129,7 @@ template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
     const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type*)
 {
   return "A 2-d array containing `numeric` data.  Like the regular 2-d matrices"
       ", this can be a `matrix`, or a `data.frame`. However, this type can also"
@@ -146,8 +146,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  `<Model>` refers to the type of model that "
       "is being stored, so, e.g., for `cf()`, the type will be `CFModel`. "

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -47,8 +47,8 @@ void AddToCLI11(const std::string& cliName,
       [&param](const std::string& value)
       {
         using TupleType = std::tuple<T, typename ParameterType<T>::type>;
-        TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
-        std::get<0>(std::get<1>(tuple)) = boost::any_cast<std::string>(value);
+        TupleType& tuple = *ANY_CAST<TupleType>(&param.value);
+        std::get<0>(std::get<1>(tuple)) = ANY_CAST<std::string>(value);
         param.wasPassed = true;
       },
       param.desc.c_str());
@@ -79,8 +79,8 @@ void AddToCLI11(const std::string& cliName,
       [&param](const std::string& value)
       {
         using TupleType = std::tuple<T*, typename ParameterType<T>::type>;
-        TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
-        std::get<1>(tuple) = boost::any_cast<std::string>(value);
+        TupleType& tuple = *ANY_CAST<TupleType>(&param.value);
+        std::get<1>(tuple) = ANY_CAST<std::string>(value);
         param.wasPassed = true;
       },
       param.desc.c_str());
@@ -109,8 +109,8 @@ void AddToCLI11(const std::string& cliName,
       [&param](const std::string& value)
       {
         using TupleType = std::tuple<T, typename ParameterType<T>::type>;
-        TupleType& tuple = *boost::any_cast<TupleType>(&param.value);
-        std::get<0>(std::get<1>(tuple)) = boost::any_cast<std::string>(value);
+        TupleType& tuple = *ANY_CAST<TupleType>(&param.value);
+        std::get<0>(std::get<1>(tuple)) = ANY_CAST<std::string>(value);
         param.wasPassed = true;
       },
       param.desc.c_str());

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -33,15 +33,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<std::is_same<T,
-                    bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::enable_if<std::is_same<T,
+                const typename std::enable_if<!std::is_same<T,
+                    bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -65,15 +65,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<std::is_same<T,
-                    bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::enable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<!std::is_same<T,
+                    bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -97,13 +97,13 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<
-                    std::is_same<T, bool>>::type* = 0,
-                const typename boost::enable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<!
+                    std::is_same<T, bool>::value>::type* = 0,
+                const typename std::enable_if<
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                   std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -127,15 +127,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::disable_if<
-                    std::is_same<T, bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<!
+                    std::is_same<T, bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_option_function<T>(cliName.c_str(),
       [&param](const T& value)
@@ -157,15 +157,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename boost::enable_if<
-                    std::is_same<T, bool>>::type* = 0,
-                const typename boost::disable_if<
-                    arma::is_arma_type<T>>::type* = 0,
-                const typename boost::disable_if<
-                    data::HasSerialize<T>>::type* = 0,
-                const typename boost::disable_if<std::is_same<T,
+                const typename std::enable_if<
+                    std::is_same<T, bool>::value>::type* = 0,
+                const typename std::enable_if<!
+                    arma::is_arma_type<T>::value>::type* = 0,
+                const typename std::enable_if<!
+                    data::HasSerialize<T>::value>::type* = 0,
+                const typename std::enable_if<!std::is_same<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>::type* = 0)
+                    arma::mat>>::value>::type* = 0)
 {
   app.add_flag_function(cliName.c_str(),
       [&param](const T& value)

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -57,7 +57,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */ = 0);

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -26,12 +26,12 @@ namespace cli {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace cli {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (!std::is_same<T, bool>::value)
@@ -44,7 +44,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -88,7 +88,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "'" + s + "'";
@@ -115,8 +115,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "''";
 }

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -100,7 +100,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -33,7 +33,7 @@ std::string DefaultParamImpl(
 {
   std::ostringstream oss;
   if (!std::is_same<T, bool>::value)
-    oss << boost::any_cast<T>(data.value);
+    oss << ANY_CAST<T>(data.value);
 
   return oss.str();
 }
@@ -48,7 +48,7 @@ std::string DefaultParamImpl(
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
-  const T& vector = boost::any_cast<T>(data.value);
+  const T& vector = ANY_CAST<T>(data.value);
   oss << "[";
   if (std::is_same<T, std::vector<std::string>>::value)
   {
@@ -90,7 +90,7 @@ std::string DefaultParamImpl(
     util::ParamData& data,
     const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
-  const std::string& s = *boost::any_cast<std::string>(&data.value);
+  const std::string& s = *ANY_CAST<std::string>(&data.value);
   return "'" + s + "'";
 }
 

--- a/src/mlpack/bindings/cli/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/delete_allocated_memory.hpp
@@ -43,7 +43,7 @@ void DeleteAllocatedMemoryImpl(
 {
   // Delete the allocated memory (hopefully we actually own it).
   typedef std::tuple<T*, std::string> TupleType;
-  delete std::get<0>(*boost::any_cast<TupleType>(&d.value));
+  delete std::get<0>(*ANY_CAST<TupleType>(&d.value));
 }
 
 template<typename T>

--- a/src/mlpack/bindings/cli/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/delete_allocated_memory.hpp
@@ -21,8 +21,8 @@ namespace cli {
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -30,7 +30,7 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -38,8 +38,8 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
   typedef std::tuple<T*, std::string> TupleType;

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -45,7 +45,7 @@ void* GetAllocatedMemory(
   // Here we have a model, which is a tuple, and we need the address of the
   // memory.
   typedef std::tuple<T*, std::string> TupleType;
-  return std::get<0>(*boost::any_cast<TupleType>(&d.value));
+  return std::get<0>(*ANY_CAST<TupleType>(&d.value));
 }
 
 template<typename T>

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -22,8 +22,8 @@ namespace cli {
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -31,7 +31,7 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -39,8 +39,8 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Here we have a model, which is a tuple, and we need the address of the
   // memory.

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -34,7 +34,7 @@ T& GetParam(
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // No mapping is needed, so just cast it directly.
-  return *boost::any_cast<T>(&d.value);
+  return *ANY_CAST<T>(&d.value);
 }
 
 /**
@@ -52,7 +52,7 @@ T& GetParam(
   // times, but I am not bothered by that---it shouldn't be something that
   // happens.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
-  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
+  TupleType& tuple = *ANY_CAST<TupleType>(&d.value);
   const std::string& value = std::get<0>(std::get<1>(tuple));
   T& matrix = std::get<0>(tuple);
   size_t& n_rows = std::get<1>(std::get<1>(tuple));
@@ -86,7 +86,7 @@ T& GetParam(
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
-  TupleType* tuple = boost::any_cast<TupleType>(&d.value);
+  TupleType* tuple = ANY_CAST<TupleType>(&d.value);
   const std::string& value = std::get<0>(std::get<1>(*tuple));
   T& t = std::get<0>(*tuple);
   size_t& n_rows = std::get<1>(std::get<1>(*tuple));
@@ -116,7 +116,7 @@ T*& GetParam(
   // If the model is an input model, we have to load it from file.  'value'
   // contains the filename.
   typedef std::tuple<T*, std::string> TupleType;
-  TupleType* tuple = boost::any_cast<TupleType>(&d.value);
+  TupleType* tuple = ANY_CAST<TupleType>(&d.value);
   const std::string& value = std::get<1>(*tuple);
   if (d.input && !d.loaded)
   {

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -28,10 +28,10 @@ namespace cli {
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // No mapping is needed, so just cast it directly.
   return *boost::any_cast<T>(&d.value);
@@ -45,7 +45,7 @@ T& GetParam(
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // If the matrix is an input matrix, we have to load the matrix.  'value'
   // contains the filename.  It's possible we could load empty matrices many
@@ -80,8 +80,8 @@ T& GetParam(
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
@@ -110,8 +110,8 @@ T& GetParam(
 template<typename T>
 T*& GetParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // If the model is an input model, we have to load it from file.  'value'
   // contains the filename.

--- a/src/mlpack/bindings/cli/get_printable_param.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param.hpp
@@ -27,11 +27,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Print a vector option, with spaces between it.
@@ -57,8 +57,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print an option into a std::string.  This should print a short, one-line

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -30,7 +30,7 @@ std::string GetPrintableParam(
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
-  oss << boost::any_cast<T>(data.value);
+  oss << ANY_CAST<T>(data.value);
   return oss.str();
 }
 
@@ -41,7 +41,7 @@ std::string GetPrintableParam(
     const typename std::enable_if<util::IsStdVector<T>::value>::type*
         /* junk */)
 {
-  const T& t = boost::any_cast<T>(data.value);
+  const T& t = ANY_CAST<T>(data.value);
 
   std::ostringstream oss;
   for (size_t i = 0; i < t.size(); ++i)
@@ -80,7 +80,7 @@ std::string GetPrintableParam(
 {
   // Extract the string from the tuple that's being held.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
-  const TupleType* tuple = boost::any_cast<TupleType>(&data.value);
+  const TupleType* tuple = ANY_CAST<TupleType>(&data.value);
 
   std::ostringstream oss;
   oss << "'" << std::get<0>(std::get<1>(*tuple)) << "'";
@@ -108,7 +108,7 @@ std::string GetPrintableParam(
 {
   // Extract the string from the tuple that's being held.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
-  const TupleType* tuple = boost::any_cast<TupleType>(&data.value);
+  const TupleType* tuple = ANY_CAST<TupleType>(&data.value);
 
   std::ostringstream oss;
   oss << std::get<1>(*tuple);

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -23,11 +23,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -103,8 +103,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   // Extract the string from the tuple that's being held.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/get_printable_param_name.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_name.hpp
@@ -26,10 +26,10 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -38,7 +38,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -47,8 +47,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -57,8 +57,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/cli/get_printable_param_name_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_name_impl.hpp
@@ -26,10 +26,10 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name;
 }
@@ -41,7 +41,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -53,8 +53,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -66,8 +66,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name + "_file";
 }

--- a/src/mlpack/bindings/cli/get_printable_param_value.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_value.hpp
@@ -27,10 +27,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -40,7 +40,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -50,8 +50,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -61,8 +61,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/cli/get_printable_param_value_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_value_impl.hpp
@@ -28,10 +28,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input;
 }
@@ -44,7 +44,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return input + ".csv";
 }
@@ -57,8 +57,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return input + ".bin";
 }
@@ -71,8 +71,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input + ".arff";
 }

--- a/src/mlpack/bindings/cli/get_printable_type.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type.hpp
@@ -23,11 +23,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -60,8 +60,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/cli/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type_impl.hpp
@@ -101,7 +101,7 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
     const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return data.cppType + " file";

--- a/src/mlpack/bindings/cli/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type_impl.hpp
@@ -25,11 +25,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   if (std::is_same<T, bool>::value)
     return "flag";
@@ -101,8 +101,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return data.cppType + " file";
 }

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -33,7 +33,7 @@ T& GetRawParam(
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // No mapping is needed, so just cast it directly.
-  return *boost::any_cast<T>(&d.value);
+  return *ANY_CAST<T>(&d.value);
 }
 
 /**
@@ -49,7 +49,7 @@ T& GetRawParam(
 {
   // Don't load the matrix.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
-  T& value = std::get<0>(*boost::any_cast<TupleType>(&d.value));
+  T& value = std::get<0>(*ANY_CAST<TupleType>(&d.value));
   return value;
 }
 
@@ -64,7 +64,7 @@ T*& GetRawParam(
 {
   // Don't load the model.
   typedef std::tuple<T*, std::string> TupleType;
-  T*& value = std::get<0>(*boost::any_cast<TupleType>(&d.value));
+  T*& value = std::get<0>(*ANY_CAST<TupleType>(&d.value));
   return value;
 }
 

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -27,10 +27,10 @@ namespace cli {
 template<typename T>
 T& GetRawParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // No mapping is needed, so just cast it directly.
   return *boost::any_cast<T>(&d.value);
@@ -42,7 +42,7 @@ T& GetRawParam(
 template<typename T>
 T& GetRawParam(
     util::ParamData& d,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* = 0)
@@ -59,8 +59,8 @@ T& GetRawParam(
 template<typename T>
 T*& GetRawParam(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Don't load the model.
   typedef std::tuple<T*, std::string> TupleType;

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -58,10 +58,10 @@ void InPlaceCopyInternal(
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
-  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
+  TupleType& tuple = *ANY_CAST<TupleType>(&d.value);
   std::string& value = std::get<0>(std::get<1>(tuple));
 
-  const TupleType& inputTuple = *boost::any_cast<TupleType>(&input.value);
+  const TupleType& inputTuple = *ANY_CAST<TupleType>(&input.value);
   value = std::get<0>(std::get<1>(inputTuple));
 }
 
@@ -81,10 +81,10 @@ void InPlaceCopyInternal(
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
-  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
+  TupleType& tuple = *ANY_CAST<TupleType>(&d.value);
   std::string& value = std::get<1>(tuple);
 
-  const TupleType& inputTuple = *boost::any_cast<TupleType>(&input.value);
+  const TupleType& inputTuple = *ANY_CAST<TupleType>(&input.value);
   value = std::get<1>(inputTuple);
 }
 

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -31,10 +31,10 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& /* d */,
     util::ParamData& /* input */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Nothing to do.
 }

--- a/src/mlpack/bindings/cli/map_parameter_name.hpp
+++ b/src/mlpack/bindings/cli/map_parameter_name.hpp
@@ -27,10 +27,10 @@ namespace cli {
 template<typename T>
 std::string MapParameterName(
     const std::string& identifier,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return identifier;
 }
@@ -43,7 +43,7 @@ std::string MapParameterName(
 template<typename T>
 std::string MapParameterName(
     const std::string& identifier,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value ||

--- a/src/mlpack/bindings/cli/output_param.hpp
+++ b/src/mlpack/bindings/cli/output_param.hpp
@@ -26,11 +26,11 @@ namespace cli {
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Output a vector option (print to stdout).
@@ -38,7 +38,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Output a matrix option (this saves it to the given file).
@@ -46,7 +46,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Output a serializable class option (this saves it to the given file).
@@ -54,8 +54,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Output a mapped dataset.
@@ -63,8 +63,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Output an option.  This is the function that will be called by the IO

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -30,7 +30,7 @@ void OutputParamImpl(
     const typename std::enable_if<!std::is_same<T,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
-  std::cout << data.name << ": " << *boost::any_cast<T>(&data.value)
+  std::cout << data.name << ": " << *ANY_CAST<T>(&data.value)
       << std::endl;
 }
 
@@ -41,7 +41,7 @@ void OutputParamImpl(
     const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   std::cout << data.name << ": ";
-  const T& t = *boost::any_cast<T>(&data.value);
+  const T& t = *ANY_CAST<T>(&data.value);
   for (size_t i = 0; i < t.size(); ++i)
     std::cout << t[i] << " ";
   std::cout << std::endl;
@@ -54,9 +54,9 @@ void OutputParamImpl(
     const typename std::enable_if<arma::is_arma_type<T>::value>::type* /* junk */)
 {
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
-  const T& output = std::get<0>(*boost::any_cast<TupleType>(&data.value));
+  const T& output = std::get<0>(*ANY_CAST<TupleType>(&data.value));
   const std::string& filename =
-      std::get<0>(std::get<1>(*boost::any_cast<TupleType>(&data.value)));
+      std::get<0>(std::get<1>(*ANY_CAST<TupleType>(&data.value)));
 
   if (output.n_elem > 0 && filename != "")
   {
@@ -78,10 +78,10 @@ void OutputParamImpl(
   // const.  In this case we can assume it though, since we will be saving and
   // not loading.
   typedef std::tuple<T*, std::string> TupleType;
-  T*& output = const_cast<T*&>(std::get<0>(*boost::any_cast<TupleType>(
+  T*& output = const_cast<T*&>(std::get<0>(*ANY_CAST<TupleType>(
       &data.value)));
   const std::string& filename =
-      std::get<1>(*boost::any_cast<TupleType>(&data.value));
+      std::get<1>(*ANY_CAST<TupleType>(&data.value));
 
   if (filename != "")
     data::Save(filename, "model", *output);
@@ -96,9 +96,9 @@ void OutputParamImpl(
 {
   // Output the matrix with the mappings.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
-  const T& tuple = std::get<0>(*boost::any_cast<TupleType>(&data.value));
+  const T& tuple = std::get<0>(*ANY_CAST<TupleType>(&data.value));
   const std::string& filename =
-      std::get<0>(std::get<1>(*boost::any_cast<TupleType>(&data.value)));
+      std::get<0>(std::get<1>(*ANY_CAST<TupleType>(&data.value)));
   const arma::mat& matrix = std::get<1>(tuple);
 
   // The mapping isn't taken into account.  We should write a data::Save()

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -24,11 +24,11 @@ namespace cli {
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::cout << data.name << ": " << *boost::any_cast<T>(&data.value)
       << std::endl;
@@ -38,7 +38,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   std::cout << data.name << ": ";
   const T& t = *boost::any_cast<T>(&data.value);
@@ -51,7 +51,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* /* junk */)
 {
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   const T& output = std::get<0>(*boost::any_cast<TupleType>(&data.value));
@@ -71,8 +71,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   // The const cast is necessary here because Serialize() can't ever be marked
   // const.  In this case we can assume it though, since we will be saving and
@@ -91,8 +91,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   // Output the matrix with the mappings.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;

--- a/src/mlpack/bindings/cli/print_type_doc.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace cli {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/cli/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace cli {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -165,8 +165,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "A filename containing an mlpack model.  These can have one of three "
       "formats: binary (.bin), text (.txt), and XML (.xml).  The XML format "

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -64,8 +64,8 @@ void SetParam(
 {
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
-  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
-  std::get<0>(std::get<1>(tuple)) = boost::any_cast<std::string>(value);
+  TupleType& tuple = *ANY_CAST<TupleType>(&d.value);
+  std::get<0>(std::get<1>(tuple)) = ANY_CAST<std::string>(value);
 }
 
 /**
@@ -81,8 +81,8 @@ void SetParam(
 {
   // We're setting the string filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
-  TupleType& tuple = *boost::any_cast<TupleType>(&d.value);
-  std::get<1>(tuple) = boost::any_cast<std::string>(value);
+  TupleType& tuple = *ANY_CAST<TupleType>(&d.value);
+  std::get<1>(tuple) = ANY_CAST<std::string>(value);
 }
 
 /**

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -27,11 +27,11 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const boost::any& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, bool>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, bool>::value>::type* = 0)
 {
   // No mapping is needed.
   d.value = value;
@@ -44,7 +44,7 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const boost::any& /* value */,
-    const typename boost::enable_if<std::is_same<T, bool>>::type* = 0)
+    const typename std::enable_if<std::is_same<T, bool>::value>::type* = 0)
 {
   // Force set to the value of whether or not this was passed.
   d.value = d.wasPassed;
@@ -60,7 +60,7 @@ void SetParam(
     const boost::any& value,
     const typename std::enable_if<arma::is_arma_type<T>::value ||
                                   std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
@@ -76,8 +76,8 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const boost::any& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -60,7 +60,7 @@ void SetParam(
     const boost::any& value,
     const typename std::enable_if<arma::is_arma_type<T>::value ||
                                   std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value::value>::type* = 0)
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/string_type_param.hpp
+++ b/src/mlpack/bindings/cli/string_type_param.hpp
@@ -26,22 +26,22 @@ namespace cli {
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return a string containing the type of the parameter, for vector options.
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return a string containing the type of the parameter,
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return a string containing the type of a parameter.  This overload is used if

--- a/src/mlpack/bindings/cli/string_type_param_impl.hpp
+++ b/src/mlpack/bindings/cli/string_type_param_impl.hpp
@@ -23,8 +23,8 @@ namespace cli {
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */)
 {
   // Don't know what type this is.
   return "unknown";
@@ -35,7 +35,7 @@ std::string StringTypeParamImpl(
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   return "vector";
 }
@@ -45,7 +45,7 @@ std::string StringTypeParamImpl(
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "string";
 }

--- a/src/mlpack/bindings/go/default_param.hpp
+++ b/src/mlpack/bindings/go/default_param.hpp
@@ -26,12 +26,12 @@ namespace go {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,10 +57,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+                                   arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/go/default_param_impl.hpp
+++ b/src/mlpack/bindings/go/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace go {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -90,7 +90,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -134,8 +134,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "nil";
 }

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -37,11 +37,11 @@ inline std::string GetGoType(
 template<>
 inline std::string GetGoType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -49,11 +49,11 @@ inline std::string GetGoType<int>(
 template<>
 inline std::string GetGoType<float>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<float>>::type*,
-    const typename boost::disable_if<data::HasSerialize<float>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<float>>::type*,
-    const typename boost::disable_if<std::is_same<float,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*,
+    const typename std::enable_if<!std::is_same<float,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float32";
 }
@@ -61,11 +61,11 @@ inline std::string GetGoType<float>(
 template<>
 inline std::string GetGoType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float64";
 }
@@ -73,11 +73,11 @@ inline std::string GetGoType<double>(
 template<>
 inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "string";
 }
@@ -85,11 +85,11 @@ inline std::string GetGoType<std::string>(
 template<>
 inline std::string GetGoType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "bool";
 }
@@ -97,7 +97,7 @@ inline std::string GetGoType<bool>(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return "[]" + GetGoType<typename T::value_type>(d);
 }
@@ -105,9 +105,9 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   return "mat.Dense";
 }
@@ -115,8 +115,8 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   return "matrixWithInfo";
 }
@@ -124,8 +124,8 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::string goStrippedType, strippedType, printedType, defaultsType;
   StripType(d.cppType, goStrippedType, strippedType, printedType, defaultsType);

--- a/src/mlpack/bindings/go/get_printable_param.hpp
+++ b/src/mlpack/bindings/go/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -23,75 +23,75 @@ namespace go {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -23,11 +23,11 @@ namespace go {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "unknown";
 }
@@ -35,11 +35,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -47,11 +47,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float64";
 }
@@ -59,11 +59,11 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "string";
 }
@@ -71,11 +71,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "bool";
 }
@@ -83,9 +83,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "array of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -93,9 +93,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = "*mat.Dense";
   if (T::is_row || T::is_col)
@@ -107,8 +107,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "matrixWithInfo";
 }
@@ -116,10 +116,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string goStrippedType, strippedType, printedType, defaultsType;
   StripType(d.cppType, goStrippedType, strippedType, printedType, defaultsType);

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -24,9 +24,9 @@ namespace go {
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -34,9 +34,9 @@ inline std::string GetType(
 template<>
 inline std::string GetType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*)
 {
   return "Int";
 }
@@ -44,9 +44,9 @@ inline std::string GetType<int>(
 template<>
 inline std::string GetType<float>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<float>>::type*,
-    const typename boost::disable_if<data::HasSerialize<float>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<float>>::type*)
+    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*)
 {
   return "Float";
 }
@@ -54,9 +54,9 @@ inline std::string GetType<float>(
 template<>
 inline std::string GetType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*)
 {
   return "Double";
 }
@@ -64,9 +64,9 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {
   return "String";
 }
@@ -74,9 +74,9 @@ inline std::string GetType<std::string>(
 template<>
 inline std::string GetType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*)
 {
   return "Bool";
 }
@@ -84,7 +84,7 @@ inline std::string GetType<bool>(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return "Vec" + GetType<typename T::value_type>(d);
 }
@@ -92,7 +92,7 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   std::string type = "";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -120,8 +120,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return d.cppType + "*";
 }

--- a/src/mlpack/bindings/go/print_defn_input.hpp
+++ b/src/mlpack/bindings/go/print_defn_input.hpp
@@ -28,10 +28,10 @@ namespace go {
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   if (d.required)
   {
@@ -46,7 +46,7 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // param_name *mat.Dense
   if (d.required)
@@ -62,8 +62,8 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // param_name *DataWithInfo
   if (d.required)
@@ -79,8 +79,8 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_defn_output.hpp
+++ b/src/mlpack/bindings/go/print_defn_output.hpp
@@ -27,10 +27,10 @@ namespace go {
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::cout << GetGoType<T>(d);
 }
@@ -41,7 +41,7 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // *mat.Dense
   std::cout << "*" << GetGoType<T>(d);
@@ -53,8 +53,8 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // *mat.Dense
   std::cout << "*" << GetGoType<T>(d);
@@ -66,8 +66,8 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_input_processing.hpp
+++ b/src/mlpack/bindings/go/print_input_processing.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -129,7 +129,7 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -189,8 +189,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -250,8 +250,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, get the correct classparamName if needed.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_method_config.hpp
+++ b/src/mlpack/bindings/go/print_method_config.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -64,7 +64,7 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -96,8 +96,8 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -129,8 +129,8 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 

--- a/src/mlpack/bindings/go/print_method_init.hpp
+++ b/src/mlpack/bindings/go/print_method_init.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -86,7 +86,7 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -118,8 +118,8 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -151,8 +151,8 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 

--- a/src/mlpack/bindings/go/print_output_processing.hpp
+++ b/src/mlpack/bindings/go/print_output_processing.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -56,7 +56,7 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
     const typename std::enable_if<!std::is_same<T,
         std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
@@ -83,8 +83,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -109,8 +109,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/go/print_type_doc.hpp
+++ b/src/mlpack/bindings/go/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/go/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/go/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace go {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -122,8 +122,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  This type holds a pointer to C++ memory "
       "containing the mlpack model.  Note that this means the mlpack model "

--- a/src/mlpack/bindings/julia/default_param.hpp
+++ b/src/mlpack/bindings/julia/default_param.hpp
@@ -26,12 +26,12 @@ namespace julia {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,10 +57,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+                                   arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/julia/default_param_impl.hpp
+++ b/src/mlpack/bindings/julia/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace julia {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -134,8 +134,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "nothing";
 }

--- a/src/mlpack/bindings/julia/get_printable_param.hpp
+++ b/src/mlpack/bindings/julia/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/julia/get_printable_type.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type.hpp
@@ -23,11 +23,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -60,8 +60,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/julia/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type_impl.hpp
@@ -26,11 +26,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   if (std::is_same<T, bool>::value)
     return "Bool";
@@ -102,8 +102,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   std::string type = util::StripType(data.cppType);
   if (type == "mlpackModel")

--- a/src/mlpack/bindings/julia/print_type_doc.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace julia {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/julia/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace julia {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -153,8 +153,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  `<Model>` refers to the type of model that "
       "is being stored, so, e.g., for `CF()`, the type will be `CFModel`. "

--- a/src/mlpack/bindings/markdown/get_printable_param.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/markdown/get_printable_param_name.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_name.hpp
@@ -26,10 +26,10 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -38,7 +38,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -47,8 +47,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -57,8 +57,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/markdown/get_printable_param_name_impl.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_name_impl.hpp
@@ -26,10 +26,10 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name;
 }
@@ -41,7 +41,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -53,8 +53,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "--" + data.name + "_file";
 }
@@ -66,8 +66,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "--" + data.name + "_file";
 }

--- a/src/mlpack/bindings/markdown/get_printable_param_value.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_value.hpp
@@ -27,10 +27,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -40,7 +40,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -50,8 +50,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -61,8 +61,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Get the parameter's name as seen by the user.

--- a/src/mlpack/bindings/markdown/get_printable_param_value_impl.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_value_impl.hpp
@@ -28,10 +28,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input;
 }
@@ -44,7 +44,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
 {
   return input + ".csv";
 }
@@ -57,8 +57,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return input + ".bin";
 }
@@ -71,8 +71,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return input + ".arff";
 }

--- a/src/mlpack/bindings/markdown/is_serializable.hpp
+++ b/src/mlpack/bindings/markdown/is_serializable.hpp
@@ -25,7 +25,7 @@ namespace markdown {
  */
 template<typename T>
 bool IsSerializable(
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
 {
   return false;
 }
@@ -35,8 +35,8 @@ bool IsSerializable(
  */
 template<typename T>
 bool IsSerializable(
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return true;
 }

--- a/src/mlpack/bindings/python/default_param.hpp
+++ b/src/mlpack/bindings/python/default_param.hpp
@@ -26,12 +26,12 @@ namespace python {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -39,7 +39,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Return the default value of a string option.
@@ -47,7 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type* = 0);
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -57,10 +57,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+                                   arma::mat>>::value>::type* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -69,8 +69,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be

--- a/src/mlpack/bindings/python/default_param_impl.hpp
+++ b/src/mlpack/bindings/python/default_param_impl.hpp
@@ -24,12 +24,12 @@ namespace python {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T, std::string>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
@@ -46,7 +46,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T, std::string>>::type*)
+    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
 {
   const std::string& s = *boost::any_cast<std::string>(&data.value);
   return "'" + s + "'";
@@ -102,7 +102,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::enable_if_c<
+    const typename std::enable_if<
         arma::is_arma_type<T>::value ||
         std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
                                    arma::mat>>::value>::type* /* junk */)
@@ -134,8 +134,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   return "None";
 }

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -23,9 +23,9 @@ namespace python {
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return "unknown";
 }
@@ -33,9 +33,9 @@ inline std::string GetCythonType(
 template<>
 inline std::string GetCythonType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*)
 {
   return "int";
 }
@@ -43,9 +43,9 @@ inline std::string GetCythonType<int>(
 template<>
 inline std::string GetCythonType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*)
 {
   return "double";
 }
@@ -53,9 +53,9 @@ inline std::string GetCythonType<double>(
 template<>
 inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*)
 {
   return "string";
 }
@@ -63,9 +63,9 @@ inline std::string GetCythonType<std::string>(
 template<>
 inline std::string GetCythonType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*)
 {
   return "size_t";
 }
@@ -73,9 +73,9 @@ inline std::string GetCythonType<size_t>(
 template<>
 inline std::string GetCythonType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*)
 {
   return "cbool";
 }
@@ -83,7 +83,7 @@ inline std::string GetCythonType<bool>(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   return "vector[" + GetCythonType<typename T::value_type>(d) + "]";
 }
@@ -91,7 +91,7 @@ inline std::string GetCythonType(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   std::string type = "Mat";
   if (T::is_row)
@@ -105,8 +105,8 @@ inline std::string GetCythonType(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   return d.cppType + "*";
 }

--- a/src/mlpack/bindings/python/get_printable_param.hpp
+++ b/src/mlpack/bindings/python/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace python {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Get the matrix.
   const T& matrix = boost::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << boost::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // Get the matrix.
   const T& tuple = boost::any_cast<T>(data.value);

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -23,84 +23,84 @@ namespace python {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*);
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -22,11 +22,11 @@ namespace python {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "unknown";
 }
@@ -34,11 +34,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<int>>::type*,
-    const typename boost::disable_if<data::HasSerialize<int>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<int>>::type*,
-    const typename boost::disable_if<std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
+    const typename std::enable_if<!std::is_same<int,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -46,11 +46,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<double>>::type*,
-    const typename boost::disable_if<data::HasSerialize<double>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<double>>::type*,
-    const typename boost::disable_if<std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
+    const typename std::enable_if<!std::is_same<double,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "float";
 }
@@ -58,11 +58,11 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<std::string>>::type*,
-    const typename boost::disable_if<data::HasSerialize<std::string>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<std::string>>::type*,
-    const typename boost::disable_if<std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<std::string>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<std::string>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<std::string>::value>::type*,
+    const typename std::enable_if<!std::is_same<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "str";
 }
@@ -70,11 +70,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<size_t>>::type*,
-    const typename boost::disable_if<data::HasSerialize<size_t>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<size_t>>::type*,
-    const typename boost::disable_if<std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
+    const typename std::enable_if<!std::is_same<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "int";
 }
@@ -82,11 +82,11 @@ inline std::string GetPrintableType<size_t>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename boost::disable_if<util::IsStdVector<bool>>::type*,
-    const typename boost::disable_if<data::HasSerialize<bool>>::type*,
-    const typename boost::disable_if<arma::is_arma_type<bool>>::type*,
-    const typename boost::disable_if<std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
+    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
+    const typename std::enable_if<!std::is_same<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "bool";
 }
@@ -94,9 +94,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::enable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "list of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -104,9 +104,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   std::string type = "matrix";
   if (std::is_same<typename T::elem_type, double>::value)
@@ -127,8 +127,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return "categorical matrix";
 }
@@ -136,10 +136,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   return d.cppType + "Type";
 }

--- a/src/mlpack/bindings/python/import_decl.hpp
+++ b/src/mlpack/bindings/python/import_decl.hpp
@@ -26,8 +26,8 @@ template<typename T>
 void ImportDecl(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, we have to parse the type.  If we have something like, e.g.,
   // 'LogisticRegression<>', we must convert this to 'LogisticRegression[T=*].'
@@ -53,8 +53,8 @@ template<typename T>
 void ImportDecl(
     util::ParamData& /* d */,
     const size_t /* indent */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
 {
   // Print nothing.
 }
@@ -66,7 +66,7 @@ template<typename T>
 void ImportDecl(
     util::ParamData& /* d */,
     const size_t /* indent */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Print nothing.
 }

--- a/src/mlpack/bindings/python/print_class_defn.hpp
+++ b/src/mlpack/bindings/python/print_class_defn.hpp
@@ -25,8 +25,8 @@ namespace python {
 template<typename T>
 void PrintClassDefn(
     util::ParamData& /* d */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -37,7 +37,7 @@ void PrintClassDefn(
 template<typename T>
 void PrintClassDefn(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -48,8 +48,8 @@ void PrintClassDefn(
 template<typename T>
 void PrintClassDefn(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, we have to parse the type.  If we have something like, e.g.,
   // 'LogisticRegression<>', we must convert this to 'LogisticRegression[].'

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -31,11 +31,11 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // The copy_all_inputs parameter must be handled first, and therefore is
   // outside the scope of this code.
@@ -164,11 +164,11 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -251,8 +251,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -372,9 +372,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // First, get the correct class name if needed.
   std::string strippedType, printedType, defaultsType;
@@ -445,9 +445,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   // The user should pass in a matrix type of some sort.
   const std::string prefix(indent, ' ');

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -30,10 +30,10 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -86,7 +86,7 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -128,8 +128,8 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -170,8 +170,8 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Get the type names we need to use.
   std::string strippedType, printedType, defaultsType;

--- a/src/mlpack/bindings/python/print_type_doc.hpp
+++ b/src/mlpack/bindings/python/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace python {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print the command-line type of an option into a string.

--- a/src/mlpack/bindings/python/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/python/print_type_doc_impl.hpp
@@ -24,11 +24,11 @@ namespace python {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::disable_if<util::IsStdVector<T>>::type*,
-    const typename boost::disable_if<data::HasSerialize<T>>::type*,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
 {
   // A flag type.
   if (std::is_same<T, bool>::value)
@@ -150,8 +150,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type*,
-    const typename boost::enable_if<data::HasSerialize<T>>::type*)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
 {
   return "An mlpack model pointer.  This type can be pickled to or from disk, "
       "and internally holds a pointer to C++ memory containing the mlpack "

--- a/src/mlpack/bindings/tests/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/delete_allocated_memory.hpp
@@ -21,8 +21,8 @@ namespace tests {
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -30,7 +30,7 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   // Do nothing.
 }
@@ -38,8 +38,8 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
   delete *boost::any_cast<T*>(&d.value);

--- a/src/mlpack/bindings/tests/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/get_allocated_memory.hpp
@@ -22,8 +22,8 @@ namespace tests {
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -31,7 +31,7 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
   return NULL;
 }
@@ -39,8 +39,8 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
 {
   // Here we have a model; return its memory location.
   return *boost::any_cast<T*>(&d.value);

--- a/src/mlpack/bindings/tests/get_printable_param.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param.hpp
@@ -27,11 +27,11 @@ namespace tests {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* = 0,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* = 0,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Print a vector option, with spaces between it.
@@ -39,7 +39,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* = 0);
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
 
 /**
  * Print a matrix option (this just prints the filename).
@@ -47,7 +47,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* = 0);
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
 
 /**
  * Print a serializable class option (this just prints the filename).
@@ -55,8 +55,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* = 0);
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
 
 /**
  * Print a mapped matrix option (this just prints the filename).
@@ -64,8 +64,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* = 0);
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
 
 /**
  * Print an option into a std::string.  This should print a short, one-line

--- a/src/mlpack/bindings/tests/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param_impl.hpp
@@ -22,11 +22,11 @@ namespace tests {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::disable_if<util::IsStdVector<T>>::type* /* junk */,
-    const typename boost::disable_if<data::HasSerialize<T>>::type* /* junk */,
-    const typename boost::disable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<!util::IsStdVector<T>::value>::type* /* junk */,
+    const typename std::enable_if<!data::HasSerialize<T>::value>::type* /* junk */,
+    const typename std::enable_if<!std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   std::ostringstream oss;
   oss << boost::any_cast<T>(data.value);
@@ -37,7 +37,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::enable_if<util::IsStdVector<T>>::type* /* junk */)
+    const typename std::enable_if<util::IsStdVector<T>::value>::type* /* junk */)
 {
   const T& t = boost::any_cast<T>(data.value);
 
@@ -51,7 +51,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& /* data */,
-    const typename boost::enable_if<arma::is_arma_type<T>>::type* /* junk */)
+    const typename std::enable_if<arma::is_arma_type<T>::value>::type* /* junk */)
 {
   return "matrix type";
 }
@@ -60,8 +60,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename boost::disable_if<arma::is_arma_type<T>>::type* /* junk */,
-    const typename boost::enable_if<data::HasSerialize<T>>::type* /* junk */)
+    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* /* junk */,
+    const typename std::enable_if<data::HasSerialize<T>::value>::type* /* junk */)
 {
   // Extract the string from the tuple that's being held.
   std::ostringstream oss;
@@ -73,8 +73,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& /* data */,
-    const typename boost::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>>::type* /* junk */)
+    const typename std::enable_if<std::is_same<T,
+        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
 {
   return "matrix/DatatsetInfo tuple";
 }

--- a/src/mlpack/core/std_backport/any.hpp
+++ b/src/mlpack/core/std_backport/any.hpp
@@ -1,0 +1,935 @@
+////////////////////////////////////////////////////////////////////////////////
+/// \file any.hpp
+///
+/// \brief This header provides definitions from the C++ header <any>
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2020 Matthew Rodusek All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BPSTD_ANY_HPP
+#define BPSTD_ANY_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "detail/config.hpp"
+#include "type_traits.hpp"  // enable_if_t, is_*
+#include "utility.hpp"      // in_place_type_t, move, forward
+
+#include <typeinfo>         // std::bad_cast, std::type_info
+#include <initializer_list> // std::initializer_list
+#include <new>              // placement-new
+#include <cassert>          // assert
+
+BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE
+
+namespace bpstd {
+
+  class any;
+
+  //============================================================================
+  // class : bad_any_cast
+  //============================================================================
+
+  class bad_any_cast : public std::bad_cast
+  {
+    const char* what() const noexcept override;
+  };
+
+  //============================================================================
+  // class : any
+  //============================================================================
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// \brief An object that can hold values of any type via type-erasure
+  ///
+  /// The class any describes a type-safe container for single values of any
+  /// type.
+  ///
+  /// 1) An object of class any stores an instance of any type that satisfies
+  /// the constructor requirements or is empty, and this is referred to as the
+  /// state of the class any object. The stored instance is called the
+  /// contained object. Two states are equivalent if they are either both
+  /// empty or if both are not empty and if the contained objects are
+  /// equivalent.
+  ///
+  /// 2) The non-member any_cast functions provide type-safe access to the
+  /// contained object.
+  ///
+  /// This implementation uses small-buffer optimization to avoid dynamic
+  /// memory if the object is below a (4 * sizeof(void*))
+  //////////////////////////////////////////////////////////////////////////////
+  class any
+  {
+    //--------------------------------------------------------------------------
+    // Constructors / Destructor / Assignment
+    //--------------------------------------------------------------------------
+  public:
+
+    /// \brief Constructs an any instance that does not contain any value
+    any() noexcept;
+
+    /// \brief Moves an any instance by moving the stored underlying value
+    ///
+    /// \post \p other is left valueless
+    ///
+    /// \param other the other instance to move
+    any(any&& other) noexcept;
+
+    /// \brief Copies an any instance by copying the stored underlying value
+    ///
+    /// \param other the other instance to copy
+    any(const any& other);
+
+    /// \brief Constructs this any using \p value for the underlying instance
+    ///
+    /// \param value the value to construct this any out of
+    template<typename ValueType,
+             typename=enable_if_t<!is_same<decay_t<ValueType>,any>::value &&
+                                   is_copy_constructible<decay_t<ValueType>>::value>>
+    // cppcheck-suppress noExplicitConstructor
+    any(ValueType&& value);
+
+    /// \brief Constructs an 'any' of type ValueType by forwarding \p args to
+    ///        its constructor
+    ///
+    /// \note This constructor only participates in overload resolution if
+    ///       ValueType is constructible from \p args
+    ///
+    /// \param args the arguments to forward to ValueType's constructor
+    template<typename ValueType, typename...Args,
+             typename=enable_if_t<is_constructible<decay_t<ValueType>,Args...>::value &&
+                                  is_copy_constructible<decay_t<ValueType>>::value>>
+    explicit any(in_place_type_t<ValueType>, Args&&...args);
+
+    /// \brief Constructs an 'any' of type ValueType by forwarding \p args to
+    ///        its constructor
+    ///
+    /// \note This constructor only participates in overload resolution if
+    ///       ValueType is constructible from \p args
+    ///
+    /// \param il an initializer_list of arguments
+    /// \param args the arguments to forward to ValueType's constructor
+    template<typename ValueType, typename U, typename...Args,
+             typename=enable_if_t<is_constructible<decay_t<ValueType>,std::initializer_list<U>,Args...>::value &&
+                                  is_copy_constructible<decay_t<ValueType>>::value>>
+    explicit any(in_place_type_t<ValueType>,
+                 std::initializer_list<U> il,
+                 Args&&...args);
+
+    //--------------------------------------------------------------------------
+
+    ~any();
+
+    //--------------------------------------------------------------------------
+
+    /// \brief Assigns the contents of \p other to this any
+    ///
+    /// \param other the other any to move
+    /// \return reference to \c (*this)
+    any& operator=(any&& other) noexcept;
+
+    /// \brief Assigns the contents of \p other to this any
+    ///
+    /// \param other the other any to copy
+    /// \return reference to \c (*this)
+    any& operator=(const any& other);
+
+    /// \brief Assigns \p value to this any
+    ///
+    /// \param value the value to assign
+    /// \return reference to \c (*this)
+    template<typename ValueType,
+             typename=enable_if_t<!is_same<decay_t<ValueType>,any>::value &&
+                                   is_copy_constructible<decay_t<ValueType>>::value>>
+    any& operator=(ValueType&& value);
+
+    //--------------------------------------------------------------------------
+    // Modifiers
+    //--------------------------------------------------------------------------
+  public:
+
+    /// \{
+    /// \brief Emplaces a \c ValueType into this any, destroying the previous
+    ///        value if it contained one
+    ///
+    /// \tparam ValueType the type to construct
+    /// \param args the arguments to forward to \c ValueType's constructor
+    /// \return reference to the constructed value
+    template<typename ValueType, typename...Args,
+              typename=enable_if_t<is_constructible<decay_t<ValueType>,Args...>::value &&
+                                   is_copy_constructible<decay_t<ValueType>>::value>>
+    decay_t<ValueType>& emplace(Args&&...args);
+    template<typename ValueType, typename U, typename...Args,
+              typename=enable_if_t<is_constructible<decay_t<ValueType>,std::initializer_list<U>,Args...>::value &&
+                                   is_copy_constructible<decay_t<ValueType>>::value>>
+    decay_t<ValueType>& emplace(std::initializer_list<U> il, Args&&...args );
+    /// \}
+
+    /// \brief Destroys the underlying stored value, leaving this any
+    ///        empty.
+    void reset() noexcept;
+
+    /// \brief Swaps the contents of \c this with \p other
+    ///
+    /// \post \p other contains the old contents of \c this, and \c this
+    ///       contains the old contents of \p other
+    ///
+    /// \param other the other any to swap contents with
+    void swap(any& other) noexcept;
+
+    //--------------------------------------------------------------------------
+    // Observers
+    //--------------------------------------------------------------------------
+  public:
+
+    /// \brief Checks whether this any contains a value
+    ///
+    /// \return \c true if this contains a value
+    bool has_value() const noexcept;
+
+    /// \brief Gets the type_info for the underlying stored type, or
+    ///        \c typeid(void) if \ref has_value() returns \c false
+    ///
+    /// \return the typeid of the stored type
+    const std::type_info& type() const noexcept;
+
+    //--------------------------------------------------------------------------
+    // Private Static Members / Types
+    //--------------------------------------------------------------------------
+  private:
+
+    // Internal buffer size + alignment
+    static constexpr auto buffer_size  = 4u * sizeof(void*);
+    static constexpr auto buffer_align = alignof(void*);
+
+    // buffer (for internal storage)
+    using internal_buffer = typename aligned_storage<buffer_size,buffer_align>::type;
+
+    union storage
+    {
+      internal_buffer internal;
+      void*           external;
+    };
+
+    //--------------------------------------------------------------------------
+
+    // trait to determine if internal storage is required
+    template<typename T>
+    using requires_internal_storage = bool_constant<
+      (sizeof(T) <= buffer_size) &&
+      ((buffer_align % alignof(T)) == 0) &&
+      is_nothrow_move_constructible<T>::value
+    >;
+
+    //-----------------------------------------------------------------------
+
+    template<typename T>
+    struct internal_storage_handler;
+
+    template<typename T>
+    struct external_storage_handler;
+
+    template<typename T>
+    using storage_handler = conditional_t<
+      requires_internal_storage<T>::value,
+      internal_storage_handler<T>,
+      external_storage_handler<T>
+    >;
+
+    //-----------------------------------------------------------------------
+
+    enum class operation
+    {
+      destroy, ///< Operation for calling the underlying's destructor
+      copy,    ///< Operation for copying the underlying value
+      move,    ///< Operation for moving the underlying value
+      value,   ///< Operation for accessing the underlying value
+      type,    ///< Operation for accessing the underlying type
+    };
+
+    //-----------------------------------------------------------------------
+
+    using storage_handler_ptr = const void*(*)(operation, const storage*,const storage*);
+
+    template<typename T>
+    friend T* any_cast(any*) noexcept;
+    template<typename T>
+    friend const T* any_cast(const any*) noexcept;
+
+    //-----------------------------------------------------------------------
+    // Private Members
+    //-----------------------------------------------------------------------
+  private:
+
+    storage             m_storage;
+    storage_handler_ptr m_storage_handler;
+  };
+
+  //=========================================================================
+  // non-member functions : class : any
+  //=========================================================================
+
+  //-------------------------------------------------------------------------
+  // utilities
+  //-------------------------------------------------------------------------
+
+  /// \brief Swaps the contents of \p lhs and \p rhs
+  void swap(any& lhs, any& rhs) noexcept;
+
+  //-------------------------------------------------------------------------
+  // casts
+  //-------------------------------------------------------------------------
+
+  /// \{
+  /// \brief Attempts to cast an any back to the underlying type T
+  ///
+  /// \throw bad_any_cast if \p any is not exactly of type \p T
+  /// \tparam T the type to cast to
+  /// \return the object
+  template<typename T>
+  T any_cast(any& operand);
+  template<typename T>
+  T any_cast(any&& operand);
+  template<typename T>
+  T any_cast(const any& operand);
+  /// \}
+
+  /// \{
+  /// \brief Attempts to cast an any back to the underlying type T
+  ///
+  /// \tparam T the type to cast to
+  /// \return pointer to the object if successfull, nullptr otherwise
+  template<typename T>
+  T* any_cast(any* operand) noexcept;
+  template<typename T>
+  const T* any_cast(const any* operand) noexcept;
+  /// \}
+
+} // namespace bpstd
+
+//=============================================================================
+// definitions : class : bad_any_cast
+//=============================================================================
+
+inline
+const char* bpstd::bad_any_cast::what()
+  const noexcept
+{
+  return "bad_any_cast";
+}
+
+//=============================================================================
+// class : any::internal_storage_handler
+//=============================================================================
+
+template<typename T>
+struct bpstd::any::internal_storage_handler
+{
+  template<typename...Args>
+  static T* construct(storage& s, Args&&...args);
+
+  template<typename U, typename...Args>
+  static T* construct(storage& s, std::initializer_list<U> il, Args&&...args);
+
+  static void destroy(storage& s);
+
+  static const void* handle(operation op,
+                            const storage* self,
+                            const storage* other);
+};
+
+//=============================================================================
+// definition : class : any::internal_storage_handler
+//=============================================================================
+
+template<typename T>
+template<typename...Args>
+inline BPSTD_INLINE_VISIBILITY
+T* bpstd::any::internal_storage_handler<T>
+  ::construct(storage& s, Args&&...args)
+{
+  return ::new(&s.internal) T(bpstd::forward<Args>(args)...);
+}
+
+template<typename T>
+template<typename U, typename...Args>
+inline BPSTD_INLINE_VISIBILITY
+T* bpstd::any::internal_storage_handler<T>
+  ::construct(storage& s, std::initializer_list<U> il, Args&&...args)
+{
+  return ::new(&s.internal) T(il, bpstd::forward<Args>(args)...);
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+void bpstd::any::internal_storage_handler<T>
+  ::destroy(storage& s)
+{
+  auto* t = static_cast<T*>(static_cast<void*>(&s.internal));
+  t->~T();
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+const void* bpstd::any::internal_storage_handler<T>
+  ::handle(operation op,
+           const storage* self,
+           const storage* other)
+{
+  switch (op)
+  {
+    case operation::destroy:
+    {
+      assert(self != nullptr);
+      BPSTD_UNUSED(other);
+
+      destroy(const_cast<storage&>(*self));
+      break;
+    }
+
+    case operation::copy:
+    {
+      assert(self != nullptr);
+      assert(other != nullptr);
+
+      // Copy construct from the internal storage
+      const auto* p = reinterpret_cast<const T*>(&other->internal);
+      construct( const_cast<storage&>(*self), *p);
+      break;
+    }
+
+    case operation::move:
+    {
+      assert(self != nullptr);
+      assert(other != nullptr);
+
+      // Move construct from the internal storage. '
+      const auto* p = reinterpret_cast<const T*>(&other->internal);
+      construct(const_cast<storage&>(*self), bpstd::move(*const_cast<T*>(p)));
+      break;
+    }
+
+    case operation::value:
+    {
+      assert(self != nullptr);
+      BPSTD_UNUSED(other);
+
+      // NOTE(bitwize): This seemingly arbitrary conversion is for proper
+      //   type-safety/correctness. Otherwise, converting an aligned_storage_t*
+      //   to void* and then to T* would violate strict-aliasing -- which
+      //   would be undefined-behavior. Behavior is only well-defined for
+      //   casts from void* to T* if the the void* originated from a T*.
+      const auto* p = reinterpret_cast<const T*>(&self->internal);
+      return static_cast<const void*>(p);
+    }
+
+    case operation::type:
+    {
+      BPSTD_UNUSED(self);
+      BPSTD_UNUSED(other);
+
+      return static_cast<const void*>(&typeid(T));
+    }
+  }
+  return nullptr;
+}
+
+//=============================================================================
+// class : any::external_storage_handler
+//=============================================================================
+
+template<typename T>
+struct bpstd::any::external_storage_handler
+{
+  template<typename...Args>
+  static T* construct(storage& s, Args&&...args);
+
+  template<typename U, typename...Args>
+  static T* construct(storage& s, std::initializer_list<U> il, Args&&...args);
+
+  static void destroy(storage& s);
+
+  static const void* handle(operation op,
+                            const storage* self,
+                            const storage* other);
+};
+
+
+//=============================================================================
+// definition : class : any::external_storage_handler
+//=============================================================================
+
+template<typename T>
+template<typename...Args>
+inline BPSTD_INLINE_VISIBILITY
+T* bpstd::any::external_storage_handler<T>
+  ::construct(storage& s, Args&&...args)
+{
+  s.external = new T(bpstd::forward<Args>(args)...);
+  return static_cast<T*>(s.external);
+}
+
+template<typename T>
+template<typename U, typename...Args>
+inline BPSTD_INLINE_VISIBILITY
+T* bpstd::any::external_storage_handler<T>
+  ::construct(storage& s, std::initializer_list<U> il, Args&&...args)
+{
+  s.external = new T(il, bpstd::forward<Args>(args)...);
+  return static_cast<T*>(s.external);
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+void bpstd::any::external_storage_handler<T>
+  ::destroy(storage& s)
+{
+  delete static_cast<T*>(s.external);
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+const void* bpstd::any::external_storage_handler<T>
+  ::handle( operation op,
+            const storage* self,
+            const storage* other )
+{
+  switch (op)
+  {
+    case operation::destroy:
+    {
+      assert(self != nullptr);
+      BPSTD_UNUSED(other);
+
+      destroy(const_cast<storage&>(*self));
+      break;
+    }
+
+    case operation::copy:
+    {
+      assert(self != nullptr);
+      assert(other != nullptr);
+
+      // Copy construct from the internal storage
+      construct( const_cast<storage&>(*self),
+                 *static_cast<const T*>(other->external));
+      break;
+    }
+
+    case operation::move:
+    {
+      BPSTD_UNUSED(self != nullptr);
+      assert(other != nullptr);
+
+      const auto p = static_cast<const T*>(other->external);
+      // Move construct from the internal storage. '
+      construct(const_cast<storage&>(*self), bpstd::move(*const_cast<T*>(p)));
+      break;
+    }
+
+    case operation::value:
+    {
+      assert(self != nullptr);
+      BPSTD_UNUSED(other);
+
+      // self->external was already created as a T*; no need to cast like in
+      // internal.
+      return self->external;
+    }
+
+    case operation::type:
+    {
+      BPSTD_UNUSED(self);
+      BPSTD_UNUSED(other);
+
+      return &typeid(T);
+    }
+  }
+  return nullptr;
+}
+
+//=============================================================================
+// definitions : class : any
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Constructors / Destructor / Assignment
+//-----------------------------------------------------------------------------
+
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::any()
+  noexcept
+  : m_storage{},
+    m_storage_handler{nullptr}
+{
+
+}
+
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::any(any&& other)
+  noexcept
+  : m_storage{},
+    m_storage_handler{other.m_storage_handler}
+{
+  if (m_storage_handler != nullptr) {
+    m_storage_handler(operation::move, &m_storage, &other.m_storage);
+  }
+}
+
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::any(const any& other)
+  : m_storage{},
+    m_storage_handler{nullptr}
+{
+
+  if (other.m_storage_handler != nullptr) {
+    // Set handler after constructing, in case of exception
+    const auto handler = other.m_storage_handler;
+
+    handler(operation::copy, &m_storage, &other.m_storage);
+    m_storage_handler = handler;
+  }
+}
+
+template<typename ValueType, typename>
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::any(ValueType&& value)
+  : m_storage{},
+    m_storage_handler{nullptr}
+{
+  // Set handler after constructing, in case of exception
+  using handler_type = storage_handler<decay_t<ValueType>>;
+
+  handler_type::construct(m_storage, bpstd::forward<ValueType>(value));
+  m_storage_handler = &handler_type::handle;
+}
+
+template<typename ValueType, typename...Args, typename>
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::any(in_place_type_t<ValueType>, Args&&...args)
+  : m_storage{},
+    m_storage_handler{nullptr}
+{
+  // Set handler after constructing, in case of exception
+  using handler_type = storage_handler<decay_t<ValueType>>;
+
+  handler_type::construct(m_storage, bpstd::forward<Args>(args)...);
+  m_storage_handler = &handler_type::handle;
+}
+
+template<typename ValueType, typename U, typename...Args, typename>
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::any(in_place_type_t<ValueType>,
+                       std::initializer_list<U> il,
+                       Args&&...args)
+  : m_storage{},
+    m_storage_handler{nullptr}
+{
+  // Set handler after constructing, in case of exception
+  using handler_type = storage_handler<decay_t<ValueType>>;
+
+  handler_type::construct(m_storage, il, bpstd::forward<Args>(args)...);
+  m_storage_handler = &handler_type::handle;
+}
+
+//-----------------------------------------------------------------------------
+
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any::~any()
+{
+  reset();
+}
+
+//-----------------------------------------------------------------------------
+
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any& bpstd::any::operator=(any&& other)
+  noexcept
+{
+  reset();
+
+  if (other.m_storage_handler != nullptr) {
+    m_storage_handler = other.m_storage_handler;
+    m_storage_handler(operation::move, &m_storage, &other.m_storage);
+  }
+
+  return (*this);
+}
+
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any& bpstd::any::operator=(const any& other)
+{
+  reset();
+
+  if (other.m_storage_handler != nullptr) {
+    // Set handler after constructing, in case of exception
+    const auto handler = other.m_storage_handler;
+
+    handler(operation::copy, &m_storage, &other.m_storage);
+    m_storage_handler = handler;
+  }
+
+  return (*this);
+}
+
+template<typename ValueType, typename>
+inline BPSTD_INLINE_VISIBILITY
+bpstd::any& bpstd::any::operator=(ValueType&& value)
+{
+  using handler_type = storage_handler<decay_t<ValueType>>;
+
+  reset();
+
+  handler_type::construct(m_storage, bpstd::forward<ValueType>(value));
+  m_storage_handler = &handler_type::handle;
+
+  return (*this);
+}
+
+//-----------------------------------------------------------------------------
+// Modifiers
+//-----------------------------------------------------------------------------
+
+template<typename ValueType, typename...Args, typename>
+inline BPSTD_INLINE_VISIBILITY
+bpstd::decay_t<ValueType>&
+  bpstd::any::emplace(Args&&...args)
+{
+  using handler_type = storage_handler<decay_t<ValueType>>;
+
+  reset();
+
+  auto& result = *handler_type::construct(m_storage,
+                                          bpstd::forward<Args>(args)...);
+  m_storage_handler = &handler_type::handle;
+
+  return result;
+}
+
+template<typename ValueType, typename U, typename...Args, typename>
+inline BPSTD_INLINE_VISIBILITY
+bpstd::decay_t<ValueType>&
+  bpstd::any::emplace(std::initializer_list<U> il,
+                      Args&&...args)
+{
+  using handler_type = storage_handler<decay_t<ValueType>>;
+
+  reset();
+
+  auto& result = *handler_type::construct(m_storage,
+                                          il,
+                                          bpstd::forward<Args>(args)...);
+  m_storage_handler = &handler_type::handle;
+
+  return result;
+}
+
+inline BPSTD_INLINE_VISIBILITY
+void bpstd::any::reset()
+  noexcept
+{
+  if (m_storage_handler != nullptr) {
+    m_storage_handler(operation::destroy, &m_storage, nullptr);
+    m_storage_handler = nullptr;
+  }
+}
+
+inline BPSTD_INLINE_VISIBILITY
+void bpstd::any::swap(any& other)
+  noexcept
+{
+  using std::swap;
+
+  if (m_storage_handler != nullptr && other.m_storage_handler != nullptr)
+  {
+    auto tmp = any{};
+
+    // tmp := self
+    tmp.m_storage_handler = m_storage_handler;
+    m_storage_handler(operation::move, &tmp.m_storage, &m_storage);
+    m_storage_handler(operation::destroy, &m_storage, nullptr);
+
+    // self := other
+    m_storage_handler = other.m_storage_handler;
+    m_storage_handler(operation::move, &m_storage, &other.m_storage);
+    m_storage_handler(operation::destroy, &other.m_storage, nullptr);
+
+    // other := tmp
+    other.m_storage_handler = tmp.m_storage_handler;
+    other.m_storage_handler(operation::move, &other.m_storage, &tmp.m_storage);
+  }
+  else if (other.m_storage_handler != nullptr)
+  {
+    swap(m_storage_handler, other.m_storage_handler);
+
+    // self := other
+    m_storage_handler(operation::move, &m_storage, &other.m_storage);
+    m_storage_handler(operation::destroy, &other.m_storage, nullptr);
+  }
+  else if (m_storage_handler != nullptr)
+  {
+    swap(m_storage_handler, other.m_storage_handler);
+
+    // other := self
+    other.m_storage_handler(operation::move, &other.m_storage, &m_storage);
+    other.m_storage_handler(operation::destroy, &m_storage, nullptr);
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+inline BPSTD_INLINE_VISIBILITY
+bool bpstd::any::has_value()
+  const noexcept
+{
+  return m_storage_handler != nullptr;
+}
+
+inline BPSTD_INLINE_VISIBILITY
+const std::type_info& bpstd::any::type()
+  const noexcept
+{
+  if (has_value()) {
+    auto* p = m_storage_handler(operation::type, nullptr, nullptr);
+    return (*static_cast<const std::type_info*>(p));
+  }
+  return typeid(void);
+}
+
+//=============================================================================
+// definition : non-member functions : class : any
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// utilities
+//-----------------------------------------------------------------------------
+
+inline BPSTD_INLINE_VISIBILITY
+void bpstd::swap(any& lhs, any& rhs)
+  noexcept
+{
+  lhs.swap(rhs);
+}
+
+//-----------------------------------------------------------------------------
+// casts
+//-----------------------------------------------------------------------------
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+T bpstd::any_cast(any& operand)
+{
+  using underlying_type = remove_cvref_t<T>;
+
+  static_assert(
+    is_constructible<T, underlying_type&>::value,
+    "A program is ill-formed if T is not constructible from U&"
+  );
+
+  auto* p = any_cast<underlying_type>(&operand);
+  if (p == nullptr) {
+    throw bad_any_cast{};
+  }
+  return static_cast<T>(*p);
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+T bpstd::any_cast(any&& operand)
+{
+  using underlying_type = remove_cvref_t<T>;
+
+  static_assert(
+    is_constructible<T, underlying_type>::value,
+    "A program is ill-formed if T is not constructible from U"
+  );
+
+  auto* p = any_cast<underlying_type>(&operand);
+  if (p == nullptr) {
+    throw bad_any_cast{};
+  }
+  return static_cast<T>(bpstd::move(*p));
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+T bpstd::any_cast(const any& operand)
+{
+  using underlying_type = remove_cvref_t<T>;
+
+  static_assert(
+    is_constructible<T, const underlying_type&>::value,
+    "A program is ill-formed if T is not constructible from const U&"
+  );
+
+  const auto* p = any_cast<underlying_type>(&operand);
+  if (p == nullptr) {
+    throw bad_any_cast{};
+  }
+  return static_cast<T>(*p);
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+T* bpstd::any_cast(any* operand)
+  noexcept
+{
+  if (!operand) {
+    return nullptr;
+  }
+  if (operand->type() != typeid(T)) {
+    return nullptr;
+  }
+
+  auto p = operand->m_storage_handler(any::operation::value,
+                                      &operand->m_storage,
+                                      nullptr);
+  return const_cast<T*>(static_cast<const T*>(p));
+}
+
+template<typename T>
+inline BPSTD_INLINE_VISIBILITY
+const T* bpstd::any_cast(const any* operand)
+  noexcept
+{
+  if (!operand) {
+    return nullptr;
+  }
+  if (operand->type() != typeid(T)) {
+    return nullptr;
+  }
+
+  auto* p = operand->m_storage_handler(any::operation::value,
+                                       &operand->m_storage,
+                                       nullptr);
+  return static_cast<const T*>(p);
+}
+
+BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE
+
+#endif /* BPSTD_ANY_HPP */

--- a/src/mlpack/core/std_backport/detail/config.hpp
+++ b/src/mlpack/core/std_backport/detail/config.hpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+/// \file config.hpp
+///
+/// \brief This header provides configuration data for the bpstd library
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2020 Matthew Rodusek All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BPSTD_DETAIL_CONFIG_HPP
+#define BPSTD_DETAIL_CONFIG_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#if !defined(__cplusplus)
+# error This library requires a C++ compiler
+#endif
+
+// _MSC_VER check is due to MSVC not defining __cplusplus to be 201103L
+#if !defined(_MSC_VER) && __cplusplus < 201103L
+# error This library must be compiled with C++11 support
+#endif
+
+#if defined(__cplusplus) && __cplusplus >= 201402L
+# define BPSTD_CPP14_CONSTEXPR constexpr
+# define BPSTD_HAS_TEMPLATE_VARIABLES 1
+#else
+# define BPSTD_CPP14_CONSTEXPR
+# define BPSTD_HAS_TEMPLATE_VARIABLES 0
+#endif
+
+#if defined(__cplusplus) && __cplusplus >= 201703L
+# define BPSTD_CPP17_CONSTEXPR constexpr
+# define BPSTD_CPP17_INLINE inline
+# define BPSTD_HAS_INLINE_VARIABLES 1
+#else
+# define BPSTD_CPP17_CONSTEXPR
+# define BPSTD_CPP17_INLINE
+# define BPSTD_HAS_INLINE_VARIABLES 0
+#endif
+
+#define BPSTD_UNUSED(x) static_cast<void>(x)
+
+// Use __may_alias__ attribute on gcc and clang
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ > 5)
+# define BPSTD_MAY_ALIAS __attribute__((__may_alias__))
+#else // defined(__clang__) || defined __GNUC__
+# define BPSTD_MAY_ALIAS
+#endif // defined __clang__ || defined __GNUC__
+
+#if !defined(BPSTD_INLINE_VISIBILITY)
+// When using 'clang-cl', don't forceinline -- since it results in code generation
+// failures in 'variant'
+# if defined(__clang__) && defined(_MSC_VER)
+#  define BPSTD_INLINE_VISIBILITY __attribute__((visibility("hidden"), no_instrument_function))
+# elif defined(__clang__) || defined(__GNUC__)
+#  define BPSTD_INLINE_VISIBILITY __attribute__((visibility("hidden"), always_inline, no_instrument_function))
+# elif defined(_MSC_VER)
+#  define BPSTD_INLINE_VISIBILITY __forceinline
+# else
+#  define BPSTD_INLINE_VISIBILITY
+# endif
+#endif // !defined(BPSTD_INLINE_VISIBILITY)
+
+#if defined(_MSC_VER)
+# define BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE \
+  __pragma(warning(push)) \
+  __pragma(warning(disable:4714)) \
+  __pragma(warning(disable:4100))
+#else
+# define BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE
+#endif
+
+#if defined(_MSC_VER)
+# define BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE \
+  __pragma(warning(pop))
+#else
+# define BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE
+#endif
+
+#endif /* BPSTD_DETAIL_CONFIG_HPP */

--- a/src/mlpack/core/std_backport/detail/invoke.hpp
+++ b/src/mlpack/core/std_backport/detail/invoke.hpp
@@ -1,0 +1,188 @@
+////////////////////////////////////////////////////////////////////////////////
+/// \file invoke.hpp
+///
+/// \brief This internal header provides the definition of the INVOKE overload
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2020 Matthew Rodusek All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BPSTD_DETAIL_INVOKE_HPP
+#define BPSTD_DETAIL_INVOKE_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "config.hpp"  // BPSTD_INLINE_VISIBILITY
+#include "move.hpp"    // forward
+#include <type_traits> // std::true_type, std::false_type, etc
+#include <functional>  // std::reference_wrapper
+
+#include <utility>
+
+BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE
+
+namespace bpstd {
+  namespace detail {
+
+    template<typename T>
+    struct is_reference_wrapper : std::false_type {};
+
+    template<typename U>
+    struct is_reference_wrapper<std::reference_wrapper<U>> : std::true_type {};
+
+    template <typename Base, typename T, typename Derived, typename... Args>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(T Base::*pmf, Derived&& ref, Args&&... args)
+      noexcept(noexcept((::bpstd::forward<Derived>(ref).*pmf)(::bpstd::forward<Args>(args)...)))
+      -> typename std::enable_if<std::is_function<T>::value &&
+                                 std::is_base_of<Base, typename std::decay<Derived>::type>::value,
+          decltype((::bpstd::forward<Derived>(ref).*pmf)(::bpstd::forward<Args>(args)...))>::type
+    {
+      return (bpstd::forward<Derived>(ref).*pmf)(bpstd::forward<Args>(args)...);
+    }
+
+    template <typename Base, typename T, typename RefWrap, typename... Args>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(T Base::*pmf, RefWrap&& ref, Args&&... args)
+      noexcept(noexcept((ref.get().*pmf)(std::forward<Args>(args)...)))
+      -> typename std::enable_if<std::is_function<T>::value &&
+                          is_reference_wrapper<typename std::decay<RefWrap>::type>::value,
+          decltype((ref.get().*pmf)(::bpstd::forward<Args>(args)...))>::type
+    {
+      return (ref.get().*pmf)(bpstd::forward<Args>(args)...);
+    }
+
+    template<typename Base, typename T, typename Pointer, typename... Args>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(T Base::*pmf, Pointer&& ptr, Args&&... args)
+      noexcept(noexcept(((*std::forward<Pointer>(ptr)).*pmf)(std::forward<Args>(args)...)))
+      -> typename std::enable_if<std::is_function<T>::value &&
+                          !is_reference_wrapper<typename std::decay<Pointer>::type>::value &&
+                          !std::is_base_of<Base, typename std::decay<Pointer>::type>::value,
+          decltype(((*::bpstd::forward<Pointer>(ptr)).*pmf)(::bpstd::forward<Args>(args)...))>::type
+    {
+      return ((*bpstd::forward<Pointer>(ptr)).*pmf)(bpstd::forward<Args>(args)...);
+    }
+
+    template<typename Base, typename T, typename Derived>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(T Base::*pmd, Derived&& ref)
+      noexcept(noexcept(std::forward<Derived>(ref).*pmd))
+      -> typename std::enable_if<!std::is_function<T>::value &&
+                          std::is_base_of<Base, typename std::decay<Derived>::type>::value,
+          decltype(::bpstd::forward<Derived>(ref).*pmd)>::type
+    {
+      return bpstd::forward<Derived>(ref).*pmd;
+    }
+
+    template<typename Base, typename T, typename RefWrap>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(T Base::*pmd, RefWrap&& ref)
+      noexcept(noexcept(ref.get().*pmd))
+      -> typename std::enable_if<!std::is_function<T>::value &&
+                                 is_reference_wrapper<typename std::decay<RefWrap>::type>::value,
+          decltype(ref.get().*pmd)>::type
+    {
+      return ref.get().*pmd;
+    }
+
+    template<typename Base, typename T, typename Pointer>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(T Base::*pmd, Pointer&& ptr)
+      noexcept(noexcept((*std::forward<Pointer>(ptr)).*pmd))
+      -> typename std::enable_if<!std::is_function<T>::value &&
+                          !is_reference_wrapper<typename std::decay<Pointer>::type>::value &&
+                          !std::is_base_of<Base, typename std::decay<Pointer>::type>::value,
+          decltype((*::bpstd::forward<Pointer>(ptr)).*pmd)>::type
+    {
+      return (*bpstd::forward<Pointer>(ptr)).*pmd;
+    }
+
+    template<typename F, typename... Args>
+    inline BPSTD_INLINE_VISIBILITY constexpr
+    auto INVOKE(F&& f, Args&&... args)
+        noexcept(noexcept(std::forward<F>(f)(std::forward<Args>(args)...)))
+      -> typename std::enable_if<!std::is_member_pointer<typename std::decay<F>::type>::value,
+        decltype(::bpstd::forward<F>(f)(::bpstd::forward<Args>(args)...))>::type
+    {
+      return bpstd::forward<F>(f)(bpstd::forward<Args>(args)...);
+    }
+
+    //==========================================================================
+    // is_nothrow_invocable
+    //==========================================================================
+
+    template <typename Fn, typename...Args>
+    struct is_nothrow_invocable
+    {
+      template <typename Fn2, typename...Args2>
+      static auto test( Fn2&&, Args2&&... )
+        -> decltype(INVOKE(std::declval<Fn2>(), std::declval<Args2>()...),
+                    std::integral_constant<bool,noexcept(INVOKE(std::declval<Fn2>(), std::declval<Args2>()...))>{});
+
+      static auto test(...)
+        -> std::false_type;
+
+      using type = decltype(test(std::declval<Fn>(), std::declval<Args>()...));
+      static constexpr bool value = type::value;
+    };
+
+    //==========================================================================
+    // is_invocable
+    //==========================================================================
+
+    template<typename Fn, typename...Args>
+    struct is_invocable
+    {
+      template <typename Fn2, typename...Args2>
+      static auto test( Fn2&&, Args2&&... )
+        -> decltype(INVOKE(std::declval<Fn2>(), std::declval<Args2>()...), std::true_type{});
+
+      static auto test(...)
+        -> std::false_type;
+
+      using type = decltype(test(std::declval<Fn>(), std::declval<Args>()...));
+      static constexpr bool value = type::value;
+    };
+
+    // Used to SFINAE away non-invocable types
+    template <bool B, typename Fn, typename...Args>
+    struct invoke_result_impl{};
+
+    template <typename Fn, typename...Args>
+    struct invoke_result_impl<true, Fn, Args...>{
+      using type = decltype(INVOKE(std::declval<Fn>(), std::declval<Args>()...));
+    };
+
+    template <typename Fn, typename...Args>
+    struct invoke_result
+      : invoke_result_impl<is_invocable<Fn,Args...>::value, Fn, Args...>{};
+
+  } // namespace detail
+} // namespace bpstd
+
+BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE
+
+#endif /* BPSTD_DETAIL_INVOKE_HPP */

--- a/src/mlpack/core/std_backport/detail/move.hpp
+++ b/src/mlpack/core/std_backport/detail/move.hpp
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////////////
+/// \file move.hpp
+///
+/// \brief This internal header provides the definition of the move and forward
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2020 Matthew Rodusek All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BPSTD_DETAIL_MOVE_HPP
+#define BPSTD_DETAIL_MOVE_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "config.hpp"
+
+#include <type_traits>
+
+BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE
+
+namespace bpstd {
+
+  //----------------------------------------------------------------------------
+  // Utilities
+  //----------------------------------------------------------------------------
+
+  /// \{
+  /// \brief Forwards a reference \p t
+  ///
+  /// \tparam T the type to forward
+  /// \param t the reference
+  /// \return the forwarded reference
+  template <typename T>
+  constexpr T&& forward(typename std::remove_reference<T>::type& t) noexcept;
+  template <typename T>
+  constexpr T&& forward(typename std::remove_reference<T>::type&& t) noexcept;
+  /// \}
+
+  /// \brief Casts \p x to an rvalue
+  ///
+  /// \param x the parameter to move
+  /// \return rvalue reference to \p x
+  template <typename T>
+  constexpr T&& move(T& x) noexcept;
+
+  /// \brief Casts \p x to an rvalue
+  ///
+  /// \param x the parameter to move
+  /// \return rvalue reference to \p x
+  template <typename T>
+  constexpr typename std::remove_reference<T>::type&& move(T&& x) noexcept;
+
+} // namespace bpstd
+
+//------------------------------------------------------------------------------
+// Utilities
+//------------------------------------------------------------------------------
+
+template <typename T>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T&& bpstd::forward(typename std::remove_reference<T>::type& t)
+  noexcept
+{
+  return static_cast<T&&>(t);
+}
+
+template <typename T>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T&& bpstd::forward(typename std::remove_reference<T>::type&& t)
+  noexcept
+{
+  return static_cast<T&&>(t);
+}
+
+template <typename T>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T&& bpstd::move(T& x)
+  noexcept
+{
+  return static_cast<T&&>(x);
+}
+
+template <typename T>
+inline BPSTD_INLINE_VISIBILITY constexpr
+typename std::remove_reference<T>::type&& bpstd::move(T&& x)
+  noexcept
+{
+  return static_cast<T&&>(x);
+}
+
+BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE
+
+#endif /* BPSTD_DETAIL_MOVE_HPP */

--- a/src/mlpack/core/std_backport/type_traits.hpp
+++ b/src/mlpack/core/std_backport/type_traits.hpp
@@ -1,0 +1,1398 @@
+////////////////////////////////////////////////////////////////////////////////
+/// \file type_traits.hpp
+///
+/// \brief This header provides definitions from the C++ header <type_traits>
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2020 Matthew Rodusek All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BPSTD_TYPE_TRAITS_HPP
+#define BPSTD_TYPE_TRAITS_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "detail/config.hpp"
+#include "detail/move.hpp"   // move, forward
+#include "detail/invoke.hpp" // detail::INVOKE
+
+#include <type_traits>
+#include <cstddef> // std::size_t
+
+BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE
+
+// GCC versions prior to gcc-5 did not implement the type traits for triviality
+// in completion. Several traits are implemented under a different names from
+// pre-standardization, such as 'has_trivial_copy_destructor' instead of
+// 'is_trivially_destructible'. However, most of these cannot be implemented
+// without compiler support.
+//
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2014
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
+# define BPSTD_HAS_TRIVIAL_TYPE_TRAITS 0
+#else
+# define BPSTD_HAS_TRIVIAL_TYPE_TRAITS 1
+#endif
+
+namespace bpstd {
+
+  //============================================================================
+  // Type constants
+  //============================================================================
+
+  template <typename T, T V>
+  using integral_constant = std::integral_constant<T, V>;
+
+  template <bool B>
+  using bool_constant = integral_constant<bool,B>;
+
+  using std::true_type;
+  using std::false_type;
+
+  template <typename T>
+  struct type_identity {
+    using type = T;
+  };
+
+  namespace detail {
+    template <typename T>
+    struct make_void : type_identity<void>{};
+  } // namespace detail
+
+  template <typename T>
+  using void_t = typename detail::make_void<T>::type;
+
+  //============================================================================
+  // Metafunctions
+  //============================================================================
+
+  template <bool B, typename T = void>
+  using enable_if = std::enable_if<B, T>;
+
+  template <bool B, typename T = void>
+  using enable_if_t = typename enable_if<B, T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <bool B, typename True, typename False>
+  using conditional = std::conditional<B, True, False>;
+
+  template <bool B, typename True, typename False>
+  using conditional_t = typename conditional<B, True, False>::type;
+
+  /// \brief Type trait to determine the bool_constant from a logical
+  ///        AND operation of other bool_constants
+  ///
+  /// The result is aliased as \c ::value
+  template<typename...>
+  struct conjunction;
+
+  template<typename B1>
+  struct conjunction<B1> : B1{};
+
+  template<typename B1, typename... Bn>
+  struct conjunction<B1, Bn...>
+    : conditional_t<B1::value, conjunction<Bn...>, B1>{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<typename...Bs>
+  BPSTD_CPP17_INLINE constexpr auto disconjunction_v = conjunction<Bs...>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  /// \brief Type trait to determine the \c bool_constant from a logical
+  ///        OR operations of other bool_constant
+  ///
+  /// The result is aliased as \c ::value
+  template<typename...>
+  struct disjunction : false_type { };
+
+  template<typename B1>
+  struct disjunction<B1> : B1{};
+
+  template<typename B1, typename... Bn>
+  struct disjunction<B1, Bn...>
+    : conditional_t<B1::value != false, B1, disjunction<Bn...>>{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<typename...Bs>
+  BPSTD_CPP17_INLINE constexpr auto disjunction_v = disjunction<Bs...>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  /// \brief Utility metafunction for negating a bool_constant
+  ///
+  /// The result is aliased as \c ::value
+  ///
+  /// \tparam B the constant
+  template<typename B>
+  struct negation : bool_constant<!static_cast<bool>(B::value)>{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<typename B>
+  BPSTD_CPP17_INLINE constexpr auto negation_v = negation<B>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename Fn, typename...Args>
+  using invoke_result = detail::invoke_result<Fn,Args...>;
+
+  template <typename Fn, typename...Args>
+  using invoke_result_t = typename invoke_result<Fn,Args...>::type;
+
+  //----------------------------------------------------------------------------
+
+  namespace detail {
+
+    template <bool IsInvocable, typename R, typename Fn, typename...Args>
+    struct is_invocable_return : std::is_convertible<invoke_result_t<Fn,Args...>, R>{};
+
+    template <typename R, typename Fn, typename...Args>
+    struct is_invocable_return<false, R, Fn, Args...> : false_type{};
+
+  } // namespace detail
+
+  template <typename Fn, typename...Args>
+  using is_invocable = detail::is_invocable<Fn, Args...>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<typename Fn, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_invocable_v = is_invocable<Fn, Args...>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename R, typename Fn, typename...Args>
+  struct is_invocable_r
+    : detail::is_invocable_return<is_invocable<Fn,Args...>::value, R, Fn, Args...>{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename R, typename Fn, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_invocable_r_v = is_invocable_r<R, Fn, Args...>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename Fn, typename...Args>
+  using is_nothrow_invocable = detail::is_nothrow_invocable<Fn, Args...>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<typename Fn, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_invocable_v = is_nothrow_invocable<Fn, Args...>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename R, typename Fn, typename...Args>
+  struct is_nothrow_invocable_r
+    : detail::is_invocable_return<is_nothrow_invocable<Fn,Args...>::value, R, Fn, Args...>{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename R, typename Fn, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_invocable_r_v
+    = is_nothrow_invocable_r<R, Fn, Args...>::value;
+#endif
+
+  //============================================================================
+  // Type categories
+  //============================================================================
+
+  template <typename T>
+  using is_void = std::is_void<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_void_v = is_void<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  struct is_null_pointer : false_type{};
+
+  template <>
+  struct is_null_pointer<decltype(nullptr)> : true_type{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_null_pointer_v = is_null_pointer<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_array = std::is_array<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_array_v = is_array<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_pointer = std::is_pointer<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_pointer_v = is_pointer<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_enum = std::is_enum<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_enum_v = is_enum<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_union = std::is_union<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_union_v = is_union<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_class = std::is_class<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_class_v = is_class<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_function = std::is_function<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_function_v = is_function<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_object = std::is_object<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_object_v = is_object<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_scalar = std::is_scalar<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_scalar_v = is_scalar<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_compound = std::is_compound<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_compound_v = is_compound<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_integral = std::is_integral<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_integral_v = is_integral<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_floating_point = std::is_floating_point<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_floating_point_v = is_floating_point<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_fundamental = std::is_fundamental<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_fundamental_v = is_fundamental<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_arithmetic = std::is_arithmetic<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_arithmetic_v = is_arithmetic<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_reference = std::is_reference<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_reference_v = is_reference<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_lvalue_reference = std::is_lvalue_reference<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_lvalue_reference_v = is_lvalue_reference<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_rvalue_reference = std::is_rvalue_reference<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_rvalue_reference_v = is_rvalue_reference<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_member_pointer = std::is_member_pointer<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_member_pointer_v = is_member_pointer<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_member_object_pointer = std::is_member_object_pointer<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_member_object_pointer_v = is_member_object_pointer<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_member_function_pointer = std::is_member_function_pointer<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_member_function_pointer_v = is_member_function_pointer<T>::value;
+#endif
+
+  //============================================================================
+  // Type properties
+  //============================================================================
+
+  template <typename T>
+  using is_const = std::is_const<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_const_v = is_const<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_volatile = std::is_volatile<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_volatile_v = is_volatile<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_empty = std::is_empty<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_empty_v = is_empty<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_polymorphic = std::is_polymorphic<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_polymorphic_v = is_polymorphic<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if __cplusplus >= 201402L
+  // is_final is only defined in C++14
+  template <typename T>
+  struct is_final : std::is_final<T>{};
+#else
+  // is_final requires compiler-support to implement.
+  // Without this support, the best we can do is require explicit
+  // specializations of 'is_final' for any types that are known to be final
+  template <typename T>
+  struct is_final : false_type{};
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_final_v = is_final<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_abstract = std::is_abstract<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_abstract_v = is_abstract<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  // is_aggregate is only defined in C++17
+#if __cplusplus >= 201703L
+
+  template <typename T>
+  using is_aggregate = std::is_aggregate<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_aggregate_v = is_aggregate<T>::value;
+#endif
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_trivial = std::is_trivial<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivial_v = is_trivial<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_copyable = std::is_trivially_copyable<T>;
+
+#else
+
+  // std::is_trivially_copyable is not implemented in gcc < 5, and unfortunately
+  // can't be implemented without compiler intrinsics. This definition is
+  // left out to avoid problems
+  template <typename T>
+  using is_trivially_copyable = false_type;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_copyable_v = is_trivially_copyable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_standard_layout = std::is_standard_layout<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_standard_layout_v = is_standard_layout<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_literal_type = std::is_literal_type<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_literal_type_v = is_literal_type<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_pod = std::is_pod<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_pod_v = is_pod<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_signed = std::is_signed<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_signed_v = is_signed<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_unsigned = std::is_unsigned<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_unsigned_v = is_unsigned<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  struct is_bounded_array : false_type{};
+
+  template <typename T, std::size_t N>
+  struct is_bounded_array<T[N]> : true_type{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_bounded_array_v = is_bounded_array<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+
+  template <typename T>
+  struct is_unbounded_array : false_type{};
+
+  template <typename T>
+  struct is_unbounded_array<T[]> : true_type{};
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_unbounded_array_v = is_unbounded_array<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  // has_unique_object_representation only defined in C++17
+#if __cplusplus >= 201703L
+  template <typename T>
+  using has_unique_object_representations = std::has_unique_object_representations<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto has_unique_object_representations_v = has_unique_object_representations<T>::value;
+#endif
+#endif
+
+  //============================================================================
+  // Type Modification
+  //============================================================================
+
+  template <typename T>
+  using remove_cv = std::remove_cv<T>;
+
+  template <typename T>
+  using remove_cv_t = typename remove_cv<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_const = std::remove_const<T>;
+
+  template <typename T>
+  using remove_const_t = typename remove_const<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_volatile = std::remove_volatile<T>;
+
+  template <typename T>
+  using remove_volatile_t = typename remove_volatile<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using add_cv = std::add_cv<T>;
+
+  template <typename T>
+  using add_cv_t = typename add_cv<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using add_const = std::add_const<T>;
+
+  template <typename T>
+  using add_const_t = typename add_const<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using add_volatile = std::add_volatile<T>;
+
+  template <typename T>
+  using add_volatile_t = typename add_volatile<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using make_signed = std::make_signed<T>;
+
+  template <typename T>
+  using make_signed_t = typename make_signed<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using make_unsigned = std::make_unsigned<T>;
+
+  template <typename T>
+  using make_unsigned_t = typename make_unsigned<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_reference = std::remove_reference<T>;
+
+  template <typename T>
+  using remove_reference_t = typename remove_reference<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using add_lvalue_reference = std::add_lvalue_reference<T>;
+
+  template <typename T>
+  using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using add_rvalue_reference = std::add_rvalue_reference<T>;
+
+  template <typename T>
+  using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_pointer = std::remove_pointer<T>;
+
+  template <typename T>
+  using remove_pointer_t = typename remove_pointer<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using add_pointer = std::add_pointer<T>;
+
+  template <typename T>
+  using add_pointer_t = typename add_pointer<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_extent = std::remove_extent<T>;
+
+  template <typename T>
+  using remove_extent_t = typename remove_extent<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_all_extents = std::remove_all_extents<T>;
+
+  template <typename T>
+  using remove_all_extents_t = typename remove_all_extents<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using remove_cvref = remove_cv<remove_reference_t<T>>;
+
+  template <typename T>
+  using remove_cvref_t = typename remove_cvref<T>::type;
+
+  //============================================================================
+  // Type Transformation
+  //============================================================================
+
+  template <std::size_t Size, std::size_t Align>
+  struct aligned_storage
+  {
+    struct type {
+      alignas(Align) char storage[Size];
+    };
+  };
+
+  template <std::size_t Size, std::size_t Align>
+  using aligned_storage_t = typename aligned_storage<Size, Align>::type;
+
+  //----------------------------------------------------------------------------
+
+  namespace detail {
+
+    template <std::size_t...Sizes>
+    struct largest;
+
+    template <std::size_t Size0, std::size_t Size1, std::size_t...Sizes>
+    struct largest<Size0, Size1, Sizes...>
+      : largest<(Size0 > Size1 ? Size0 : Size1), Sizes...>{};
+
+    template <std::size_t Size0>
+    struct largest<Size0> : integral_constant<std::size_t,Size0>{};
+
+  } // namespace detail
+
+  // gcc < 5 does not implement 'std::aligned_union', despite it being a type
+  // in the C++11 standard -- so it's implemented here to ensure that its
+  // available.
+  template <std::size_t Len, typename... Ts>
+  struct aligned_union
+  {
+    static constexpr std::size_t alignment_value = detail::largest<alignof(Ts)...>::value;
+
+    struct type
+    {
+      alignas(alignment_value) char buffer[detail::largest<Len, sizeof(Ts)...>::value];
+    };
+  };
+
+  template <std::size_t Len, typename... Ts>
+  constexpr std::size_t aligned_union<Len,Ts...>::alignment_value;
+
+  template <std::size_t Len, typename...Ts>
+  using aligned_union_t = typename aligned_union<Len, Ts...>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using decay = std::decay<T>;
+
+  template <typename T>
+  using decay_t = typename decay<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename...Ts>
+  using common_type = std::common_type<Ts...>;
+
+  template <typename...Ts>
+  using common_type_t = typename common_type<Ts...>::type;
+
+  //----------------------------------------------------------------------------
+
+  namespace detail {
+
+    template <bool IsEnum, typename T>
+    struct underlying_type_impl : type_identity<T>{};
+
+    template <typename T>
+    struct underlying_type_impl<false, T>{};
+
+  } // namespace detail
+
+  template <typename T>
+  struct underlying_type : detail::underlying_type_impl<is_enum<T>::value, T>{};
+
+  template <typename T>
+  using underlying_type_t = typename underlying_type<T>::type;
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using result_of = std::result_of<T>;
+
+  template <typename T>
+  using result_of_t = typename result_of<T>::type;
+
+  //============================================================================
+  // Supported Operations
+  //============================================================================
+
+  template <typename T, typename...Args>
+  using is_constructible = std::is_constructible<T, Args...>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_constructible_v = is_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T, typename...Args>
+  using is_trivially_constructible = std::is_trivially_constructible<T, Args...>;
+
+#else
+
+  // std::is_trivially_constructible is not implemented in gcc < 5, and
+  // there exists no utilities to implement it in the language without extensions.
+  // This is left defined to false_type so that the trait may be used, despite
+  // yielding incorrect results
+  template <typename T, typename...Args>
+  using is_trivially_constructible = false_type;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_constructible_v = is_trivially_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T, typename...Args>
+  using is_nothrow_constructible = std::is_nothrow_constructible<T, Args...>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename...Args>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_constructible_v = is_nothrow_constructible<T, Args...>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_default_constructible = std::is_default_constructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_default_constructible_v = is_default_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_default_constructible = std::is_trivially_default_constructible<T>;
+
+#else
+
+  // std::is_trivially_default_constructible is not implemented in gcc < 5,
+  // however there exists a non-standard
+  // 'std::has_trivial_default_constructor' which performs a similar check
+  template <typename T>
+  using is_trivially_default_constructible = std::has_trivial_default_constructor<T>;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_default_constructible_v = is_trivially_default_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_nothrow_default_constructible = std::is_nothrow_default_constructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_default_constructible_v = is_nothrow_default_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_copy_constructible = std::is_copy_constructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_copy_constructible_v = is_copy_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_copy_constructible = std::is_trivially_copy_constructible<T>;
+
+#else
+
+  // std::is_trivially_copy_constructible is not implemented in gcc < 5,
+  // however there exists a non-standard
+  // 'std::has_trivial_copy_constructor' which performs a similar check
+  template <typename T>
+  using is_trivially_copy_constructible = std::has_trivial_copy_constructor<T>;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_copy_constructible_v = is_trivially_copy_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_nothrow_copy_constructible = std::is_nothrow_copy_constructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_copy_constructible_v = is_nothrow_copy_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_move_constructible = std::is_move_constructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_move_constructible_v = is_move_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_move_constructible = std::is_trivially_move_constructible<T>;
+
+#else
+
+  // std::is_trivially_move_constructible is not implemented in gcc < 5, and
+  // there exists no utilities to implement it in the language without extensions.
+  // This is left defined to false_type so that the trait may be used, despite
+  // yielding incorrect results
+  template <typename T>
+  using is_trivially_move_constructible = false_type;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_move_constructible_v = is_trivially_move_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_nothrow_move_constructible = std::is_nothrow_move_constructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_move_constructible_v = is_nothrow_move_constructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T, typename U>
+  using is_assignable = std::is_assignable<T, U>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_assignable_v = is_assignable<T, U>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T, typename U>
+  using is_trivially_assignable = std::is_trivially_assignable<T, U>;
+
+#else
+
+  // std::is_trivially_assignable is not implemented in gcc < 5, and
+  // there exists no utilities to implement it in the language without extensions.
+  // This is left defined to false_type so that the trait may be used, despite
+  // yielding incorrect results
+  template <typename T, typename U>
+  using is_trivially_assignable = false_type;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_assignable_v = is_trivially_assignable<T, U>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T, typename U>
+  using is_nothrow_assignable = std::is_nothrow_assignable<T, U>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_assignable_v = is_nothrow_assignable<T, U>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_copy_assignable = std::is_copy_assignable<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_copy_assignable_v = is_copy_assignable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_copy_assignable = std::is_trivially_copy_assignable<T>;
+
+#else
+
+  // std::is_trivially_copy_assignable is not implemented in gcc < 5,
+  // however there exists a non-standard
+  // 'std::has_trivial_copy_assign' which performs a similar check
+  template <typename T>
+  using is_trivially_copy_assignable = std::has_trivial_copy_assign<T>;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_copy_assignable_v = is_trivially_copy_assignable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_nothrow_copy_assignable = std::is_nothrow_copy_assignable<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_copy_assignable_v = is_nothrow_copy_assignable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_move_assignable = std::is_move_assignable<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_move_assignable_v = is_move_assignable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_move_assignable = std::is_trivially_move_assignable<T>;
+
+#else
+
+  // std::is_trivially_move_assignable is not implemented in gcc < 5, and
+  // there exists no utilities to implement it in the language without extensions.
+  // This is left defined to false_type so that the trait may be used, despite
+  // yielding incorrect results
+  template <typename T>
+  using is_trivially_move_assignable = false_type;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_move_assignable_v = is_trivially_move_assignable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_nothrow_move_assignable = std::is_nothrow_move_assignable<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_move_assignable_v = is_nothrow_move_assignable<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_destructible = std::is_destructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_destructible_v = is_destructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+#if BPSTD_HAS_TRIVIAL_TYPE_TRAITS
+
+  template <typename T>
+  using is_trivially_destructible = std::is_trivially_destructible<T>;
+
+#else
+
+  // std::is_trivially_destructible is not implemented in gcc < 5, however there
+  // exists a non-standard '__has_trivial_destructor' which performs a
+  // similar check
+  template <typename T>
+  using is_trivially_destructible = bool_constant<(__has_trivial_destructor(T))>;
+
+#endif
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_trivially_destructible_v = is_trivially_destructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using is_nothrow_destructible = std::is_nothrow_destructible<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_destructible_v = is_nothrow_destructible<T>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename T>
+  using has_virtual_destructor = std::has_virtual_destructor<T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto has_virtual_destructor_v = has_virtual_destructor<T>::value;
+#endif
+
+  //============================================================================
+  // Relationship
+  //============================================================================
+
+  template <typename T, typename U>
+  using is_same = std::is_same<T, U>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_same_v = is_same<T, U>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename Base, typename Derived>
+  using is_base_of = std::is_base_of<Base,Derived>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename Base, typename Derived>
+  BPSTD_CPP17_INLINE constexpr auto is_base_of_v = is_base_of<Base,Derived>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  template <typename From, typename To>
+  using is_convertible = std::is_convertible<From, To>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename From, typename To>
+  BPSTD_CPP17_INLINE constexpr auto is_convertible_v = is_convertible<From, To>::value;
+#endif
+
+  //----------------------------------------------------------------------------
+
+  namespace detail {
+
+    template <bool IsConvertible, typename From, typename To>
+    struct is_nothrow_convertible_impl : false_type{};
+
+    template <typename From, typename To>
+    struct is_nothrow_convertible_impl<true, From, To>
+    {
+      static void test(To) noexcept;
+
+      BPSTD_CPP17_INLINE static constexpr auto value =
+        noexcept(test(std::declval<From>()));
+    };
+
+  } // namespace detail
+
+  template <typename From, typename To>
+  using is_nothrow_convertible = bool_constant<
+    detail::is_nothrow_convertible_impl<is_convertible<From,To>::value,From,To>::value
+  >;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename From, typename To>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_convertible_v = is_nothrow_convertible<From, To>::value;
+#endif
+
+  namespace detail {
+    namespace adl_swap {
+
+      void swap();
+
+      //------------------------------------------------------------------------
+
+      template <typename T, typename U>
+      struct is_std_swappable_with : false_type{};
+
+      template <typename T>
+      struct is_std_swappable_with<T,T>
+        : conjunction<
+            is_move_constructible<remove_cvref_t<remove_extent_t<T>>>,
+            is_move_assignable<remove_cvref_t<remove_extent_t<T>>>,
+            is_lvalue_reference<T>
+          >{};
+
+      template <typename T, typename U>
+      struct is_nothrow_std_swappable_with : false_type{};
+
+      template <typename T>
+      struct is_nothrow_std_swappable_with<T,T>
+        : conjunction<
+            is_nothrow_move_constructible<remove_cvref_t<remove_extent_t<T>>>,
+            is_nothrow_move_assignable<remove_cvref_t<remove_extent_t<T>>>,
+            is_lvalue_reference<T>
+          >{};
+
+      //------------------------------------------------------------------------
+#if !defined(_MSC_FULL_VER) || _MSC_FULL_VER >= 191426428
+
+      template <typename T, typename U>
+      using detect_adl_swap = decltype(swap(std::declval<T>(), std::declval<U>()));
+
+      template <typename T, typename U, template <typename, typename> class Op, typename = void>
+      struct is_adl_swappable_with : false_type{};
+
+      template <typename T, typename U, template <typename, typename> class Op>
+      struct is_adl_swappable_with<T,U,Op, void_t<Op<T,U>>>
+        : true_type{};
+
+      template <typename T, typename U, bool IsSwappable = is_adl_swappable_with<T,U,detect_adl_swap>::value>
+      struct is_nothrow_adl_swappable_with : false_type{};
+
+      template <typename T, typename U>
+      struct is_nothrow_adl_swappable_with<T,U, true>
+        : bool_constant<noexcept(swap(std::declval<T>(), std::declval<U>()))>{};
+#endif
+
+    } // namespace adl_swap
+
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 191426428
+
+    // MSVC 2017 15.7 or above is required for expression SFINAE.
+    // I'm not sure if 'is_swappable_with' is properly implementable without
+    // it, since we need to test calling of 'swap' unqualified.
+    // For now, the best we can do is test whether std::swap works, until a
+    // more full-featured compiler is used.
+
+    template <typename T, typename U>
+    struct is_swappable_with
+      : adl_swap::is_std_swappable_with<T,U>{};
+
+    template <typename T, typename U>
+    struct is_nothrow_swappable_with
+      : adl_swap::is_nothrow_std_swappable_with<T,U>{};
+
+#else
+
+    template <typename T, typename U>
+    struct is_swappable_with
+      : conditional_t<adl_swap::is_adl_swappable_with<T,U, adl_swap::detect_adl_swap>::value,
+          adl_swap::is_adl_swappable_with<T,U, adl_swap::detect_adl_swap>,
+          adl_swap::is_std_swappable_with<T,U>
+        >{};
+
+    template <typename T, typename U>
+    struct is_nothrow_swappable_with
+      : conditional_t<adl_swap::is_adl_swappable_with<T,U, adl_swap::detect_adl_swap>::value,
+          adl_swap::is_nothrow_adl_swappable_with<T,U>,
+          adl_swap::is_nothrow_std_swappable_with<T,U>
+        >{};
+
+#endif
+
+  } // namespace detail
+
+  template <typename T, typename U>
+  using is_swappable_with = detail::is_swappable_with<remove_cvref_t<T>&,remove_cvref_t<U>&>;
+
+  template <typename T>
+  using is_swappable = is_swappable_with<T,T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_swappable_with_v = is_swappable_with<T, U>::value;
+
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_swappable_v = is_swappable<T>::value;
+#endif
+
+  template <typename T, typename U>
+  using is_nothrow_swappable_with = detail::is_nothrow_swappable_with<remove_cvref_t<T>&,remove_cvref_t<U>&>;
+
+  template <typename T>
+  using is_nothrow_swappable = is_nothrow_swappable_with<T,T>;
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template <typename T, typename U>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_swappable_with_v = is_nothrow_swappable_with<T, U>::value;
+
+  template <typename T>
+  BPSTD_CPP17_INLINE constexpr auto is_nothrow_swappable_v = is_nothrow_swappable_with<T, T>::value;
+#endif
+
+} // namespace bpstd
+
+BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE
+
+#endif /* BPSTD_TYPE_TRAITS_HPP */

--- a/src/mlpack/core/std_backport/utility.hpp
+++ b/src/mlpack/core/std_backport/utility.hpp
@@ -1,0 +1,382 @@
+////////////////////////////////////////////////////////////////////////////////
+/// \file utility.hpp
+///
+/// \brief This header provides definitions from the C++ header <utility>
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2020 Matthew Rodusek All rights reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BPSTD_UTILITY_HPP
+#define BPSTD_UTILITY_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "detail/config.hpp"
+#include "detail/move.hpp" // IWYU pragma: export
+#include "type_traits.hpp" // add_const_t
+
+#include <utility> // to proxy the API
+#include <cstddef> // std::size_t
+
+BPSTD_COMPILER_DIAGNOSTIC_PREAMBLE
+
+namespace bpstd {
+
+  //============================================================================
+  // struct : in_place_t
+  //============================================================================
+
+  /// \brief This function is a special disambiguation tag for variadic
+  ///        functions, used in any and optional
+  ///
+  /// \note Calling this function results in undefined behaviour.
+  struct in_place_t
+  {
+    explicit in_place_t() = default;
+  };
+  BPSTD_CPP17_INLINE constexpr in_place_t in_place{};
+
+  //============================================================================
+  // in_place_type_t
+  //============================================================================
+
+  /// \brief This function is a special disambiguation tag for variadic
+  ///        functions, used in any and optional
+  ///
+  /// \note Calling this function results in undefined behaviour.
+  template<typename T>
+  struct in_place_type_t
+  {
+    explicit in_place_type_t() = default;
+  };
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<typename T>
+  BPSTD_CPP17_INLINE constexpr in_place_type_t<T> in_place_type{};
+#endif
+
+  //============================================================================
+  // in_place_index_t
+  //============================================================================
+
+  /// \brief This function is a special disambiguation tag for variadic
+  ///        functions, used in any and optional
+  ///
+  /// \note Calling this function results in undefined behaviour.
+  template<std::size_t I> struct in_place_index_t
+  {
+    explicit in_place_index_t() = default;
+  };
+
+#if BPSTD_HAS_TEMPLATE_VARIABLES
+  template<std::size_t I>
+  BPSTD_CPP17_INLINE constexpr in_place_index_t<I> in_place_index{};
+#endif
+
+  //============================================================================
+  // non-member functions
+  //============================================================================
+
+  //----------------------------------------------------------------------------
+  // Utilities
+  //----------------------------------------------------------------------------
+
+  /// \brief Moves a type \p x if it move-construction is non-throwing
+  ///
+  /// \param x the parameter to move
+  /// \return an rvalue reference if nothrow moveable, const reference otherwise
+  template <typename T>
+  constexpr typename bpstd::conditional<
+    !bpstd::is_nothrow_move_constructible<T>::value && bpstd::is_copy_constructible<T>::value,
+    const T&,
+    T&&
+  >::type move_if_noexcept(T& x) noexcept;
+
+  /// \brief Forms an lvalue reference to const type of t
+  ///
+  /// \param t the type to form an lvalue reference to
+  /// \return the reference to const T
+  template <typename T>
+  constexpr add_const_t<T>& as_const(T& t) noexcept;
+  template <typename T>
+  void as_const(const T&&) = delete;
+
+  /// \brief Replaces the value of obj with new_value and returns the old value
+  ///        of obj.
+  ///
+  /// \pre \p T must meet the requirements of MoveConstructible.
+  ///
+  /// \pre It must be possible to move-assign objects of type \p U to objects of
+  ///      type \p T
+  ///
+  /// \param obj object whose value to replace
+  /// \param new_value the value to assign to obj
+  template <typename T, typename U = T>
+  BPSTD_CPP14_CONSTEXPR T exchange(T& obj, U&& new_value);
+
+  //============================================================================
+  // class : pair
+  //============================================================================
+
+  template <typename T, typename U>
+  using pair = std::pair<T,U>;
+
+  //============================================================================
+  // non-member functions : class : pair
+  //============================================================================
+
+  //----------------------------------------------------------------------------
+  // Utilities
+  //----------------------------------------------------------------------------
+
+  // C++11 does not implement const pair&&
+  template <std::size_t N, typename T, typename U>
+  constexpr conditional_t<N==0,T,U>& get(pair<T, U>& p) noexcept;
+  template <std::size_t N, typename T, typename U>
+  constexpr conditional_t<N==0,T,U>&& get(pair<T, U>&& p) noexcept;
+  template <std::size_t N, typename T, typename U>
+  constexpr const conditional_t<N==0,T,U>& get(const pair<T, U>& p) noexcept;
+  template <std::size_t N, typename T, typename U>
+  constexpr const conditional_t<N==0,T,U>&& get(const pair<T, U>&& p) noexcept;
+
+  template <typename T, typename U>
+  constexpr T& get(pair<T, U>& p) noexcept;
+  template <typename T, typename U>
+  constexpr T&& get(pair<T, U>&& p) noexcept;
+  template <typename T, typename U>
+  constexpr const T& get(const pair<T, U>& p) noexcept;
+  template <typename T, typename U>
+  constexpr const T&& get(const pair<T, U>&& p) noexcept;
+
+  template <typename T, typename U>
+  constexpr T& get(pair<U, T>& p) noexcept;
+  template <typename T, typename U>
+  constexpr const T& get(const pair<U, T>& p) noexcept;
+  template <typename T, typename U>
+  constexpr T&& get(pair<U, T>&& p) noexcept;
+  template <typename T, typename U>
+  constexpr const T&& get(const pair<U, T>&& p) noexcept;
+
+  //============================================================================
+  // struct : integer_sequence
+  //============================================================================
+
+  template <typename T, T... Ints>
+  struct integer_sequence
+  {
+    using value_type = T;
+
+    static constexpr std::size_t size() noexcept { return sizeof...(Ints); }
+  };
+
+  template <std::size_t... Ints>
+  using index_sequence = integer_sequence<std::size_t, Ints...>;
+
+  namespace detail {
+    template <typename T, bool End, T N, T...Tails>
+    struct make_integer_sequence_impl
+      : make_integer_sequence_impl<T,((N-1) == T(0)), N-1, N-1, Tails...>{};
+
+    template <typename T, T N, T...Tails>
+    struct make_integer_sequence_impl<T, true, N, Tails...>
+      : type_identity<integer_sequence<T, Tails...>>{};
+
+  } // namespace detail
+
+  template <typename T, T N>
+  using make_integer_sequence
+    = typename detail::make_integer_sequence_impl<T, (N==T(0)), N>::type;
+
+  template<std::size_t N>
+  using make_index_sequence = make_integer_sequence<std::size_t, N>;
+
+  template<typename... T>
+  using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
+} // namespace bpstd
+
+//==============================================================================
+// non-member functions
+//==============================================================================
+
+//------------------------------------------------------------------------------
+// Utilities
+//------------------------------------------------------------------------------
+
+template <typename T>
+inline BPSTD_INLINE_VISIBILITY constexpr
+typename bpstd::conditional<
+  !bpstd::is_nothrow_move_constructible<T>::value && bpstd::is_copy_constructible<T>::value,
+  const T&,
+  T&&
+>::type bpstd::move_if_noexcept(T& x)
+  noexcept
+{
+  using result_type = conditional_t<
+    !is_nothrow_move_constructible<T>::value && is_copy_constructible<T>::value,
+    const T&,
+    T&&
+  >;
+
+  return static_cast<result_type>(x);
+}
+
+template <typename T>
+inline BPSTD_INLINE_VISIBILITY constexpr
+bpstd::add_const_t<T>& bpstd::as_const(T& t)
+  noexcept
+{
+  return t;
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY BPSTD_CPP14_CONSTEXPR
+T bpstd::exchange(T& obj, U&& new_value)
+{
+  auto old_value = bpstd::move(obj);
+  obj = bpstd::forward<U>(new_value);
+  return old_value;
+}
+
+//==============================================================================
+// definitions : non-member functions : class : pair
+//==============================================================================
+
+//------------------------------------------------------------------------------
+// Utilities
+//------------------------------------------------------------------------------
+
+template <std::size_t N, typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+bpstd::conditional_t<N==0,T,U>&
+  bpstd::get(pair<T, U>& p)
+  noexcept
+{
+  static_assert(N<=1, "N must be either 0 or 1 for get<N>(pair<T,U>)");
+
+  return std::get<N>(p);
+}
+
+template <std::size_t N, typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+bpstd::conditional_t<N==0,T,U>&&
+  bpstd::get(pair<T, U>&& p)
+  noexcept
+{
+  static_assert(N<=1, "N must be either 0 or 1 for get<N>(pair<T,U>)");
+
+  return move(std::get<N>(p));
+}
+
+template <std::size_t N, typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+const bpstd::conditional_t<N==0,T,U>&
+  bpstd::get(const pair<T, U>& p)
+  noexcept
+{
+  static_assert(N<=1, "N must be either 0 or 1 for get<N>(pair<T,U>)");
+
+  return std::get<N>(p);
+}
+
+template <std::size_t N, typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+const bpstd::conditional_t<N==0,T,U>&&
+  bpstd::get(const pair<T, U>&& p)
+  noexcept
+{
+  static_assert(N<=1, "N must be either 0 or 1 for get<N>(pair<T,U>)");
+
+  return move(std::get<N>(p));
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T& bpstd::get(pair<T, U>& p)
+  noexcept
+{
+  return p.first;
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+const T& bpstd::get(const pair<T, U>& p)
+  noexcept
+{
+  return p.first;
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T&& bpstd::get(pair<T, U>&& p)
+  noexcept
+{
+  return move(p.first);
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+const T&& bpstd::get(const pair<T, U>&& p)
+  noexcept
+{
+  return move(p.first);
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T& bpstd::get(pair<U, T>& p)
+  noexcept
+{
+  return p.second;
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+const T& bpstd::get(const pair<U, T>& p)
+  noexcept
+{
+  return p.second;
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+T&& bpstd::get(pair<U, T>&& p)
+  noexcept
+{
+  return move(p.second);
+}
+
+template <typename T, typename U>
+inline BPSTD_INLINE_VISIBILITY constexpr
+const T&& bpstd::get(const pair<U, T>&& p)
+  noexcept
+{
+  return move(p.second);
+}
+
+BPSTD_COMPILER_DIAGNOSTIC_POSTAMBLE
+
+#endif /* BPSTD_UTILITY_HPP */

--- a/src/mlpack/core/util/io_impl.hpp
+++ b/src/mlpack/core/util/io_impl.hpp
@@ -60,7 +60,7 @@ T& IO::GetParam(const std::string& identifier)
   }
   else
   {
-    return *boost::any_cast<T>(&d.value);
+    return *ANY_CAST<T>(&d.value);
   }
 }
 

--- a/src/mlpack/core/util/param_data.hpp
+++ b/src/mlpack/core/util/param_data.hpp
@@ -79,7 +79,7 @@ struct ParamData
   bool persistent;
   //! The actual value that is held.  If the user has passed a different type,
   //! this may be a tuple containing multiple values.
-  boost::any value;
+  bpstd::any value;
   //! The true name of the type, as it would be written in C++.
   std::string cppType;
 };

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -73,6 +73,19 @@ using enable_if_t = typename enable_if<B, T>::type;
 #endif
 #endif
 
+// Backport std::any from C+17 to C++11 to replace boost::any.
+// Use bpstd backport implementation only if compiler does not
+// support C++17.
+#if __cplusplus <=201703L
+  #include <mlpack/core/std_backport/any.hpp>
+  #define ANY bpstd::any
+  #define ANY_CAST bpstd::any_cast
+#else
+  #include <any>
+  #define ANY std::any
+  #define ANY_CAST std::any_cast
+#endif 
+
 // Increase the number of template arguments for the boost list class.
 #undef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
 #undef BOOST_MPL_LIMIT_LIST_SIZE


### PR DESCRIPTION
This pull request should be merged after merging #2998.
It will replace `boost::any` with a backported version of `std::any`. I will test several backported versions of C++17 to C++11, and see which will present fewer issues.
I will remove `boost::string_view` and if possible remove boost::math in this pull request.
