### PR TITLE
Don't use alias in `Adaboost::Classify()`

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -261,7 +261,7 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
   for (size_t i = 0; i < predictedLabels.n_cols; ++i)
   {
     probabilities.col(i) /= arma::accu(probabilities.col(i));
-    probabilities.unsafe_col(i).max(maxIndex);
+    probabilities.col(i).max(maxIndex);
     predictedLabels(i) = maxIndex;
   }
 }

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -256,14 +256,12 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
       probabilities(tempPredictedLabels(j), j) += alpha[i];
   }
 
-  arma::colvec pRow;
   arma::uword maxIndex = 0;
 
   for (size_t i = 0; i < predictedLabels.n_cols; ++i)
   {
     probabilities.col(i) /= arma::accu(probabilities.col(i));
-    pRow = probabilities.unsafe_col(i);
-    pRow.max(maxIndex);
+    probabilities.unsafe_col(i).max(maxIndex);
     predictedLabels(i) = maxIndex;
   }
 }


### PR DESCRIPTION
While testing Armadillo 11.2.x for [this issue](https://gitlab.com/conradsnicta/armadillo-code/-/issues/218), I found a small bug: the alias created by `unsafe_col()` gets overwritten when it's updated!  One solution is to move the `arma::rowvec` declaration into the loop; but the other solution, which is probably better, is just to use `max()` directly.  (I think very many years ago, that was not an option, as that function didn't exist then.)