### PR TITLE
Test Pipeline hotfix

### DIFF
--- a/.ci/ci.yaml
+++ b/.ci/ci.yaml
@@ -41,18 +41,18 @@ jobs:
     matrix:
       Plain:
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
-        # python.version: '2.7'
+        python.version: '3.7'
       Python:
         binding: 'python'
         python.version: '3.7'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=ON -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
       Julia:
-        # python.version: '2.7'
+        python.version: '3.7'
         julia.version: '1.6.3'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_JULIA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
       Go:
         binding: 'go'
-        # python.version: '2.7'
+        python.version: '3.7'
         go.version: '1.11.0'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=ON -DBUILD_R_BINDINGS=OFF'
 

--- a/.ci/ci.yaml
+++ b/.ci/ci.yaml
@@ -41,18 +41,18 @@ jobs:
     matrix:
       Plain:
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
-        python.version: '2.7'
+        # python.version: '2.7'
       Python:
         binding: 'python'
         python.version: '3.7'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=ON -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
       Julia:
-        python.version: '2.7'
+        # python.version: '2.7'
         julia.version: '1.6.3'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_JULIA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
       Go:
         binding: 'go'
-        python.version: '2.7'
+        # python.version: '2.7'
         go.version: '1.11.0'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=ON -DBUILD_R_BINDINGS=OFF'
 

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -7,12 +7,12 @@ steps:
 # Set python version.
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '$(python.version)'
+    versionSpec: '3.7'
 
 # Install Build Dependencies
 - script: |
     set -e
-    sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
     unset BOOST_ROOT
     brew install libomp openblas armadillo boost cereal ensmallen
 

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -7,7 +7,7 @@ steps:
 # Set python version.
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.7'
+    versionSpec: '$(python.version)'
 
 # Install Build Dependencies
 - script: |

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -146,6 +146,7 @@ Copyright:
   Copyright 2021, Muhammad Fawwaz Mayda <maydafawwaz@gmail.com>
   Copyright 2021, Roshan Nrusing Swain <swainroshan001@gmail.com>
   Copyright 2021, Suvarsha Chennareddy <suvarshachennareddy@gmail.com>
+  Copyright 2021, Shubham Agrawal <shubham.agra1206@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.


### PR DESCRIPTION
I have removed the requirement of Xcode 12.2 as macOS 11 is the latest one in the azure pipeline. And this PR is for the macOS pipeline only.
Relevant Issue:
https://github.com/actions/virtual-environments/issues/4060