### PR TITLE
Remove boost::priority_queue from FastMKS

### DIFF
--- a/src/mlpack/methods/fastmks/fastmks_rules.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_rules.hpp
@@ -16,7 +16,7 @@
 #include <mlpack/core/kernels/kernel_traits.hpp>
 #include <mlpack/core/tree/cover_tree/cover_tree.hpp>
 #include <mlpack/core/tree/traversal_info.hpp>
-#include <boost/heap/priority_queue.hpp>
+#include <algorithm>
 
 namespace mlpack {
 namespace fastmks {
@@ -145,15 +145,10 @@ class FastMKSRules
     };
   };
 
-  //! Use a min heap to represent the list of candidate points.
-  //! We will use a boost::heap::priority_queue instead of a std::priority_queue
-  //! because we need to iterate over all the candidates and std::priority_queue
-  //! doesn't provide that interface.
-  typedef boost::heap::priority_queue<Candidate,
-      boost::heap::compare<CandidateCmp>> CandidateList;
-
-  //! Set of candidates for each point.
-  std::vector<CandidateList> candidates;
+  //! Set of candidates for each point.  We use a min-heap built on a
+  //! std::vector to represent the list of candidate points for each query
+  //! point.
+  std::vector<std::vector<Candidate>> candidates;
 
   //! Number of points to search for.
   const size_t k;


### PR DESCRIPTION
We previously used `boost::priority_queue` inside of the `FastMKSRules` class so that we could easily iterate over the elements of the priority queue---this was the reason we didn't use `std::priority_queue`.  But, we can achieve the same functionality by using a `std::vector` with a max-heap created on top of it, with `std::make_heap()`.

There is no functionality change here, just a change in the data structure---and a step closer to no more boost. :)