### PR TITLE
Replace boost::heap::priority_queue with std::vector

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -148,6 +148,7 @@ Copyright:
   Copyright 2021, Suvarsha Chennareddy <suvarshachennareddy@gmail.com>
   Copyright 2021, Shubham Agrawal <shubham.agra1206@gmail.com>
   Copyright 2022, Sri Madhan M <srimadhan11@gmail.com>
+  Copyright 2022, Zhuojin Liu <zhuojinliu.cs@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
@@ -93,7 +93,7 @@ CosineTree::CosineTree(const arma::mat& dataset,
   arma::vec tempVector = arma::zeros(dataset.n_rows);
   root.L2Error(-1.0); // We don't know what the error is.
   root.BasisVector(tempVector);
-  treeQueue.push_back(&root); // treeQueue is empty now, so we don't need to call std::push_heap here
+  treeQueue.push_back(&root); // treeQueue is empty now, so we don't need to call std::push_heap here.
 
   // Initialize Monte Carlo error estimate for comparison.
   double monteCarloError = root.FrobNormSquared();

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
@@ -86,13 +86,15 @@ CosineTree::CosineTree(const arma::mat& dataset,
 {
   // Declare the cosine tree priority queue.
   CosineNodeQueue treeQueue;
+  CompareCosineNode comp;
 
   // Define root node of the tree and add it to the queue.
   CosineTree root(dataset);
   arma::vec tempVector = arma::zeros(dataset.n_rows);
   root.L2Error(-1.0); // We don't know what the error is.
   root.BasisVector(tempVector);
-  treeQueue.push(&root);
+  treeQueue.push_back(&root);
+  std::push_heap(treeQueue.begin(), treeQueue.end(), comp);
 
   // Initialize Monte Carlo error estimate for comparison.
   double monteCarloError = root.FrobNormSquared();
@@ -102,8 +104,9 @@ CosineTree::CosineTree(const arma::mat& dataset,
   {
     // Pop node from queue with highest projection error.
     CosineTree* currentNode;
-    currentNode = treeQueue.top();
-    treeQueue.pop();
+    currentNode = treeQueue.front();
+    std::pop_heap(treeQueue.begin(), treeQueue.end());
+    treeQueue.pop_back();
 
     // If the priority is 0, we can't improve anything, and we can assume that
     // we've done the best we can.
@@ -142,8 +145,10 @@ CosineTree::CosineTree(const arma::mat& dataset,
     MonteCarloError(currentRight, treeQueue, &lBasisVector, &rBasisVector);
 
     // Push child nodes into the priority queue.
-    treeQueue.push(currentLeft);
-    treeQueue.push(currentRight);
+    treeQueue.push_back(currentLeft);
+    std::push_heap(treeQueue.begin(), treeQueue.end(), comp);
+    treeQueue.push_back(currentRight);
+    std::push_heap(treeQueue.begin(), treeQueue.end(), comp);
 
     // Calculate Monte Carlo error estimate for the root node.
     monteCarloError = MonteCarloError(&root, treeQueue);
@@ -377,11 +382,11 @@ void CosineTree::ModifiedGramSchmidt(CosineNodeQueue& treeQueue,
 
   // Variables for iterating throught the priority queue.
   CosineTree *currentNode;
-  CosineNodeQueue::const_iterator i = treeQueue.begin();
+  CosineNodeQueue::const_iterator i = treeQueue.cbegin();
 
   // For every vector in the current basis, remove its projection from the
   // centroid.
-  for ( ; i != treeQueue.end(); ++i)
+  for ( ; i != treeQueue.cend(); ++i)
   {
     currentNode = *i;
 
@@ -437,11 +442,11 @@ double CosineTree::MonteCarloError(CosineTree* node,
     projection.zeros(projectionSize);
 
     CosineTree *currentNode;
-    CosineNodeQueue::const_iterator j = treeQueue.begin();
+    CosineNodeQueue::const_iterator j = treeQueue.cbegin();
 
     size_t k = 0;
     // Compute the projection of the sampled vector onto the existing subspace.
-    for ( ; j != treeQueue.end(); ++j, ++k)
+    for ( ; j != treeQueue.cend(); ++j, ++k)
     {
       currentNode = *j;
 
@@ -492,11 +497,11 @@ void CosineTree::ConstructBasis(CosineNodeQueue& treeQueue)
 
   // Variables for iterating through the priority queue.
   CosineTree *currentNode;
-  CosineNodeQueue::const_iterator i = treeQueue.begin();
+  CosineNodeQueue::const_iterator i = treeQueue.cbegin();
 
   // Transfer basis vectors from the queue to the basis matrix.
   size_t j = 0;
-  for ( ; i != treeQueue.end(); ++i, ++j)
+  for ( ; i != treeQueue.cend(); ++i, ++j)
   {
     currentNode = *i;
     basis.col(j) = currentNode->BasisVector();

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
@@ -93,8 +93,7 @@ CosineTree::CosineTree(const arma::mat& dataset,
   arma::vec tempVector = arma::zeros(dataset.n_rows);
   root.L2Error(-1.0); // We don't know what the error is.
   root.BasisVector(tempVector);
-  treeQueue.push_back(&root);
-  std::push_heap(treeQueue.begin(), treeQueue.end(), comp);
+  treeQueue.push_back(&root); // treeQueue is empty now, so we don't need to call std::push_heap here
 
   // Initialize Monte Carlo error estimate for comparison.
   double monteCarloError = root.FrobNormSquared();

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.cpp
@@ -105,7 +105,7 @@ CosineTree::CosineTree(const arma::mat& dataset,
     // Pop node from queue with highest projection error.
     CosineTree* currentNode;
     currentNode = treeQueue.front();
-    std::pop_heap(treeQueue.begin(), treeQueue.end());
+    std::pop_heap(treeQueue.begin(), treeQueue.end(), comp);
     treeQueue.pop_back();
 
     // If the priority is 0, we can't improve anything, and we can assume that

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
@@ -13,7 +13,6 @@
 #define MLPACK_CORE_TREE_COSINE_TREE_COSINE_TREE_HPP
 
 #include <mlpack/prereqs.hpp>
-#include <vector>
 #include <queue>
 
 namespace mlpack {

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
@@ -13,7 +13,8 @@
 #define MLPACK_CORE_TREE_COSINE_TREE_COSINE_TREE_HPP
 
 #include <mlpack/prereqs.hpp>
-#include <boost/heap/priority_queue.hpp>
+#include <vector>
+#include <queue>
 
 namespace mlpack {
 namespace tree {
@@ -23,8 +24,7 @@ class CompareCosineNode;
 class CosineTree;
 
 // CosineNodeQueue typedef.
-typedef boost::heap::priority_queue<CosineTree*,
-    boost::heap::compare<CompareCosineNode> > CosineNodeQueue;
+typedef std::vector<CosineTree*> CosineNodeQueue;
 
 class CosineTree
 {

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
@@ -13,7 +13,6 @@
 #define MLPACK_CORE_TREE_COSINE_TREE_COSINE_TREE_HPP
 
 #include <mlpack/prereqs.hpp>
-#include <queue>
 
 namespace mlpack {
 namespace tree {

--- a/src/mlpack/prereqs.hpp
+++ b/src/mlpack/prereqs.hpp
@@ -33,6 +33,8 @@
 #include <stdexcept>
 #include <tuple>
 #include <utility>
+#include <vector>
+#include <queue>
 
 // But if it's not defined, we'll do it.
 #ifndef M_PI

--- a/src/mlpack/tests/cosine_tree_test.cpp
+++ b/src/mlpack/tests/cosine_tree_test.cpp
@@ -214,7 +214,7 @@ TEST_CASE("CosineTreeModifiedGramSchmidt", "[CosineTreeTest]")
   {
     CosineTree* currentNode;
     currentNode = basisQueue.front();
-    std::pop_heap(basisQueue.begin(), basisQueue.end());
+    std::pop_heap(basisQueue.begin(), basisQueue.end(), comp);
     basisQueue.pop_back();
 
     delete currentNode;

--- a/src/mlpack/tests/cosine_tree_test.cpp
+++ b/src/mlpack/tests/cosine_tree_test.cpp
@@ -174,6 +174,7 @@ TEST_CASE("CosineTreeModifiedGramSchmidt", "[CosineTreeTest]")
   arma::mat data = arma::randu(numRows, numCols);
 
   // Declare a queue and a dummy CosineTree object.
+  CompareCosineNode comp;
   CosineNodeQueue basisQueue;
   CosineTree dummyTree(data, epsilon, delta);
 
@@ -191,10 +192,10 @@ TEST_CASE("CosineTreeModifiedGramSchmidt", "[CosineTreeTest]")
     dummyTree.ModifiedGramSchmidt(basisQueue, centroid, newBasisVector);
 
     // Check if the obtained vector is orthonormal to the basis vectors.
-    CosineNodeQueue::const_iterator j = basisQueue.begin();
+    CosineNodeQueue::const_iterator j = basisQueue.cbegin();
     CosineTree* currentNode;
 
-    for (; j != basisQueue.end(); ++j)
+    for (; j != basisQueue.cend(); ++j)
     {
       currentNode = *j;
       REQUIRE(arma::dot(currentNode->BasisVector(), newBasisVector) ==
@@ -204,15 +205,17 @@ TEST_CASE("CosineTreeModifiedGramSchmidt", "[CosineTreeTest]")
     // Add the obtained vector to the basis.
     basisNode->BasisVector(newBasisVector);
     basisNode->L2Error(arma::randu());
-    basisQueue.push(basisNode);
+    basisQueue.push_back(basisNode);
+    std::push_heap(basisQueue.begin(), basisQueue.end(), comp);
   }
 
   // Deallocate memory given to the objects.
   for (size_t i = 0; i < numCols; ++i)
   {
     CosineTree* currentNode;
-    currentNode = basisQueue.top();
-    basisQueue.pop();
+    currentNode = basisQueue.front();
+    std::pop_heap(basisQueue.begin(), basisQueue.end());
+    basisQueue.pop_back();
 
     delete currentNode;
   }


### PR DESCRIPTION
As #3095 suggests, I removed the remaining `boost::heap::priority_queue` parts in `mlpack/core/tree/cosine_tree/cosine_tree.hpp` and changed the way to push/pop items in `mlpack/core/tree/cosine_tree/cosine_tree.cpp` and `mlpack/tests/cosine_tree_test.cpp`.