### PR TITLE
Use `python -m pip install` instead of `setup.py install`

### DIFF
--- a/src/mlpack/bindings/python/PythonInstall.cmake
+++ b/src/mlpack/bindings/python/PythonInstall.cmake
@@ -3,15 +3,18 @@
 # A utility script to install Python bindings and fail fatally if installation
 # was not successful.
 if (DEFINED ENV{DESTDIR})
-  execute_process(COMMAND ${PYTHON_EXECUTABLE}
-      "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
-          --prefix=${PYTHON_INSTALL_PREFIX} --root=$ENV{DESTDIR}
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install
+          --prefix=${PYTHON_INSTALL_PREFIX}
+          --root=$ENV{DESTDIR} .
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
+      RESULT_VARIABLE setup_res)
+elseif (WIN32)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install .
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 else ()
-  execute_process(COMMAND ${PYTHON_EXECUTABLE}
-      "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py" install
-          --prefix=${PYTHON_INSTALL_PREFIX}
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install
+          --prefix=${PYTHON_INSTALL_PREFIX} .
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 endif ()


### PR DESCRIPTION
As of maybe a year or so ago, the command `python setup.py install` is now [deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html).  The suggestion is to instead use `python -m pip install .`.  So, this patch adapts our CMake Python binding install configuration to do exactly that, and also adds a block for Windows where we don't need to set `--prefix` or `--root`.

Somehow, this patch was necessary to fix some builds for conda-forge on OS X.

In any case, it also makes us not depend on deprecated functionality, which is good. :)