### PR TITLE
Optimize and strip Cython compiled libraries

### DIFF
--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -49,15 +49,28 @@ else:
   extra_cxx_flags = re.sub(' +', ' ', cxx_flags)
   cxx_flags += ' '
   cxx_flags += extra_cxx_flags
-  extra_args = ['-DBINDING_TYPE=BINDING_TYPE_PYX', '-std=c++14']
+
+  extra_args = []
+  if platform.system() == 'Windows':
+    # Argument specification is different on MSVC, and also use C++17.
+    extra_args.extend(['/DBINDING_TYPE=BINDING_TYPE_PYX', '/std:c++17', '/MD',
+        '/O2', '/Ob2', '/DNDEBUG'])
+  elif platform.system() == 'Darwin':
+    extra_args.append('-DBINDING_TYPE=BINDING_TYPE_PYX')
+    extra_args.append('-std=c++17')
+    # On OS X and Linux, we try to reduce the size of the generated libraries
+    # by removing debugging symbols and stripping.
+    extra_args.append('-g0')
+  else:
+    extra_args.append('-DBINDING_TYPE=BINDING_TYPE_PYX')
+    extra_args.append('-std=c++17')
+    extra_args.append('-g0')
+    extra_link_args.append('-Wl,--strip-all')
+
   if '${OpenMP_CXX_FLAGS}' != '':
     extra_args.append('${OpenMP_CXX_FLAGS}')
   if cxx_flags:
     extra_args.extend(cxx_flags.split(' '))
-
-  # Extra options for MSVC compiler.
-  if platform.system() == 'Windows':
-    extra_args.extend(['/MD', '/O2', '/Ob2', '/DNDEBUG'])
 
   # This is used for parallel builds; CMake will set PYX_TO_BUILD accordingly.
   if module is not None:


### PR DESCRIPTION
This modifies the Python binding build configuration to compile without debugging symbols, and strip the compiled libraries.  This can help result in *significantly* smaller wheels.  Compared to mlpack 3.4.2, the compiled libraries in the Python wheel are 10x smaller; part of that has to do with this patch, part of it has to do with all the other changes that have happened since mlpack 3.4.2.

The `-g0` option overrides any previous setting of `-g`; this is necessary because Cython by default will compile with `-g` (which is maybe a little bit of a confusing choice to me, but oh well).