### PR TITLE
Clean reorder warning

### DIFF
--- a/src/mlpack/methods/ann/layer/group_norm.hpp
+++ b/src/mlpack/methods/ann/layer/group_norm.hpp
@@ -152,11 +152,11 @@ class GroupNorm
   void serialize(Archive& ar, const uint32_t /* version */);
 
  private:
-  //! Locally-stored number of input units.
-  size_t size;
-
   //! Locally-stored group count.
   size_t groupCount;
+
+  //! Locally-stored number of input units.
+  size_t size;
 
   //! Locally-stored epsilon value.
   double eps;

--- a/src/mlpack/methods/xgboost/loss_functions/sse_loss.hpp
+++ b/src/mlpack/methods/xgboost/loss_functions/sse_loss.hpp
@@ -94,10 +94,10 @@ class SSELoss
         (arma::accu(hessians) + lambda);
   }
  private:
-  //! The L2 regularization parameter.
-  const double lambda;
   //! The L1 regularization parameter.
   const double alpha;
+  //! The L2 regularization parameter.
+  const double lambda;
   //! First order gradients.
   arma::vec gradients;
   //! Second order gradients (hessians).


### PR DESCRIPTION
Following up on my last PR, this one is similar and trying to achieve the same objective.
I am trying to remove all warnings from `mlpack_tests` therefore this PR clean the reorder error.
