### PR TITLE
Remove ar parameter to avoid the warning

### DIFF
--- a/src/mlpack/methods/ann/layer/relu6.hpp
+++ b/src/mlpack/methods/ann/layer/relu6.hpp
@@ -84,7 +84,7 @@ class ReLU6
    * Serialize the layer.
    */
   template<typename Archive>
-  void serialize(Archive& ar, const uint32_t /* version */);
+  void serialize(Archive& /* ar */, const uint32_t /* version */);
 
  private:
   //! Locally-stored output parameter object.

--- a/src/mlpack/methods/ann/layer/relu6_impl.hpp
+++ b/src/mlpack/methods/ann/layer/relu6_impl.hpp
@@ -65,7 +65,7 @@ void ReLU6<InputDataType, OutputDataType>::Backward(
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void ReLU6<InputDataType, OutputDataType>::serialize(
-    Archive& ar,
+    Archive& /* ar */,
     const uint32_t /* version */)
 {
   // Nothing to do here.


### PR DESCRIPTION
Serialization is not used in this layer, therefore the warning of
an unused parameter is becoming annoying when trying to compile the
mlpack_test, making it impossible to find different errors in small
terminal. Since we are using boost_visitor, the unfolding of layers
is taking several pages of the terminal to print this small warning.

Hoping that this will mitigate one of the warnings.

Signed-off-by: Omar Shrit <omar@shrit.me>