### PR TITLE
Adding support for bandicoot

### DIFF
--- a/src/mlpack/core/data/load.hpp
+++ b/src/mlpack/core/data/load.hpp
@@ -69,9 +69,10 @@ namespace data /** Functions to load and save matrices and models. */ {
  * @param inputLoadType Used to determine the type of file to load (default arma::auto_detect).
  * @return Boolean value indicating success or failure of load.
  */
-template<typename eT>
-bool Load(const std::string& filename,
-          arma::Mat<eT>& matrix,
+template<typename MatType>
+typename std::enable_if<std::is_same<MatType, arma::Mat<typename MatType::elem_type>>::value || std::is_same<MatType, arma::Mat<typename MatType::elem_type>>::value, bool>::type
+Load(const std::string& filename,
+          MatType& matrix,
           const bool fatal = false,
           const bool transpose = true,
           const FileType inputLoadType = FileType::AutoDetect);

--- a/src/mlpack/core/data/load_impl.hpp
+++ b/src/mlpack/core/data/load_impl.hpp
@@ -81,9 +81,10 @@ bool inline inplace_transpose(MatType& X, bool fatal)
   }
 }
 
-template<typename eT>
-bool Load(const std::string& filename,
-          arma::Mat<eT>& matrix,
+template<typename MatType>
+typename std::enable_if<std::is_same<MatType, arma::Mat<typename MatType::elem_type>>::value || std::is_same<MatType, arma::Mat<typename MatType::elem_type>>::value, bool>::type
+Load(const std::string& filename,
+          MatType& matrix,
           const bool fatal,
           const bool transpose,
           const FileType inputLoadType)


### PR DESCRIPTION
- Changing template signature of load function.

- Using `std::enable_if<>` combined with `std::is_same<>`

- Inside `std::enable_if<>` we have two conditions, i.e. one fore `arma` and one for `coot`

- Currently not using namespace `coot` as it will throw error: `coot not declared in this scope`