### PR TITLE
Correction in ANN layers

### DIFF
--- a/src/mlpack/methods/ann/layer/add_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_impl.hpp
@@ -20,7 +20,9 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename MatType>
-AddType<MatType>::AddType() : outSize(0)
+AddType<MatType>::AddType() : 
+    Layer<MatType>(),
+    outSize(0)
 {
   // Nothing to do.
 }

--- a/src/mlpack/methods/ann/layer/alpha_dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/alpha_dropout_impl.hpp
@@ -26,6 +26,7 @@ template<typename MatType>
 AlphaDropoutType<MatType>::AlphaDropoutType(
     const double ratio,
     const double alphaDash) :
+    Layer<MatType>(),
     ratio(ratio),
     alphaDash(alphaDash)
 {

--- a/src/mlpack/methods/ann/layer/concatenate_impl.hpp
+++ b/src/mlpack/methods/ann/layer/concatenate_impl.hpp
@@ -22,6 +22,7 @@ namespace ann /** Artificial Neural Network. */ {
 template<typename MatType>
 ConcatenateType<MatType>::
 ConcatenateType(const MatType& concat) :
+    Layer<MatType>(),
     concat(concat)
 {
   // Nothing to do here.

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -29,7 +29,7 @@ ConvolutionType<
     BackwardConvolutionRule,
     GradientConvolutionRule,
     MatType
->::ConvolutionType()
+>::ConvolutionType() : Layer<MatType>()
 {
   // Nothing to do here.
 }
@@ -87,6 +87,7 @@ ConvolutionType<
     const std::tuple<size_t, size_t>& padW,
     const std::tuple<size_t, size_t>& padH,
     const std::string& paddingTypeIn) :
+    Layer<MatType>(),
     maps(maps),
     kernelWidth(kernelWidth),
     kernelHeight(kernelHeight),

--- a/src/mlpack/methods/ann/layer/dropout_impl.hpp
+++ b/src/mlpack/methods/ann/layer/dropout_impl.hpp
@@ -22,6 +22,7 @@ namespace ann /** Artificial Neural Network. */ {
 template<typename MatType>
 DropoutType<MatType>::DropoutType(
     const double ratio) :
+    Layer<MatType>(),
     ratio(ratio),
     scale(1.0 / (1.0 - ratio))
 {

--- a/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
@@ -19,7 +19,8 @@ namespace mlpack {
 namespace ann /** Artificial Neural Network. */ {
 
 template<typename MatType>
-LogSoftMaxType<MatType>::LogSoftMaxType()
+LogSoftMaxType<MatType>::LogSoftMaxType() :
+    Layer<MatType>()
 {
   // Nothing to do here.
 }

--- a/src/mlpack/methods/ann/layer/padding.hpp
+++ b/src/mlpack/methods/ann/layer/padding.hpp
@@ -36,8 +36,6 @@ class PaddingType : public Layer<MatType>
    * @param padWRight Right padding width of the input.
    * @param padHTop Top padding height of the input.
    * @param padHBottom Bottom padding height of the input.
-   * @param inputWidth Width of the input.
-   * @param inputHeight Height of the input.
    */
   PaddingType(const size_t padWLeft = 0,
               const size_t padWRight = 0,
@@ -46,6 +44,18 @@ class PaddingType : public Layer<MatType>
 
   //! Clone the PaddingType object. This handles polymorphism correctly.
   PaddingType* Clone() const { return new PaddingType(*this); }
+
+  //! Virtual destructor.
+  virtual ~PaddingType() { }
+
+  //! Copy the given PaddingType.
+  PaddingType(const PaddingType& other);
+  //! Take ownership of the given PaddingType.
+  PaddingType(PaddingType&& other);
+  //! Copy the given PaddingType.
+  PaddingType& operator=(const PaddingType& other);
+  //! Take ownership of the given PaddingType.
+  PaddingType& operator=(PaddingType&& other);
 
   /**
    * Ordinary feed forward pass of a neural network, evaluating the function

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -25,6 +25,7 @@ PaddingType<MatType>::PaddingType(
     const size_t padWRight,
     const size_t padHTop,
     const size_t padHBottom) :
+    Layer<MatType>(),
     padWLeft(padWLeft),
     padWRight(padWRight),
     padHTop(padHTop),
@@ -32,6 +33,60 @@ PaddingType<MatType>::PaddingType(
     totalInMaps(0)
 {
   // Nothing to do here.
+}
+
+template<typename MatType>
+PaddingType<MatType>::PaddingType(const PaddingType& other) :
+    Layer<MatType>(other),
+    padWLeft(other.padWLeft),
+    padWRight(other.padWRight),
+    padHTop(other.padHTop),
+    padHBottom(other.padHBottom),
+    totalInMaps(other.totalInMaps)
+{
+  // Nothing to do here.
+}
+
+template<typename MatType>
+PaddingType<MatType>::PaddingType(PaddingType&& other) :
+    Layer<MatType>(std::move(other)),
+    padWLeft(std::move(other.padWLeft)),
+    padWRight(std::move(other.padWRight)),
+    padHTop(std::move(other.padHTop)),
+    padHBottom(std::move(other.padHBottom)),
+    totalInMaps(std::move(other.totalInMaps))
+{
+  // Nothing to do here.
+}
+
+template<typename MatType>
+PaddingType<MatType>&
+PaddingType<MatType>::operator=(const PaddingType& other)
+{
+  if (this != &other)
+    Layer<MatType>::operator=(other);
+    padWLeft = other.padWLeft;
+    padWRight = other.padWRight;
+    padHTop = other.padHTop;
+    padHBottom = other.padHBottom;
+    totalInMaps = other.totalInMaps;
+
+  return *this;
+}
+
+template<typename MatType>
+PaddingType<MatType>&
+PaddingType<MatType>::operator=(PaddingType&& other)
+{
+  if (this != &other)
+    Layer<MatType>::operator=(std::move(other));
+    padWLeft = std::move(other.padWLeft);
+    padWRight = std::move(other.padWRight);
+    padHTop = std::move(other.padHTop);
+    padHBottom = std::move(other.padHBottom);
+    totalInMaps = std::move(other.totalInMaps);
+
+  return *this;
 }
 
 template<typename MatType>

--- a/src/mlpack/methods/ann/layer/padding_impl.hpp
+++ b/src/mlpack/methods/ann/layer/padding_impl.hpp
@@ -64,12 +64,14 @@ PaddingType<MatType>&
 PaddingType<MatType>::operator=(const PaddingType& other)
 {
   if (this != &other)
+  {
     Layer<MatType>::operator=(other);
     padWLeft = other.padWLeft;
     padWRight = other.padWRight;
     padHTop = other.padHTop;
     padHBottom = other.padHBottom;
     totalInMaps = other.totalInMaps;
+  }
 
   return *this;
 }
@@ -79,12 +81,14 @@ PaddingType<MatType>&
 PaddingType<MatType>::operator=(PaddingType&& other)
 {
   if (this != &other)
+  {
     Layer<MatType>::operator=(std::move(other));
     padWLeft = std::move(other.padWLeft);
     padWRight = std::move(other.padWRight);
     padHTop = std::move(other.padHTop);
     padHBottom = std::move(other.padHBottom);
     totalInMaps = std::move(other.totalInMaps);
+  }
 
   return *this;
 }

--- a/src/mlpack/methods/ann/layer/radial_basis_function_impl.hpp
+++ b/src/mlpack/methods/ann/layer/radial_basis_function_impl.hpp
@@ -30,6 +30,7 @@ RBFType<MatType, Activation>::RBFType(
     const size_t outSize,
     MatType& centres,
     double betas) :
+    Layer<MatType>(),
     outSize(outSize),
     betas(betas),
     centres(centres)

--- a/src/mlpack/methods/ann/layer/softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/softmax_impl.hpp
@@ -35,7 +35,7 @@ SoftmaxType<MatType>::SoftmaxType(const SoftmaxType& other) :
 
 template<typename MatType>
 SoftmaxType<MatType>::SoftmaxType(SoftmaxType&& other) :
-    Layer<MatType>(other)
+    Layer<MatType>(std::move(other))
 {
   // Nothing to do here.
 }


### PR DESCRIPTION
- Added `Layer<MatType>()` in the constructor wherever it is missing.
- Added copy and move constructor in PaddingType layer.
- Fixed SoftmaxType move constructor.