### PR TITLE
Add checks for labels and input sizes for split function

### DIFF
--- a/src/mlpack/core/data/split_data.hpp
+++ b/src/mlpack/core/data/split_data.hpp
@@ -147,6 +147,7 @@ void StratifiedSplit(const arma::Mat<T>& input,
   if (!typeCheck)
     throw std::runtime_error("data::Split(): when stratified sampling is done, "
         "labels must have type `arma::Row<>`!");
+  util::CheckSameSizes(input, inputLabel, "data::Split()");
   size_t trainIdx = 0;
   size_t testIdx = 0;
   size_t trainSize = 0;
@@ -261,6 +262,7 @@ void Split(const arma::Mat<T>& input,
            const double testRatio,
            const bool shuffleData = true)
 {
+  util::CheckSameSizes(input, inputLabel, "data::Split()");
   if (shuffleData)
   {
     arma::uvec order = arma::shuffle(arma::linspace<arma::uvec>(0,
@@ -455,6 +457,7 @@ void Split(const FieldType& input,
            const double testRatio,
            const bool shuffleData = true)
 {
+  util::CheckSameSizes(input, inputLabel, "data::Split()");
   if (shuffleData)
   {
     arma::uvec order = arma::shuffle(arma::linspace<arma::uvec>(0,

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -33,11 +33,11 @@ inline void CheckSameSizes(const DataType& data,
                            const std::string& callerDescription,
                            const std::string& addInfo = "labels")
 {
-  if (data.n_cols != label.n_elem)
+  if (data.n_cols != label.n_cols)
   {
     std::ostringstream oss;
     oss << callerDescription << ": number of points (" << data.n_cols << ") "
-        << "does not match number of " << addInfo << " (" << label.n_elem
+        << "does not match number of " << addInfo << " (" << label.n_cols
         << ")!" << std::endl;
     throw std::invalid_argument(oss.str());
   }

--- a/src/mlpack/tests/size_checks_test.cpp
+++ b/src/mlpack/tests/size_checks_test.cpp
@@ -1,7 +1,7 @@
 /**
  * @file size_checks_test.cpp
  * @author Bisakh Mondal
- * 
+ *
  * Test file for Utility size_checks.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the

--- a/src/mlpack/tests/size_checks_test.cpp
+++ b/src/mlpack/tests/size_checks_test.cpp
@@ -21,8 +21,8 @@ using namespace mlpack::util;
 TEST_CASE("CheckSizeTest", "[SizeCheckTest]")
 {
   arma::mat data = arma::randu<arma::mat>(20, 30);
-  arma::colvec firstLabels = arma::randu<arma::colvec>(20);
-  arma::colvec secondLabels = arma::randu<arma::colvec>(30);
+  arma::rowvec firstLabels = arma::randu<arma::rowvec>(20);
+  arma::rowvec secondLabels = arma::randu<arma::rowvec>(30);
   arma::mat thirdLabels = arma::randu<arma::mat>(40, 30);
 
   REQUIRE_THROWS_AS(CheckSameSizes(data, firstLabels, "TestChecking"),

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -177,12 +177,11 @@ TEST_CASE("SplitLabeledDataResultMat", "[SplitDataTest]")
 
 TEST_CASE("SplitCheckSize", "[SplitDataTest]")
 {
-  arma::mat input(2,10);
-  input.randu();
+  arma::mat input = randu<arma::mat>(2, 10);
 
-  const Row<size_t> firstLabels = arma::linspace<Row<size_t>> (0, input.n_cols-1, input.n_cols);
+  const Row<size_t> firstLabels = arma::linspace<Row<size_t>> (0, input.n_cols - 1, input.n_cols);
 
-  const Row<size_t> secondLabels = arma::linspace<Row<size_t>> (0, input.n_cols, input.n_cols+1);
+  const Row<size_t> secondLabels = arma::linspace<Row<size_t>> (0, input.n_cols, input.n_cols + 1);
 
   REQUIRE_THROWS_AS(Split(input, secondLabels, 0.2), std::invalid_argument);
 

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -175,6 +175,20 @@ TEST_CASE("SplitLabeledDataResultMat", "[SplitDataTest]")
   CheckDuplication(std::get<2>(value), std::get<3>(value));
 }
 
+TEST_CASE("SplitCheckSize", "[SplitDataTest]")
+{
+  arma::mat input(2,10);
+  input.randu();
+
+  const Row<size_t> firstLabels = arma::linspace<Row<size_t>> (0, input.n_cols-1, input.n_cols);
+
+  const Row<size_t> secondLabels = arma::linspace<Row<size_t>> (0, input.n_cols, input.n_cols+1);
+
+  REQUIRE_THROWS_AS(Split(input, secondLabels, 0.2), std::invalid_argument);
+
+  REQUIRE_NOTHROW(Split(input, firstLabels, 0.2));
+}
+
 /**
  * The same test as above, but on a larger dataset.
  */


### PR DESCRIPTION
Issue: #2991 

Document discussing the changes ideas:
https://docs.google.com/document/d/1fdNIKlXlcOAXTVIhdSeDvxYS9F5-95qviFZxjsBswBQ/edit?usp=sharing

@zoq 