### PR TITLE
Add missing step from README to build tests.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 ###### ????-??-??
   * Fix mapping of categorical data for Julia bindings (#3305).
 
+  * README fix: `make mlpack_test` is required before running tests (#3315).
+
 ### mlpack 4.0.0
 ###### 2022-10-23
   * Bump C++ standard requirement to C++14 (#3233).

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ codebase.  It is easy to build and run the tests with CMake and CTest, as below:
 mkdir build && cd build/
 cmake -DBUILD_TESTS=ON ../
 make
+make mlpack_test
 ctest .
 ```
 


### PR DESCRIPTION
This comes from #3314.

When a user sets `BUILD_TESTS` to `ON`, and then does `make`, the `mlpack_test` program is actually not built (because it is defined with the CMake option `EXCLUDE_FROM_ALL`).  The reason for that is to prevent users who don't care about the tests from having to sit through the compilation of the tests, which can take a long time.

So, when building the tests, right now, we must also run `make mlpack_test` explicitly.  This PR just updates the documentation accordingly.