### PR TITLE
Remove `RangeType` change comment (attempt #2)

### DIFF
--- a/src/mlpack/core/math/range.hpp
+++ b/src/mlpack/core/math/range.hpp
@@ -17,15 +17,10 @@ namespace mlpack {
 template<typename T>
 class RangeType;
 
-//! 3.0.0 TODO: break reverse-compatibility by changing RangeType to Range.
 typedef RangeType<double> Range;
 
 /**
  * Simple real-valued range.  It contains an upper and lower bound.
- *
- * Note that until mlpack 3.0.0, this class is named RangeType<> and for the
- * specification where T is double, you can use Range.  As of mlpack 3.0.0, this
- * class will be renamed Range<>.
  *
  * @tparam T type of element held by this range.
  */


### PR DESCRIPTION
This is a second attempt at #3270.  The description is copied below:

A long time ago, it seemed like a good idea to change `RangeType<T>` to `Range<T>` for mlpack 3; but, in https://github.com/mlpack/mlpack/pull/2777, we adopted the convention that the "default" type was the "short name", and the templated type had `Type<>` on the end; e.g., `Linear` is `LinearType<arma::mat>`.

I don't see any reason to change that convention, so, I just removed the comment here; we can keep `Range = RangeType<double>`.