### PR TITLE
Remove dependency of `python_copy` on mlpack for Ninja build system

### DIFF
--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -125,8 +125,8 @@ if (DEBUG)
   set(DISABLE_CFLAGS "NDEBUG;MLPACK_HAS_BFD_DL" PARENT_SCOPE)
 endif ()
 
-add_custom_target(python ALL DEPENDS mlpack)
-add_custom_target(python_copy ALL DEPENDS mlpack)
+add_custom_target(python ALL DEPENDS python_copy)
+add_custom_target(python_copy ALL)
 # The python_configure target is added later; this is a dummy target.
 add_custom_target(python_configured ALL)
 


### PR DESCRIPTION
The conda-forge build system uses the Ninja generator on Windows.  However, I found that Ninja complained of a dependency cycle in targets: python -> python_copy -> mlpack -> python.  I am not sure exactly how that happened, but in any case this patch, which simplifies the dependency structure of the Python targets, fixes it.  It turns out that `python_copy` actually does not depend on `mlpack`, so I removed that, and then made `python` depend on `python_copy`.  With this, Ninja is happy.