### PR TITLE
Catch all exceptions in Julia

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Bugfix: catch all exceptions when running bindings from Julia, instead of
+    crashing (#3304).
 
 ### mlpack 4.0.0
 ###### 2022-10-23

--- a/src/mlpack/bindings/julia/julia_method.cpp.in
+++ b/src/mlpack/bindings/julia/julia_method.cpp.in
@@ -22,7 +22,7 @@ bool BINDING_FUNCTION(void* params, void* timers)
     BINDING_FUNCTION(*p, *t);
     return true;
   }
-  catch (std::runtime_error& e)
+  catch (std::exception& e)
   {
     std::cout << e.what() << std::endl;
     return false;


### PR DESCRIPTION
Ideally, when running an mlpack binding from Julia, we want to catch all exceptions, instead of crashing.

A typo in the existing code meant we only caught `std::runtime_error`s instead of any exception.  So, easy fix: just catch `std::exception` instead.

Note that for these to be caught correctly, the Julia bindings should not be compiled with `-DARMA_NO_DEBUG`, otherwise the out-of-bounds checks will not be done and may cause invalid memory accesses and segfaults, instead of throwing exceptions.