### PR TITLE
Change CMAKE_SOURCE_DIR to CURRENT_SOURCE for easily import mlpack in Project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
 endif ()
 
 # Include modules in the CMake directory.
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
 # If we are on a Unix-like system, use the GNU install directories module.
 # Otherwise set the values manually.
@@ -425,7 +425,7 @@ endif ()
 include(CMake/TargetDistclean.cmake OPTIONAL)
 
 include_directories(BEFORE ${MLPACK_INCLUDE_DIRS})
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src/)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src/)
 
 # On Windows, things end up under Debug/ or Release/.
 if (WIN32)

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -113,7 +113,7 @@ install(TARGETS mlpack
 add_dependencies(mlpack mlpack_headers)
 
 # Extract the version number.
-file(READ "${CMAKE_SOURCE_DIR}/src/mlpack/core/util/version.hpp"
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/core/util/version.hpp"
   VERSION_HPP_CONTENTS)
 string(REGEX REPLACE ".*#define MLPACK_VERSION_MAJOR ([0-9]+).*" "\\1"
   MLPACK_VERSION_MAJOR "${VERSION_HPP_CONTENTS}")


### PR DESCRIPTION
### Reference PR #3045

To import mlpack in Project by FetchContent, some issue appear because the PATH arn't correct.
Change SOURCE by CURRENT_SOURCE because findPackage(FindStbImage.cmake) fail.