### PR TITLE
Update CMake usage in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ cmake ../
 sudo make install
 ```
 
+Note: Since CMake v3.14.0 the `cmake` command can create the build folder itself.
+The above commands can be rewritten as follows:
+
+```sh
+cmake -S . -B build
+sudo cmake --build build --target install
+```
+
 You can add a few arguments to the `cmake` command to control the behavior of
 the configuration and build process.  Simply add these to the `cmake` command.
 Some options are given below:


### PR DESCRIPTION
CMake 3.14.0 released in March 2019 [1] added the command line config options `-S <source-dir>` and `-B <build-dir>` and the build argument `--build <build-dir>` [2]. These options are universally valid independent of the build system used (`make`, `nmake`, `ninja`, `MSBuild`,...), making the provided CMake commands more generic.

As reference Ubuntu 20.04 ships the CMake 3.16.3 [3] version.

- [1] https://gitlab.kitware.com/cmake/cmake/-/tags/v3.14.0
- [2] https://cmake.org/cmake/help/v3.14/release/3.14.html#command-line
- [3] https://packages.ubuntu.com/focal/cmake