### PR TITLE
Serialization Hotfix

### DIFF
--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -600,7 +600,9 @@ void ConvolutionType<
   ar(CEREAL_NVP(padWRight));
   ar(CEREAL_NVP(padHBottom));
   ar(CEREAL_NVP(padHTop));
+  ar(CEREAL_NVP(useBias));
   ar(CEREAL_NVP(padding));
+  ar(CEREAL_NVP(paddingType));
   ar(CEREAL_NVP(inMaps));
   ar(CEREAL_NVP(higherInDimensions));
 }

--- a/src/mlpack/methods/ann/layer/grouped_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution_impl.hpp
@@ -654,6 +654,7 @@ void GroupedConvolutionType<
   ar(CEREAL_NVP(padHTop));
   ar(CEREAL_NVP(useBias));
   ar(CEREAL_NVP(padding));
+  ar(CEREAL_NVP(paddingType));
   ar(CEREAL_NVP(inMaps));
   ar(CEREAL_NVP(higherInDimensions));
 }


### PR DESCRIPTION
Forgot to serialize `useBias` and `paddingType`, which is setting `useBias` to false, causing unexpected problems while using serialized models.