### PR TITLE
Fix `KFoldCVPerceptronTest`

### DIFF
--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -618,12 +618,13 @@ TEST_CASE("KFoldCVAccuracyTest", "[CVTest]")
  */
 TEST_CASE("KFoldCVPerceptronTest", "[CVTest]")
 {
-  // The same as the test above (for Naive Bayes), but with the perceptron.
+  // Basically the same as the test above (for Naive Bayes), but with the
+  // perceptron.
 
-  // Making a 10-points dataset. The last point should be classified wrong when
-  // it is tested separately.
-  arma::mat data("0 1 2 3 100 101 102 103 104 5");
-  arma::Row<size_t> labels("0 0 0 0 1 1 1 1 1 1");
+  // Making a 10-points dataset. All points should always be correctly
+  // classified.
+  arma::mat data("0 0 0 0 0 1 1 1 1 1");
+  arma::Row<size_t> labels("0 0 0 0 0 1 1 1 1 1");
   size_t numClasses = 2;
 
   // 10-fold cross-validation, no shuffling.
@@ -631,7 +632,7 @@ TEST_CASE("KFoldCVPerceptronTest", "[CVTest]")
 
   // We should succeed in classifying separately the first nine samples, and
   // fail with the remaining one.
-  double expectedAccuracy = (9 * 1.0 + 0.0) / 10;
+  double expectedAccuracy = 1.0;
 
   REQUIRE(cv.Evaluate() == Approx(expectedAccuracy).epsilon(1e-7));
 


### PR DESCRIPTION
In #3190 I added a test for `KFoldCV` for the perceptron, which is based on a similar test that uses the Naive Bayes classifier.  However, the way that the perceptron trains is different, and it turns out we do not have a guarantee that the last point will indeed be classified incorrectly; it is actually possible that the weights the perceptron may learn may get the last point right.

I thought about potential workarounds for a while, then I realized that the purpose of the test is to ensure that `KFoldCV` compiles successfully for the `Perceptron`; so I made the test "easier".  It still checks whether or not `KFoldCV<Perceptron>` compiles and works.