### PR TITLE
Fix bugs in ANN loss functions

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
@@ -38,8 +38,12 @@ class BCELoss
    *
    * @param eps The minimum value used for computing logarithms
    *            and denominators in a numerically stable way.
-   * @param reduction Reduction type. If true, it returns the mean of 
-   *                  the loss. Else, it returns the sum.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
   BCELoss(const double eps = 1e-10, const bool reduction = true);
 
@@ -77,9 +81,9 @@ class BCELoss
   //! Modify the epsilon.
   double& Eps() { return eps; }
 
-  //! Get the reduction.
+  //! Get the type of reduction used.
   bool Reduction() const { return reduction; }
-  //! Set the reduction.
+  //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }
 
   /**
@@ -95,7 +99,8 @@ class BCELoss
   //! The minimum value used for computing logarithms and denominators
   double eps;
 
-  //! Reduction type. If true, performs mean of loss else sum.
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
   bool reduction;
 }; // class BCELoss
 

--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
@@ -100,8 +100,7 @@ class BCELoss
   //! The minimum value used for computing logarithms and denominators
   double eps;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class BCELoss
 

--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
@@ -81,7 +81,8 @@ class BCELoss
   //! Modify the epsilon.
   double& Eps() { return eps; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss_impl.hpp
@@ -34,11 +34,13 @@ BCELoss<InputDataType, OutputDataType>::Forward(
 {
   typedef typename PredictionType::elem_type ElemType;
 
-  ElemType loss = -arma::accu(target % arma::log(prediction + eps) +
+  ElemType lossSum = -arma::accu(target % arma::log(prediction + eps) +
       (1. - target) % arma::log(1. - prediction + eps));
+
   if (reduction)
-    loss /= prediction.n_elem;
-  return loss;
+    return lossSum;
+
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -49,7 +51,8 @@ void BCELoss<InputDataType, OutputDataType>::Backward(
     LossType& loss)
 {
   loss = (1. - target) / (1. - prediction + eps) - target / (prediction + eps);
-  if (reduction)
+
+  if (!reduction)
     loss /= prediction.n_elem;
 }
 
@@ -60,6 +63,7 @@ void BCELoss<InputDataType, OutputDataType>::serialize(
     const uint32_t /* version */)
 {
   ar(CEREAL_NVP(eps));
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss_impl.hpp
@@ -53,7 +53,7 @@ void BCELoss<InputDataType, OutputDataType>::Backward(
   loss = (1. - target) / (1. - prediction + eps) - target / (prediction + eps);
 
   if (!reduction)
-    loss /= prediction.n_elem;
+    loss /= target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -46,13 +46,15 @@ class CosineEmbeddingLoss
    *               Refer definition of cosine-embedding-loss above.
    * @param similarity Determines whether to use similarity or dissimilarity for
    *                   comparision.
-   * @param takeMean Boolean variable to specify whether to take mean or not.
-   *                 Specifies reduction method i.e. sum or mean corresponding
-   *                 to 0 and 1 respectively. Default value = 0.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
   CosineEmbeddingLoss(const double margin = 0.0,
                       const bool similarity = true,
-                      const bool takeMean = false);
+                      const bool reduction = true);
 
   /**
    * Ordinary feed forward pass of a neural network.
@@ -93,10 +95,10 @@ class CosineEmbeddingLoss
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
 
-  //! Get the value of takeMean.
-  bool TakeMean() const { return takeMean; }
-  //! Modify the value of takeMean.
-  bool& TakeMean() { return takeMean; }
+ //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
 
   //! Get the value of margin.
   double Margin() const { return margin; }
@@ -130,8 +132,9 @@ class CosineEmbeddingLoss
   //! Locally-stored value of similarity hyper-parameter.
   bool similarity;
 
-  //! Locally-stored value of takeMean hyper-parameter.
-  bool takeMean;
+//! Boolean value that tells if reduction
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class CosineEmbeddingLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -95,7 +95,8 @@ class CosineEmbeddingLoss
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
 
- //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -133,8 +133,7 @@ class CosineEmbeddingLoss
   //! Locally-stored value of similarity hyper-parameter.
   bool similarity;
 
-//! Boolean value that tells if reduction
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class CosineEmbeddingLoss
 

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
@@ -20,8 +20,8 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
 CosineEmbeddingLoss<InputDataType, OutputDataType>::CosineEmbeddingLoss(
-    const double margin, const bool similarity, const bool takeMean):
-    margin(margin), similarity(similarity), takeMean(takeMean)
+    const double margin, const bool similarity, const bool reduction):
+    margin(margin), similarity(similarity), reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -42,7 +42,7 @@ CosineEmbeddingLoss<InputDataType, OutputDataType>::Forward(
 
   arma::colvec inputTemp1 = arma::vectorise(prediction);
   arma::colvec inputTemp2 = arma::vectorise(target);
-  ElemType loss = 0.0;
+  ElemType lossSum = 0.0;
 
   for (size_t i = 0; i < inputTemp1.n_elem; i += cols)
   {
@@ -50,18 +50,18 @@ CosineEmbeddingLoss<InputDataType, OutputDataType>::Forward(
         inputTemp1(arma::span(i, i + cols - 1)), inputTemp2(arma::span(i,
         i + cols - 1)));
     if (similarity)
-      loss += 1 - cosDist;
+      lossSum += 1 - cosDist;
     else
     {
       const ElemType currentLoss = cosDist - margin;
-      loss += currentLoss > 0 ? currentLoss : 0;
+      lossSum += currentLoss > 0 ? currentLoss : 0;
     }
   }
 
-  if (takeMean)
-    loss = (ElemType) loss / batchSize;
+  if (reduction)
+    return lossSum;
 
-  return loss;
+  return (ElemType) lossSum / batchSize;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -74,6 +74,7 @@ void CosineEmbeddingLoss<InputDataType, OutputDataType>::Backward(
   typedef typename PredictionType::elem_type ElemType;
 
   const size_t cols = prediction.n_cols;
+  const size_t batchSize = prediction.n_elem / cols;
   if (arma::size(prediction) != arma::size(target))
     Log::Fatal << "Input Tensors must have same dimensions." << std::endl;
 
@@ -99,6 +100,9 @@ void CosineEmbeddingLoss<InputDataType, OutputDataType>::Backward(
           1)))) / std::sqrt(arma::accu(arma::pow(inputTemp1(arma::span(i, i +
           cols - 1)), 2)));
     }
+
+    if (!reduction)
+      outputTemp = outputTemp / batchSize;
   }
 }
 
@@ -109,7 +113,7 @@ void CosineEmbeddingLoss<InputDataType, OutputDataType>::serialize(
 {
   ar(CEREAL_NVP(margin));
   ar(CEREAL_NVP(similarity));
-  ar(CEREAL_NVP(takeMean));
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
@@ -89,8 +89,7 @@ class EarthMoverDistance
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
   
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class EarthMoverDistance
 

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
@@ -73,7 +73,8 @@ class EarthMoverDistance
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
@@ -35,8 +35,14 @@ class EarthMoverDistance
  public:
   /**
    * Create the EarthMoverDistance object.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  EarthMoverDistance();
+  EarthMoverDistance(const bool reduction = true);
 
   /**
    * Ordinary feed forward pass of a neural network.
@@ -67,6 +73,11 @@ class EarthMoverDistance
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the layer.
    */
@@ -76,6 +87,10 @@ class EarthMoverDistance
  private:
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+  
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class EarthMoverDistance
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance_impl.hpp
@@ -38,7 +38,7 @@ EarthMoverDistance<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance_impl.hpp
@@ -19,7 +19,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-EarthMoverDistance<InputDataType, OutputDataType>::EarthMoverDistance()
+EarthMoverDistance<InputDataType, OutputDataType>
+  ::EarthMoverDistance(const bool reduction) : reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -31,7 +32,13 @@ EarthMoverDistance<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  return -arma::accu(target % prediction);
+  typename PredictionType::elem_type lossSum = 
+      -arma::accu(target % prediction);
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -42,15 +49,18 @@ void EarthMoverDistance<InputDataType, OutputDataType>::Backward(
     LossType& loss)
 {
   loss = -target;
+
+  if (!reduction)
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void EarthMoverDistance<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const uint32_t /* version */)
 {
-  /* Nothing to do here */
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp
@@ -76,7 +76,8 @@ class HingeEmbeddingLoss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const {return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() {return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp
@@ -38,8 +38,14 @@ class HingeEmbeddingLoss
  public:
   /**
    * Create the Hinge Embedding object.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  HingeEmbeddingLoss();
+  HingeEmbeddingLoss(const bool reduction = true);
 
   /**
    * Computes the Hinge Embedding loss function.
@@ -70,6 +76,11 @@ class HingeEmbeddingLoss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const {return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() {return reduction; }
+
   /**
    * Serialize the loss function.
    */
@@ -79,6 +90,10 @@ class HingeEmbeddingLoss
  private:
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! Boolean values that tells if reduction
+  // is 'sum' or 'mean'.
+  bool reduction;
 }; // class HingeEmbeddingLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss_impl.hpp
@@ -39,7 +39,7 @@ HingeEmbeddingLoss<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -52,7 +52,7 @@ void HingeEmbeddingLoss<InputDataType, OutputDataType>::Backward(
   loss = target;
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -77,7 +77,8 @@ class HingeLoss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -93,7 +93,7 @@ class HingeLoss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! The boolean value that tells if reduction is sum or mean.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class HingeLoss
 

--- a/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
@@ -102,8 +102,7 @@ class HuberLoss
   //! Hyperparameter `delta` defines the point upto which MSE is considered.
   double delta;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class HuberLoss
 

--- a/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
@@ -83,7 +83,8 @@ class HuberLoss
   //! Set the value of delta.
   double& Delta() { return delta; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
@@ -41,9 +41,13 @@ class HuberLoss
    *
    * @param delta The threshold value upto which squared error is followed and
    *              after which absolute error is considered.
-   * @param mean If true then mean loss is computed otherwise sum.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  HuberLoss(const double delta = 1.0, const bool mean = true);
+  HuberLoss(const double delta = 1.0, const bool reduction = true);
 
   /**
    * Computes the Huber Loss function.
@@ -79,10 +83,10 @@ class HuberLoss
   //! Set the value of delta.
   double& Delta() { return delta; }
 
-  //! Get the value of reduction type.
-  bool Mean() const { return mean; }
-  //! Set the value of reduction type.
-  bool& Mean() { return mean; }
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
 
   /**
    * Serialize the layer.
@@ -97,8 +101,9 @@ class HuberLoss
   //! Hyperparameter `delta` defines the point upto which MSE is considered.
   double delta;
 
-  //! Reduction type. If true, performs mean of loss else sum.
-  bool mean;
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class HuberLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
@@ -47,7 +47,7 @@ HuberLoss<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -69,7 +69,7 @@ void HuberLoss<InputDataType, OutputDataType>::Backward(
   }
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
@@ -21,9 +21,9 @@ namespace ann /** Artificial Neural Network. */ {
 template<typename InputDataType, typename OutputDataType>
 HuberLoss<InputDataType, OutputDataType>::HuberLoss(
   const double delta,
-  const bool mean):
+  const bool reduction):
   delta(delta),
-  mean(mean)
+  reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -36,14 +36,18 @@ HuberLoss<InputDataType, OutputDataType>::Forward(
     const TargetType& target)
 {
   typedef typename PredictionType::elem_type ElemType;
-  ElemType loss = 0;
+  ElemType lossSum = 0;
   for (size_t i = 0; i < prediction.n_elem; ++i)
   {
       const ElemType absError = std::abs(target[i] - prediction[i]);
-      loss += absError > delta ?
+      lossSum += absError > delta ?
           delta * (absError - 0.5 * delta) : 0.5 * std::pow(absError, 2);
   }
-  return mean ? loss / prediction.n_elem : loss;
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -62,9 +66,10 @@ void HuberLoss<InputDataType, OutputDataType>::Backward(
     loss[i] = absError > delta ?
         -delta * (target[i] - prediction[i]) / absError :
         prediction[i] - target[i];
-    if (mean)
-      loss[i] /= loss.n_elem;
   }
+
+  if (!reduction)
+    loss = loss / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -74,7 +79,7 @@ void HuberLoss<InputDataType, OutputDataType>::serialize(
     const uint32_t /* version */)
 {
   ar(CEREAL_NVP(delta));
-  ar(CEREAL_NVP(mean));
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
@@ -86,7 +86,8 @@ class KLDivergence
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
@@ -101,8 +101,7 @@ class KLDivergence
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class KLDivergence
 

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
@@ -49,9 +49,13 @@ class KLDivergence
    * Create the Kullback–Leibler Divergence object with the specified
    * parameters.
    *
-   * @param takeMean Boolean variable to specify whether to take mean or not.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  KLDivergence(const bool takeMean = false);
+  KLDivergence(const bool reduction = true);
 
   /**
    * Computes the Kullback–Leibler divergence error function.
@@ -82,11 +86,10 @@ class KLDivergence
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the value of takeMean.
-  bool TakeMean() const { return takeMean; }
-  //! Modify the value of takeMean.
-  bool& TakeMean() { return takeMean; }
-
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
   /**
    * Serialize the loss function
    */
@@ -97,8 +100,9 @@ class KLDivergence
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean variable for taking mean or not.
-  bool takeMean;
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class KLDivergence
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
@@ -39,7 +39,7 @@ KLDivergence<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -52,7 +52,7 @@ void KLDivergence<InputDataType, OutputDataType>::Backward(
   loss = - target;
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence_impl.hpp
@@ -20,8 +20,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-KLDivergence<InputDataType, OutputDataType>::KLDivergence(const bool takeMean) :
-    takeMean(takeMean)
+KLDivergence<InputDataType, OutputDataType>::KLDivergence(const bool reduction):
+    reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -33,15 +33,13 @@ KLDivergence<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  if (takeMean)
-  {
-    return arma::as_scalar(arma::mean(
-        arma::mean(prediction % (arma::log(prediction) - arma::log(target)))));
-  }
-  else
-  {
-    return arma::accu(prediction % (arma::log(prediction) - arma::log(target)));
-  }
+  PredictionType loss = target % (arma::log(target) - prediction);
+  typename PredictionType::elem_type lossSum = arma::accu(loss);
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -51,15 +49,10 @@ void KLDivergence<InputDataType, OutputDataType>::Backward(
     const TargetType& target,
     LossType& loss)
 {
-  if (takeMean)
-  {
-    loss = arma::mean(arma::mean(
-        arma::log(prediction) - arma::log(target) + 1));
-  }
-  else
-  {
-    loss = arma::accu(arma::log(prediction) - arma::log(target) + 1);
-  }
+  loss = - target;
+
+  if (!reduction)
+    loss = loss / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -68,7 +61,7 @@ void KLDivergence<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const uint32_t /* version */)
 {
-  ar(CEREAL_NVP(takeMean));
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
@@ -74,7 +74,8 @@ class L1Loss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
@@ -43,7 +43,7 @@ class L1Loss
    *                  is set to true by default.
    *
    */
-  L1Loss(const bool mean = true);
+  L1Loss(const bool reduction = true);
 
   /**
    * Computes the L1 Loss function.

--- a/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
@@ -90,8 +90,7 @@ class L1Loss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class L1Loss
 

--- a/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
@@ -18,8 +18,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 /**
- * The L1 loss is a loss function that measures the mean absolute error (MAE) 
- * between each element in the input x and target y 
+ * The L1 loss is a loss function that measures the mean absolute error (MAE)
+ * between each element in the input x and target y. 
  *
  * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
  *         arma::sp_mat or arma::cube).
@@ -36,8 +36,12 @@ class L1Loss
   /**
    * Create the L1Loss object.
    *
-   * @param mean Reduction type. If true, it returns the mean of 
-   * the loss. Else, it returns the sum.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
+   *
    */
   L1Loss(const bool mean = true);
 
@@ -70,10 +74,10 @@ class L1Loss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the value of reduction type.
-  bool Mean() const { return mean; }
-  //! Set the value of reduction type.
-  bool& Mean() { return mean; }
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
 
   /**
    * Serialize the layer.
@@ -85,8 +89,9 @@ class L1Loss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Reduction type. If true, performs mean of loss else sum.
-  bool mean;
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class L1Loss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/l1_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss_impl.hpp
@@ -19,8 +19,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-L1Loss<InputDataType, OutputDataType>::L1Loss(const bool mean):
-  mean(mean)
+L1Loss<InputDataType, OutputDataType>::L1Loss(const bool reduction):
+  reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -32,10 +32,13 @@ L1Loss<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  if (mean)
-    return arma::accu(arma::mean(prediction - target));
+  PredictionType loss = arma::abs(prediction - target);
+  typename PredictionType::elem_type lossSum = arma::accu(loss);
 
-  return arma::accu(prediction - target);
+  if (reduction)
+    return lossSum;
+
+  return lossSum / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -46,6 +49,9 @@ void L1Loss<InputDataType, OutputDataType>::Backward(
     LossType& loss)
 {
   loss = arma::sign(prediction - target);
+  
+  if (!reduction)
+    loss = loss / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -54,7 +60,7 @@ void L1Loss<InputDataType, OutputDataType>::serialize(
     Archive& ar,
     const uint32_t /* version */)
 {
-  ar(CEREAL_NVP(mean));
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/l1_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss_impl.hpp
@@ -38,7 +38,7 @@ L1Loss<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -51,7 +51,7 @@ void L1Loss<InputDataType, OutputDataType>::Backward(
   loss = arma::sign(prediction - target);
   
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
@@ -86,7 +86,8 @@ class LogCoshLoss
   //! Modify the value of hyperparameter a.
   double& A() { return a; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
@@ -39,14 +39,18 @@ class LogCoshLoss
    * Create the Log-Hyperbolic-Cosine object with the specified
    * parameters.
    *
-   * @param a A double type value for smoothening loss function.
-   *          It must be positive a real number, Sharpness of loss
-   *          function is directly proportional to a. It can also
-   *          act as a scaling factor hence making the loss
-   *          function more sensitive to small losses around the
-   *          origin. Default value = 1.0.
+   * @param a A double type value for smoothening loss function. It must be a
+   *          positive real number. Sharpness of loss function is directly
+   *          proportional to a. It can also act as a scaling factor, hence
+   *          making the loss function more sensitive to small losses around
+   *          the origin. Default value = 1.0.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  LogCoshLoss(const double a = 1.0);
+  LogCoshLoss(const double a = 1.0, const bool reduction = true);
 
   /**
    * Computes the Log-Hyperbolic-Cosine loss function.
@@ -82,6 +86,11 @@ class LogCoshLoss
   //! Modify the value of hyperparameter a.
   double& A() { return a; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the loss function.
    */
@@ -94,6 +103,10 @@ class LogCoshLoss
 
   //! Hyperparameter a for smoothening function curve.
   double a;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class LogCoshLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
@@ -105,8 +105,7 @@ class LogCoshLoss
   //! Hyperparameter a for smoothening function curve.
   double a;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class LogCoshLoss
 

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
@@ -20,8 +20,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-LogCoshLoss<InputDataType, OutputDataType>::LogCoshLoss
-  (const double a, const bool reduction) :
+LogCoshLoss<InputDataType, OutputDataType>::LogCoshLoss(
+    const double a, const bool reduction) :
     a(a) , reduction(reduction)
 {
   Log::Assert(a > 0, "Hyper-Parameter \'a\' must be positive");

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
@@ -40,7 +40,7 @@ LogCoshLoss<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -53,7 +53,7 @@ void LogCoshLoss<InputDataType, OutputDataType>::Backward(
   loss = arma::tanh(a * (target - prediction));
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss_impl.hpp
@@ -35,7 +35,7 @@ LogCoshLoss<InputDataType, OutputDataType>::Forward(
     const TargetType& target)
 {
   typename PredictionType::elem_type lossSum = 
-    arma::accu(arma::log(arma::cosh(a * (target - prediction)))) / a;
+      arma::accu(arma::log(arma::cosh(a * (target - prediction)))) / a;
 
   if (reduction)
     return lossSum;

--- a/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
@@ -103,8 +103,7 @@ class MarginRankingLoss
   //! The margin value used in calculating Margin Ranking Loss.
   double margin;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class MarginRankingLoss
 

--- a/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
@@ -37,10 +37,14 @@ class MarginRankingLoss
  public:
   /**
    * Create the MarginRankingLoss object with Hyperparameter margin.
-   * Hyperparameter margin defines a minimum distance between correctly ranked
-   * samples.
+   * @param margin defines a minimum distance between correctly ranked samples.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  MarginRankingLoss(const double margin = 1.0);
+  MarginRankingLoss(const double margin = 1.0, const bool reduction = true);
 
   /**
    * Computes the Margin Ranking Loss function.
@@ -80,6 +84,11 @@ class MarginRankingLoss
   //! Modify the margin parameter.
   double& Margin() { return margin; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the layer.
    */
@@ -92,6 +101,10 @@ class MarginRankingLoss
 
   //! The margin value used in calculating Margin Ranking Loss.
   double margin;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class MarginRankingLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
@@ -84,7 +84,8 @@ class MarginRankingLoss
   //! Modify the margin parameter.
   double& Margin() { return margin; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
@@ -35,8 +35,16 @@ class MeanBiasError
  public:
   /**
    * Create the MeanBiasError object.
+   *
+   * @param reduction Specifies the reduction to apply to
+   *                  the output. If false, 'mean' reduction 
+   *                  is used, where sum of the output will
+   *                  be divided by the number of elements
+   *                  in the output. If true, 'sum' reduction
+   *                  is used and the output will be summed.
+   *                  It is set to true by default.
    */
-  MeanBiasError();
+  MeanBiasError(const bool reduction = true);
 
   /**
    * Computes the mean bias error function.
@@ -67,6 +75,12 @@ class MeanBiasError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const {return reduction; }
+
+  //! Modify the type of reduction used.
+  bool& Reduction() {return reduction; }
+
   /**
    * Serialize the layer.
    */
@@ -76,6 +90,10 @@ class MeanBiasError
  private:
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! The boolen value that tells if reduction
+  //! is 'sum' or 'mean'.
+  bool reduction;
 }; // class MeanBiasError
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
@@ -75,9 +75,9 @@ class MeanBiasError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const {return reduction; }
-
   //! Modify the type of reduction used.
   bool& Reduction() {return reduction; }
 

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
@@ -91,8 +91,7 @@ class MeanBiasError
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! The boolen value that tells if reduction
-  //! is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class MeanBiasError
 

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
@@ -39,7 +39,7 @@ MeanBiasError<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum/ prediction.n_elem;
+  return lossSum/ target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -53,7 +53,7 @@ void MeanBiasError<InputDataType, OutputDataType>::Backward(
   loss.fill(-1.0);
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
@@ -20,9 +20,10 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-MeanBiasError<InputDataType, OutputDataType>::MeanBiasError()
+MeanBiasError<InputDataType, OutputDataType>::
+  MeanBiasError(const bool reduction) : reduction(reduction)
 {
-  // Nothing to do here.
+  // Nothing to do here
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -32,7 +33,13 @@ MeanBiasError<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  return arma::accu(target - prediction) / target.n_cols;
+  PredictionType loss = target - prediction;
+  typename PredictionType::elem_type lossSum = arma::accu(loss);
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum/ prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -44,15 +51,18 @@ void MeanBiasError<InputDataType, OutputDataType>::Backward(
 {
   loss.set_size(arma::size(prediction));
   loss.fill(-1.0);
+
+  if (!reduction)
+    loss = loss / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void MeanBiasError<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const uint32_t /* version */)
 {
-  // Nothing to do here.
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
@@ -39,7 +39,7 @@ MeanBiasError<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum/ target.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -53,7 +53,7 @@ void MeanBiasError<InputDataType, OutputDataType>::Backward(
   loss.fill(-1.0);
 
   if (!reduction)
-    loss = loss / target.n_elem;
+    loss = loss / loss.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -90,8 +90,7 @@ class MeanSquaredError
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class MeanSquaredError
 

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -74,7 +74,8 @@ class MeanSquaredError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
   
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -36,8 +36,14 @@ class MeanSquaredError
  public:
   /**
    * Create the MeanSquaredError object.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  MeanSquaredError();
+  MeanSquaredError(const bool reduction = true);
 
   /**
    * Computes the mean squared error function.
@@ -67,6 +73,11 @@ class MeanSquaredError
   OutputDataType& OutputParameter() const { return outputParameter; }
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
+  
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
 
   /**
    * Serialize the layer
@@ -77,6 +88,10 @@ class MeanSquaredError
  private:
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class MeanSquaredError
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
@@ -48,7 +48,7 @@ void MeanSquaredError<InputDataType, OutputDataType>::Backward(
     const TargetType& target,
     LossType& loss)
 {
-  loss = 2 * (prediction - target) ;
+  loss = 2 * (prediction - target);
 
   if (!reduction)
     loss = loss / prediction.n_elem;

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
@@ -19,7 +19,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
-MeanSquaredError<InputDataType, OutputDataType>::MeanSquaredError()
+MeanSquaredError<InputDataType, OutputDataType>
+  ::MeanSquaredError(const bool reduction) : reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -31,7 +32,13 @@ MeanSquaredError<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  return arma::accu(arma::square(prediction - target)) / target.n_cols;
+  typename PredictionType::elem_type lossSum =
+    arma::accu(arma::square(prediction - target));
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -41,16 +48,19 @@ void MeanSquaredError<InputDataType, OutputDataType>::Backward(
     const TargetType& target,
     LossType& loss)
 {
-  loss = 2 * (prediction - target) / target.n_cols;
+  loss = 2 * (prediction - target) ;
+
+  if (!reduction)
+    loss = loss / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void MeanSquaredError<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const uint32_t /* version */)
 {
-  // Nothing to do here.
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
@@ -33,7 +33,7 @@ MeanSquaredError<InputDataType, OutputDataType>::Forward(
     const TargetType& target)
 {
   typename PredictionType::elem_type lossSum =
-    arma::accu(arma::square(prediction - target));
+      arma::accu(arma::square(prediction - target));
 
   if (reduction)
     return lossSum;

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error_impl.hpp
@@ -38,7 +38,7 @@ MeanSquaredError<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -51,7 +51,7 @@ void MeanSquaredError<InputDataType, OutputDataType>::Backward(
   loss = 2 * (prediction - target);
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
@@ -73,7 +73,8 @@ class MeanSquaredLogarithmicError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
@@ -35,8 +35,14 @@ class MeanSquaredLogarithmicError
  public:
   /**
    * Create the MeanSquaredLogarithmicError object.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  MeanSquaredLogarithmicError();
+  MeanSquaredLogarithmicError(const bool reduction = true);
 
   /**
    * Computes the mean squared logarithmic error function.
@@ -67,6 +73,11 @@ class MeanSquaredLogarithmicError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the layer
    */
@@ -76,6 +87,10 @@ class MeanSquaredLogarithmicError
  private:
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class MeanSquaredLogarithmicError
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
@@ -89,8 +89,7 @@ class MeanSquaredLogarithmicError
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class MeanSquaredLogarithmicError
 

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
@@ -20,7 +20,7 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
 MeanSquaredLogarithmicError<InputDataType, OutputDataType>
-::MeanSquaredLogarithmicError()
+::MeanSquaredLogarithmicError(const bool reduction) : reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -32,8 +32,14 @@ MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  return arma::accu(arma::square(arma::log(1. + target) -
-      arma::log(1. + prediction))) / target.n_cols;
+  typename PredictionType::elem_type lossSum =  
+    arma::accu(arma::square(arma::log(1. + target) -
+      arma::log(1. + prediction))) ;
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -44,16 +50,19 @@ void MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Backward(
     LossType& loss)
 {
   loss = 2 * (arma::log(1. + prediction) - arma::log(1. + target)) /
-      ((1. + prediction) * target.n_cols);
+      (1. + prediction);
+
+  if (!reduction)
+    loss = loss / prediction.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void MeanSquaredLogarithmicError<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar,
     const uint32_t /* version */)
 {
-  // Nothing to do here.
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
@@ -33,8 +33,8 @@ MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Forward(
     const TargetType& target)
 {
   typename PredictionType::elem_type lossSum =  
-    arma::accu(arma::square(arma::log(1. + target) -
-      arma::log(1. + prediction))) ;
+      arma::accu(arma::square(arma::log(1.0 + target) -
+      arma::log(1.0 + prediction)));
 
   if (reduction)
     return lossSum;

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error_impl.hpp
@@ -39,7 +39,7 @@ MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Forward(
   if (reduction)
     return lossSum;
 
-  return lossSum / prediction.n_elem;
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -53,7 +53,7 @@ void MeanSquaredLogarithmicError<InputDataType, OutputDataType>::Backward(
       (1. + prediction);
 
   if (!reduction)
-    loss = loss / prediction.n_elem;
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>

--- a/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss.hpp
@@ -80,7 +80,8 @@ class MultiLabelSoftMarginLoss
   //! Modify the weights assigned to each class.
   arma::rowvec& ClassWeights() { return classWeights; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss.hpp
@@ -96,7 +96,7 @@ class MultiLabelSoftMarginLoss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! The boolean value that tells if reduction is sum or mean.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 
   //! A (1, numClasses) shaped vector with weights for each class.

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -19,7 +19,7 @@ namespace ann /** Artificial Neural Network. */ {
 
 /**
  * Implementation of the negative log likelihood layer. The negative log
- * likelihood layer expectes that the input contains log-probabilities for each
+ * likelihood layer expects that the input contains log-probabilities for each
  * class. The layer also expects a class index, in the range between 1 and the
  * number of classes, as target when calling the Forward function.
  *
@@ -37,8 +37,14 @@ class NegativeLogLikelihood
  public:
   /**
    * Create the NegativeLogLikelihoodLayer object.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  NegativeLogLikelihood();
+  NegativeLogLikelihood(const bool reduction = true);
 
   /**
    * Computes the Negative log likelihood.
@@ -84,6 +90,11 @@ class NegativeLogLikelihood
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the layer
    */
@@ -99,6 +110,10 @@ class NegativeLogLikelihood
 
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class NegativeLogLikelihood
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -112,8 +112,7 @@ class NegativeLogLikelihood
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class NegativeLogLikelihood
 

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -90,7 +90,8 @@ class NegativeLogLikelihood
   //! Modify the delta.
   OutputDataType& Delta() { return delta; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -20,8 +20,8 @@ namespace ann /** Artificial Neural Network. */ {
 /**
  * Implementation of the negative log likelihood layer. The negative log
  * likelihood layer expects that the input contains log-probabilities for each
- * class. The layer also expects a class index, in the range between 1 and the
- * number of classes, as target when calling the Forward function.
+ * class. The layer also expects a class index, in the range between 0 and 
+ * number of classes -1, as target when calling the Forward function.
  *
  * @tparam InputDataType Type of the input data (arma::colvec, arma::mat,
  *         arma::sp_mat or arma::cube).

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
@@ -59,13 +59,15 @@ void NegativeLogLikelihood<InputDataType, OutputDataType>::Backward(
       const TargetType& target,
       LossType& loss)
 {
-  loss = arma::zeros<LossType>(prediction.n_rows, prediction.n_cols);
-  for (size_t i = 0; i < prediction.n_cols; ++i)
+  loss.zeros(size(prediction));
+  typename TargetType::elem_type currentTarget;
+  for (size_t i = 0; i < target.n_cols; ++i)
   {
-    Log::Assert(target(i) >= 0 && target(i) < prediction.n_rows,
+    currentTarget = target(i);
+    Log::Assert(currentTarget >= 0 && currentTarget < prediction.n_rows,
         "Target class out of range.");
 
-    loss(target(i), i) = -1;
+    loss(i, currentTarget) = -1;
   }
 
   if (!reduction)

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
@@ -32,15 +32,19 @@ NegativeLogLikelihood<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  typedef typename PredictionType::elem_type ElemType;
-  ElemType lossSum = 0;
-  for (size_t i = 0; i < prediction.n_cols; ++i)
+  PredictionType loss;
+  loss.zeros(size(target));
+  typename TargetType::elem_type currentTarget;
+  for (size_t i = 0; i < target.n_cols; ++i)
   {
-    Log::Assert(target(i) >= 0 && target(i) < prediction.n_rows,
+    currentTarget = target(i);
+    Log::Assert(currentTarget >=0 && currentTarget < prediction.n_rows,
         "Target class out of range.");
 
-    lossSum -= prediction(target(i), i);
+    loss(i) -= prediction(i, currentTarget);
   }
+
+  typename PredictionType::elem_type lossSum= arma::accu(loss);
 
   if (reduction)
     return lossSum;

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
@@ -32,19 +32,15 @@ NegativeLogLikelihood<InputDataType, OutputDataType>::Forward(
     const PredictionType& prediction,
     const TargetType& target)
 {
-  PredictionType loss;
-  loss.zeros(size(target));
-  typename TargetType::elem_type currentTarget;
-  for (size_t i = 0; i < target.n_cols; ++i)
+  typedef typename PredictionType::elem_type ElemType;
+  ElemType lossSum = 0;
+  for (size_t i = 0; i < prediction.n_cols; ++i)
   {
-    currentTarget = target(i);
-    Log::Assert(currentTarget >=0 && currentTarget < prediction.n_rows,
+    Log::Assert(target(i) >= 0 && target(i) < prediction.n_rows,
         "Target class out of range.");
 
-    loss(i) -= prediction(i, currentTarget);
+    lossSum -= prediction(target(i), i);
   }
-
-  typename PredictionType::elem_type lossSum= arma::accu(loss);
 
   if (reduction)
     return lossSum;
@@ -59,15 +55,13 @@ void NegativeLogLikelihood<InputDataType, OutputDataType>::Backward(
       const TargetType& target,
       LossType& loss)
 {
-  loss.zeros(size(prediction));
-  typename TargetType::elem_type currentTarget;
-  for (size_t i = 0; i < target.n_cols; ++i)
+  loss = arma::zeros<LossType>(prediction.n_rows, prediction.n_cols);
+  for (size_t i = 0; i < prediction.n_cols; ++i)
   {
-    currentTarget = target(i);
-    Log::Assert(currentTarget >= 0 && currentTarget < prediction.n_rows,
+    Log::Assert(target(i) >= 0 && target(i) < prediction.n_rows,
         "Target class out of range.");
 
-    loss(i, currentTarget) = -1;
+    loss(target(i), i) = -1;
   }
 
   if (!reduction)

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
@@ -156,8 +156,7 @@ class PoissonNLLLoss
   //! eps is a small value required to prevent 0 in logarithms and denominators.
   typename InputDataType::elem_type eps;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 
 }; // class PoissonNLLLoss

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
@@ -116,7 +116,8 @@ class PoissonNLLLoss
   //! logarithms and denominators.
   typename InputDataType::elem_type& Eps() { return eps; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
@@ -45,12 +45,16 @@ class PoissonNLLLoss
    * @param full Boolean value that determines whether to include Stirling's
    *        approximation term.
    * @param eps A small value to prevent 0 in denominators and logarithms.
-   * @param mean When true, mean loss is computed otherwise total loss.
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
   PoissonNLLLoss(const bool logInput = true,
                  const bool full = false,
                  const typename InputDataType::elem_type eps = 1e-08,
-                 const bool mean = true);
+                 const bool reduction = true);
 
   /**
    * Computes the Poisson negative log likelihood Loss.
@@ -112,13 +116,10 @@ class PoissonNLLLoss
   //! logarithms and denominators.
   typename InputDataType::elem_type& Eps() { return eps; }
 
-  //! Get the value of mean. It's a boolean value that tells if
-  //! mean of the total loss has to be taken.
-  bool Mean() const { return mean; }
-  //! Modify the value of mean. It's a boolean value that tells if
-  //! mean of the total loss has to be taken.
-  bool& Mean() { return mean; }
-
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
   /**
    * Serialize the layer.
    */
@@ -154,8 +155,10 @@ class PoissonNLLLoss
   //! eps is a small value required to prevent 0 in logarithms and denominators.
   typename InputDataType::elem_type eps;
 
-  //! Boolean value that tells if mean of the total loss has to be taken.
-  bool mean;
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
+
 }; // class PoissonNLLLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss_impl.hpp
@@ -24,11 +24,11 @@ PoissonNLLLoss<InputDataType, OutputDataType>::PoissonNLLLoss(
     const bool logInput,
     const bool full,
     const typename InputDataType::elem_type eps,
-    const bool mean):
+    const bool reduction):
     logInput(logInput),
     full(full),
     eps(eps),
-    mean(mean)
+    reduction(reduction)
 {
   Log::Assert(eps >= 0, "Epsilon (eps) must be greater than or equal to zero.");
 }
@@ -57,8 +57,12 @@ PoissonNLLLoss<InputDataType, OutputDataType>::Forward(
         + 0.5 * arma::log(2 * M_PI * target);
     loss.elem(arma::find(mask)) += approx.elem(arma::find(mask));
   }
-
-  return mean ? arma::accu(loss) / loss.n_elem : arma::accu(loss);
+  typename PredictionType::elem_type lossSum = arma::accu(loss);
+  
+  if (reduction)
+    return lossSum;
+  
+  return lossSum / loss.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -75,7 +79,7 @@ void PoissonNLLLoss<InputDataType, OutputDataType>::Backward(
   else
     loss = (1 - target / (prediction + eps));
 
-  if (mean)
+  if (!reduction)
     loss = loss / loss.n_elem;
 }
 
@@ -88,7 +92,7 @@ void PoissonNLLLoss<InputDataType, OutputDataType>::serialize(
   ar(CEREAL_NVP(logInput));
   ar(CEREAL_NVP(full));
   ar(CEREAL_NVP(eps));
-  ar(CEREAL_NVP(mean));
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
@@ -96,8 +96,7 @@ class ReconstructionLoss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class ReconstructionLoss
 

--- a/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
@@ -39,8 +39,14 @@ class ReconstructionLoss
  public:
   /**
    * Create the ReconstructionLoss object.
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
    */
-  ReconstructionLoss();
+  ReconstructionLoss(const bool reduction = true);
 
   /**
    * Computes the reconstruction loss.
@@ -71,6 +77,11 @@ class ReconstructionLoss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the layer
    */
@@ -83,6 +94,10 @@ class ReconstructionLoss
 
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class ReconstructionLoss
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
@@ -77,7 +77,8 @@ class ReconstructionLoss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
@@ -109,8 +109,7 @@ class SigmoidCrossEntropyError
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! Boolean value that tells if reduction 
-  //  is 'sum' or 'mean'.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class SigmoidCrossEntropy
 

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
@@ -3,7 +3,7 @@
  * @author Kris Singh
  * @author Shikhar Jaiswal
  *
- * Definition of the cross-entropy with logit performance function.
+ * Definition of the cross-entropy with logits performance function.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -54,8 +54,14 @@ class SigmoidCrossEntropyError
  public:
   /**
    * Create the SigmoidCrossEntropyError object.
-   */
-  SigmoidCrossEntropyError();
+   *
+   * @param reduction Specifies the reduction to apply to the output. If false,
+   *                  'mean' reduction is used, where sum of the output will be
+   *                  divided by the number of elements in the output. If true,
+   *                  'sum' reduction is used and the output will be summed. It
+   *                  is set to true by default.
+   */                  
+  SigmoidCrossEntropyError(const bool reduction = true);
 
   /**
    * Computes the Sigmoid CrossEntropy Error functions.
@@ -87,6 +93,11 @@ class SigmoidCrossEntropyError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
+  //! Get the type of reduction used.
+  bool Reduction() const { return reduction; }
+  //! Modify the type of reduction used.
+  bool& Reduction() { return reduction; }
+
   /**
    * Serialize the layer.
    */
@@ -96,6 +107,10 @@ class SigmoidCrossEntropyError
  private:
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
+
+  //! Boolean value that tells if reduction 
+  //  is 'sum' or 'mean'.
+  bool reduction;
 }; // class SigmoidCrossEntropy
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
@@ -93,7 +93,8 @@ class SigmoidCrossEntropyError
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
@@ -42,8 +42,7 @@ SigmoidCrossEntropyError<InputDataType, OutputDataType>::Forward(
         std::log(1 + std::exp(-std::abs(prediction[i])));
   }
 
-  ElemType lossSum = 
-    maximum - arma::accu(prediction % target);
+  ElemType lossSum = maximum - arma::accu(prediction % target);
 
   if (reduction)
     return lossSum;

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
@@ -22,7 +22,7 @@ namespace ann /** Artificial Neural Network. */ {
 
 template<typename InputDataType, typename OutputDataType>
 SigmoidCrossEntropyError<InputDataType, OutputDataType>
-::SigmoidCrossEntropyError()
+::SigmoidCrossEntropyError(const bool reduction): reduction(reduction)
 {
   // Nothing to do here.
 }
@@ -42,7 +42,13 @@ SigmoidCrossEntropyError<InputDataType, OutputDataType>::Forward(
         std::log(1 + std::exp(-std::abs(prediction[i])));
   }
 
-  return maximum - arma::accu(prediction % target);
+  ElemType lossSum = 
+    maximum - arma::accu(prediction % target);
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
@@ -53,15 +59,18 @@ inline void SigmoidCrossEntropyError<InputDataType, OutputDataType>::Backward(
     LossType& loss)
 {
   loss = 1.0 / (1.0 + arma::exp(-prediction)) - target;
+
+  if (!reduction)
+    loss = loss / target.n_elem;
 }
 
 template<typename InputDataType, typename OutputDataType>
 template<typename Archive>
 void SigmoidCrossEntropyError<InputDataType, OutputDataType>::serialize(
-    Archive& /* ar */,
+    Archive& ar ,
     const uint32_t /* version */)
 {
-  // Nothing to do here
+  ar(CEREAL_NVP(reduction));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/loss_functions/soft_margin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/soft_margin_loss.hpp
@@ -90,7 +90,7 @@ class SoftMarginLoss
   //! Locally-stored output parameter object.
   OutputDataType outputParameter;
 
-  //! The boolean value that tells if reduction is sum or mean.
+  //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
 }; // class SoftMarginLoss
 

--- a/src/mlpack/methods/ann/loss_functions/soft_margin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/soft_margin_loss.hpp
@@ -74,7 +74,8 @@ class SoftMarginLoss
   //! Modify the output parameter.
   OutputDataType& OutputParameter() { return outputParameter; }
 
-  //! Get the type of reduction used.
+  //! Get the reduction type, represented as boolean
+  //! (false 'mean' reduction, true 'sum' reduction).
   bool Reduction() const { return reduction; }
   //! Modify the type of reduction used.
   bool& Reduction() { return reduction; }

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -837,7 +837,7 @@ TEST_CASE("CosineEmbeddingLossTest", "[LossFunctionsTest]")
   REQUIRE(arma::accu(output) == Approx(-0.36649111).epsilon(1e-3));
 
   // Check Output for mean type of reduction.
-  CosineEmbeddingLoss<> module3(0.0, true, true);
+  CosineEmbeddingLoss<> module3(0.0, true, false);
   loss = module3.Forward(input3, input4);
   REQUIRE(loss == Approx(0.092325).epsilon(1e-3));
 
@@ -848,7 +848,7 @@ TEST_CASE("CosineEmbeddingLossTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module3.Backward(input3, input4, output);
-  REQUIRE(arma::accu(output) == Approx(0.36649111).epsilon(1e-4));
+  REQUIRE(arma::accu(output) == Approx(0.0236749374).epsilon(1e-4));
 }
 
 /*

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -1265,3 +1265,51 @@ TEST_CASE("MultiLabelSoftMarginLossWeightedTest", "[LossFunctionsTest]")
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
 }
+
+/**
+ * Simple Negative Log Likelihood Loss test.
+ */
+TEST_CASE("NegativeLogLikelihoodLossTest", "[LossFunctionsTest]")
+{
+  arma::mat input, target, output;
+  arma::mat expectedOutput;
+  double loss;
+  NegativeLogLikelihood<> module;
+
+  // Test for sum reduction.
+  input = arma::mat("-0.1689 -0.2862 -1.0543 -1.2865 -2.0033 -1.9392 -0.6196 "
+      "-1.4797 -3.8886 -2.2532 -2.1769 -0.7011");
+  target = arma::mat("2 2 1 2");
+  expectedOutput = arma::mat("0 0 0 0 0 0 -1.0000 0 -1.0000 -1.0000 0 -1.0000");
+  input.reshape(4, 3);
+  expectedOutput.reshape(4, 3);
+
+  // Test the Forward function. Loss should be 7.4625.
+  // Value calculated using torch.nn.NLLLoss(reduction='sum').
+  loss = module.Forward(input, target);
+  REQUIRE(loss == Approx(7.4625).epsilon(1e-3));
+
+  // Test the Backward function.
+  module.Backward(input, target, output);
+  REQUIRE(arma::as_scalar(arma::accu(output)) == Approx(-4).epsilon(1e-3));
+  REQUIRE(output.n_rows == input.n_rows);
+  REQUIRE(output.n_cols == input.n_cols);
+  CheckMatrices(output, expectedOutput, 0.1);
+
+  // Test for mean reduction by modifying reduction parameter using accessor.
+  module.Reduction() = false;
+  expectedOutput = arma::mat("0 0 0 0 0 0 -0.2500 0 -0.2500 -0.2500 0 -0.2500");
+  expectedOutput.reshape(4, 3);
+
+  // Test the Forward function. Loss should be 1.86562.
+  // Value calculated using torch.nn.NLLLoss(reduction='mean').
+  loss = module.Forward(input, target);
+  REQUIRE(loss == Approx(1.86562).epsilon(1e-3));
+
+  // Test the Backward function.
+  module.Backward(input, target, output);
+  REQUIRE(arma::as_scalar(arma::accu(output)) == Approx(-1).epsilon(1e-3));
+  REQUIRE(output.n_rows == input.n_rows);
+  REQUIRE(output.n_cols == input.n_cols);
+  CheckMatrices(output, expectedOutput, 0.1);
+}

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -1277,12 +1277,12 @@ TEST_CASE("NegativeLogLikelihoodLossTest", "[LossFunctionsTest]")
   NegativeLogLikelihood<> module;
 
   // Test for sum reduction.
-  input = arma::mat("-0.1689 -0.2862 -1.0543 -1.2865 -2.0033 -1.9392 -0.6196 "
-      "-1.4797 -3.8886 -2.2532 -2.1769 -0.7011");
+  input = arma::mat("-0.1689 -2.0033 -3.8886 -0.2862 -1.9392 -2.2532"
+      " -1.0543 -0.6196 -2.1769 -1.2865 -1.4797 -0.7011");
   target = arma::mat("2 2 1 2");
-  expectedOutput = arma::mat("0 0 0 0 0 0 -1.0000 0 -1.0000 -1.0000 0 -1.0000");
-  input.reshape(4, 3);
-  expectedOutput.reshape(4, 3);
+  expectedOutput = arma::mat("0 0 -1.0000 0 0 -1.0000 0 -1.0000 0 0 0 -1.0000");
+  input.reshape(3, 4);
+  expectedOutput.reshape(3, 4);
 
   // Test the Forward function. Loss should be 7.4625.
   // Value calculated using torch.nn.NLLLoss(reduction='sum').
@@ -1298,8 +1298,8 @@ TEST_CASE("NegativeLogLikelihoodLossTest", "[LossFunctionsTest]")
 
   // Test for mean reduction by modifying reduction parameter using accessor.
   module.Reduction() = false;
-  expectedOutput = arma::mat("0 0 0 0 0 0 -0.2500 0 -0.2500 -0.2500 0 -0.2500");
-  expectedOutput.reshape(4, 3);
+  expectedOutput = arma::mat("0 0 -0.2500 0 0 -0.2500 0 -0.2500 0 0 0 -0.2500");
+  expectedOutput.reshape(3, 4);
 
   // Test the Forward function. Loss should be 1.86562.
   // Value calculated using torch.nn.NLLLoss(reduction='mean').

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -325,8 +325,8 @@ TEST_CASE("SimpleMeanSquaredErrorTest", "[LossFunctionsTest]")
 TEST_CASE("SimpleBinaryCrossEntropyLossTest", "[LossFunctionsTest]")
 {
   arma::mat input1, input2, input3, output, target1, target2, target3;
-  BCELoss<> module1(1e-6, false);
-  BCELoss<> module2(1e-6, true);
+  BCELoss<> module1(1e-6, true);
+  BCELoss<> module2(1e-6, false);
   // Test the Forward function on a user generator input and compare it against
   // the manually calculated result.
   input1 = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5");

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -275,9 +275,9 @@ TEST_CASE("SimpleMeanSquaredLogarithmicErrorTest", "[LossFunctionsTest]")
 TEST_CASE("SimpleMeanSquaredErrorTest", "[LossFunctionsTest]")
 {
   arma::mat input, output, target;
-  MeanSquaredError<> module;
+  MeanSquaredError<> module(false);
 
-  // Test the Forward function on a user generator input and compare it against
+  // Test the Forward function on a user generated input and compare it against
   // the manually calculated result.
   input = arma::mat("1.0 0.0 1.0 0.0 -1.0 0.0 -1.0 0.0");
   target = arma::zeros(1, 8);
@@ -298,6 +298,19 @@ TEST_CASE("SimpleMeanSquaredErrorTest", "[LossFunctionsTest]")
   target = arma::mat("3");
   error = module.Forward(input, target);
   REQUIRE(error == 1.0);
+
+  // Test the Backward function on a single input.
+  module.Backward(input, target, output);
+  // Test whether the output is negative.
+  REQUIRE(arma::accu(output) == -2);
+  REQUIRE(output.n_elem == 1);
+
+  // Test for sum reduction
+  module.Reduction() = true;
+
+  // Test the Forward function
+  error = module.Forward(input, target);
+  REQUIRE(error == Approx(1.0).epsilon(1e-5));
 
   // Test the Backward function on a single input.
   module.Backward(input, target, output);

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -108,10 +108,10 @@ TEST_CASE("PoissonNLLLossTest", "[LossFunctionsTest]")
   arma::mat input, target, input4, target4;
   arma::mat output1, output2, output3, output4;
   arma::mat expOutput1, expOutput2, expOutput3, expOutput4;
-  PoissonNLLLoss<> module1;
-  PoissonNLLLoss<> module2(true, true, 1e-08, false);
-  PoissonNLLLoss<> module3(true, true, 1e-08, true);
-  PoissonNLLLoss<> module4(false, true, 1e-08, true);
+  PoissonNLLLoss<> module1(true, false, 1e-8, false);
+  PoissonNLLLoss<> module2(true, true, 1e-08, true);
+  PoissonNLLLoss<> module3(true, true, 1e-08, false);
+  PoissonNLLLoss<> module4(false, true, 1e-08, false);
 
   // Test the Forward function on a user generated input.
   input = arma::mat("1.0 1.0 1.9 1.6 -1.9 3.7 -1.0 0.5");

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -667,35 +667,25 @@ TEST_CASE("HingeEmbeddingLossTest", "[LossFunctionsTest]")
  */
 TEST_CASE("SimpleL1LossTest", "[LossFunctionsTest]")
 {
-  arma::mat input1, input2, output, target1, target2;
-  L1Loss<> module(false);
+  arma::mat input, output, target;
+  double loss;
+  L1Loss<> module(true);
 
   // Test the Forward function on a user generator input and compare it against
   // the manually calculated result.
-  input1 = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5 0.5");
-  target1 = arma::zeros(1, 7);
-  double error1 = module.Forward(input1, target1);
-  REQUIRE(error1 == 3.5);
-
-  input2 = arma::mat("0 1 1 0 1 0 0 1");
-  target2 = arma::mat("0 1 1 0 1 0 0 1");
-  double error2 = module.Forward(input2, target2);
-  REQUIRE(error2 == Approx(0.0).epsilon(1e-5));
+  input = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5 0.5");
+  target = arma::zeros(1, 7);
+  loss = module.Forward(input, target);
+  // Value calculated using torch.nn.L1Loss(reduction='sum').
+  REQUIRE(loss == 3.5);
 
   // Test the Backward function.
-  module.Backward(input1, target1, output);
+  module.Backward(input, target, output);
   for (double el : output)
     REQUIRE(el  == 1);
 
-  REQUIRE(output.n_rows == input1.n_rows);
-  REQUIRE(output.n_cols == input1.n_cols);
-
-  module.Backward(input2, target2, output);
-  for (double el : output)
-    REQUIRE(el == 0);
-
-  REQUIRE(output.n_rows == input2.n_rows);
-  REQUIRE(output.n_cols == input2.n_cols);
+  REQUIRE(output.n_rows == input.n_rows);
+  REQUIRE(output.n_cols == input.n_cols);
 }
 
 /**

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -643,15 +643,29 @@ TEST_CASE("LogCoshLossTest", "[LossFunctionsTest]")
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
 
-  // Test the Forward function. Loss should be 0.546621.
+  // Test for sum reduction
   input = arma::mat("1 2 3 4 5");
   target = arma::mat("1 2.4 3.4 4.2 5.5");
+  // Test the Forward function. Loss should be 0.546621.
   loss = module.Forward(input, target);
   REQUIRE(loss == Approx(0.546621).epsilon(1e-3));
 
   // Test the Backward function.
   module.Backward(input, target, output);
   REQUIRE(arma::accu(output) == Approx(2.46962).epsilon(1e-3));
+  REQUIRE(output.n_rows == input.n_rows);
+  REQUIRE(output.n_cols == input.n_cols);
+
+    // Test for mean reduction by modifying reduction parameter using accessor.
+  module.Reduction() = false;
+
+  // Test the Forward function. Loss should be 0.109324.
+  loss = module.Forward(input, target);
+  REQUIRE(loss == Approx(0.109324).epsilon(1e-3));
+
+  // Test the Backward function.
+  module.Backward(input, target, output);
+  REQUIRE(arma::accu(output) == Approx(0.49392).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
 }

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -640,38 +640,51 @@ TEST_CASE("LogCoshLossTest", "[LossFunctionsTest]")
  */
 TEST_CASE("HingeEmbeddingLossTest", "[LossFunctionsTest]")
 {
-  arma::mat input, target, output;
+  arma::mat input, target, output, expectedOutput;
   double loss;
   HingeEmbeddingLoss<> module;
 
-  // Test the Forward function. Loss should be 0 if input = target.
-  input = arma::ones(10, 1);
-  target = arma::ones(10, 1);
+  // Test for sum reduction
+  input = arma::mat("0.1778 0.0957 0.1397 0.2256 0.1203 0.2403 0.1925 0.3144 "
+      "-0.2264 -0.3400 -0.3336 -0.8695");
+  target = arma::mat("1 1 -1 1 1 -1 1 1 -1 1 1 1");
+  expectedOutput = arma::mat("1 1 -1 1 1 -1 1 1 -1 1 1 1");
+  input.reshape(4, 3);
+  target.reshape(4, 3);
+  expectedOutput.reshape(4, 3);
+
+  // Test the forward function
+  // Loss should be 2.4296
+  // Value calculated using torch.nn.HingeEmbeddingLoss(reduction='sum')
   loss = module.Forward(input, target);
-  REQUIRE(loss == 0);
+  REQUIRE(loss == Approx(2.4296).epsilon(1e-3));
 
-  // Test the Backward function for input = target.
+  // Test the Backward function
   module.Backward(input, target, output);
-  for (double el : output)
-  {
-    // For input = target we should get 0.0 everywhere.
-    REQUIRE(el == Approx(0.0).epsilon(1e-5));
-  }
-
+  REQUIRE(arma::as_scalar(arma::accu(output)) == Approx(6).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
+  CheckMatrices(output, expectedOutput, 1e-3);
 
-  // Test the Forward function. Loss should be 0.84.
-  input = arma::mat("0.1 0.8 0.6 0.0 0.5");
-  target = arma::mat("0 1.0 1.0 0 0");
+  // Test for mean reduction by modifying reduction
+  // parameter through the accessor.
+  module.Reduction() = false;
+  expectedOutput = arma::mat("0.0833 0.0833 -0.0833 0.0833 0.0833 -0.0833 "
+    "0.0833 0.0833 -0.0833 0.0833 0.0833 0.0833");
+  expectedOutput.reshape(4, 3);
+
+  // Test the forward function
+  // Loss should be 0.202467
+  // Value calculated using torch.nn.HingeEmbeddingLoss(reduction='mean')
   loss = module.Forward(input, target);
-  REQUIRE(loss == Approx(0.84).epsilon(1e-3));
+  REQUIRE(loss == Approx(0.202467).epsilon(1e-3));
 
-  // Test the Backward function.
+  // Test the backward function
   module.Backward(input, target, output);
-  REQUIRE(arma::accu(output) == Approx(-2).epsilon(1e-3));
+  REQUIRE(arma::as_scalar(arma::accu(output)) == Approx(0.5).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
+  CheckMatrices(output, expectedOutput, 0.1);
 }
 
 /**

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -224,33 +224,49 @@ TEST_CASE("SimpleKLDivergenceTest", "[LossFunctionsTest]")
  */
 TEST_CASE("SimpleMeanSquaredLogarithmicErrorTest", "[LossFunctionsTest]")
 {
-  arma::mat input, output, target;
+    arma::mat input, target, output, expectedOutput;
+  double loss;
   MeanSquaredLogarithmicError<> module;
 
-  // Test the Forward function on a user generator input and compare it against
-  // the manually calculated result.
-  input = arma::zeros(1, 8);
-  target = arma::zeros(1, 8);
-  double error = module.Forward(input, target);
-  REQUIRE(error == Approx(0.0).margin(1e-5));
+  // Test for sum reduction.
+  input = arma::mat("-0.0494 1.1958 1.0486 -0.2121 1.6028 0.0737 -0.7091 "
+      "0.8612 0.9639 0.9648 0.0745 0.5924");
+  target = arma::mat("0.4316 0.0164 -0.4478 1.1452 0.5106 0.9255 0.5571 0.0864 "
+      "0.7059 -0.8288 -0.0231 1.0526");
+  expectedOutput = arma::mat("-0.8615 0.7016 1.2799 -2.5425 0.4181 -1.0880 "
+      "-11.5339 0.5785 0.1434 2.4840 0.1772 -0.3188");
+  input.reshape(4, 3);
+  target.reshape(4, 3);
+  expectedOutput.reshape(4, 3);
+
+  // Test the Forward function. Loss should be 13.2728.
+  loss = module.Forward(input, target);
+  REQUIRE(loss == Approx(13.2728).epsilon(1e-3));
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  // The output should be equal to 0.
-  CheckMatrices(input, output);
+  REQUIRE(arma::as_scalar(arma::accu(output)) == Approx(-10.5619).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
+  CheckMatrices(output, expectedOutput, 0.1);
 
-  // Test the error function on a single input.
-  input = arma::mat("2");
-  target = arma::mat("3");
-  error = module.Forward(input, target);
-  REQUIRE(error == Approx(0.082760974810151655).epsilon(1e-3));
+  // Test for mean reduction by modifying reduction parameter using accessor.
+  module.Reduction() = false;
+  expectedOutput = arma::mat("-0.0718 0.0585 0.1067 -0.2119 0.0348 -0.0907 "
+      "-0.9612 0.0482 0.0120 0.2070 0.0148 -0.0266");
+  expectedOutput.reshape(4, 3);
 
-  // Test the Backward function on a single input.
+  // Test the Forward function. Loss should be 1.10606.
+  loss = module.Forward(input, target);
+  REQUIRE(loss == Approx(1.10606).epsilon(1e-3));
+
+  // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(arma::accu(output) == Approx(-0.1917880483011872).epsilon(1e-3));
-  REQUIRE(output.n_elem == 1);
+  REQUIRE(arma::as_scalar(arma::accu(output)) ==
+      Approx(-0.880156).epsilon(1e-3));
+  REQUIRE(output.n_rows == input.n_rows);
+  REQUIRE(output.n_cols == input.n_cols);
+  CheckMatrices(output, expectedOutput, 0.1);
 }
 
 /*


### PR DESCRIPTION
This PR aims to fix the bugs in ANN loss functions as pointed out in #2444.

- [x] L1 Loss.
- [x] Mean Bias Error.
- [x] Hinge Embedding Loss.
- [x] Huber Loss.
- [x] KL divergence.
- [x] Margin Ranking Loss.
- [x] Cosine Embedding Loss.
- [ ] Dice Loss : doens't make sense to add 'mean' reduction to this.
- [x] Earth Mover Distance.
- [x] Hinge Loss: correct implementation & reduction also already implemented.
- [x] Log cosh loss.
- [ ]  Mean Absolute Percentage Error: doens't make sense to add 'sum' reduction to this. Pytorch computes 'mean' & 'sqrt mean'.
- [x] Mean squared Error.
- [x] Soft Magin Loss: correct implementation & reduction also already implemented.
- [x] Multi Label SoftMargin Loss: correct implementation & reduction already implemented. 
- [x] Mean squared logarithmic Error.
- [x] NLL loss.
- [x] Poisson NLL loss.
- [x] Binary Cross Entropy Loss.
- [x] Reconstruction Loss.
- [x] Sigmoid Cross Entropy Loss.
- [ ] Triplet Margin Loss.