### PR TITLE
Update binding documentation for threadsafe IO

### DIFF
--- a/doc/guide/bindings.hpp
+++ b/doc/guide/bindings.hpp
@@ -1285,8 +1285,9 @@ binding.
 
 @subsection bindings_python_testing Testing the Python bindings
 
-We cannot do our tests only from the Catch in C++ because we need to see that we
-are able to load parameters properly from Python and return output correctly.
+In addition to the C++ tests we have implemented for each binding, we also have
+tests from Python that ensure that we can successfully transfer parameter values
+from Python to C++ and return output correctly.
 
 The tests are in @c src/mlpack/bindings/python/tests/ and test both the actual
 bindings and also the auxiliary Python code included in


### PR DESCRIPTION
This is a follow-up to #2995 which has its own issue: #3049.

Basically, when the bindings were revamped to be threadsafe, I forgot to update the guide that describes the automatic binding system.  So, this PR just updates everything, and so hopefully it should be an easier (and more up-to-date!) read for anyone interested in learning about the binding system. :)