### PR TITLE
add ROC AUC metric

### DIFF
--- a/src/mlpack/core/cv/metrics/CMakeLists.txt
+++ b/src/mlpack/core/cv/metrics/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SOURCES
   recall_impl.hpp
   r2_score.hpp
   r2_score_impl.hpp
+  roc_auc.hpp
+  roc_auc_impl.hpp
 )
 
 # Add directory name to sources.

--- a/src/mlpack/core/cv/metrics/roc_auc.hpp
+++ b/src/mlpack/core/cv/metrics/roc_auc.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file core/cv/metrics/roc_auc.hpp
+ * @author Suvarsha Chennareddy
+ *
+ * The Area Under the Receiver Operating Characteristic Curve (ROC AUC)
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_ROC_AUC_HPP
+#define MLPACK_CORE_CV_METRICS_ROC_AUC_HPP
+
+#include <mlpack/core.hpp>
+
+namespace mlpack {
+namespace cv {
+
+/**
+ * The ROC_AUC is a metric of performance for a binary classifiers (and even 
+ * for multiclass classifiers) that measures the two-dimensional area 
+ * underneath the entire ROC curve. For multiclass classifiers, a generalization 
+ * implemented by Hand and Till is used.
+ *
+ */
+template<size_t classification = 1>
+class ROC_AUC
+{
+public:
+  /**
+   * Run prediction and calculate the ROC AUC.
+   *
+   * @param model A classifier that returns probabilities for 
+   * @param data Column-major data containing test items.
+   * @param responses Ground truth (correct) target values for the test items,
+   *     should be either a row vector.
+   */
+template<typename MLAlgorithm, typename DataType, typename ResponsesType>
+static double Evaluate(MLAlgorithm& model,
+                         const DataType& data,
+                         const ResponsesType& responses);
+
+  /**
+   * Information for hyper-parameter tuning code. It indicates that we want
+   * to minimize the measurement.
+   */
+static const bool NeedsMinimization = false;
+
+private:
+ /**
+     Run classification and calculate ROC AUC for binary classification
+ */
+template<size_t _classification,
+         typename MLAlgorithm,
+         typename DataType,
+         typename ResponsesType,
+         typename = std::enable_if_t<_classification == 1>>
+ static double Evaluate(MLAlgorithm& model,
+            const DataType& data,
+            const ResponsesType& responses);
+
+/**
+    Run classification and calculate AUC (generalization of the AUC established 
+    by Hand and Till) for multiclass classification. 
+*/
+template<size_t _classification,
+         typename MLAlgorithm,
+         typename DataType,
+         typename ResponsesType,
+         typename = std::enable_if_t<_classification == 2>,
+         typename = void>
+static double Evaluate(MLAlgorithm& model,
+        const DataType& data,
+        const ResponsesType& responses);
+
+
+template<typename ResponsesType>
+static void sortRanks(arma::mat predictions, ResponsesType labels, size_t  i, size_t j, 
+    size_t ni, size_t nj, arma::uvec& sortedRanks);
+
+static size_t sumOfRanks(arma::uvec sortedRanks, size_t n);
+
+};
+
+} // namespace cv
+} // namespace mlpack
+
+// Include implementation.
+#include "roc_auc_impl.hpp"
+
+#endif

--- a/src/mlpack/core/cv/metrics/roc_auc_impl.hpp
+++ b/src/mlpack/core/cv/metrics/roc_auc_impl.hpp
@@ -1,0 +1,214 @@
+/**
+ * @file core/cv/metrics/roc_auc_impl.hpp
+ * @author Suvarsha Chennareddy
+ *
+ * The implementation of the class ROC AUC Score.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CORE_CV_METRICS_ROC_AUC_IMPL_HPP
+#define MLPACK_CORE_CV_METRICS_ROC_AUC_IMPL_HPP
+
+namespace mlpack {
+namespace cv {
+
+template<size_t classification>
+template<typename MLAlgorithm, typename DataType, typename ResponsesType>
+double ROC_AUC<classification>::Evaluate(MLAlgorithm& model,
+                         const DataType& data,
+                         const ResponsesType& labels)
+{
+    return Evaluate<classification>(model, data, labels);
+}
+
+/*
+* Calculate the ROC AUC by splitting the area under the ROC graph into trapezoids.
+* Only works for a binary setting.
+*/
+template<size_t classification>
+template<size_t _classification,
+    typename MLAlgorithm,
+    typename DataType,
+    typename ResponsesType,
+    typename>
+double ROC_AUC<classification>::Evaluate(MLAlgorithm& model,
+    const DataType& data,
+    const ResponsesType& labels)
+{
+    //Check dimensions
+    util::CheckSameSizes(data, labels, "ROC_AUC::Evaluate()");
+
+    arma::mat probabilities;
+
+
+    // Taking Predicted Output (probabilities) from the model.
+    model.Classify(data, probabilities);
+
+    arma::Col<size_t> posLabels = arma::conv_to<arma::Col<size_t>>::from(
+        (labels == 1));
+
+    arma::Col<double> predictedResponses = arma::conv_to<arma::Col<double>>::from(
+        probabilities.row(1));
+
+    //Sort the predictions.
+    arma::Col<double> sortedPredictedResponses = arma::sort(predictedResponses,
+        "ascend", 0);
+
+    //cout << sortedPredictedResponses << endl;
+    //TP stands for True Positives and FP stands for False Positives.
+    double TP1, FP1, TP2, FP2;
+
+    double Area = 0;
+
+    //Find the sum of the 1s in the responses vector. 
+    //This value will be used later for the normalizing constant.
+    double no_of_positive = arma::accu(posLabels);
+
+    //The predictions themeselves will be used as thresholds. 
+    //This is to find all possible (TP, FP) points.
+    TP1 = arma::accu(
+        (predictedResponses >= sortedPredictedResponses(0)) && posLabels
+        );
+    FP1 = arma::accu(
+        (predictedResponses >= sortedPredictedResponses(0)) > posLabels
+        );
+
+    //Loop throught the thresholds
+    for (size_t i = 1; i < (size_t)predictedResponses.n_elem; i++) {
+
+        TP2 = arma::accu(
+            (predictedResponses >= sortedPredictedResponses(i)) && posLabels
+            );
+        FP2 = arma::accu(
+            (predictedResponses >= sortedPredictedResponses(i)) > posLabels
+            );
+
+
+        //Area of the trapezium formed by points (TP1, FP1) and (TP2, FP2).
+        Area += (FP1 - FP2) * (TP1 + TP2) / 2;
+        TP1 = TP2;
+        FP1 = FP2;
+    }
+    //The sum of all those trapezium areas divided by the 
+    //normalizing constant will give the ROC AUC.
+    return Area / (no_of_positive * (posLabels.n_elem - no_of_positive));
+}
+/*
+* For a multiclass setting, a generalized form of the AUC implemented 
+* by Hand and Till is used.
+* Source: https://link.springer.com/content/pdf/10.1023%2FA%3A1010920819831.pdf
+*/
+template<size_t classification>
+template<size_t _classification,
+         typename MLAlgorithm,
+         typename DataType,
+         typename ResponsesType,
+         typename,
+         typename>
+double ROC_AUC<classification>::Evaluate(MLAlgorithm& model,
+        const DataType& data,
+        const ResponsesType& labels)
+{
+    //Check dimensions
+    util::CheckSameSizes(data, labels, "ROC_AUC::Evaluate()");
+
+    arma::Row<size_t> predictions;
+    arma::mat probabilities;
+
+
+    // Taking Predicted Output (probabilities) from the model.
+    model.Classify(data, predictions,  probabilities);
+
+    //cout << probabilities << endl;
+
+    double AUC = 0;
+    arma::uvec temp;
+    size_t ni = 0;
+    size_t nj = 0;
+    for (size_t i = 0; i < (size_t)probabilities.n_rows; i++) {
+
+        //The number of observations that belong to the class i.
+        ni = arma::accu((labels == i));
+
+        for (size_t j = i + 1; j < (size_t)probabilities.n_rows; j++) {
+
+            //The number of observations that belong to the class j.
+            nj = arma::accu((labels == j));
+
+            //temp stores the sorted ranks of estimated probabilities
+            //belonging to class i for all class i and j observations 
+            sortRanks(probabilities, labels, i, j, ni, nj, temp);
+
+            //Calculate the term A(i | j)
+            AUC += (double) (sumOfRanks(temp, ni) - (ni*(ni + 1))/ 2)/(ni*nj);
+
+
+            //temp stores the sorted ranks of estimated probabilities
+            //belonging to class j for all class i and j observations
+            sortRanks(probabilities, labels, j, i, nj, ni, temp);
+
+            //Calculate the term A(j | i)
+            AUC += (double) (sumOfRanks(temp, nj) - (nj*(nj + 1))/ 2)/(ni*nj);
+            //Normaliz
+        }
+
+    }
+
+    //Normalize with the constant c*(c-1) where c is number of classes
+    return AUC/(probabilities.n_rows*(probabilities.n_rows - 1));
+}
+/*
+* Method to find the vector of sorted ranks of estimated probabilities 
+* belonging to class i for all class i and j observations 
+*/
+template<size_t classification>
+template<typename ResponsesType>
+void ROC_AUC<classification>::sortRanks(arma::mat probabilities, 
+                                        ResponsesType labels,  
+                                        size_t  i, size_t j, 
+                                        size_t ni, size_t nj,
+                                        arma::uvec& sortedRanks) {
+    //Find the estimated probabilities of class i from the class i and j observations
+    //and sort them
+    arma::Row<double> i_classifications = arma::conv_to<arma::Row<double>>::from(
+            (labels == i));
+
+    arma::Row<double> j_classifications = arma::conv_to<arma::Row<double>>::from(
+            (labels == j));
+
+    arma::Row<double> i_probabilities = arma::sort(
+            probabilities.row(i) % i_classifications, "ascend", 1);
+    arma::Row<double> j_probabilities = arma::sort(
+            probabilities.row(i) % j_classifications, "ascend", 1);
+
+    //Get rid of zero terms
+    i_probabilities.shed_cols(0, labels.n_elem - ni-1);
+    j_probabilities.shed_cols(0, labels.n_elem - nj-1);
+
+    //Get the sorted indexes
+    sortedRanks = arma::sort_index(
+        arma::join_rows(i_probabilities, j_probabilities),
+        "ascend");
+}
+
+/**
+* Method to calculate the sum of ranks of estimated probabilities of class i 
+* from observations that belong to class i (S term)
+*/
+template<size_t classification>
+size_t ROC_AUC<classification>::sumOfRanks(arma::uvec sortedRanks, size_t n) {
+    size_t s = 0;
+    for (size_t i = 0; i < (size_t)sortedRanks.n_elem; i++) {
+        if (sortedRanks(i) < n) {
+            s += i+1;
+        }
+    }
+    return s;
+}
+} // namespace cv
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE("BinaryClassificationMetricsTest", "[CVTest]")
       LogisticRegression<>, mat, arma::Row<size_t>>(
           lr, data, labels) == Approx(0.708333).epsilon(1e-7));
  
-} //0.5833
+} 
 
 /**
  * Test for confusion matrix.

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -55,6 +55,10 @@ TEST_CASE("BinaryClassificationMetricsTest", "[CVTest]")
   // Using the same data for training and testing.
   arma::mat data = arma::linspace<arma::rowvec>(1.0, 10.0, 10);
 
+  //Data for testing the ROC AUC metric under a 
+  //binary classification problem
+  arma::mat data2 = arma::linspace<arma::rowvec>(-0.000001, 0.000001, 10);
+
   // Labels that will be considered as "ground truth".
   arma::Row<size_t> labels("0 0 1 0 0  1 0 1 0 1");
 
@@ -74,7 +78,12 @@ TEST_CASE("BinaryClassificationMetricsTest", "[CVTest]")
 
   double f1 = 2 * 0.6 * 0.75 / (0.6 + 0.75);
   REQUIRE(F1<Binary>::Evaluate(lr, data, labels) == Approx(f1).epsilon(1e-7));
-}
+
+  REQUIRE(ROC_AUC<(size_t)1>::Evaluate<
+      LogisticRegression<>, mat, arma::Row<size_t>>(
+          lr, data, labels) == Approx(0.708333).epsilon(1e-7));
+ 
+} //0.5833
 
 /**
  * Test for confusion matrix.
@@ -144,6 +153,10 @@ TEST_CASE("MulticlassClassificationMetricsTest", "[CVTest]")
       2 * 1.0 * 1.0 / (1.0 + 1.0)) / 4;
   REQUIRE(F1<Macro>::Evaluate(nb, data, labels)
           == Approx(macroaveragedF1).epsilon(1e-7));
+
+  REQUIRE(ROC_AUC<(size_t)2>::Evaluate<
+      NaiveBayesClassifier<>, mat, arma::Row<size_t>>(
+          nb, data, labels) == Approx(0.884259).epsilon(1e-7));
 }
 
 /**


### PR DESCRIPTION
Hello everyone!
I implemented the ROC AUC score metric that was recommended in the issue #3074. 
Here, the multiclass AUC was implemented using a generalization by Hand and Till in the year 2001 (source: [A Simple Generalisation of the Area Under the ROC Curve for Multiple Class Classification Problems](https://link.springer.com/article/10.1023/A:1010920819831))
@srimadhan11 had already attempted to implement his own version, however I noticed that he was inactive for the past couple of weeks. Hence, I decided to create my implement it myself. Hope that's all right with everyone.
Any comments on this would be greatly appreciated.
Thank You!