### PR TITLE
Remove boost tokenization from LoadARFF()

### DIFF
--- a/src/mlpack/core/data/load_arff.hpp
+++ b/src/mlpack/core/data/load_arff.hpp
@@ -14,7 +14,7 @@
 
 #include <mlpack/prereqs.hpp>
 #include "dataset_mapper.hpp"
-#include <boost/tokenizer.hpp>
+#include "string_algorithms.hpp"
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -57,11 +57,9 @@ void LoadARFF(const std::string& filename,
     // @data.
     if (line[0] == '@')
     {
-      typedef boost::tokenizer<boost::escaped_list_separator<char>> Tokenizer;
-      std::string separators = " \t%"; // Split on comments too.
-      boost::escaped_list_separator<char> sep("\\", separators, "\"'");
-      Tokenizer tok(line, sep);
-      Tokenizer::iterator it = tok.begin();
+      std::string separators = "\t% \\ \"'";
+      std::vector<std::string> tok = Tokenize(line, separators);
+      std::vector<std::string>::iterator it = tok.begin();
 
       // Get the annotation we are looking at.
       std::string annotation(*it);
@@ -108,9 +106,9 @@ void LoadARFF(const std::string& filename,
                 return c == '{' || c == '}' || c == ' ' || c == '\t';
               });
 
-          boost::escaped_list_separator<char> sep("\\", ",", "\"'");
-          Tokenizer dimTok(origDimType, sep);
-          Tokenizer::iterator it = dimTok.begin();
+          std::string sep = "\\ , \"'";
+          std::vector<std::string> dimTok = Tokenize(origDimType, sep);
+          std::vector<std::string>::iterator it = dimTok.begin();
           std::vector<std::string> categories;
 
           while (it != dimTok.end())
@@ -211,13 +209,12 @@ void LoadARFF(const std::string& filename,
       throw std::runtime_error("cannot yet parse sparse ARFF data");
 
     // Tokenize the line.
-    typedef boost::tokenizer<boost::escaped_list_separator<char>> Tokenizer;
-    boost::escaped_list_separator<char> sep("\\", ",", "\"");
-    Tokenizer tok(line, sep);
+    std::string sep = "\\ , \"";
+    std::vector<std::string> tok = Tokenize(line, sep);
 
     size_t col = 0;
     std::stringstream token;
-    for (Tokenizer::iterator it = tok.begin(); it != tok.end(); ++it)
+    for (std::vector<std::string>::iterator it = tok.begin(); it != tok.end(); ++it)
     {
       // Check that we are not too many columns in.
       if (col >= matrix.n_rows)

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -57,8 +57,7 @@ void LoadARFF(const std::string& filename,
     // @data.
     if (line[0] == '@')
     {
-      std::string separators = "\t% \\ \"'";
-      std::vector<std::string> tok = Tokenize(line, separators);
+      std::vector<std::string> tok = Tokenize(line, ' ', '"');
       std::vector<std::string>::iterator it = tok.begin();
 
       // Get the annotation we are looking at.
@@ -106,8 +105,7 @@ void LoadARFF(const std::string& filename,
                 return c == '{' || c == '}' || c == ' ' || c == '\t';
               });
 
-          std::string sep = "\\ , \"'";
-          std::vector<std::string> dimTok = Tokenize(origDimType, sep);
+          std::vector<std::string> dimTok = Tokenize(origDimType, ',', '"');
           std::vector<std::string>::iterator it = dimTok.begin();
           std::vector<std::string> categories;
 
@@ -209,8 +207,7 @@ void LoadARFF(const std::string& filename,
       throw std::runtime_error("cannot yet parse sparse ARFF data");
 
     // Tokenize the line.
-    std::string sep = "\\ , \"";
-    std::vector<std::string> tok = Tokenize(line, sep);
+    std::vector<std::string> tok = Tokenize(line, ',', '"');
 
     size_t col = 0;
     std::stringstream token;

--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -110,29 +110,74 @@ inline void TrimIf(std::string &str, std::function<bool(char)> func)
 }
 
 /**
- * Splits the given string into tokens. String will be separated
- * by all the characters that are part of delimiters(string delim).
+ * Splits the given string into tokens. String will be separated by all the
+ * characters that are part of delimiters (string delim).
  *
  * You can have a single delimiter or a group of delimiters.
  * Multiple delimiters: string delim = "| ? @ , /"
  *
  * @param line string which need to be tokenized
  * @param delims delimiter characters
+ * @param escapes escape characters
  */
-inline std::vector<std::string> Tokenize(std::string& line, std::string& delims)
+inline std::vector<std::string> Tokenize(
+    std::string& line,
+    char tokenDelim,
+    char escape)
 {
-    std::vector<std::string> vec;
-    char* token;
+  std::vector<std::string> tokens;
 
-    token = strtok(&line[0], &delims[0]);
+  // Shortcut: if the line is empty, it has no tokens.
+  if (line.size() == 0)
+    return tokens;
 
-    while (token != NULL)
+  bool inEscape = false;
+  bool lastBackslash = false;
+  std::string currentToken;
+  size_t lastSplitIndex = 0;
+  for (size_t currentIndex = 0; currentIndex < line.size(); ++currentIndex)
+  {
+    char c = line[currentIndex];
+
+    if (c == '\\')
     {
-        vec.push_back(token);
-        token = strtok(NULL, &delims[0]);
+      // Make sure we mark that we just encountered a backslash.
+      lastBackslash = true;
+      continue;
+    }
+    else if (c == escape && !lastBackslash)
+    {
+      // We've encountered one of our escape characters, so if we were already
+      // in an escape sequence, we are no longer, and if we weren't, we are now.
+      inEscape = !inEscape;
+    }
+    else if (c == escape && lastBackslash)
+    {
+      // If we are in an escape sequence and we encounter an escaped delimiter,
+      // we want to remove the '\' that prepends the escaped delimiter.
+      currentToken.append(line.substr(lastSplitIndex,
+          currentIndex - 2 - lastSplitIndex));
+      lastSplitIndex = currentIndex;
+    }
+    else if (c == tokenDelim && !inEscape)
+    {
+      // If the current character is a delimiter, then finish the previous token
+      // and add it to the list of tokens.
+      currentToken.append(line.substr(lastSplitIndex,
+          currentIndex - lastSplitIndex));
+      tokens.push_back(currentToken);
+      currentToken.clear();
+      lastSplitIndex = currentIndex + 1;
     }
 
-    return vec;
+    lastBackslash = false;
+  }
+
+  // Push the last token.
+  currentToken.append(line.substr(lastSplitIndex));
+  tokens.push_back(currentToken);
+
+  return tokens;
 }
 
 }  // namespace data

--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -109,6 +109,32 @@ inline void TrimIf(std::string &str, std::function<bool(char)> func)
   str = trimmedStr;
 }
 
+/**
+ * Splits the given string into tokens. String will be separated
+ * by all the characters that are part of delimiters(string delim).
+ *
+ * You can have a single delimiter or a group of delimiters.
+ * Multiple delimiters: string delim = "| ? @ , /"
+ *
+ * @param line string which need to be tokenized
+ * @param delims delimiter characters
+ */
+inline std::vector<std::string> Tokenize(std::string& line, std::string& delims)
+{
+    std::vector<std::string> vec;
+    char* token;
+
+    token = strtok(&line[0], &delims[0]);
+
+    while (token != NULL)
+    {
+        vec.push_back(token);
+        token = strtok(NULL, &delims[0]);
+    }
+
+    return vec;
+}
+
 }  // namespace data
 }  // namespace mlpack
 

--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -110,15 +110,18 @@ inline void TrimIf(std::string &str, std::function<bool(char)> func)
 }
 
 /**
- * Splits the given string into tokens. String will be separated by all the
- * characters that are part of delimiters (string delim).
+ * Splits the given string into tokens, using the given delimiter to split.
+ * An escape character should be specified to indicate escape sequences where
+ * the delimiter may be safely used.  For instance, with the delimiter ',' and
+ * the escape character '"' (a double quote), the line
  *
- * You can have a single delimiter or a group of delimiters.
- * Multiple delimiters: string delim = "| ? @ , /"
+ * hello, "one, two"
  *
- * @param line string which need to be tokenized
- * @param delims delimiter characters
- * @param escapes escape characters
+ * will be split into two tokens: "hello", and "one, two".
+ *
+ * @param line Input string to tokenize.
+ * @param tokenDelim Character to use as delimiter between tokens.
+ * @param escape Escape character, usually " or '.
  */
 inline std::vector<std::string> Tokenize(
     std::string& line,

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -54,7 +54,6 @@ using namespace mlpack::neighbor;
 using namespace mlpack::ann;
 
 using namespace arma;
-using namespace boost;
 using namespace cereal;
 using namespace std;
 


### PR DESCRIPTION
I noticed that the last piece of Boost usage remaining is in the `LoadARFF()` function, which @heisenbuug worked on adapting in #3098.  But, #3098 has a merge conflict now, since some other parts of mlpack have changed under it.  So I adapted that a little bit by cherry-picking the commits from that branch and made it pass the tests.  Thanks @heisenbuug for getting it started!  Hopefully this can get it across the finish line. :)