### PR TITLE
Arma norm

### DIFF
--- a/src/mlpack/core/metrics/lmetric_impl.hpp
+++ b/src/mlpack/core/metrics/lmetric_impl.hpp
@@ -61,7 +61,20 @@ typename VecTypeA::elem_type LMetric<2, true>::Evaluate(
     const VecTypeA& a,
     const VecTypeB& b)
 {
-  return arma::norm(a - b, 2);
+  // if ((std::is_same<typename VecTypeA::elem_type, double>::value or
+  //     std::is_same<typename VecTypeA::elem_type, float>::value) and
+  //     (std::is_same<typename VecTypeB::elem_type, double>::value or
+  //     std::is_same<typename VecTypeB::elem_type, float>::value))
+  // {
+    //std::cout << "EXECUTED" << std::endl;
+    return arma::norm(a - b, 2);
+  // }
+  // else
+  // {
+  //   arma::mat new_a = arma::conv_to<arma::mat>::from(a);
+  //   arma::mat new_b = arma::conv_to<arma::mat>::from(b);
+  //   return arma::norm(new_a - new_b, 2);
+  // }
 }
 
 template<>

--- a/src/mlpack/core/metrics/lmetric_impl.hpp
+++ b/src/mlpack/core/metrics/lmetric_impl.hpp
@@ -61,20 +61,19 @@ typename VecTypeA::elem_type LMetric<2, true>::Evaluate(
     const VecTypeA& a,
     const VecTypeB& b)
 {
-  // if ((std::is_same<typename VecTypeA::elem_type, double>::value or
-  //     std::is_same<typename VecTypeA::elem_type, float>::value) and
-  //     (std::is_same<typename VecTypeB::elem_type, double>::value or
-  //     std::is_same<typename VecTypeB::elem_type, float>::value))
-  // {
-    //std::cout << "EXECUTED" << std::endl;
+  if ((std::is_same<typename VecTypeA::elem_type, double>::value or
+     std::is_same<typename VecTypeA::elem_type, float>::value) and
+     (std::is_same<typename VecTypeB::elem_type, double>::value or
+     std::is_same<typename VecTypeB::elem_type, float>::value))
+  {
     return arma::norm(a - b, 2);
-  // }
-  // else
-  // {
-  //   arma::mat new_a = arma::conv_to<arma::mat>::from(a);
-  //   arma::mat new_b = arma::conv_to<arma::mat>::from(b);
-  //   return arma::norm(new_a - new_b, 2);
-  // }
+  }
+  else
+  {
+    arma::mat new_a = arma::conv_to<arma::mat>::from(a);
+    arma::mat new_b = arma::conv_to<arma::mat>::from(b);
+    return arma::norm(new_a - new_b, 2);
+  }
 }
 
 template<>


### PR DESCRIPTION
This fixes the issue related to Armadillo norm only works for double and float element types.
I think it is the best we can get since applying SFINAE on this function will result in complex code for no reason.
Here is a comparison of the Knn master and this PR, just to verify that it does not affect the results.


knn_master

```
?master /mlpack/build> ./bin/mlpack_knn -k 3 -r covertype-20k.csv -a naive -v --leaf_size 20
[WARN ] Should pass either '--neighbors_file (-n)' or '--distances_file (-d)' or both; nearest neighbor search results will not be saved!
[INFO ] Using reference data from Loading 'covertype-20k.csv' as CSV data.  Size is 55 x 20000.
[INFO ] 'covertype-20k.csv' (20000x55 matrix).
[INFO ] Searching for 3 neighbors with brute-force (naive) search...
[INFO ] Search complete.
[INFO ] 
[INFO ] Execution parameters:
[INFO ]   algorithm: naive
[INFO ]   distances_file: ''
[INFO ]   epsilon: 0
[INFO ]   help: 0
[INFO ]   info: 
[INFO ]   input_model_file: 
[INFO ]   k: 3
[INFO ]   leaf_size: 20
[INFO ]   neighbors_file: ''
[INFO ]   output_model_file: 
[INFO ]   query_file: ''
[INFO ]   random_basis: 0
[INFO ]   reference_file: 'covertype-20k.csv' (20000x55 matrix)
[INFO ]   rho: 0
[INFO ]   seed: 0
[INFO ]   tau: 0
[INFO ]   tree_type: kd
[INFO ]   true_distances_file: ''
[INFO ]   true_neighbors_file: ''
[INFO ]   verbose: 1
[INFO ]   version: 0
[INFO ] Program timers:
[INFO ]   computing_neighbors: 28.766716s
[INFO ]   loading_data: 0.168028s
[INFO ]   total_time: 28.935359s
```

knn_this_branch
```
?arma_norm /mlpack/build> ./bin/mlpack_knn -k 3 -r covertype-20k.csv -a naive -v --leaf_size 20                                                                                         
[WARN ] Should pass either '--neighbors_file (-n)' or '--distances_file (-d)' or both; nearest neighbor search results will not be saved!                                                    
[INFO ] Using reference data from Loading 'covertype-20k.csv' as CSV data.  Size is 55 x 20000.                                                                                              
[INFO ] 'covertype-20k.csv' (20000x55 matrix).
[INFO ] Searching for 3 neighbors with brute-force (naive) search...
[INFO ] Search complete.
[INFO ] 
[INFO ] Execution parameters:
[INFO ]   algorithm: naive
[INFO ]   distances_file: ''
[INFO ]   epsilon: 0
[INFO ]   help: 0
[INFO ]   info: 
[INFO ]   input_model_file: 
[INFO ]   k: 3
[INFO ]   leaf_size: 20
[INFO ]   neighbors_file: ''
[INFO ]   output_model_file: 
[INFO ]   query_file: ''
[INFO ]   random_basis: 0
[INFO ]   reference_file: 'covertype-20k.csv' (20000x55 matrix)
[INFO ]   rho: 0
[INFO ]   seed: 0
[INFO ]   tau: 0
[INFO ]   tree_type: kd
[INFO ]   true_distances_file: ''
[INFO ]   true_neighbors_file: ''
[INFO ]   verbose: 1
[INFO ]   version: 0
[INFO ] Program timers:
[INFO ]   computing_neighbors: 28.785233s
[INFO ]   loading_data: 0.156491s
[INFO ]   total_time: 28.942209s
```