### PR TITLE
Added checks for relative input shapes in linear regression and k means clustering

### DIFF
--- a/src/mlpack/methods/kmeans/kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/kmeans_impl.hpp
@@ -14,6 +14,7 @@
 
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/util/sfinae_utility.hpp>
+#include <mlpack/core/util/size_checks.hpp>
 
 namespace mlpack {
 namespace kmeans {
@@ -161,15 +162,9 @@ Cluster(const MatType& data,
   // Check validity of initial guess.
   if (initialGuess)
   {
-    if (centroids.n_cols != clusters)
-      Log::Fatal << "KMeans::Cluster(): wrong number of initial cluster "
-        << "centroids (" << centroids.n_cols << ", should be " << clusters
-        << ")!" << std::endl;
+    util::CheckSameSizes(centroids, clusters, "KMeans::Cluster()");
 
-    if (centroids.n_rows != data.n_rows)
-      Log::Fatal << "KMeans::Cluster(): initial cluster centroids have wrong "
-        << " dimensionality (" << centroids.n_rows << ", should be "
-        << data.n_rows << ")!" << std::endl;
+    util::CheckSameDimensionality(centroids, data, "KMeans::Cluster()");
   }
 
   // Use the partitioner to come up with the partition assignments and calculate

--- a/src/mlpack/methods/kmeans/kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/kmeans_impl.hpp
@@ -162,9 +162,9 @@ Cluster(const MatType& data,
   // Check validity of initial guess.
   if (initialGuess)
   {
-    util::CheckSameSizes(centroids, clusters, "KMeans::Cluster()");
+    util::CheckSameSizes(centroids, clusters, "KMeans::Cluster()", "clusters");
 
-    util::CheckSameDimensionality(centroids, data, "KMeans::Cluster()");
+    util::CheckSameDimensionality(data, centroids, "KMeans::Cluster()");
   }
 
   // Use the partitioner to come up with the partition assignments and calculate

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,7 +100,7 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    util::CheckSameDimensionality(points, parameters.n_rows-1, "LinearRegression::Predict()", "points");
+    util::CheckSameDimensionality(points, (unsigned long int) (parameters.n_rows-1), "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,7 +100,7 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    Log::Assert(points.n_rows == parameters.n_rows - 1);
+    util::CheckSameDimensionality(points, parameters.n_rows-1, "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))
@@ -112,7 +112,7 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in
     // the dataset.
-    Log::Assert(points.n_rows == parameters.n_rows);
+    util::CheckSameDimensionality(points, parameters, "LinearRegression::Predict()", "points");
     predictions = arma::trans(parameters) * points;
   }
 }

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -82,15 +82,7 @@ double LinearRegression::Train(const arma::mat& predictors,
   }
 
   // Convert to this form:
-  // a * (X X^T) = y X^T.{
-  if (data.n_cols != size)
-  {
-    std::ostringstream oss;
-    oss << callerDescription << ": number of points (" << data.n_cols << ") "
-        << "does not match number of " << addInfo << " (" << size << ")!"
-        << std::endl;
-    throw std::invalid_argument(oss.str());
-  }
+  // a * (X X^T) = y X^T.
   // Then we'll use Armadillo to solve it.
   // The total runtime of this should be O(d^2 N) + O(d^3) + O(dN).
   // (assuming the SVD is used to solve it)

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,7 +100,7 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    util::CheckSameDimensionality(points, (unsigned long int) (parameters.n_rows-1), "LinearRegression::Predict()", "points");
+    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows-1), "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -12,6 +12,7 @@
  */
 #include "linear_regression.hpp"
 #include <mlpack/core/util/log.hpp>
+#include <mlpack/core/util/size_checks.hpp>
 
 using namespace mlpack;
 using namespace mlpack::regression;
@@ -57,6 +58,10 @@ double LinearRegression::Train(const arma::mat& predictors,
   // We store the number of rows and columns of the predictors.
   // Reminder: Armadillo stores the data transposed from how we think of it,
   //           that is, columns are actually rows (see: column major order).
+  
+  // Sanity check on data
+  util::CheckSameSizes(predictors, responses, "LinearRegression::Train()");
+  
   const size_t nCols = predictors.n_cols;
 
   arma::mat p = predictors;
@@ -77,7 +82,15 @@ double LinearRegression::Train(const arma::mat& predictors,
   }
 
   // Convert to this form:
-  // a * (X X^T) = y X^T.
+  // a * (X X^T) = y X^T.{
+  if (data.n_cols != size)
+  {
+    std::ostringstream oss;
+    oss << callerDescription << ": number of points (" << data.n_cols << ") "
+        << "does not match number of " << addInfo << " (" << size << ")!"
+        << std::endl;
+    throw std::invalid_argument(oss.str());
+  }
   // Then we'll use Armadillo to solve it.
   // The total runtime of this should be O(d^2 N) + O(d^3) + O(dN).
   // (assuming the SVD is used to solve it)
@@ -115,6 +128,9 @@ void LinearRegression::Predict(const arma::mat& points,
 double LinearRegression::ComputeError(const arma::mat& predictors,
                                       const arma::rowvec& responses) const
 {
+  // Sanity check on data
+  util::CheckSameSizes(predictors, responses, "LinearRegression::Train()");
+
   // Get the number of columns and rows of the dataset.
   const size_t nCols = predictors.n_cols;
   const size_t nRows = predictors.n_rows;

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -169,7 +169,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timer)
       responses = params.Get<rowvec>("training_responses");
       timer.Stop("load_responses");
 
-      util::CheckSameSizes(regressors, responses, "BINDING_FUNCTION()");
+      if (responses.n_cols != regressors.n_cols)
+      {
+        Log::Fatal << "The responses must have the same number of columns "
+            "as the training set." << endl;
+      }
     }
 
     timer.Start("regression");

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -169,11 +169,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timer)
       responses = params.Get<rowvec>("training_responses");
       timer.Stop("load_responses");
 
-      if (responses.n_cols != regressors.n_cols)
-      {
-        Log::Fatal << "The responses must have the same number of columns "
-            "as the training set." << endl;
-      }
+      util::CheckSameSizes(regressors, responses, "BINDING_FUNCTION()");
     }
 
     timer.Start("regression");


### PR DESCRIPTION
This PR implements a part of the idea discussed in issue #2820. I have added size checks using CheckSameSizes and CheckSameDimensionality utilities in ```src/mlpack/core/methods/kmeans/kmeans.hpp```, ```src/mlpack/core/methods/linear_regression/linear_regression.cpp``` and ```src/mlpack/core/methods/linear_regression/linear_regression_main.cpp```. I located all places in which such changes could be made in these methods using [grep](https://github.com/mlpack/mlpack/pull/2370#pullrequestreview-436211692). 

Kindly review these and inform me about any changes I should make. I am new to open source and your reviews will help me a lot. Thanks.