### PR TITLE
Addition of ReLU6

### DIFF
--- a/src/mlpack/methods/ann/layer/CMakeLists.txt
+++ b/src/mlpack/methods/ann/layer/CMakeLists.txt
@@ -99,6 +99,8 @@ set(SOURCES
   recurrent_attention_impl.hpp
   reinforce_normal.hpp
   reinforce_normal_impl.hpp
+  relu6.hpp
+  relu6_impl.hpp
   reparametrization.hpp
   reparametrization_impl.hpp
   radial_basis_function.hpp

--- a/src/mlpack/methods/ann/layer/layer.hpp
+++ b/src/mlpack/methods/ann/layer/layer.hpp
@@ -64,6 +64,7 @@
 #include "recurrent_attention.hpp"
 #include "recurrent.hpp"
 #include "reinforce_normal.hpp"
+#include "relu6.hpp"
 #include "reparametrization.hpp"
 #include "select.hpp"
 #include "sequential.hpp"

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -47,6 +47,7 @@
 #include <mlpack/methods/ann/layer/pixel_shuffle.hpp>
 #include <mlpack/methods/ann/layer/positional_encoding.hpp>
 #include <mlpack/methods/ann/layer/reinforce_normal.hpp>
+#include <mlpack/methods/ann/layer/relu6.hpp>
 #include <mlpack/methods/ann/layer/reparametrization.hpp>
 #include <mlpack/methods/ann/layer/select.hpp>
 #include <mlpack/methods/ann/layer/softmax.hpp>
@@ -83,6 +84,7 @@ template<typename InputDataType, typename OutputDataType> class FastLSTM;
 template<typename InputDataType, typename OutputDataType> class VRClassReward;
 template<typename InputDataType, typename OutputDataType> class Concatenate;
 template<typename InputDataType, typename OutputDataType> class Padding;
+template<typename InputDataType, typename OutputDataType> class ReLU6;
 
 template<typename InputDataType,
          typename OutputDataType,
@@ -233,6 +235,7 @@ using MoreTypes = boost::variant<
         Recurrent<arma::mat, arma::mat>*,
         RecurrentAttention<arma::mat, arma::mat>*,
         ReinforceNormal<arma::mat, arma::mat>*,
+        ReLU6<arma::mat, arma::mat>*,
         Reparametrization<arma::mat, arma::mat>*,
         Select<arma::mat, arma::mat>*,
         SpatialDropout<arma::mat, arma::mat>*,

--- a/src/mlpack/methods/ann/layer/relu6.hpp
+++ b/src/mlpack/methods/ann/layer/relu6.hpp
@@ -43,7 +43,7 @@ class ReLU6
  /**
   * Create the ReLU6 object.
   */
-  ReLu6();
+  ReLU6();
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function
@@ -72,6 +72,11 @@ class ReLU6
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the delta.
+  OutputDataType const& Delta() const { return delta; }
+  //! Modify the delta.
+  OutputDataType& Delta() { return delta; }
+
   //! Get size of weights.
   size_t WeightSize() const { return 0; }
 
@@ -85,6 +90,8 @@ class ReLU6
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
+  //! Locally-stored delta object.
+  OutputDataType delta;
 }; // class ReLU6
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/relu6.hpp
+++ b/src/mlpack/methods/ann/layer/relu6.hpp
@@ -1,0 +1,96 @@
+/**
+ * @file methods/ann/layer/relu6.hpp
+ * @author Aakash kaushik
+ *
+ * For more information, kindly refer to the following paper.
+ *
+ * @code
+ * @article{Andrew G2017,
+ *  author = {Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko,
+ *      Weijun Wang, Tobias Weyand, Marco Andreetto, Hartwig Adam},
+ *  title = {MobileNets: Efficient Convolutional Neural Networks for Mobile
+ *      Vision Applications},
+ *  year = {2017},
+ *  url = {https://arxiv.org/pdf/1704.04861}
+ * }
+ * @endcode
+ * 
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LAYER_RELU6_HPP
+#define MLPACK_METHODS_ANN_LAYER_RELU6_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+/**
+ * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ * @tparam OutputDataType Type of the output data (arma::colvec, arma::mat,
+ *         arma::sp_mat or arma::cube).
+ */
+template<typename InputDataType = arma::mat,
+    typename OutputDataType = arma::mat>
+class ReLU6()
+{
+ public:
+
+ /**
+  * Create the ReLU6 object.
+  */
+  ReLu6()
+
+  /**
+   * Ordinary feed forward pass of a neural network, evaluating the function
+   * f(x) by propagating the activity forward through f.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param output Resulting output activation.
+   */
+  template<typename InputType, typename OutputType>
+  void Forward(const InputType& input, OutputType& output);
+
+  /**
+   * Ordinary feed backward pass of a neural network, calculating the function
+   * f(x) by propagating x backwards through f. Using the results from the feed
+   * forward pass.
+   *
+   * @param input The propagated input activation.
+   * @param gy The backpropagated error.
+   * @param g The calculated gradient.
+   */
+  template<typename DataType>
+  void Backward(const DataType& input, const DataType& gy, DataType& g);
+
+  //! Get the output parameter.
+  OutputDataType const& OutputParameter() const { return outputParameter; }
+  //! Modify the output parameter.
+  OutputDataType& OutputParameter() { return outputParameter; }
+
+  //! Get size of weights.
+  size_t WeightSize() const { return 0; }
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */);
+
+ private:
+  //! Locally-stored output parameter object.
+  OutputDataType outputParameter;
+
+}; // class ReLU6
+
+} // namespace ann
+} // namespace mlpack
+
+// Include implementation.
+#include "relu6_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/layer/relu6.hpp
+++ b/src/mlpack/methods/ann/layer/relu6.hpp
@@ -35,15 +35,15 @@ namespace ann /** Artificial Neural Network. */ {
  *         arma::sp_mat or arma::cube).
  */
 template<typename InputDataType = arma::mat,
-    typename OutputDataType = arma::mat>
-class ReLU6()
+         typename OutputDataType = arma::mat>
+class ReLU6
 {
  public:
 
  /**
   * Create the ReLU6 object.
   */
-  ReLu6()
+  ReLu6();
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/relu6_impl.hpp
+++ b/src/mlpack/methods/ann/layer/relu6_impl.hpp
@@ -1,0 +1,67 @@
+/**
+ * @file methods/ann/layer/relu6_impl.hpp
+ * @author Aakash kaushik
+ *
+ * For more information, kindly refer to the following paper.
+ *
+ * @code
+ * @article{Andrew G2017,
+ *  author = {Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko,
+ *      Weijun Wang, Tobias Weyand, Marco Andreetto, Hartwig Adam},
+ *  title = {MobileNets: Efficient Convolutional Neural Networks for Mobile
+ *      Vision Applications},
+ *  year = {2017},
+ *  url = {https://arxiv.org/pdf/1704.04861}
+ * }
+ * @endcode
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LAYER_RELU6_IMPL_HPP
+#define MLPACK_METHODS_ANN_LAYER_RELU6_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "relu6.hpp"
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */ {
+
+template<typename InputDataType, typename OutputDataType>
+ReLu6<InputDataType, OutputDataType>::ReLu6()
+{
+  // Nothing to do here.
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename InputType, typename OutputType>
+void ReLu6<InputDataType, OutputDataType>::Forward(
+    const InputType& input, OutputType& output)
+{
+  output.zeros();
+  output = arma::min(arma::max(output, input), 6.0);
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename DataType>
+void ReLu6<InputDataType, OutputDataType>::Backward(
+    const DataType& input, const DataType& gy, DataType& g)
+{
+
+}
+
+template<typename InputDataType, typename OutputDataType>
+template<typename Archive>
+void ReLu6<InputDataType, OutputDataType>::serialize(
+    Archive& ar,
+    const uint32_t /* version */)
+{
+  // Nothing to do here.
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/layer/relu6_impl.hpp
+++ b/src/mlpack/methods/ann/layer/relu6_impl.hpp
@@ -30,31 +30,41 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-ReLu6<InputDataType, OutputDataType>::ReLu6()
+ReLU6<InputDataType, OutputDataType>::ReLu6()
 {
   // Nothing to do here.
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename InputType, typename OutputType>
-void ReLu6<InputDataType, OutputDataType>::Forward(
+void ReLU6<InputDataType, OutputDataType>::Forward(
     const InputType& input, OutputType& output)
-{
-  output.zeros();
-  output = arma::min(arma::max(output, input), 6.0);
+{ 
+  OutputType outputTemp(arma::size(input));
+  outputTemp.fill(6.0);
+  output = arma::zeros<OutputType>(arma::size(input));
+  output = arma::min(arma::max(output, input), outputTemp);
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename DataType>
-void ReLu6<InputDataType, OutputDataType>::Backward(
+void ReLU6<InputDataType, OutputDataType>::Backward(
     const DataType& input, const DataType& gy, DataType& g)
 {
+  DataType derivative(arma::size(gy));
+  derivative.fill(0.0);
+  for (size_t i=0; i < input.n_elem; ++i)
+  {
+    if (input(i) < 6 && input(i) > 0)
+      derivative(i) = 1.0;
+  }
 
+  g = gy % derivative;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
-void ReLu6<InputDataType, OutputDataType>::serialize(
+void ReLU6<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const uint32_t /* version */)
 {

--- a/src/mlpack/methods/ann/layer/relu6_impl.hpp
+++ b/src/mlpack/methods/ann/layer/relu6_impl.hpp
@@ -30,7 +30,7 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-ReLU6<InputDataType, OutputDataType>::ReLu6()
+ReLU6<InputDataType, OutputDataType>::ReLU6()
 {
   // Nothing to do here.
 }
@@ -53,7 +53,7 @@ void ReLU6<InputDataType, OutputDataType>::Backward(
 {
   DataType derivative(arma::size(gy));
   derivative.fill(0.0);
-  for (size_t i=0; i < input.n_elem; ++i)
+  for (size_t i = 0; i < input.n_elem; ++i)
   {
     if (input(i) < 6 && input(i) > 0)
       derivative(i) = 1.0;

--- a/src/mlpack/tests/activation_functions_test.cpp
+++ b/src/mlpack/tests/activation_functions_test.cpp
@@ -712,7 +712,7 @@ void CheckFlattenTSwishDerivateCorrect(const arma::colvec input,
  * @param target Target data used to evaluate the ReLU6 activation.
  */
 void CheckReLU6Correct(const arma::colvec input,
-                       const arma::colvec ActivationTarget
+                       const arma::colvec ActivationTarget,
                        const arma::colvec DerivativeTarget)
 {
   // Initialize ReLU6 object.
@@ -731,7 +731,7 @@ void CheckReLU6Correct(const arma::colvec input,
   relu6.Backward(activations, error, derivatives);
   for (size_t i = 0; i < derivatives.n_elem; ++i)
   {
-    REQUIRE(derivatives.at(i) == Approx(target.at(i)).epsilon(1e-5));
+    REQUIRE(derivatives.at(i) == Approx(DerivativeTarget.at(i)).epsilon(1e-5));
   }
 }
 
@@ -747,7 +747,6 @@ TEST_CASE("ReLU6FunctionTest", "[ActivationFunctionsTest]")
   const arma::colvec desiredDerivatives("0.0 1.0 0.0 0.0 0.0");
 
   CheckReLU6Correct(activationData, desiredActivations, desiredDerivatives);
-
 }
 
 /**

--- a/src/mlpack/tests/activation_functions_test.cpp
+++ b/src/mlpack/tests/activation_functions_test.cpp
@@ -705,6 +705,52 @@ void CheckFlattenTSwishDerivateCorrect(const arma::colvec input,
 }
 
 /**
+ * Implementation of the ReLU6 activation function derivative test. The function
+ * is implemented as ReLU6 layer in the file relu6.hpp.
+ *
+ * @param input Input data used for evaluating the ReLU6 activation function.
+ * @param target Target data used to evaluate the ReLU6 activation.
+ */
+void CheckReLU6Correct(const arma::colvec input,
+                       const arma::colvec ActivationTarget
+                       const arma::colvec DerivativeTarget)
+{
+  // Initialize ReLU6 object.
+  ReLU6<> relu6;
+
+  // Test the calculation of the derivatives using the entire vector as input.
+  arma::colvec derivatives, activations;
+
+  // This error vector will be set to 1 to get the derivatives.
+  arma::colvec error = arma::ones<arma::colvec>(input.n_elem);
+  relu6.Forward(input, activations);
+  for (size_t i = 0; i < activations.n_elem; ++i)
+  {
+    REQUIRE(activations.at(i) == Approx(ActivationTarget.at(i)).epsilon(1e-5));
+  }
+  relu6.Backward(activations, error, derivatives);
+  for (size_t i = 0; i < derivatives.n_elem; ++i)
+  {
+    REQUIRE(derivatives.at(i) == Approx(target.at(i)).epsilon(1e-5));
+  }
+}
+
+/**
+ * Basic test of the ReLU6 function.
+ */
+TEST_CASE("ReLU6FunctionTest", "[ActivationFunctionsTest]")
+{
+  const arma::colvec activationData("-2.0 3.0 0.0 6.0 24.0");
+
+  const arma::colvec desiredActivations("0.0 3.0 0.0 6.0 6.0");
+
+  const arma::colvec desiredDerivatives("0.0 1.0 0.0 0.0 0.0");
+
+  CheckReLU6Correct(activationData, desiredActivations, desiredDerivatives);
+
+}
+
+/**
  * Basic test of the tanh function.
  */
 TEST_CASE("TanhFunctionTest", "[ActivationFunctionsTest]")

--- a/src/mlpack/tests/activation_functions_test.cpp
+++ b/src/mlpack/tests/activation_functions_test.cpp
@@ -742,8 +742,10 @@ TEST_CASE("ReLU6FunctionTest", "[ActivationFunctionsTest]")
 {
   const arma::colvec activationData("-2.0 3.0 0.0 6.0 24.0");
 
+  // desiredActivations taken from PyTorch.
   const arma::colvec desiredActivations("0.0 3.0 0.0 6.0 6.0");
 
+  // desiredDerivatives taken from PyTorch.
   const arma::colvec desiredDerivatives("0.0 1.0 0.0 0.0 0.0");
 
   CheckReLU6Correct(activationData, desiredActivations, desiredDerivatives);


### PR DESCRIPTION
Initial draft PR for addition of ReLU6
PyTorch reference [here](https://pytorch.org/docs/stable/generated/torch.nn.ReLU6.html)
Requirement: Needed to Implement [Mobilenet V1](https://github.com/mlpack/models/pull/72)

Function Originally introduced in the paper: [MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications](https://arxiv.org/pdf/1704.04861)