### PR TITLE
Fix `linear_regression` warning

### DIFF
--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -120,7 +120,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timer)
 
   RequireOnlyOnePassed(params, { "training", "input_model" }, true);
 
-  ReportIgnoredParam(params, {{ "test", true }}, "output_predictions");
+  ReportIgnoredParam(params, {{ "test", false }}, "output_predictions");
 
   mat regressors;
   rowvec responses;


### PR DESCRIPTION
Reported on [the mailing list](http://knife.lugatgt.org/pipermail/mlpack/2022-May/004684.html):

```
NB I'm not sure why I get a warning with this invocation - it seems to follow the documentation and it does actually produce "newPredicts.csv" with the Y' values:
[mkb at hec003-ssd](http://knife.lugatgt.org/cgi-bin/mailman/listinfo/mlpack) ~/EEC/mlpack-examples$ mlpack_linear_regression -v --training_file newTrain.csv --test_file newTest.csv  -o newPredicts.csv

[WARN ] '--output_predictions_file (-o)' ignored because '--test_file (-T)' is specified!

[INFO ] Loading 'newTrain.csv' as CSV data.  Size is 48 x 3322.

[INFO ] Loading 'newTest.csv' as CSV data.  Size is 47 x 833.

[INFO ] Saving CSV data to 'newPredicts.csv'.
```

Indeed, this was just a simple error in the code: the warning that `--output_predictions_file` is ignored should only be shown when `--test_file` is *not* specified.