### PR TITLE
Added Size checks for Matrix Completion, Kmeans and Linear Regression

### DIFF
--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -33,7 +33,7 @@ inline void CheckSameSizes(const DataType& data,
                            const std::string& callerDescription,
                            const std::string& addInfo = "labels")
 {
-  Log::Assert( label.is_rowvec() == true, "Label matrix should be a row vector \
+  Log::Assert( label.is_rowvec(), "Label matrix should be a row vector \
       .");
 
   if (data.n_cols != label.n_cols)

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -33,6 +33,9 @@ inline void CheckSameSizes(const DataType& data,
                            const std::string& callerDescription,
                            const std::string& addInfo = "labels")
 {
+  Log::Assert( label.is_rowvec() == true, "Label matrix should be a row vector \
+      .");
+
   if (data.n_cols != label.n_cols)
   {
     std::ostringstream oss;

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -26,48 +26,30 @@ namespace util {
  *     error generation.
  * @param addInfo Name to use for labels for precise error generation. Default
  *     is "labels"; for example, "weights" could also be used.
+ * @param isDataTranspose Bool parameter which can be set true to transpose data
+ *     before size-check. Default is false.
+ * @param isLabelTranspose Bool parameter which can be set true to transpose label
+ *     before size-check. Default is false.
  */
 template<typename DataType, typename LabelsType>
 inline void CheckSameSizes(const DataType& data,
                            const LabelsType& label,
                            const std::string& callerDescription,
                            const std::string& addInfo = "labels",
-                           const std::string& isTranspose = "none")
+                           const bool& isDataTranspose = false,
+                           const bool& isLabelTranspose = false)
 { 
-  if (isTranspose == "data")
-  {
-    if (data.n_rows != label.n_cols)
-    {
-      std::ostringstream oss;
-      oss << callerDescription << ": number of points (" << data.n_cols << ") "
-          << "does not match number of " << addInfo << " (" << label.n_cols
-          << ")!" << std::endl;
-      throw std::invalid_argument(oss.str());
-    }
-  }
-  else if (isTranspose == "label")
-  {
-    if (data.n_cols != label.n_rows)
-    {
-      std::ostringstream oss;
-      oss << callerDescription << ": number of points (" << data.n_cols << ") "
-          << "does not match number of " << addInfo << " (" << label.n_cols
-          << ")!" << std::endl;
-      throw std::invalid_argument(oss.str());
-    }
-  }
-  else
-  {
-    if (data.n_cols != label.n_cols)
-    {
-      std::ostringstream oss;
-      oss << callerDescription << ": number of points (" << data.n_cols << ") "
-          << "does not match number of " << addInfo << " (" << label.n_cols
-          << ")!" << std::endl;
-      throw std::invalid_argument(oss.str());
-    }
-  }
+  const size_t dataPoints = (isDataTranspose == true) ? data.n_rows : data.n_cols;
+  const size_t labelPoints = (isLabelTranspose == true) ? label.n_rows : label.n_cols;
   
+  if (dataPoints != labelPoints)
+  {
+    std::ostringstream oss;
+    oss << callerDescription << ": number of points (" << dataPoints << ") "
+        << "does not match number of " << addInfo << " (" << labelPoints
+        << ")!" << std::endl;
+    throw std::invalid_argument(oss.str());
+  }
 }
 
 /**

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -13,7 +13,6 @@
 #ifndef MLPACK_UTIL_SIZE_CHECKS_HPP
 #define MLPACK_UTIL_SIZE_CHECKS_HPP
 
-#include "log.hpp"
 
 namespace mlpack {
 namespace util {
@@ -34,8 +33,6 @@ inline void CheckSameSizes(const DataType& data,
                            const std::string& callerDescription,
                            const std::string& addInfo = "labels")
 {
-  Log::Assert( label.is_rowvec(), "Label matrix should be a row vector.");
-
   if (data.n_cols != label.n_cols)
   {
     std::ostringstream oss;

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -31,16 +31,43 @@ template<typename DataType, typename LabelsType>
 inline void CheckSameSizes(const DataType& data,
                            const LabelsType& label,
                            const std::string& callerDescription,
-                           const std::string& addInfo = "labels")
-{
-  if (data.n_cols != label.n_cols)
+                           const std::string& addInfo = "labels",
+                           const std::string& isTranspose = "none")
+{ 
+  if (isTranspose == "data")
   {
-    std::ostringstream oss;
-    oss << callerDescription << ": number of points (" << data.n_cols << ") "
-        << "does not match number of " << addInfo << " (" << label.n_cols
-        << ")!" << std::endl;
-    throw std::invalid_argument(oss.str());
+    if (data.n_rows != label.n_cols)
+    {
+      std::ostringstream oss;
+      oss << callerDescription << ": number of points (" << data.n_cols << ") "
+          << "does not match number of " << addInfo << " (" << label.n_cols
+          << ")!" << std::endl;
+      throw std::invalid_argument(oss.str());
+    }
   }
+  else if (isTranspose == "label")
+  {
+    if (data.n_cols != label.n_rows)
+    {
+      std::ostringstream oss;
+      oss << callerDescription << ": number of points (" << data.n_cols << ") "
+          << "does not match number of " << addInfo << " (" << label.n_cols
+          << ")!" << std::endl;
+      throw std::invalid_argument(oss.str());
+    }
+  }
+  else
+  {
+    if (data.n_cols != label.n_cols)
+    {
+      std::ostringstream oss;
+      oss << callerDescription << ": number of points (" << data.n_cols << ") "
+          << "does not match number of " << addInfo << " (" << label.n_cols
+          << ")!" << std::endl;
+      throw std::invalid_argument(oss.str());
+    }
+  }
+  
 }
 
 /**

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -13,6 +13,7 @@
 #ifndef MLPACK_UTIL_SIZE_CHECKS_HPP
 #define MLPACK_UTIL_SIZE_CHECKS_HPP
 
+#include "log.hpp"
 
 namespace mlpack {
 namespace util {
@@ -33,8 +34,7 @@ inline void CheckSameSizes(const DataType& data,
                            const std::string& callerDescription,
                            const std::string& addInfo = "labels")
 {
-  Log::Assert( label.is_rowvec(), "Label matrix should be a row vector \
-      .");
+  Log::Assert( label.is_rowvec(), "Label matrix should be a row vector.");
 
   if (data.n_cols != label.n_cols)
   {

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -27,6 +27,7 @@
 #define MLPACK_METHODS_ADABOOST_ADABOOST_IMPL_HPP
 
 #include "adaboost.hpp"
+#include <mlpack/core/util/size_checks.hpp>
 
 namespace mlpack {
 namespace adaboost {
@@ -71,6 +72,9 @@ double AdaBoost<WeakLearnerType, MatType>::Train(
     const size_t iterations,
     const double tolerance)
 {
+  // Sanity check on data
+  util::CheckSameDimensionality(data, labels, "Adaboost::Train()");
+
   // Clear information from previous runs.
   wl.clear();
   alpha.clear();
@@ -242,7 +246,10 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
     const MatType& test,
     arma::Row<size_t>& predictedLabels,
     arma::mat& probabilities)
-{
+{ 
+  // Sanity Check on Data
+  util::CheckSameDimensionality(test, predictedLabels, "Adaboost::Classify()");
+  
   arma::Row<size_t> tempPredictedLabels(test.n_cols);
 
   probabilities.zeros(numClasses, test.n_cols);

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -72,8 +72,6 @@ double AdaBoost<WeakLearnerType, MatType>::Train(
     const size_t iterations,
     const double tolerance)
 {
-  // Sanity check on data
-  util::CheckSameSizes(data, labels, "Adaboost::Train()");
 
   // Clear information from previous runs.
   wl.clear();
@@ -247,8 +245,6 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
     arma::Row<size_t>& predictedLabels,
     arma::mat& probabilities)
 { 
-  // Sanity Check on Data
-  util::CheckSameSizes(test, predictedLabels, "Adaboost::Classify()");
   
   arma::Row<size_t> tempPredictedLabels(test.n_cols);
 

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -27,7 +27,6 @@
 #define MLPACK_METHODS_ADABOOST_ADABOOST_IMPL_HPP
 
 #include "adaboost.hpp"
-#include <mlpack/core/util/size_checks.hpp>
 
 namespace mlpack {
 namespace adaboost {
@@ -72,7 +71,6 @@ double AdaBoost<WeakLearnerType, MatType>::Train(
     const size_t iterations,
     const double tolerance)
 {
-
   // Clear information from previous runs.
   wl.clear();
   alpha.clear();
@@ -244,8 +242,7 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
     const MatType& test,
     arma::Row<size_t>& predictedLabels,
     arma::mat& probabilities)
-{ 
-  
+{
   arma::Row<size_t> tempPredictedLabels(test.n_cols);
 
   probabilities.zeros(numClasses, test.n_cols);

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -73,7 +73,7 @@ double AdaBoost<WeakLearnerType, MatType>::Train(
     const double tolerance)
 {
   // Sanity check on data
-  util::CheckSameDimensionality(data, labels, "Adaboost::Train()");
+  util::CheckSameSizes(data, labels, "Adaboost::Train()");
 
   // Clear information from previous runs.
   wl.clear();
@@ -248,7 +248,7 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
     arma::mat& probabilities)
 { 
   // Sanity Check on Data
-  util::CheckSameDimensionality(test, predictedLabels, "Adaboost::Classify()");
+  util::CheckSameSizes(test, predictedLabels, "Adaboost::Classify()");
   
   arma::Row<size_t> tempPredictedLabels(test.n_cols);
 

--- a/src/mlpack/methods/kmeans/kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/kmeans_impl.hpp
@@ -16,7 +16,6 @@
 #include <mlpack/core/util/sfinae_utility.hpp>
 #include <mlpack/core/util/size_checks.hpp>
 
-
 namespace mlpack {
 namespace kmeans {
 

--- a/src/mlpack/methods/kmeans/kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/kmeans_impl.hpp
@@ -14,6 +14,8 @@
 
 #include <mlpack/core/metrics/lmetric.hpp>
 #include <mlpack/core/util/sfinae_utility.hpp>
+#include <mlpack/core/util/size_checks.hpp>
+
 
 namespace mlpack {
 namespace kmeans {
@@ -161,15 +163,9 @@ Cluster(const MatType& data,
   // Check validity of initial guess.
   if (initialGuess)
   {
-    if (centroids.n_cols != clusters)
-      Log::Fatal << "KMeans::Cluster(): wrong number of initial cluster "
-        << "centroids (" << centroids.n_cols << ", should be " << clusters
-        << ")!" << std::endl;
+    util::CheckSameSizes(centroids, clusters, "KMeans::Cluster()", "clusters");
 
-    if (centroids.n_rows != data.n_rows)
-      Log::Fatal << "KMeans::Cluster(): initial cluster centroids have wrong "
-        << " dimensionality (" << centroids.n_rows << ", should be "
-        << data.n_rows << ")!" << std::endl;
+    util::CheckSameDimensionality(data, centroids, "KMeans::Cluster()");
   }
 
   // Use the partitioner to come up with the partition assignments and calculate
@@ -288,10 +284,7 @@ Cluster(const MatType& data,
   // Now, the initial assignments.  First determine if they are necessary.
   if (initialAssignmentGuess)
   {
-    if (assignments.n_elem != data.n_cols)
-      Log::Fatal << "KMeans::Cluster(): initial cluster assignments (length "
-          << assignments.n_elem << ") not the same size as the dataset (size "
-          << data.n_cols << ")!" << std::endl;
+    util::CheckSameSizes(data, assignments, "KMeans::Cluster()","assignments");
 
     // Calculate initial centroids.
     arma::Row<size_t> counts;

--- a/src/mlpack/methods/kmeans/kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/kmeans_impl.hpp
@@ -164,7 +164,6 @@ Cluster(const MatType& data,
   if (initialGuess)
   {
     util::CheckSameSizes(centroids, clusters, "KMeans::Cluster()", "clusters");
-
     util::CheckSameDimensionality(data, centroids, "KMeans::Cluster()");
   }
 
@@ -284,7 +283,7 @@ Cluster(const MatType& data,
   // Now, the initial assignments.  First determine if they are necessary.
   if (initialAssignmentGuess)
   {
-    util::CheckSameSizes(data, assignments, "KMeans::Cluster()","assignments");
+    util::CheckSameSizes(data, assignments, "KMeans::Cluster()", "assignments");
 
     // Calculate initial centroids.
     arma::Row<size_t> counts;

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -12,6 +12,7 @@
  */
 #include "linear_regression.hpp"
 #include <mlpack/core/util/log.hpp>
+#include <mlpack/core/util/size_checks.hpp>
 
 using namespace mlpack;
 using namespace mlpack::regression;
@@ -57,6 +58,10 @@ double LinearRegression::Train(const arma::mat& predictors,
   // We store the number of rows and columns of the predictors.
   // Reminder: Armadillo stores the data transposed from how we think of it,
   //           that is, columns are actually rows (see: column major order).
+
+  // Sanity check on data
+  util::CheckSameSizes(predictors, responses, "LinearRegression::Train()");
+
   const size_t nCols = predictors.n_cols;
 
   arma::mat p = predictors;
@@ -95,7 +100,7 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    Log::Assert(points.n_rows == parameters.n_rows - 1);
+    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows-1), "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))
@@ -107,14 +112,17 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in
     // the dataset.
-    Log::Assert(points.n_rows == parameters.n_rows);
+    util::CheckSameDimensionality(points, parameters, "LinearRegression::Predict()", "points");
     predictions = arma::trans(parameters) * points;
   }
 }
 
 double LinearRegression::ComputeError(const arma::mat& predictors,
                                       const arma::rowvec& responses) const
-{
+{ 
+  // Sanity check on data
+  util::CheckSameSizes(predictors, responses, "LinearRegression::Train()");
+  
   // Get the number of columns and rows of the dataset.
   const size_t nCols = predictors.n_cols;
   const size_t nRows = predictors.n_rows;

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,7 +100,8 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows - 1), "LinearRegression::Predict()", "points");
+    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows - 1), 
+        "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))
@@ -112,7 +113,8 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in
     // the dataset.
-    util::CheckSameDimensionality(points, parameters, "LinearRegression::Predict()", "points");
+    util::CheckSameDimensionality(points, parameters, 
+        "LinearRegression::Predict()", "points");
     predictions = arma::trans(parameters) * points;
   }
 }

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,13 +100,9 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    // Warning : If parameters.n_rows is 0, then size_t cast would lead 
-    // it to capture UINT32_MAX. 
-    // You might get error message like this - "mismatch size x and UNIT32_MAX"
-    // Checks to ensures parameters isn't an empty matrix will be added 
-    // after PR #3140  gets merged
-    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows - 1), 
-        "LinearRegression::Predict()", "points");
+    const size_t labels = (parameters.n_rows == 0) ? size_t(0) : size_t(parameters.n_rows - 1);
+    util::CheckSameDimensionality(points, labels, "LinearRegression::Predict()", 
+        "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,6 +100,11 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
+    // Warning : If parameters.n_rows is 0, then size_t cast would lead 
+    // it to capture UINT32_MAX. 
+    // You might get error message like this - "mismatch size x and UNIT32_MAX"
+    // Checks to ensures parameters isn't an empty matrix will be added 
+    // after PR #3140  gets merged
     util::CheckSameDimensionality(points, (size_t) (parameters.n_rows - 1), 
         "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -59,7 +59,7 @@ double LinearRegression::Train(const arma::mat& predictors,
   // Reminder: Armadillo stores the data transposed from how we think of it,
   //           that is, columns are actually rows (see: column major order).
 
-  // Sanity check on data
+  // Sanity check on data.
   util::CheckSameSizes(predictors, responses, "LinearRegression::Train()");
 
   const size_t nCols = predictors.n_cols;
@@ -121,8 +121,8 @@ void LinearRegression::Predict(const arma::mat& points,
 
 double LinearRegression::ComputeError(const arma::mat& predictors,
                                       const arma::rowvec& responses) const
-{ 
-  // Sanity check on data
+{
+  // Sanity check on data.
   util::CheckSameSizes(predictors, responses, "LinearRegression::Train()");
   
   // Get the number of columns and rows of the dataset.

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,7 +100,9 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    const size_t labels = (parameters.n_rows == 0) ? size_t(0) : size_t(parameters.n_rows - 1);
+    // Prevent underflow.
+    const size_t labels = (parameters.n_rows == 0) ? size_t(0) :
+        size_t(parameters.n_rows - 1);
     util::CheckSameDimensionality(points, labels, "LinearRegression::Predict()", 
         "points");
     // Get the predictions, but this ignores the intercept value

--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -100,7 +100,7 @@ void LinearRegression::Predict(const arma::mat& points,
   {
     // We want to be sure we have the correct number of dimensions in the
     // dataset.
-    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows-1), "LinearRegression::Predict()", "points");
+    util::CheckSameDimensionality(points, (size_t) (parameters.n_rows - 1), "LinearRegression::Predict()", "points");
     // Get the predictions, but this ignores the intercept value
     // (parameters[0]).
     predictions = arma::trans(parameters.subvec(1, parameters.n_elem - 1))

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -60,7 +60,7 @@ void MatrixCompletion::CheckValues()
         << "indices does not have 2 rows!" << std::endl;
   }
 
-  util::CheckSameSizes(indices, values, "MatrixCompletion::CheckValues()", "indices");
+  util::CheckSameSizes(indices, (size_t)values.n_rows, "MatrixCompletion::CheckValues()", "values");
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -60,7 +60,8 @@ void MatrixCompletion::CheckValues()
         << "indices does not have 2 rows!" << std::endl;
   }
 
-  util::CheckSameSizes(indices, (size_t)values.n_rows, "MatrixCompletion::CheckValues()", "values");
+  arma::mat transposeValues = values.t();
+  util::CheckSameSizes(indices, transposeValues, "MatrixCompletion::CheckValues()", "values");
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -60,7 +60,7 @@ void MatrixCompletion::CheckValues()
         << "indices does not have 2 rows!" << std::endl;
   }
 
-  util::CheckSameSizes(values, indices, "MatrixCompletion::CheckValues()", "indices");
+  util::CheckSameSizes(indices, values, "MatrixCompletion::CheckValues()", "indices");
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -53,7 +53,7 @@ MatrixCompletion::MatrixCompletion(const size_t m,
 }
 
 void MatrixCompletion::CheckValues()
-{
+{ 
   if (indices.n_rows != 2)
   {
     Log::Fatal << "MatrixCompletion::CheckValues(): matrix of constraint "

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -53,7 +53,7 @@ MatrixCompletion::MatrixCompletion(const size_t m,
 }
 
 void MatrixCompletion::CheckValues()
-{ 
+{
   if (indices.n_rows != 2)
   {
     Log::Fatal << "MatrixCompletion::CheckValues(): matrix of constraint "

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "matrix_completion.hpp"
+#include <mlpack/core/util/size_checks.hpp>
 
 namespace mlpack {
 namespace matrix_completion {
@@ -59,13 +60,7 @@ void MatrixCompletion::CheckValues()
         << "indices does not have 2 rows!" << std::endl;
   }
 
-  if (indices.n_cols != values.n_elem)
-  {
-    Log::Fatal << "MatrixCompletion::CheckValues(): the number of constraint "
-        << "indices (columns of constraint indices matrix) does not match the "
-        << "number of constraint values (length of constraint value vector)!"
-        << std::endl;
-  }
+  util::CheckSameSizes(values, indices, "MatrixCompletion::CheckValues()", "indices");
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -61,7 +61,7 @@ void MatrixCompletion::CheckValues()
   }
 
   util::CheckSameSizes(indices, values, 
-      "MatrixCompletion::CheckValues()", "labels", "label");
+      "MatrixCompletion::CheckValues()", "labels", false, true);
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -60,9 +60,8 @@ void MatrixCompletion::CheckValues()
         << "indices does not have 2 rows!" << std::endl;
   }
 
-  arma::mat transposeValues = values.t();
-  util::CheckSameSizes(indices, transposeValues, 
-      "MatrixCompletion::CheckValues()", "values");
+  util::CheckSameSizes(indices, values, 
+      "MatrixCompletion::CheckValues()", "labels", "label");
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {

--- a/src/mlpack/methods/matrix_completion/matrix_completion.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.cpp
@@ -61,7 +61,8 @@ void MatrixCompletion::CheckValues()
   }
 
   arma::mat transposeValues = values.t();
-  util::CheckSameSizes(indices, transposeValues, "MatrixCompletion::CheckValues()", "values");
+  util::CheckSameSizes(indices, transposeValues, 
+      "MatrixCompletion::CheckValues()", "values");
 
   for (size_t i = 0; i < values.n_elem; ++i)
   {


### PR DESCRIPTION
This pull request aims to solve some tasks in issue #2820 with help of #2370 as discussed in the comments.

Tasks done : 
Added size checks using CheckSameSizes and CheckSameDimensionality utilities in 
- [x] Adaboost
- [x] Matrix Completion
- [x] Kmeans
- [x] Linear Regression

Please review and provide suggestions.