### PR TITLE
added input value checks for pre-process split

### DIFF
--- a/src/mlpack/core/util/param_checks_impl.hpp
+++ b/src/mlpack/core/util/param_checks_impl.hpp
@@ -332,37 +332,12 @@ void RequireNonEmptyInputValue(util::Params& params,
   if (BINDING_IGNORE_CHECK(paramName))
     return;
 
-  if (params.Has(paramName))
-  {
-    if (data.empty())
+  if (params.Has(paramName) && data.empty())
     {
       util::PrefixedOutStream& stream = fatal ? Log::Fatal : Log::Warn;
       if (!errorMessage.empty()) {
         stream << data << PRINT_PARAM_STRING(paramName) 
             << " " << errorMessage << "! " << std::endl;
-      }
-    }
-  }
-}
-
-inline void RequireNonEmptyInputValue(util::Params& params,
-    const std::string& paramName,
-    std::string filename,
-    const bool fatal,
-    const std::string& errorMessage)
-{
-  if (BINDING_IGNORE_CHECK(paramName))
-    return;
-
-  if (params.Has(paramName))
-  {
-    if (filename.empty())
-    {
-      util::PrefixedOutStream& stream = fatal ? Log::Fatal : Log::Warn;
-      if (!errorMessage.empty()) {
-        stream << filename << PRINT_PARAM_STRING(paramName) 
-            << " " << errorMessage << "! " << std::endl;
-      }
     }
   }
 }

--- a/src/mlpack/core/util/param_checks_impl.hpp
+++ b/src/mlpack/core/util/param_checks_impl.hpp
@@ -307,7 +307,6 @@ inline void ReportIgnoredParam(util::Params& params,
 }
 
 // Check if the given input data points aren't empty.
-template<typename T>
 inline void RequireNonEmptyInputValue(
     util::Params& params,
     const std::string& paramName,
@@ -324,7 +323,7 @@ inline void RequireNonEmptyInputValue(
     {
       util::PrefixedOutStream& stream = fatal ? Log::Fatal : Log::Warn;
       if (!errorMessage.empty())
-        stream << paramName << errorMessage << std::endl;
+        stream << paramName << " " << errorMessage << "!" << std::endl;
     }
   }
 }

--- a/src/mlpack/core/util/param_checks_impl.hpp
+++ b/src/mlpack/core/util/param_checks_impl.hpp
@@ -15,9 +15,6 @@
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/param_data.hpp>
 
-#include "param_checks.hpp"
-#include "get_printable_param.hpp"
-
 namespace mlpack {
 namespace util {
 
@@ -337,19 +334,34 @@ void RequireNonEmptyInputValue(util::Params& params,
 
   if (params.Has(paramName))
   {
-    T& inputData = std::move(data);
-    if (inputData.empty())
+    if (data.empty())
     {
       util::PrefixedOutStream& stream = fatal ? Log::Fatal : Log::Warn;
       if (!errorMessage.empty()) {
-        stream << inputData << PRINT_PARAM_STRING(paramName) 
-            << " " << errorMessage << "! ";
+        stream << data << PRINT_PARAM_STRING(paramName) 
+            << " " << errorMessage << "! " << std::endl;
+      }
+    }
+  }
+}
 
-        GetPrintableParam<std::string>(params,
-            const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-            const typename std::enable_if<params::HasSerialize<T>::value>::type* = 0);
+inline void RequireNonEmptyInputValue(util::Params& params,
+    const std::string& paramName,
+    std::string filename,
+    const bool fatal,
+    const std::string& errorMessage)
+{
+  if (BINDING_IGNORE_CHECK(paramName))
+    return;
 
-        stream << std::endl;
+  if (params.Has(paramName))
+  {
+    if (filename.empty())
+    {
+      util::PrefixedOutStream& stream = fatal ? Log::Fatal : Log::Warn;
+      if (!errorMessage.empty()) {
+        stream << filename << PRINT_PARAM_STRING(paramName) 
+            << " " << errorMessage << "! " << std::endl;
       }
     }
   }

--- a/src/mlpack/core/util/param_checks_impl.hpp
+++ b/src/mlpack/core/util/param_checks_impl.hpp
@@ -306,6 +306,30 @@ inline void ReportIgnoredParam(util::Params& params,
   }
 }
 
+// Check if the given input data points aren't empty.
+template<typename T>
+inline void RequireNonEmptyInputValue(
+    util::Params& params,
+    const std::string& paramName,
+    const bool fatal,
+    const std::string& errorMessage)
+{
+  if (BINDING_IGNORE_CHECK(paramName))
+    return;
+
+  if (params.Has(paramName))
+  {
+    arma::mat trainingData = std::move(params.Get<arma::mat>(paramName));
+    if (trainingData.empty())
+    {
+      util::PrefixedOutStream& stream = fatal ? Log::Fatal : Log::Warn;
+      if (!errorMessage.empty())
+        stream << paramName << errorMessage << std::endl;
+    }
+  }
+}
+
+
 } // namespace util
 } // namespace mlpack
 

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -153,7 +153,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   arma::mat& data = params.Get<arma::mat>("input");
 
   // input data can't be empty.
-  RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
+  std::string& filename =  mlpack::bindings::cli::GetPrintableParam(params, 0, 0);
+  if (filename != "")
+    RequireNonEmptyInputValue(params, "input", filename, true, "must be non-empty: cannot split an empty dataset");
+  else
+    RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
 
   // If parameters for labels exist, we must split the labels too.
   if (params.Has("input_labels"))

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -153,11 +153,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   arma::mat& data = params.Get<arma::mat>("input");
 
   // input data can't be empty.
-  std::string& filename =  mlpack::bindings::cli::GetPrintableParam(params, 0, 0);
-  if (filename != "")
-    RequireNonEmptyInputValue(params, "input", filename, true, "must be non-empty: cannot split an empty dataset");
-  else
-    RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
+  RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
 
   // If parameters for labels exist, we must split the labels too.
   if (params.Has("input_labels"))

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -118,6 +118,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   const bool shuffleData = params.Get<bool>("no_shuffle");
   const bool stratifyData = params.Get<bool>("stratify_data");
 
+  // Load the data.
+  arma::mat& data = params.Get<arma::mat>("input");
+
+  // input data can't be empty.
+  RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
+
   if (params.Get<int>("seed") == 0)
     mlpack::math::RandomSeed(std::time(NULL));
   else
@@ -148,12 +154,6 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       [](double x) { return x >= 0.0 && x <= 1.0; }, true,
       "test ratio must be between 0.0 and 1.0");
 
-
-  // Load the data.
-  arma::mat& data = params.Get<arma::mat>("input");
-
-  // input data can't be empty.
-  RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
 
   // If parameters for labels exist, we must split the labels too.
   if (params.Has("input_labels"))

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -118,12 +118,6 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   const bool shuffleData = params.Get<bool>("no_shuffle");
   const bool stratifyData = params.Get<bool>("stratify_data");
 
-  // Load the data.
-  arma::mat& data = params.Get<arma::mat>("input");
-
-  // input data can't be empty.
-  RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
-
   if (params.Get<int>("seed") == 0)
     mlpack::math::RandomSeed(std::time(NULL));
   else
@@ -154,6 +148,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       [](double x) { return x >= 0.0 && x <= 1.0; }, true,
       "test ratio must be between 0.0 and 1.0");
 
+  // input data can't be empty.
+  RequireNonEmptyInputValue<arma::mat>(params, "input", params.Get<arma::mat>("input"), true, "must be non-empty: cannot split an empty dataset");
+
+  // Load the data.
+  arma::mat& data = params.Get<arma::mat>("input");
 
   // If parameters for labels exist, we must split the labels too.
   if (params.Has("input_labels"))

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -148,11 +148,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       [](double x) { return x >= 0.0 && x <= 1.0; }, true,
       "test ratio must be between 0.0 and 1.0");
 
-  // input data can't be empty.
-  RequireNonEmptyInputValue(params, "input", true, "can not be empty");
 
   // Load the data.
   arma::mat& data = params.Get<arma::mat>("input");
+
+  // input data can't be empty.
+  RequireNonEmptyInputValue<arma::mat>(params, "input", data, true, "must be non-empty: cannot split an empty dataset");
 
   // If parameters for labels exist, we must split the labels too.
   if (params.Has("input_labels"))

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -149,7 +149,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       "test ratio must be between 0.0 and 1.0");
 
   // input data can't be empty.
-  RequireNonEmptyInputValue(params, "input", true, " can not be empty!");
+  RequireNonEmptyInputValue(params, "input", true, "can not be empty");
 
   // Load the data.
   arma::mat& data = params.Get<arma::mat>("input");

--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -148,6 +148,9 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       [](double x) { return x >= 0.0 && x <= 1.0; }, true,
       "test ratio must be between 0.0 and 1.0");
 
+  // input data can't be empty.
+  RequireNonEmptyInputValue(params, "input", true, " can not be empty!");
+
   // Load the data.
   arma::mat& data = params.Get<arma::mat>("input");
 

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,6 +375,6 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
-  REQUIRE_THROWS_AS(RUN_BINDING() , std::bad_exception);
+  REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,7 +375,7 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
-  // REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
-  REQUIRE_THROWS_WITH(RUN_BINDING(), "Mat::max(): object has no elements");
+  REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
+  // REQUIRE_THROWS_WITH(RUN_BINDING(), "Mat::max(): object has no elements");
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,6 +375,6 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   RUN_BINDING();
-  REQUIRE_THROWS_AS(inputData.is_empty() , std::bad_length_error);
-  REQUIRE_THROWS_AS(labels.is_empty() , std::bad_length_error);
+  REQUIRE_THROWS_AS(inputData.is_empty() , std::length_error);
+  REQUIRE_THROWS_AS(labels.is_empty() , std::length_error);
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -376,6 +376,6 @@ TEST_CASE_METHOD(
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
   // REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
-  REQUIRE_THROWS_WITH(RUN_BINDING, "Mat::max(): object has no elements");
+  REQUIRE_THROWS_WITH(RUN_BINDING(), "Mat::max(): object has no elements");
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -367,12 +367,8 @@ TEST_CASE_METHOD(
     "[PreprocessSplitMainTest][BindingTests]")
 {
   // Load custom dataset.
-  arma::mat inputData;
-  arma::Mat<size_t> labels;
-  if (!data::Load("empty_dataset.csv", inputData))
-    FAIL("Cannot load training dataset empty_dataset.csv!");
-  if (!data::Load("empty_dataset_labels.txt", labels))
-    FAIL("Unable to load label dataset empty_dataset_labels.txt!");
+  arma::mat inputData(0,0);
+  arma::Mat<size_t> labels(0,0);
 
   SetInputParam("input", std::move(inputData));
   SetInputParam("input_labels", std::move(labels));

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,6 +375,6 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
-  REQUIRE_THROWS_AS(RUN_BINDING() , std::length_error);
+  REQUIRE_THROWS_AS(RUN_BINDING() , std::bad_exception);
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,6 +375,7 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
-  REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
+  // REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
+  REQUIRE_THROWS_WITH(RUN_BINDING, "Mat::max(): object has no elements");
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -374,7 +374,7 @@ TEST_CASE_METHOD(
   SetInputParam("input_labels", std::move(labels));
 
   // Now check that the input dataset is not empty.
-  Log::Fatal.ignoreInput = true;
-  REQUIRE_THROWS_AS(RUN_BINDING(), std::bad_alloc);
-  Log::Fatal.ignoreInput = false;
+  RUN_BINDING()
+  REQUIRE_THROWS_AS(inputData.is_empty() , std::bad_length_error);
+  REQUIRE_THROWS_AS(labels.is_empty() , std::bad_length_error);
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -373,18 +373,10 @@ TEST_CASE_METHOD(
   if (!data::Load("vc2_labels.txt", labels))
     FAIL("Unable to load label dataset vc2_labels.txt!");
 
-  // Store size of input dataset.
-  int inputSize = inputData.n_cols;
-  int labelSize = labels.n_cols;
-
-  // Input custom data points and labels.
-  SetInputParam("input", std::move(inputData));
-  SetInputParam("input_labels", std::move(labels));
-
   RUN_BINDING();
 
   // Now check that the input data is not empty.
-  REQUIRE(inputSize !== 0);
-  
-  REQUIRE(labelSize !== 0);
+  REQUIRE(inputData.is_empty() == false);
+
+  REQUIRE(labels.is_empty() == false);
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,7 +375,7 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
-  REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
-  // REQUIRE_THROWS_WITH(RUN_BINDING(), "Mat::max(): object has no elements");
+  // REQUIRE_THROWS_AS(RUN_BINDING() , std::unexpected_handler);
+  REQUIRE_THROWS_WITH(RUN_BINDING(), "Mat::max(): object has no elements");
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -374,7 +374,5 @@ TEST_CASE_METHOD(
   SetInputParam("input_labels", std::move(labels));
 
   // Now check that the input dataset is not empty.
-  RUN_BINDING();
-  REQUIRE_THROWS_AS(inputData.is_empty() , std::length_error);
-  REQUIRE_THROWS_AS(labels.is_empty() , std::length_error);
+  REQUIRE_THROWS_AS(RUN_BINDING() , std::length_error);
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -359,7 +359,8 @@ TEST_CASE_METHOD(
 }
 
 /**
- * Check that if training size is not zero.
+ * Check that if input dataset is not empty.
+ * Empty dataset can not be split.
  */
 TEST_CASE_METHOD(
     PreprocessSplitTestFixture, "PreprocessSplitNonEmptyInputTest",
@@ -373,10 +374,11 @@ TEST_CASE_METHOD(
   if (!data::Load("vc2_labels.txt", labels))
     FAIL("Unable to load label dataset vc2_labels.txt!");
 
-  RUN_BINDING();
+  SetInputParam("input", std::move(inputData));
+  SetInputParam("input_labels", std::move(labels));
 
-  // Now check that the input data is not empty.
-  REQUIRE(inputData.is_empty() == false);
-
-  REQUIRE(labels.is_empty() == false);
+  // Now check that the input dataset is not empty.
+  Log::Fatal.ignoreInput = true;
+  REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);
+  Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -369,10 +369,10 @@ TEST_CASE_METHOD(
   // Load custom dataset.
   arma::mat inputData;
   arma::Mat<size_t> labels;
-  if (!data::Load("vc2.csv", inputData))
-    FAIL("Cannot load train dataset vc2.csv!");
-  if (!data::Load("vc2_labels.txt", labels))
-    FAIL("Unable to load label dataset vc2_labels.txt!");
+  if (!data::Load("empty_dataset.csv", inputData))
+    FAIL("Cannot load training dataset empty_dataset.csv!");
+  if (!data::Load("empty_dataset_labels.txt", labels))
+    FAIL("Unable to load label dataset empty_dataset_labels.txt!");
 
   SetInputParam("input", std::move(inputData));
   SetInputParam("input_labels", std::move(labels));

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -375,6 +375,6 @@ TEST_CASE_METHOD(
 
   // Now check that the input dataset is not empty.
   Log::Fatal.ignoreInput = true;
-  REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);
+  REQUIRE_THROWS_AS(RUN_BINDING(), std::bad_alloc);
   Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -374,7 +374,7 @@ TEST_CASE_METHOD(
   SetInputParam("input_labels", std::move(labels));
 
   // Now check that the input dataset is not empty.
-  RUN_BINDING()
+  RUN_BINDING();
   REQUIRE_THROWS_AS(inputData.is_empty() , std::bad_length_error);
   REQUIRE_THROWS_AS(labels.is_empty() , std::bad_length_error);
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -374,5 +374,7 @@ TEST_CASE_METHOD(
   SetInputParam("input_labels", std::move(labels));
 
   // Now check that the input dataset is not empty.
+  Log::Fatal.ignoreInput = true;
   REQUIRE_THROWS_AS(RUN_BINDING() , std::length_error);
+  Log::Fatal.ignoreInput = false;
 }

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -357,3 +357,34 @@ TEST_CASE_METHOD(
   REQUIRE(static_cast<uvec>(find(
       params.Get<arma::Mat<size_t>>("test_labels") == 2)).n_rows == 20);
 }
+
+/**
+ * Check that if training size is not zero.
+ */
+TEST_CASE_METHOD(
+    PreprocessSplitTestFixture, "PreprocessSplitNonEmptyInputTest",
+    "[PreprocessSplitMainTest][BindingTests]")
+{
+  // Load custom dataset.
+  arma::mat inputData;
+  arma::Mat<size_t> labels;
+  if (!data::Load("vc2.csv", inputData))
+    FAIL("Cannot load train dataset vc2.csv!");
+  if (!data::Load("vc2_labels.txt", labels))
+    FAIL("Unable to load label dataset vc2_labels.txt!");
+
+  // Store size of input dataset.
+  int inputSize = inputData.n_cols;
+  int labelSize = labels.n_cols;
+
+  // Input custom data points and labels.
+  SetInputParam("input", std::move(inputData));
+  SetInputParam("input_labels", std::move(labels));
+
+  RUN_BINDING();
+
+  // Now check that the input data is not empty.
+  REQUIRE(inputSize !== 0);
+  
+  REQUIRE(labelSize !== 0);
+}


### PR DESCRIPTION
refer to #2820 and #3123
This is for adding non-empty input data checks to ``pre-process-split`` function.