### PR TITLE
Create variable using MatType instead of arma::mat

### DIFF
--- a/src/mlpack/methods/linear_svm/linear_svm_function_impl.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_function_impl.hpp
@@ -115,7 +115,7 @@ void LinearSVMFunction<MatType>::Shuffle()
       dataset.n_cols - 1, dataset.n_cols));
 
   // Re-sort data.
-  arma::mat newData = dataset.cols(ordering);
+  MatType newData = dataset.cols(ordering);
   math::ClearAlias(dataset);
   dataset = std::move(newData);
 


### PR DESCRIPTION
LinearSVM<MatType>::Shuffle local variable `newData` is changed to `MatType` instead of `arma::mat`.