### PR TITLE
Fix documentation type for `decision_tree` binding

### DIFF
--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -15,7 +15,7 @@ add_all_bindings(bayesian_linear_regression bayesian_linear_regression
     "regression")
 add_all_bindings(cf cf "misc. / other")
 add_all_bindings(dbscan dbscan "clustering")
-add_all_bindings(decision_tree decision_tree "clustering")
+add_all_bindings(decision_tree decision_tree "classification")
 add_all_bindings(det det "misc. / other")
 add_all_bindings(emst emst "geometry")
 add_all_bindings(fastmks fastmks "geometry")


### PR DESCRIPTION
Decision trees are classification algorithms, not clustering algorithms.  I must have made a typo during a refactoring.

This will fix the fact that `decision_tree()` is listed under "clustering" instead of "classification" on the binding documentation pages:
https://www.mlpack.org/doc/stable/python_documentation.html
(see the left sidebar)