### PR TITLE
avoid deprecation warnings in armadillo 11.2+

### DIFF
--- a/src/mlpack/tests/ann_layer_test.cpp
+++ b/src/mlpack/tests/ann_layer_test.cpp
@@ -4901,15 +4901,14 @@ TEST_CASE("MeanPoolingTestCase", "[ANNLayerTest]")
   module2.ComputeOutputDimensions();
 
   // Calculated using torch.nn.MeanPool2d().
-  arma::mat result1, result2;
-  result1  <<  0.7500  <<  4.2500  <<  arma::endr
-           <<  1.7500  <<  4.0000  <<  arma::endr
-           <<  2.7500  <<  6.0000  <<  arma::endr
-           <<  3.5000  <<  2.5000  <<  arma::endr;
-
-  result2  <<  0.7500  <<  4.2500  <<  arma::endr
-           <<  1.7500  <<  4.0000  <<  arma::endr
-           <<  2.7500  <<  6.0000  <<  arma::endr;
+  arma::mat result1 = { { 0.7500, 4.2500 },
+                        { 1.7500, 4.0000 },
+                        { 2.7500, 6.0000 },
+                        { 3.5000, 2.5000 } };
+  
+  arma::mat result2 = { { 0.7500, 4.2500 },
+                        { 1.7500, 4.0000 },
+                        { 2.7500, 6.0000 } };
 
   arma::mat output1, output2;
   output1.set_size(8, 1);
@@ -4923,15 +4922,15 @@ TEST_CASE("MeanPoolingTestCase", "[ANNLayerTest]")
   CheckMatrices(output1, result1, 1e-1);
   CheckMatrices(output2, result2, 1e-1);
 
-  arma::mat prevDelta1, prevDelta2;
-  prevDelta1  << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr;
+  arma::mat prevDelta1 = { { 3.6000, -0.9000 },
+                           { 3.6000, -0.9000 },
+                           { 3.6000, -0.9000 },
+                           { 3.6000, -0.9000 } };
 
-  prevDelta2  << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr;
+  arma::mat prevDelta2 = { { 3.6000, -0.9000 }, 
+                           { 3.6000, -0.9000 }, 
+                           { 3.6000, -0.9000 } };
+
   arma::mat delta1, delta2;
   delta1.set_size(28, 1);
   delta2.set_size(28, 1);

--- a/src/mlpack/tests/loss_functions_test.cpp
+++ b/src/mlpack/tests/loss_functions_test.cpp
@@ -857,10 +857,8 @@ TEST_CASE("MarginRankingLossTest", "[LossFunctionsTest]")
       "-4.8090 4.3455 5.2070");
   input2 = arma::mat("-4.5288 -9.2766 -0.5882 -5.6643 -6.0175 8.8506 3.4759 "
       "-9.4886 2.2755 8.4951");
-  expectedOutput << 0.0000 << 0.0000 << 1.0000 << 0.0000 << 1.0000 << -1.0000 
-                 << 0.0000 << 0.0000 << 1.0000 << -1.0000 <<arma::endr << 0.0000
-                 << 0.0000 << -1.0000 << 0.0000 << -1.0000 << 1.0000 << 0.0000
-                 << 0.0000 << -1.0000 << 1.0000 << arma::endr;
+  expectedOutput = { { 0.0, 0.0,  1.0, 0.0,  1.0, -1.0, 0.0, 0.0,  1.0, -1.0 }, 
+                     { 0.0, 0.0, -1.0, 0.0, -1.0,  1.0, 0.0, 0.0, -1.0,  1.0 } };
   input = arma::join_cols(input1, input2);
   target = arma::mat("1 1 -1 1 -1 1 1 1 -1 1");
 
@@ -887,10 +885,8 @@ TEST_CASE("MarginRankingLossTest", "[LossFunctionsTest]")
 
   // Test the backward function
   module.Backward(input, target, output);
-  expectedOutput << 0.0000 << 0.0000 << 0.1000 << 0.0000 << 0.1000 << -0.1000 
-                 << 0.0000 << 0.0000 << 0.1000 << -0.1000 <<arma::endr << 0.0000
-                 << 0.0000 << -0.1000 << 0.0000 << -0.1000 << 0.1000 << 0.0000
-                 << 0.0000 << -0.1000 << 0.1000 << arma::endr;
+  expectedOutput = { { 0.0, 0.0,  0.1, 0.0,  0.1, -0.1, 0.0, 0.0,  0.1, -0.1 },
+                     { 0.0, 0.0, -0.1, 0.0, -0.1,  0.1, 0.0, 0.0, -0.1,  0.1 } };
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);


### PR DESCRIPTION
matrix initialisation via `operator<<` now emits a compile time deprecation warning as of armadillo 11.2+.

to avoid the deprecation warnings, change matrix initialisation to use C++11 iniitalizer_list.

cf. https://github.com/mlpack/ensmallen/pull/347
