### PR TITLE
avoid deprecation warnings in Armadillo 11.2+

### DIFF
--- a/src/mlpack/tests/ann/layer/add_merge.cpp
+++ b/src/mlpack/tests/ann/layer/add_merge.cpp
@@ -53,15 +53,14 @@ TEST_CASE("AddMergeTestCase", "[ANNLayerTest]")
   module2.ComputeOutputDimensions();
 
   // Calculated using torch.nn.MeanPool2d().
-  arma::mat result1, result2;
-  result1  <<  1.5000  <<  8.5000  <<  arma::endr
-           <<  3.5000  <<  8.0000  <<  arma::endr
-           <<  5.5000  <<  12.0000 <<  arma::endr
-           <<  7.0000  <<  5.0000  <<  arma::endr;
+  arma::mat result1 = { { 1.5,  8.5 },
+                        { 3.5,  8.0 },
+                        { 5.5, 12.0 },
+                        { 7.0,  5.0 } };
 
-  result2  <<  1.5000  <<  8.5000  <<  arma::endr
-           <<  3.5000  <<  8.0000  <<  arma::endr
-           <<  5.5000  <<  12.0000 <<  arma::endr;
+  arma::mat result2 = { { 1.5,  8.5 },
+                        { 3.5,  8.0 }, 
+                        { 5.5, 12.0 } };
 
   arma::mat output1, output2;
   output1.set_size(8, 1);
@@ -76,14 +75,14 @@ TEST_CASE("AddMergeTestCase", "[ANNLayerTest]")
   CheckMatrices(output2, result2, 1e-1);
 
   arma::mat prevDelta1, prevDelta2;
-  prevDelta1  << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr;
+  arma::mat prevDelta1 = { { 3.6, -0.9 },
+                           { 3.6, -0.9 }, 
+                           { 3.6, -0.9 }, 
+                           { 3.6, -0.9 } };
 
-  prevDelta2  << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr;
+  arma::mat prevDelta2 = { { 3.6, -0.9 },
+                           { 3.6, -0.9 },
+                           { 3.6, -0.9 } };
   arma::mat delta1, delta2;
   delta1.set_size(28, 1);
   delta2.set_size(28, 1);

--- a/src/mlpack/tests/ann/layer/add_merge.cpp
+++ b/src/mlpack/tests/ann/layer/add_merge.cpp
@@ -74,7 +74,6 @@ TEST_CASE("AddMergeTestCase", "[ANNLayerTest]")
   CheckMatrices(output1, result1, 1e-1);
   CheckMatrices(output2, result2, 1e-1);
 
-  arma::mat prevDelta1, prevDelta2;
   arma::mat prevDelta1 = { { 3.6, -0.9 },
                            { 3.6, -0.9 }, 
                            { 3.6, -0.9 }, 

--- a/src/mlpack/tests/ann/layer/batch_norm.cpp
+++ b/src/mlpack/tests/ann/layer/batch_norm.cpp
@@ -29,10 +29,10 @@ using namespace mlpack::ann;
  */
 TEST_CASE("BatchNormTest", "[ANNLayerTest]")
 {
-  arma::mat input, output;
-  input << 5.1 << 3.5 << 1.4 << arma::endr
-        << 4.9 << 3.0 << 1.4 << arma::endr
-        << 4.7 << 3.2 << 1.3 << arma::endr;
+  arma::mat output;
+  arma::mat input = { { 5.1, 3.5, 1.4 },
+                      { 4.9, 3.0, 1.4 },
+                      { 4.7, 3.2, 1.3 } };
 
   input = input.t();
 

--- a/src/mlpack/tests/ann/layer/mean_pooling.cpp
+++ b/src/mlpack/tests/ann/layer/mean_pooling.cpp
@@ -47,15 +47,14 @@ TEST_CASE("MeanPoolingTestCase", "[ANNLayerTest]")
   module2.ComputeOutputDimensions();
 
   // Calculated using torch.nn.MeanPool2d().
-  arma::mat result1, result2;
-  result1  <<  0.7500  <<  4.2500  <<  arma::endr
-           <<  1.7500  <<  4.0000  <<  arma::endr
-           <<  2.7500  <<  6.0000  <<  arma::endr
-           <<  3.5000  <<  2.5000  <<  arma::endr;
+  arma::mat result1 = { { 0.75, 4.25 },
+                        { 1.75, 4.00 },
+                        { 2.75, 6.00 },
+                        { 3.50, 2.50 } };
 
-  result2  <<  0.7500  <<  4.2500  <<  arma::endr
-           <<  1.7500  <<  4.0000  <<  arma::endr
-           <<  2.7500  <<  6.0000  <<  arma::endr;
+  arma::mat result2 = { { 0.75, 4.25 },
+                        { 1.75, 4.00 },
+                        { 2.75, 6.00 } };
 
   arma::mat output1, output2;
   output1.set_size(8, 1);
@@ -69,15 +68,15 @@ TEST_CASE("MeanPoolingTestCase", "[ANNLayerTest]")
   CheckMatrices(output1, result1, 1e-1);
   CheckMatrices(output2, result2, 1e-1);
 
-  arma::mat prevDelta1, prevDelta2;
-  prevDelta1  << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr;
+  arma::mat prevDelta1 = { { 3.6, -0.9 },
+                           { 3.6, -0.9 },
+                           { 3.6, -0.9 },
+                           { 3.6, -0.9 } };
 
-  prevDelta2  << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr
-              << 3.6000 << -0.9000 << arma::endr;
+  arma::mat prevDelta2 = { { 3.6, -0.9 },
+                           { 3.6, -0.9 },
+                           { 3.6, -0.9 } };
+  
   arma::mat delta1, delta2;
   delta1.set_size(28, 1);
   delta2.set_size(28, 1);


### PR DESCRIPTION
Change matrix initialisation from old style `<<` into C++11 initializer_list.

This is to avoid compile-time deprecation warnings present in Armadillo 11.2+.

Continuation of #3235.
