### PR TITLE
Actually install `namespace_compat.hpp`

### DIFF
--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES
 install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/base.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/core.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/namespace_compat.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/prereqs.hpp"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mlpack/")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/core" DESTINATION


### PR DESCRIPTION
In #3269, I added the file `namespace_compat.hpp`, but forgot to actually modify CMake so that that file gets installed.

This one-line PR just adds `namespace_compat.hpp` to the list of sources to install when `make install` is called.