### PR TITLE
Fix DET cross-validation loop

### DIFF
--- a/src/mlpack/methods/det/dt_utils_impl.hpp
+++ b/src/mlpack/methods/det/dt_utils_impl.hpp
@@ -239,7 +239,7 @@ DTree<MatType, TagType>* Trainer(MatType& dataset,
       }
 
       // Update the cv regularization constant.
-      cvRegularizationConstants[i] += 2.0 * cvVal / (double) cvData.n_cols;
+      cvRegularizationConstants[i] = 2.0 * cvVal / (double) cvData.n_cols;
 
       // Determine the new alpha value and prune accordingly.
       double cvOldAlpha = 0.5 * (prunedSequence[i + 1].first
@@ -256,8 +256,10 @@ DTree<MatType, TagType>* Trainer(MatType& dataset,
     }
 
     if (prunedSequence.size() > 2)
-      cvRegularizationConstants[prunedSequence.size() - 2] += 2.0 * cvVal
+    {
+      cvRegularizationConstants[prunedSequence.size() - 2] = 2.0 * cvVal
         / (double) cvData.n_cols;
+    }
 
     #pragma omp critical(DTreeCVUpdate)
     regularizationConstants += cvRegularizationConstants;
@@ -265,18 +267,18 @@ DTree<MatType, TagType>* Trainer(MatType& dataset,
   timers.Stop("cross_validation");
 
   double optimalAlpha = -1.0;
-  long double cvBestError = -std::numeric_limits<long double>::max();
+  long double cvBestNegError = -std::numeric_limits<long double>::max();
 
   for (size_t i = 0; i < prunedSequence.size() - 1; ++i)
   {
     // We can no longer work in the log-space for this because we have no
     // guarantee the quantity will be positive.
-    long double thisError = -std::exp((long double) prunedSequence[i].second) +
+    long double thisNegError = std::exp((long double) prunedSequence[i].second) -
         (long double) regularizationConstants[i];
 
-    if (thisError > cvBestError)
+    if (thisNegError > cvBestNegError)
     {
-      cvBestError = thisError;
+      cvBestNegError = thisNegError;
       optimalAlpha = prunedSequence[i].first;
     }
   }


### PR DESCRIPTION
Thanks to @SuvarshaChennareddy for pointing this out in #3238!

In fe7d1039 (that commit is from 2012!), I made some changes to the density estimation tree cross-validation code.  When I did that, I inadvertently changed the loop that maximized negative error to a loop that maximized error---that's backwards!  So, I went through the original code before that commit, compared it with the changes in the commit, and this revealed the issue.  I inverted the computation of `thisError`, and renamed it more accurately to `thisNegError`.

(I also changed some `+=`s to `=` for clarity, since those values were only ever assigned once.)