### PR TITLE
Fix Julia category mapping

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Fix mapping of categorical data for Julia bindings (#3305).
 
 ### mlpack 4.0.0
 ###### 2022-10-23

--- a/src/mlpack/bindings/julia/julia_util.cpp
+++ b/src/mlpack/bindings/julia/julia_util.cpp
@@ -266,17 +266,16 @@ void SetParamMatWithInfo(void* params,
       hasCategoricals = true;
   }
 
-  arma::mat m(memptr, arma::uword(rows), arma::uword(cols), false, false);
+  arma::mat alias(memptr, arma::uword(rows), arma::uword(cols), false, false);
+  arma::mat m = pointsAreRows ? alias.t() : alias;
+  std::cout << "matrix size: " << m.n_rows << " x " << m.n_cols << "; input "
+      << "size " << rows << " x " << cols << " with pointsAreRows " << pointsAreRows << "\n";
 
   // Do we need to find how many categories we have?
   if (hasCategoricals)
   {
     // Compute the maximum in each dimension.
-    arma::vec maxs;
-    if (pointsAreRows)
-      maxs = arma::max(m, 0).t();
-    else
-      maxs = arma::max(m, 1);
+    const arma::vec maxs = arma::max(m, 1);
 
     for (size_t i = 0; i < d.Dimensionality(); ++i)
     {
@@ -289,6 +288,11 @@ void SetParamMatWithInfo(void* params,
           oss << j;
           d.MapString<double>(oss.str(), i);
         }
+
+        // In Julia we specify the categorical value from 1 to the number of
+        // categories, but in C++ we expect 0 to the number of categories minus
+        // one.  (Just like the labels.)
+        m.row(i) -= 1.0;
       }
     }
   }

--- a/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
+++ b/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
@@ -191,11 +191,15 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
         {
           if (ceil(m(i, c)) != m(i, c))
             throw std::invalid_argument("non-integer value in categorical!");
-          else if (m(i, c) <= 0)
-            throw std::invalid_argument("negative/zero value in categorical!");
-          else if (size_t(m(i, c)) > di.NumMappings(i))
+          else if (m(i, c) < 0)
+            throw std::invalid_argument("negative value in categorical!");
+          else if (size_t(m(i, c)) >= di.NumMappings(i))
             throw std::invalid_argument("value outside number of categories!");
         }
+
+        // Since this goes back to Julia as a regular matrix, we have to
+        // manually convert the categorical features to be one-indexed.
+        m.row(i) += 1.0;
       }
     }
 


### PR DESCRIPTION
Julia is a one-indexed language; so, when the user gives us labels from Julia, we expect them to be in the range `[1, numClasses]`.  Internally, we must map them to `[0, numClasses - 1]` when passing to mlpack, since mlpack and Armadillo are zero-indexed and that is our convention.  For labels, this works just fine.

When we pass categorical data, we have the same one-indexed expectation from Julia: the Julia user will give us a `Matrix{Float64}` as well as a `Vector{Bool}`.  The boolean vector specifies which dimensions are categorical, and then those dimensions in the `Matrix{Float64}` should take values in `[1, numCategories]`.  Here, we must also do the same transformation to `[0, numCategories - 1]`.

However, that transformation was not implemented, which caused the failure in #3300.

This PR fixes the problem, by subtracting one from any categorical dimensions before passing the data into mlpack.