### PR TITLE
Adaptive Pooling Hotfix

### DIFF
--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling_impl.hpp
@@ -146,6 +146,8 @@ void AdaptiveMaxPoolingType<MatType>::serialize(
   ar(cereal::base_class<Layer<MatType>>(this));
 
   ar(CEREAL_NVP(poolingLayer));
+  ar(CEREAL_NVP(outputWidth));
+  ar(CEREAL_NVP(outputHeight));
 }
 
 } // namespace ann

--- a/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_mean_pooling_impl.hpp
@@ -146,6 +146,8 @@ void AdaptiveMeanPoolingType<MatType>::serialize(
   ar(cereal::base_class<Layer<MatType>>(this));
 
   ar(CEREAL_NVP(poolingLayer));
+  ar(CEREAL_NVP(outputWidth));
+  ar(CEREAL_NVP(outputHeight));
 }
 
 } // namespace ann


### PR DESCRIPTION
Fixed serialization issue. This issue first appeared when trying the serialization test on SqueezeNet.
Gives `[FATAL] Given output shape (94556213170576, 94556213170192) is not possible for given input shape (13, 13).`

On gdb
```cpp
$1 = {<mlpack::ann::Layer<arma::Mat<double> >> = {_vptr.Layer = 0x55ff936de0e8 <vtable for mlpack::ann::AdaptiveMeanPoolingType<arma::Mat<double> >+16>,
    inputDimensions = std::vector of length 3, capacity 3 = {13, 13, 5}, outputDimensions = std::vector of length 3, capacity 3 = {94556213170576, 94556213170192, 5},
    validOutputDimensions = false, training = false}, poolingLayer = {<mlpack::ann::Layer<arma::Mat<double> >> = {
      _vptr.Layer = 0x55ff936de190 <vtable for mlpack::ann::MeanPoolingType<arma::Mat<double> >+16>, inputDimensions = std::vector of length 3, capacity 3 = {13, 13, 5},
      outputDimensions = std::vector of length 3, capacity 3 = {1, 1, 5}, validOutputDimensions = false, training = false}, kernelWidth = 13, kernelHeight = 13,
    strideWidth = 13, strideHeight = 13, floor = true, channels = 5}, outputWidth = 94556213170576, outputHeight = 94556213170192}
```
