### PR TITLE
Updated link to repository issues page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ If you find a bug in mlpack or have any problems, numerous routes are available
 for help.
 
 Github is used for bug tracking, and can be found at
-https://github.com/mlpack/mlpack/.
+https://github.com/mlpack/mlpack/issues.
 It is easy to register an account and file a bug there, and the mlpack
 development team will try to quickly resolve your issue.
 


### PR DESCRIPTION
Fixes #3209 

```
383 | Github is used for bug tracking, and can be found at
384 | https://github.com/mlpack/mlpack/.
385 | It is easy to register an account and file a bug there, and the mlpack
386 | development team will try to quickly resolve your issue.
```

Updated Issues URL in Line 384 of [README.md](https://github.com/mlpack/mlpack/blob/master/README.md) from https://github.com/mlpack/mlpack/ to https://github.com/mlpack/mlpack/issues