### PR TITLE
det: don't print filename unless it's actually given

### DIFF
--- a/src/mlpack/methods/det/det_main.cpp
+++ b/src/mlpack/methods/det/det_main.cpp
@@ -238,7 +238,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     arma::Row<size_t> counters;
 
     timers.Start("det_test_set_tagging");
-    if (!ofs.is_open())
+    if (!ofs.is_open() && tagFile != "")
     {
       Log::Warn << "Unable to open file '" << tagFile
           << "' to save tag membership info." << std::endl;


### PR DESCRIPTION
As reported in #3054, the `det` binding (in basically all languages) will print messages like:

```
[WARN ] Unable to open file '' to save tag membership info.
```

even if the `tag_file` option is not specified.  This is because bindings for Python and other languages will set all output options as having been passed in the `Params` object, but will not set values for them (they expect the program to fill them).  A suitable workaround here is just to not print anything at all when the given `tag_file` is an empty string.