### PR TITLE
Bump minimum Armadillo version to 9.800

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -35,7 +35,7 @@ steps:
     fi
 
     # Install armadillo.
-    curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && \
+    curl -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz | tar -xvJ && \
         cd armadillo* && \
         cmake . && \
         make && \

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -24,8 +24,6 @@ steps:
     if [ "a$(julia.version)" != "a" ]; then
       brew install --cask julia
     fi
-
-    git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
   displayName: 'Install Build Dependencies'
 
 # Configure mlpack (CMake)

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -24,10 +24,10 @@ steps:
 - bash: |
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
 
-    curl -O http://www.ratml.org/misc/armadillo-8.400.0.tar.gz -o armadillo-8.400.0.tar.gz
-    tar -xzvf armadillo-8.400.0.tar.gz
+    curl -O -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz -o armadillo-9.800.6.tar.xz
+    tar -xzvf armadillo-9.800.6.tar.xz
 
-    cd armadillo-8.400.0/ && cmake $(CMakeGenerator) \
+    cd armadillo-9.800.6/ && cmake $(CMakeGenerator) \
     -DBLAS_LIBRARY:FILEPATH=$(Agent.ToolsDirectory)/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a \
     -DLAPACK_LIBRARY:FILEPATH=$(Agent.ToolsDirectory)/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a \
     -DCMAKE_PREFIX:FILEPATH=../../armadillo \
@@ -38,7 +38,7 @@ steps:
 # Build armadillo
 - task: MSBuild@1
   inputs:
-    solution: 'armadillo-8.400.0/*.sln'
+    solution: 'armadillo-9.800.6/*.sln'
     msbuildLocationMethod: 'location'
     msbuildVersion: $(MSBuildVersion)
     configuration: 'Release'
@@ -57,8 +57,8 @@ steps:
     $(CMakeArgs) `
     -DBLAS_LIBRARIES:FILEPATH=$(Agent.ToolsDirectory)\OpenBLAS.0.2.14.1\lib\native\lib\x64\libopenblas.dll.a `
     -DLAPACK_LIBRARIES:FILEPATH=$(Agent.ToolsDirectory)\OpenBLAS.0.2.14.1\lib\native\lib\x64\libopenblas.dll.a `
-    -DARMADILLO_INCLUDE_DIR="..\armadillo-8.400.0\include" `
-    -DARMADILLO_LIBRARY="..\armadillo-8.400.0\Release\armadillo.lib" `
+    -DARMADILLO_INCLUDE_DIR="..\armadillo-9.800.6\include" `
+    -DARMADILLO_LIBRARY="..\armadillo-9.800.6\Release\armadillo.lib" `
     -DBOOST_INCLUDEDIR=$(Agent.ToolsDirectory)\boost.1.60.0.0\lib\native\include `
     -DBOOST_LIBRARYDIR=$(Agent.ToolsDirectory)\boost_libs `
     -DCEREAL_INCLUDE_DIR=$(Agent.ToolsDirectory)\unofficial-flayan-cereal.1.2.2\build\native\include `

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           run: |
             sudo apt-get update
             sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev libcereal-dev
-            curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
+            curl -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz | tar -xvJ && cd armadillo*
             cmake . && make && sudo make install && cd ..
 
         - name: Install R-bindings dependencies

--- a/.github/workflows/update-boost-version.yaml
+++ b/.github/workflows/update-boost-version.yaml
@@ -13,7 +13,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libboost-all-dev libcereal-dev
-          curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
+          curl -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz | tar -xvJ && cd armadillo*
           cmake . && make && sudo make install && cd .. && rm -r armadillo*
 
       - name: Get Latest Boost Tagged Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(BUILD_GO_SHLIB "Build Go shared library." OFF)
 option(BUILD_DOCS "Build doxygen documentation (if doxygen is available)." ON)
 
 # Set minimum library version required by mlpack.
-set(ARMADILLO_VERSION "9.800.6")
+set(ARMADILLO_VERSION "9.800")
 set(ENSMALLEN_VERSION "2.10.0")
 set(BOOST_VERSION "1.58")
 set(CEREAL_VERSION "1.1.2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(BUILD_GO_SHLIB "Build Go shared library." OFF)
 option(BUILD_DOCS "Build doxygen documentation (if doxygen is available)." ON)
 
 # Set minimum library version required by mlpack.
-set(ARMADILLO_VERSION "8.400.0")
+set(ARMADILLO_VERSION "9.800.6")
 set(ENSMALLEN_VERSION "2.10.0")
 set(BOOST_VERSION "1.58")
 set(CEREAL_VERSION "1.1.2")

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Citations are beneficial for the growth and improvement of mlpack.
 
 mlpack has the following dependencies:
 
-      Armadillo      >= 9.800.6
+      Armadillo      >= 9.800
       Boost (math_c99, spirit) >= 1.58.0
       CMake          >= 3.6
       ensmallen      >= 2.10.0

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Citations are beneficial for the growth and improvement of mlpack.
 
 mlpack has the following dependencies:
 
-      Armadillo      >= 8.400.0
+      Armadillo      >= 9.800.6
       Boost (math_c99, spirit) >= 1.58.0
       CMake          >= 3.6
       ensmallen      >= 2.10.0

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -95,7 +95,7 @@ The directory can have any name, not just 'build', but 'build' is sufficient.
 mlpack depends on the following libraries, which need to be installed on the
 system and have headers present:
 
- - Armadillo >= 9.800.6 (with LAPACK support)
+ - Armadillo >= 9.800 (with LAPACK support)
  - Boost (math_c99, spirit) >= 1.58
  - cereal >= 1.1.2
  - ensmallen >= 2.10.0 (will be downloaded if not found)

--- a/doc/guide/build.hpp
+++ b/doc/guide/build.hpp
@@ -95,7 +95,7 @@ The directory can have any name, not just 'build', but 'build' is sufficient.
 mlpack depends on the following libraries, which need to be installed on the
 system and have headers present:
 
- - Armadillo >= 8.400.0 (with LAPACK support)
+ - Armadillo >= 9.800.6 (with LAPACK support)
  - Boost (math_c99, spirit) >= 1.58
  - cereal >= 1.1.2
  - ensmallen >= 2.10.0 (will be downloaded if not found)
@@ -294,7 +294,7 @@ Now similarly you can run all the binding related tests using:
 ./bin/mlpack_test "[BindingTests]"
 @endcode
 
-To run a single test, you can explicitly provide the name of the test; for example, 
+To run a single test, you can explicitly provide the name of the test; for example,
 to run BinaryClassificationMetricsTest implemented in cv_test.cpp you can run the following:
 
 @code


### PR DESCRIPTION
Bump minimum Armadillo version to 9.800.6, see https://github.com/mlpack/ensmallen/pull/318 for more details.