### PR TITLE
NaiveConvolution stride and dilation fix

### DIFF
--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -57,9 +57,16 @@ class NaiveConvolution
               const size_t dilationW = 1,
               const size_t dilationH = 1)
   {
-    output = arma::zeros<arma::Mat<eT> >(
-        (input.n_rows - (filter.n_rows - 1) * dilationW - 1) / dW + 1,
-        (input.n_cols - (filter.n_cols - 1) * dilationH -  1) / dH + 1);
+    // Compute the output size.  The filterRows and filterCols computation must
+    // take into account the fact that dilation only adds rows or columns
+    // *between* filter elements.  So, e.g., a dilation of 2 on a kernel size of
+    // 3x3 means an effective kernel size of 5x5, *not* 6x6.
+    // TODO before PR: H vs. W nomenclature?
+    const size_t filterRows = filter.n_rows * dilationH - (dilationH - 1);
+    const size_t filterCols = filter.n_cols * dilationW - (dilationW - 1);
+    const size_t outputRows = (input.n_rows - filterRows + dH) / dH;
+    const size_t outputCols = (input.n_cols - filterCols + dW) / dW;
+    output.zeros(outputRows, outputCols);
 
     // It seems to be about 3.5 times faster to use pointers instead of
     // filter(ki, kj) * input(leftInput + ki, topInput + kj) and output(i, j).
@@ -72,6 +79,7 @@ class NaiveConvolution
         const eT* kernelPtr = filter.memptr();
         for (size_t kj = 0; kj < filter.n_cols; ++kj)
         {
+          // TODO: what if we go out of the bounds of `input` here?
           const eT* inputPtr = input.colptr(kj * dilationW + j * dW) + i * dH;
           for (size_t ki = 0; ki < filter.n_rows; ++ki, ++kernelPtr,
               inputPtr += dilationH)
@@ -103,37 +111,22 @@ class NaiveConvolution
               const size_t dilationW = 1,
               const size_t dilationH = 1)
   {
-    size_t outputRows = (input.n_rows - 1) * dW + 2 * (filter.n_rows - 1)
-        * dilationW + 1;
-    size_t outputCols = (input.n_cols - 1) * dH + 2 * (filter.n_cols - 1)
-        * dilationH + 1;
-
-    for (size_t i = 0; i < dW; ++i)
-    {
-      if (((((i + outputRows - 2 * (filter.n_rows - 1) * dilationW - 1) % dW)
-          + dW) % dW) == i){
-        outputRows += i;
-        break;
-      }
-    }
-    for (size_t i = 0; i < dH; ++i)
-    {
-      if (((((i + outputCols - 2 * (filter.n_cols - 1) * dilationH - 1) % dH)
-          + dH) % dH) == i){
-        outputCols += i;
-        break;
-      }
-    }
+    // First, compute the necessary padding for the full convolution.  It is
+    // possible that this might be an overestimate.  Note that these variables
+    // only hold the padding on one side of the input.
+    const size_t filterRows = filter.n_rows * dilationH - (dilationH - 1);
+    const size_t filterCols = filter.n_cols * dilationW - (dilationW - 1);
+    const size_t paddingRows = filterRows - 1;
+    const size_t paddingCols = filterCols - 1;
 
     // Pad filter and input to the working output shape.
-    arma::Mat<eT> inputPadded = arma::zeros<arma::Mat<eT> >(outputRows,
-        outputCols);
-    inputPadded.submat((filter.n_rows - 1) * dilationW, (filter.n_cols - 1)
-        * dilationH, (filter.n_rows - 1) * dilationW + input.n_rows - 1,
-        (filter.n_cols - 1) * dilationH + input.n_cols - 1) = input;
+    arma::Mat<eT> inputPadded(input.n_rows + 2 * paddingRows,
+        input.n_cols + 2 * paddingCols, arma::fill::zeros);
+    inputPadded.submat(paddingRows, paddingCols, paddingRows + input.n_rows - 1,
+        paddingCols + input.n_cols - 1) = input;
 
     NaiveConvolution<ValidConvolution>::Convolution(inputPadded, filter,
-        output, 1, 1, dilationW, dilationH);
+        output, dW, dH, dilationW, dilationH);
   }
 
   /*

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -61,7 +61,6 @@ class NaiveConvolution
     // take into account the fact that dilation only adds rows or columns
     // *between* filter elements.  So, e.g., a dilation of 2 on a kernel size of
     // 3x3 means an effective kernel size of 5x5, *not* 6x6.
-    // TODO before PR: H vs. W nomenclature?
     const size_t filterRows = filter.n_rows * dilationH - (dilationH - 1);
     const size_t filterCols = filter.n_cols * dilationW - (dilationW - 1);
     const size_t outputRows = (input.n_rows - filterRows + dH) / dH;
@@ -79,7 +78,6 @@ class NaiveConvolution
         const eT* kernelPtr = filter.memptr();
         for (size_t kj = 0; kj < filter.n_cols; ++kj)
         {
-          // TODO: what if we go out of the bounds of `input` here?
           const eT* inputPtr = input.colptr(kj * dilationW + j * dW) + i * dH;
           for (size_t ki = 0; ki < filter.n_rows; ++ki, ++kernelPtr,
               inputPtr += dilationH)

--- a/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/atrous_convolution_impl.hpp
@@ -288,7 +288,8 @@ void AtrousConvolution<
       Rotate180(weight.slice(outMapIdx), rotatedFilter);
 
       BackwardConvolutionRule::Convolution(mappedError.slice(outMap),
-          rotatedFilter, output, 1, 1, 1, 1);
+          rotatedFilter, output, 1, 1, (dilationWidth - strideWidth + 1),
+          (dilationHeight - strideHeight + 1));
 
       // If the stride is greater than 1, we must manually insert zeros into the
       // output.

--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -2872,7 +2872,7 @@ TEST_CASE("SimpleAtrousConvolutionLayerTest", "[ANNLayerTest]")
   module1.Parameters()(8) = 2.0;
   module1.Reset();
   module1.Forward(input, output);
-  // Value calculated using tensorflow.nn.atrous_conv2d()
+  // Value calculated using tensorflow.nn.atrous_conv2d() and also by hand.
   REQUIRE(arma::accu(output) == 792.0);
 
   // Test the Backward function.


### PR DESCRIPTION
This is related to #2986 and, while it may not solve that code snippet entirely, should address the underlying issue.

I wrote some simple test cases for non-1 stride and dilation parameters in `convolution_test.cpp` and found that they failed.  So, I started going through the implementation and found some minor issues in how strides and dilation were handled.

It also seems like there is some ambiguity in what `dW` and `dH` should represent.  `dW` is documented as "stride of the filter application in the X direction"---but that should mean that a `dW` greater than 1 implies a different number of *columns* in the output, not a different number of rows.  I changed the implementation to match that understanding.

In any case, it's likely that the code in #2986 will still fail because this is only a fix for the underlying convolution operation, and not the `Convolution<>` layer.  I will fix the code snippet in #2986---but only as part of #2777 (I won't backport it to the boost::visitor implementation in `master`).