### PR TITLE
Fix comments in files that implement SVD methods for PCA

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -145,6 +145,7 @@ Copyright:
   Copyright 2021, Mark Fischinger <markfischinger@gmail.com>
   Copyright 2021, Muhammad Fawwaz Mayda <maydafawwaz@gmail.com>
   Copyright 2021, Roshan Nrusing Swain <swainroshan001@gmail.com>
+  Copyright 2021, Suvarsha Chennareddy <suvarshachennareddy@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/exact_svd_method.hpp
@@ -45,7 +45,7 @@ class ExactSVDPolicy
              arma::mat& eigvec,
              const size_t /* rank */)
   {
-    // This matrix will store the right singular values; we do not need them.
+    // This matrix will store the right singular vectors; we do not need them.
     arma::mat v;
 
     // Do singular value decomposition.  Use the economical singular value

--- a/src/mlpack/methods/pca/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/quic_svd_method.hpp
@@ -57,7 +57,7 @@ class QUICSVDPolicy
              arma::mat& eigvec,
              const size_t /* rank */)
   {
-    // This matrix will store the right singular values; we do not need them.
+    // This matrix will store the right singular vectors; we do not need them.
     arma::mat v, sigma;
 
     // Do singular value decomposition using the QUIC-SVD algorithm.

--- a/src/mlpack/methods/pca/decomposition_policies/randomized_block_krylov_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/randomized_block_krylov_method.hpp
@@ -60,7 +60,7 @@ class RandomizedBlockKrylovSVDPolicy
              arma::mat& eigvec,
              const size_t rank)
   {
-    // This matrix will store the right singular values; we do not need them.
+    // This matrix will store the right singular vectors; we do not need them.
     arma::mat v;
 
     // Do singular value decomposition using the randomized block krylov SVD

--- a/src/mlpack/methods/pca/decomposition_policies/randomized_svd_method.hpp
+++ b/src/mlpack/methods/pca/decomposition_policies/randomized_svd_method.hpp
@@ -61,7 +61,7 @@ class RandomizedSVDPolicy
              arma::mat& eigvec,
              const size_t rank)
   {
-    // This matrix will store the right singular values; we do not need them.
+    // This matrix will store the right singular vectors; we do not need them.
     arma::mat v;
 
     // Do singular value decomposition using the randomized SVD algorithm.


### PR DESCRIPTION
Changed "right singular **values**" to "right singular **vectors**". 
The term "right singular values" does not exist.