### PR TITLE
Update license to help Github's processing

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@ can redistribute the library and/or modify it under the terms of the 3-clause
 BSD license.  The text of the 3-clause BSD license is contained below.
 
 ----
-Copyright (c) 2007-2020, mlpack contributors (see COPYRIGHT.txt)
+Copyright (c) 2007-2022, mlpack contributors (see COPYRIGHT.txt)
 All rights reserved.
 
 Redistribution and use of mlpack in source and binary forms, with or without

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,25 +2,6 @@ mlpack is provided without any warranty of fitness for any purpose.  You
 can redistribute the library and/or modify it under the terms of the 3-clause
 BSD license.  The text of the 3-clause BSD license is contained below.
 
-mlpack contains some reproductions of the source code of Armadillo, which is
-licensed under the Mozilla Public License v2.0 (MPL2).  This code is found in
-src/mlpack/core/arma_extend/ and more details on the licensing are available
-there.
-
-mlpack also contains some reproductions of the source code of Boost, which is
-licensed under the Boost Software License, version 1.0.  This code is found in
-src/mlpack/core/boost_backport/ and more details on the licensing are available
-there.
-
-mlpack contain some usage of the source code of MNMLSTC Core library, which is
-a backport of C++17 features to C++11. MNMLSTC is licensed under the Apache 2.0
-License. This code can be found in src/mlpack/core/std_backport/ and more
-details about licensing can be found there.
-
-mlpack may contain some usage of the source code of stb, which is licensed 
-under the MIT License and the Public Domain (www.unlicense.org). This code
-is used in src/mlpack/core/data/load_image.hpp.
-
 ----
 Copyright (c) 2007-2020, mlpack contributors (see COPYRIGHT.txt)
 All rights reserved.
@@ -49,3 +30,9 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------
+mlpack also contains some usage of the source code of MNMLSTC Core library,
+which is a backport of C++17 features to C++11. MNMLSTC is licensed under the
+Apache 2.0 License. This code can be found in src/mlpack/core/std_backport/ and
+more details about licensing can be found there.


### PR DESCRIPTION
I removed no-longer-accurate stanzas about dependent code and did a bit of reorganization:

 * We no longer backport any Boost code.
 * We no longer reproduce any Armadillo code.
 * STB is a dependency, not inlined.

Hopefully this will help Github detect the license correctly.