### PR TITLE
Correctly link with `-lm` in Python bindings

### DIFF
--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -35,6 +35,11 @@ else:
 # Windows and Linux linking behavior.
 libraries = '${MLPACK_LIBRARIES}'.split(' ')
 
+# Workaround: if we receive "m" as a library, what was actually meant was -lm.
+for i in range(len(libraries)):
+  if libraries[i] == 'm':
+    libraries[i] = '-lm'
+
 # Potentially faulty assumption: we can always link against libraries directly
 # by just specifying the full path to them on the command line.
 extra_link_args += libraries


### PR DESCRIPTION
In certain situations (OS X is where I encountered it), one of the libraries in the CMake `MLPACK_LIBRARIES` variable is `"m"`, to indicate that we should link with `-lm`.  However, every other library in `MLPACK_LIBRARIES` is a direct path to a library to link against.  This means that when compiling Cython bindings, we get command-lines like

```
g++ ... /usr/lib/libarmadillo.dylib /usr/lib/libopenblas.dylib m
```

but that `m` isn't very helpful---it needs to be `-lm`.  This patch adds a workaround specifically for this case to the Cython build configuration.