### PR TITLE
Document Armadillo version policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,11 @@ option(DISABLE_DOWNLOADS "Disable downloads of dependencies during build." OFF)
 option(BUILD_GO_SHLIB "Build Go shared library." OFF)
 option(BUILD_DOCS "Build doxygen documentation (if doxygen is available)." ON)
 
-# Set minimum library version required by mlpack.
+# Set minimum library versions required by mlpack.
+#
+# For Armadillo, try to keep the minimum required version less than or equal to
+# what's available on the current Ubuntu LTS or most recent stable RHEL release.
+# See https://github.com/mlpack/mlpack/issues/3033 for some more discussion.
 set(ARMADILLO_VERSION "9.800")
 set(ENSMALLEN_VERSION "2.10.0")
 set(BOOST_VERSION "1.58")


### PR DESCRIPTION
This is a follow up from #3033.  I just added the strategy we settled on to the `CMakeLists.txt` so that next time we want to bump it, we perhaps have a little bit of information on where we're trying to keep the minimum version set. :)