### PR TITLE
Handle MaxPooling index computation for identical elements

### DIFF
--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -42,7 +42,7 @@ class MaxPoolingRule
   std::tuple<size_t, typename MatType::elem_type> PoolingWithIndex(
       const MatType& input)
   {
-    const size_t index = arma::index_max(arma::vectorise(input));
+    const size_t index = input.index_max();
     const typename MatType::elem_type maxVal = input[index];
 
     return std::tuple<size_t, typename MatType::elem_type>(index, maxVal);

--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -42,9 +42,8 @@ class MaxPoolingRule
   std::tuple<size_t, typename MatType::elem_type> PoolingWithIndex(
       const MatType& input)
   {
-    const typename MatType::elem_type maxVal =
-        arma::max(arma::vectorise(input));
-    const size_t index = arma::as_scalar(arma::find(input == maxVal, 1));
+    const size_t index = arma::index_max(arma::vectorise(input));
+    const typename MatType::elem_type maxVal = input[index];
 
     return std::tuple<size_t, typename MatType::elem_type>(index, maxVal);
   }


### PR DESCRIPTION
In `MaxPooling`, we use `as_scalar(find(...))` to return the index of the maximum element.  But what happens if there are multiple elements that are equivalently the maximum?  Then, `as_scalar()` will throw an exception, because `find()` will return a vector with more than one element.  So, it is safer to use `index_max()`, where this situation is not a problem.

Honestly I am surprised this situation has not already been encountered, but anyway, it is an easy bugfix.