### PR TITLE
Fix binding handling of transposed matrix parameters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 ### mlpack ?.?.?
 ###### ????-??-??
   * Fix mapping of categorical data for Julia bindings (#3305).
-  
+
   * Bugfix: catch all exceptions when running bindings from Julia, instead of
     crashing (#3304).
 
@@ -13,10 +13,13 @@
 
   * The `/std:c++17` and `/Zc:__cplusplus` options are now required when using
     Visual Studio (#3318).  Documentation and compile-time checks added.
-    
+
   * Set `BUILD_TESTS` to `OFF` by default.  If you want to build tests, like
     `mlpack_test`, manually set `BUILD_TESTS` to `ON` in your CMake
     configuration step (#3316).
+
+  * Fix handling of transposed matrix parameters in Python, Julia, R, and Go
+    bindings (#3327).
 
 ### mlpack 4.0.0
 ###### 2022-10-23

--- a/src/mlpack/bindings/R/mlpack/src/r_util.cpp
+++ b/src/mlpack/bindings/R/mlpack/src/r_util.cpp
@@ -112,10 +112,11 @@ void SetParamVecInt(SEXP params,
 // [[Rcpp::export]]
 void SetParamMat(SEXP params,
                  const std::string& paramName,
-                 const arma::mat& paramValue)
+                 const arma::mat& paramValue,
+                 bool transpose)
 {
   util::Params& p = *Rcpp::as<Rcpp::XPtr<util::Params>>(params);
-  p.Get<arma::mat>(paramName) = paramValue.t();
+  p.Get<arma::mat>(paramName) = (transpose ? paramValue.t() : paramValue);
   p.SetPassed(paramName);
 }
 

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -113,6 +113,17 @@ test_that("TestUMatrix", {
   }
 })
 
+# Test a transposed matrix.
+test_that("TestTransMatrix", {
+  x <- matrix(rexp(500, rate = .1), ncol = 5)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           tmatrix_in=x,
+                           matrix_in=x)
+  # If the binding succeeds, the output double will be 10.
+  expect_true(output$double_out == 10.0)
+})
+
 # Test a column vector input parameter.
 test_that("TestCol", {
   x <- matrix(rexp(100, rate = .1), nrow = 1)

--- a/src/mlpack/bindings/R/print_input_processing.hpp
+++ b/src/mlpack/bindings/R/print_input_processing.hpp
@@ -74,6 +74,15 @@ void PrintInputProcessing(
     util::ParamData& d,
     const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
 {
+  std::string extraTransStr = "";
+  if (d.cppType == "arma::mat")
+  {
+    if (d.noTranspose)
+      extraTransStr = ", FALSE";
+    else
+      extraTransStr = ", TRUE";
+  }
+
   if (!d.required)
   {
     /**
@@ -82,11 +91,21 @@ void PrintInputProcessing(
      *     if (!identical(<param_name>, NA)) {
      *        SetParam<type>(p, "<param_name>", to_matrix(<param_name>))
      *     }
+     *
+     * and if the parameter is an arma::mat, we will get code like
+     *
+     *     if (!identical(<param_name>, NA)) {
+     *        SetParam<type>(p, "<param_name>", to_matrix(<param_name>), TRUE)
+     *     }
+     *
+     * where the final boolean specifies whether the matrix should be
+     * transposed.
      */
     MLPACK_COUT_STREAM << "  if (!identical(" << d.name << ", NA)) {"
         << std::endl;
     MLPACK_COUT_STREAM << "    SetParam" << GetType<T>(d) << "(p, \""
-        << d.name << "\", to_matrix(" << d.name << "))" << std::endl;
+        << d.name << "\", to_matrix(" << d.name << ")" << extraTransStr << ")"
+        << std::endl;
     MLPACK_COUT_STREAM << "  }" << std::endl; // Closing brace.
   }
   else
@@ -95,9 +114,17 @@ void PrintInputProcessing(
      * This gives us code like:
      *
      *     SetParam<type>(p, "<param_name>", to_matrix(<param_name>))
+     *
+     * and if the parameter is an arma::mat, we will get code like
+     *
+     *     SetParam<type>(p, "<param_name>", to_matrix(<param_name>), TRUE)
+     *
+     * where the final boolean specifies whether the matrix should be
+     * transposed.
      */
     MLPACK_COUT_STREAM << "  SetParam" << GetType<T>(d) << "(p, \""
-        << d.name << "\", to_matrix(" << d.name << "))" << std::endl;
+        << d.name << "\", to_matrix(" << d.name << ")" << extraTransStr << ")"
+        << std::endl;
   }
   MLPACK_COUT_STREAM << std::endl; // Extra line is to clear up the code a bit.
 }

--- a/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
+++ b/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
@@ -41,6 +41,7 @@ PARAM_FLAG("flag1", "Input flag, must be specified.", "f");
 PARAM_FLAG("flag2", "Input flag, must not be specified.", "F");
 PARAM_MATRIX_IN("matrix_in", "Input matrix.", "m");
 PARAM_UMATRIX_IN("umatrix_in", "Input unsigned matrix.", "u");
+PARAM_TMATRIX_IN("tmatrix_in", "Input (transposed) matrix.", "");
 PARAM_COL_IN("col_in", "Input column.", "c");
 PARAM_UCOL_IN("ucol_in", "Input unsigned column.", "");
 PARAM_ROW_IN("row_in", "Input row.", "");
@@ -90,6 +91,30 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
 
     if (d == 4.0)
       params.Get<double>("double_out") = 5.0;
+  }
+
+  // If a transposed matrix is specified, check that it is the same as the (now
+  // required) matrix_in parameter.  If the test passes, set `double_out` to 10.
+  if (params.Has("tmatrix_in"))
+  {
+    if (!params.Has("matrix_in"))
+    {
+      throw std::runtime_error("If tmatrix_in is specified, matrix_in must also"
+          " be specified!");
+    }
+
+    arma::mat tmat = params.Get<arma::mat>("tmatrix_in");
+    arma::mat mat = params.Get<arma::mat>("matrix_in");
+
+    if (!arma::approx_equal(tmat.t(), mat, "reldiff", 0.001))
+    {
+      throw std::runtime_error("Transposed tmatrix_in and matrix_in are not "
+          "equal!");
+    }
+    else
+    {
+      params.Get<double>("double_out") = 10.0;
+    }
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and

--- a/src/mlpack/bindings/go/CMakeLists.txt
+++ b/src/mlpack/bindings/go/CMakeLists.txt
@@ -128,7 +128,7 @@ if (BUILD_GO_SHLIB)
           ${CMAKE_BINARY_DIR}/src/mlpack/bindings/go/src/mlpack.org/v1/mlpack/)
   endforeach()
 
-  if (BUILD_TESTS OR BUILD_GO_SHLIB)
+  if (BUILD_TESTS AND BUILD_GO_SHLIB)
     foreach(test_file ${TEST_SOURCES})
       add_custom_command(TARGET go_copy PRE_BUILD
           COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different
@@ -278,6 +278,6 @@ endif()
 
 endmacro ()
 
-if (BUILD_TESTS OR BUILD_GO_SHLIB)
+if (BUILD_TESTS AND BUILD_GO_SHLIB)
   add_subdirectory(tests)
 endif ()

--- a/src/mlpack/bindings/go/mlpack/arma_util.go
+++ b/src/mlpack/bindings/go/mlpack/arma_util.go
@@ -91,7 +91,7 @@ func (m *mlpackArma) allocArmaPtrMatWithInfo(p *params,
 }
 
 // Passes a Gonum matrix to C by using the underlying data from the Gonum matrix.
-func gonumToArmaMat(p *params, identifier string, m *mat.Dense) {
+func gonumToArmaMat(p *params, identifier string, m *mat.Dense, trans bool) {
   // Get the number of elements in the Armadillo column.
   r, c := m.Dims()
   blas64General := m.RawMatrix()
@@ -100,7 +100,7 @@ func gonumToArmaMat(p *params, identifier string, m *mat.Dense) {
   // Pass pointer of the underlying matrix to mlpack.
   ptr := unsafe.Pointer(&data[0])
   C.mlpackToArmaMat(p.mem, C.CString(identifier), (*C.double)(ptr),
-      C.size_t(c), C.size_t(r))
+      C.size_t(c), C.size_t(r), C.bool(trans))
 }
 
 // Passes a Gonum matrix to C by using the underlying data from the Gonum matrix.

--- a/src/mlpack/bindings/go/mlpack/capi/arma_util.cpp
+++ b/src/mlpack/bindings/go/mlpack/capi/arma_util.cpp
@@ -28,12 +28,17 @@ void mlpackToArmaMat(void* params,
                      const char* identifier,
                      double* mat,
                      const size_t row,
-                     const size_t col)
+                     const size_t col,
+                     bool transpose)
 {
   util::Params& p = *((util::Params*) params);
 
   // Advanced constructor.
   arma::mat m(mat, row, col, false, false);
+
+  // Transpose if necessary.
+  if (transpose)
+    arma::inplace_trans(m);
 
   // Set input parameter with corresponding matrix in IO.
   SetParam(p, identifier, m);

--- a/src/mlpack/bindings/go/mlpack/capi/arma_util.h
+++ b/src/mlpack/bindings/go/mlpack/capi/arma_util.h
@@ -28,7 +28,8 @@ void mlpackToArmaMat(void* params,
                      const char* identifier,
                      double* mat,
                      const size_t row,
-                     const size_t col);
+                     const size_t col,
+                     bool transpose);
 
 /**
  * Pass Gonum Dense pointer and wrap an Armadillo mat around it.

--- a/src/mlpack/bindings/go/print_input_processing.hpp
+++ b/src/mlpack/bindings/go/print_input_processing.hpp
@@ -149,12 +149,26 @@ void PrintInputProcessing(
    *
    *  // Detect if the parameter was passed; set if so.
    *  if param.Name != nil {
-   *     gonumToArma<type>(params, "paramName", param.Name)
+   *     gonumToArma<type>(params, "paramName", param.Name, false)
    *     setPassed(params, "paramName")
    *  }
+   *
+   * where the boolean parameter indicates if the matrix needs to be transposed,
+   * and is only included for arma::mat type parameters.
    */
   std::cout << prefix << "// Detect if the parameter was passed; set if so."
             << std::endl;
+
+  // Add extra transpose option, but only for arma::mat types.
+  std::string transStrExtra = "";
+  if (d.cppType == "arma::mat")
+  {
+    if (d.noTranspose)
+      transStrExtra = ", true";
+    else
+      transStrExtra = ", false";
+  }
+
   if (!d.required)
   {
     std::cout << prefix << "if param." << goParamName
@@ -163,7 +177,7 @@ void PrintInputProcessing(
     // Print function call to set the given parameter into the io.
     std::cout << prefix << prefix << "gonumToArma" << GetType<T>(d)
               << "(params, \"" << d.name << "\", param." << goParamName
-              << ")" << std::endl;
+              << transStrExtra << ")" << std::endl;
 
     // Print function call to set the given parameter as passed.
     std::cout << prefix << prefix << "setPassed(params, \"" << d.name << "\")"
@@ -176,7 +190,7 @@ void PrintInputProcessing(
     // Print function call to set the given parameter into the io.
     std::cout << prefix << "gonumToArma" << GetType<T>(d)
               << "(params, \"" << d.name << "\", " << goParamName
-              << ")" << std::endl;
+              << transStrExtra << ")" << std::endl;
 
     // Print function call to set the given parameter as passed.
     std::cout << prefix << "setPassed(params, \"" << d.name << "\")"

--- a/src/mlpack/bindings/go/tests/go_binding_test.go
+++ b/src/mlpack/bindings/go/tests/go_binding_test.go
@@ -196,6 +196,31 @@ func TestGonumUMatrix(t *testing.T) {
     }
   }
 }
+
+func TestGonumTransMatrix(t *testing.T) {
+  t.Log("Test transposed matrix input.")
+  x := mat.NewDense(3, 5, []float64{
+    1, 2, 3, 4, 5,
+    6, 7, 8, 9, 10,
+    11, 12, 13, 14, 15,
+  })
+  x2 := mat.NewDense(3, 5, []float64{
+    1, 2, 3, 4, 5,
+    6, 7, 8, 9, 10,
+    11, 12, 13, 14, 15,
+  })
+
+  param := mlpack.TestGoBindingOptions()
+  param.MatrixIn = x
+  param.TmatrixIn = x2
+  d := 4.0
+  i := 12
+  s := "hello"
+  // The binding simply needs to run successfully (without exception) to
+  // succeed.
+  mlpack.TestGoBinding(d, i, s, param)
+}
+
 func TestGonumTransposeRow(t *testing.T) {
   t.Log("Test a column vector input parameter.")
   x := mat.NewDense(1, 9, []float64{

--- a/src/mlpack/bindings/go/tests/test_go_binding_main.cpp
+++ b/src/mlpack/bindings/go/tests/test_go_binding_main.cpp
@@ -41,6 +41,7 @@ PARAM_FLAG("flag1", "Input flag, must be specified.", "f");
 PARAM_FLAG("flag2", "Input flag, must not be specified.", "F");
 PARAM_MATRIX_IN("matrix_in", "Input matrix.", "m");
 PARAM_UMATRIX_IN("umatrix_in", "Input unsigned matrix.", "u");
+PARAM_TMATRIX_IN("tmatrix_in", "Input matrix (transposed).", "");
 PARAM_COL_IN("col_in", "Input column.", "c");
 PARAM_UCOL_IN("ucol_in", "Input unsigned column.", "");
 PARAM_ROW_IN("row_in", "Input row.", "");
@@ -90,6 +91,26 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
 
     if (d == 4.0)
       params.Get<double>("double_out") = 5.0;
+  }
+
+  // If a transposed input matrix is given, it is expected to be the same as the
+  // (now required) input matrix.
+  if (params.Has("tmatrix_in"))
+  {
+    if (!params.Has("matrix_in"))
+    {
+      throw std::runtime_error("If tmatrix_in is specified, matrix_in must be "
+          "specified!");
+    }
+
+    arma::mat tmat = params.Get<arma::mat>("tmatrix_in");
+    arma::mat mat = params.Get<arma::mat>("matrix_in");
+
+    if (!arma::approx_equal(tmat.t(), mat, "reldiff", 0.001))
+    {
+      throw std::runtime_error("Transposed tmatrix_in and matrix_in are not "
+          "equal!");
+    }
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and

--- a/src/mlpack/bindings/julia/mlpack/params.jl.in
+++ b/src/mlpack/bindings/julia/mlpack/params.jl.in
@@ -47,12 +47,14 @@ function convert_to_1d(in::Array{T, 2})::Array{T, 1} where T
 end
 
 # Utility function to convert to and return a matrix.
-function to_matrix(input, T::Type)
-  if isa(input, Array{T, 1})
+function to_matrix(input, T::Type, transpose::Bool)
+  result = if isa(input, Array{T, 1})
     convert_to_2d(input)
   else
     convert(Array{T, 2}, input)
   end
+
+  return transpose ? convert(Array{T, 2}, result') : result
 end
 
 # Utility function to convert to and return a vector.
@@ -104,9 +106,10 @@ function SetParamMat(params::Ptr{Nothing},
                      paramName::String,
                      paramValue,
                      pointsAsRows::Bool,
+                     transpose::Bool,
                      juliaOwnedMemory::Set{Ptr{Nothing}})
   push!(juliaOwnedMemory, convert(Ptr{Nothing}, Base.pointer(paramValue)))
-  paramMat = to_matrix(paramValue, Float64)
+  paramMat = to_matrix(paramValue, Float64, transpose)
   ccall((:SetParamMat, library), Nothing, (Ptr{Nothing}, Cstring, Ptr{Float64},
       Csize_t, Csize_t, Bool), params, paramName, Base.pointer(paramMat),
       size(paramMat, 1), size(paramMat, 2), pointsAsRows)
@@ -116,9 +119,10 @@ function SetParamUMat(params::Ptr{Nothing},
                       paramName::String,
                       paramValue,
                       pointsAsRows::Bool,
+                      transpose::Bool,
                       juliaOwnedMemory::Set{Ptr{Nothing}})
   push!(juliaOwnedMemory, convert(Ptr{Nothing}, Base.pointer(paramValue)))
-  paramMat = to_matrix(paramValue, Int)
+  paramMat = to_matrix(paramValue, Int, transpose)
 
   # Sanity check.
   if minimum(paramMat) <= 0

--- a/src/mlpack/bindings/julia/print_input_processing_impl.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing_impl.hpp
@@ -99,7 +99,12 @@ void PrintInputProcessing(
   else
   {
     matTypeModifier = "Mat";
-    extra = ", points_are_rows";
+
+    // Determine whether we need to transpose the matrix.
+    std::string transStr =
+        (d.noTranspose ? std::string("true") : std::string("false"));
+
+    extra = ", points_are_rows, " + transStr;
   }
 
   // Now print the SetParam call.

--- a/src/mlpack/bindings/julia/tests/runtests.jl
+++ b/src/mlpack/bindings/julia/tests/runtests.jl
@@ -178,6 +178,32 @@ end
   end
 end
 
+# Test a transposed input matrix.
+@testset "TestTransMatrix" begin
+  x = rand(5, 100)
+  y = copy(x)
+
+  # If the binding does not throw an exception, then it succeeded.
+  _, _, _, _, matOut, _, _, _, _, _, _, _, _, _ =
+      test_julia_binding(4.0, 12, "hello",
+                         tmatrix_in=y,
+                         matrix_in=x,
+                         points_are_rows=true)
+end
+
+# Test a transposed input matrix, when in column-major mode.
+@testset "TestTransMatrixColMajor" begin
+  x = rand(100, 5)
+  y = copy(x)
+
+  # If the binding does not throw an exception, then it succeeded.
+  _, _, _, _, matOut, _, _, _, _, _, _, _, _, _ =
+      test_julia_binding(4.0, 12, "hello",
+                         tmatrix_in=y,
+                         matrix_in=x,
+                         points_are_rows=false)
+end
+
 # Test a column vector input parameter.
 @testset "TestCol" begin
   x = rand(100)

--- a/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
+++ b/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
@@ -41,6 +41,7 @@ PARAM_FLAG("flag1", "Input flag, must be specified.", "f");
 PARAM_FLAG("flag2", "Input flag, must not be specified.", "F");
 PARAM_MATRIX_IN("matrix_in", "Input matrix.", "m");
 PARAM_UMATRIX_IN("umatrix_in", "Input unsigned matrix.", "u");
+PARAM_TMATRIX_IN("tmatrix_in", "Input (transposed) matrix.", "");
 PARAM_COL_IN("col_in", "Input column.", "c");
 PARAM_UCOL_IN("ucol_in", "Input unsigned column.", "");
 PARAM_ROW_IN("row_in", "Input row.", "");
@@ -92,6 +93,26 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
 
     if (d == 4.0)
       params.Get<double>("double_out") = 5.0;
+  }
+
+  // If a transposed input matrix is specified, it is expected to be the same as
+  // the (now required) input matrix.
+  if (params.Has("tmatrix_in"))
+  {
+    if (!params.Has("matrix_in"))
+    {
+      throw std::runtime_error("If tmatrix_in is specified, then matrix_in is "
+          "required!");
+    }
+
+    arma::mat tmat = params.Get<arma::mat>("tmatrix_in");
+    arma::mat mat = params.Get<arma::mat>("matrix_in");
+
+    if (!arma::approx_equal(tmat.t(), mat, "reldiff", 0.001))
+    {
+      throw std::runtime_error("Transposed tmatrix_in and matrix_in are not "
+          "equal!");
+    }
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -335,12 +335,14 @@ endmacro ()
 
 # Add a test.
 if (BUILD_PYTHON_BINDINGS)
-  add_test(NAME python_bindings_test
-      COMMAND ${PYTHON_EXECUTABLE}
-          ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py test
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/)
-  set_tests_properties(python_bindings_test
-      PROPERTIES ENVIRONMENT "NO_BUILD=1;LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib/")
+  if (BUILD_TESTS)
+    add_test(NAME python_bindings_test
+        COMMAND ${PYTHON_EXECUTABLE}
+            ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/setup.py test
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/)
+    set_tests_properties(python_bindings_test
+        PROPERTIES ENVIRONMENT "NO_BUILD=1;LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib/")
+  endif ()
 endif ()
 
 if (BUILD_TESTS)

--- a/src/mlpack/bindings/python/mlpack/io.pxd
+++ b/src/mlpack/bindings/python/mlpack/io.pxd
@@ -25,6 +25,7 @@ cdef extern from "<mlpack/core/util/io.hpp>" namespace "mlpack" nogil:
 cdef extern from "<mlpack/bindings/python/mlpack/io_util.hpp>" \
     namespace "mlpack::util" nogil:
   void SetParam[T](Params, string, T&) nogil except +
+  void SetParam[T](Params, string, T&, bool) nogil except +
   void SetParamPtr[T](Params, string, T*, bool) nogil except +
   void SetParamWithInfo[T](Params, string, T&, const bool*) nogil except +
   (T*) GetParamPtr[T](Params, string) nogil except +

--- a/src/mlpack/bindings/python/mlpack/io_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/io_util.hpp
@@ -19,20 +19,47 @@
 namespace mlpack {
 namespace util {
 
+// Utility functions to correctly handle transposed Armadillo matrices.
+template<typename T>
+inline void TransposeIfNeeded(
+    const std::string& identifier,
+    T& value,
+    bool transpose)
+{
+  // No transpose needed for non-matrices.
+  return;
+}
+
+inline void TransposeIfNeeded(
+    const std::string& identifier,
+    arma::mat& value,
+    bool transpose)
+{
+  if (transpose)
+  {
+    arma::inplace_trans(value);
+  }
+}
+
 /**
  * Set the parameter to the given value.
  *
  * This function exists to work around Cython's lack of support for lvalue
  * references.
  *
+ * @param params Parameters object to use.
  * @param identifier Name of parameter.
  * @param value Value to set parameter to.
+ * @param transpose If true, and if T is a matrix type, the matrix will be
+ *     transposed in-place.
  */
 template<typename T>
 inline void SetParam(util::Params& params,
                      const std::string& identifier,
-                     T& value)
+                     T& value,
+                     bool transpose = false)
 {
+  TransposeIfNeeded(identifier, value, transpose);
   params.Get<T>(identifier) = std::move(value);
 }
 

--- a/src/mlpack/bindings/python/mlpack/matrix_utils.py
+++ b/src/mlpack/bindings/python/mlpack/matrix_utils.py
@@ -85,9 +85,9 @@ def to_matrix_with_info(x, dtype, copy=False):
   if isinstance(x, np.ndarray):
     # It is already an ndarray, so the vector of info is all 0s (all numeric).
     if len(x.shape) < 2:
-      d = np.zeros(1, dtype=np.bool)
+      d = np.zeros(1, dtype=bool)
     else:
-      d = np.zeros([x.shape[1]], dtype=np.bool)
+      d = np.zeros([x.shape[1]], dtype=bool)
 
     # Copy the matrix if needed.
     if copy:
@@ -108,9 +108,9 @@ def to_matrix_with_info(x, dtype, copy=False):
         # We can just return the matrix as-is; it's all numeric.
         t = to_matrix(x, dtype=dtype, copy=copy)
         if len(x.shape) < 2:
-          d = np.zeros(1, dtype=np.bool)
+          d = np.zeros(1, dtype=bool)
         else:
-          d = np.zeros([x.shape[1]], dtype=np.bool)
+          d = np.zeros([x.shape[1]], dtype=bool)
         return (t[0], t[1], d)
 
     if np.dtype(str) in dtype_array or np.dtype(unicode) in dtype_array:
@@ -123,7 +123,7 @@ def to_matrix_with_info(x, dtype, copy=False):
     # so go ahead and copy the dataframe and we'll work with y to make
     # modifications.
     y = x
-    d = np.zeros([x.shape[1]], dtype=np.bool)
+    d = np.zeros([x.shape[1]], dtype=bool)
 
     # Convert any 'object', 'str', or 'unicode' types to categorical.
     convertColumns = x.select_dtypes(['object'])
@@ -164,12 +164,12 @@ def to_matrix_with_info(x, dtype, copy=False):
 
     # Since we don't have a great way to check if these are using the same
     # memory location, we will probe manually (ugh).
-    oldval = x[0]
-    x[0] *= 2
+    oldval = x[0][0]
+    x[0][0] *= 2
     alias = False
-    if out[0] == x[0]:
+    if out.flat[0] == x[0][0]:
       alias = True
-      x[0] = oldval
+    x[0][0] = oldval
 
     return (out, not alias, d)
 

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -271,13 +271,18 @@ void PrintInputProcessing(
    *     param_name_tuple[0].shape = (param_name_tuple[0].size,)
    *   param_name_mat = arma_numpy.numpy_to_mat_s(param_name_tuple[0],
    *       param_name_tuple[1])
-   *   SetParam[mat](p, \<const string\> 'param_name', dereference(param_name_mat))
+   *   SetParam[mat](p, \<const string\> 'param_name', dereference(param_name_mat), True)
    *   p.SetPassed(\<const string\> 'param_name')
    *
+   * The value of the final boolean passed to SetParam is determined by whether
+   * the matrix is transposed or not.  That boolean is omitted if the parameter
+   * is a row or column.
    */
   std::cout << prefix << "# Detect if the parameter was passed; set if so."
       << std::endl;
   std::string name = GetValidName(d.name);
+  std::string transStr =
+      (d.noTranspose ? std::string("True") : std::string("False"));
 
   if (!d.required)
   {
@@ -299,7 +304,7 @@ void PrintInputProcessing(
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
           << "](p, <const string> '" << d.name << "', dereference("
-          << name << "_mat))"<< std::endl;
+          << name << "_mat))" << std::endl;
       std::cout << prefix << "  p.SetPassed(<const string> '" << d.name
           << "')" << std::endl;
       std::cout << prefix << "  del " << name << "_mat" << std::endl;
@@ -319,7 +324,7 @@ void PrintInputProcessing(
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
           << "](p, <const string> '" << d.name << "', dereference("
-          << name << "_mat))"<< std::endl;
+          << name << "_mat), " << transStr << ")" << std::endl;
       std::cout << prefix << "  p.SetPassed(<const string> '" << d.name
           << "')" << std::endl;
       std::cout << prefix << "  del " << name << "_mat" << std::endl;
@@ -343,7 +348,7 @@ void PrintInputProcessing(
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
           << "](p, <const string> '" << d.name << "', dereference("
-          << name << "_mat))"<< std::endl;
+          << name << "_mat))" << std::endl;
       std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"
           << std::endl;
       std::cout << prefix << "del " << name << "_mat" << std::endl;
@@ -362,7 +367,7 @@ void PrintInputProcessing(
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
           << "](p, <const string> '" << d.name << "', dereference(" << name
-          << "_mat))" << std::endl;
+          << "_mat), " << transStr << ")" << std::endl;
       std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"
           << std::endl;
       std::cout << prefix << "del " << name << "_mat" << std::endl;

--- a/src/mlpack/bindings/python/tests/test_python_binding.py
+++ b/src/mlpack/bindings/python/tests/test_python_binding.py
@@ -557,6 +557,35 @@ class TestPythonBinding(unittest.TestCase):
     self.assertEqual(output['umatrix_out'][2, 2], 26)
     self.assertEqual(output['umatrix_out'][2, 3], 14)
 
+  def testTransMatrix(self):
+    """
+    Test that we can correctly pass a matrix in that's specified with the
+    PARAM_TMATRIX_IN() macro, and it is correctly transposed.
+    """
+    x = np.random.rand(20, 10)
+    test_python_binding(string_in='hello',
+                        int_in=12,
+                        double_in=4.0,
+                        mat_req_in=[[1.0]],
+                        col_req_in=[1.0],
+                        matrix_in=x,
+                        tmatrix_in=x)
+
+  def testTransMatrixForceCopy(self):
+    """
+    The same test as above, but we force copies.
+    """
+    x = np.random.rand(20, 10)
+    xt = copy.deepcopy(np.transpose(x))
+    test_python_binding(string_in='hello',
+                        int_in=12,
+                        double_in=4.0,
+                        mat_req_in=[[1.0]],
+                        col_req_in=[1.0],
+                        matrix_in=x,
+                        tmatrix_in=x,
+                        copy_all_inputs=True)
+
   def testCol(self):
     """
     Test a column vector input parameter.

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -46,6 +46,7 @@ PARAM_FLAG("flag2", "Input flag, must not be specified.", "F");
 PARAM_MATRIX_IN("matrix_in", "Input matrix.", "m");
 PARAM_MATRIX_IN("smatrix_in", "Input matrix.", "");
 PARAM_UMATRIX_IN("umatrix_in", "Input unsigned matrix.", "u");
+PARAM_TMATRIX_IN("tmatrix_in", "Input transposed matrix.", "");
 PARAM_COL_IN("col_in", "Input column.", "c");
 PARAM_UCOL_IN("ucol_in", "Input unsigned column.", "");
 PARAM_ROW_IN("row_in", "Input row.", "");
@@ -112,6 +113,27 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   {
     throw std::invalid_argument("col_req_in must have '1.0' as its only "
         "single element!");
+  }
+
+  // If a transposed input matrix is given, an input matrix should also be
+  // given, and one should be the transpose of the other.
+  if (params.Has("tmatrix_in"))
+  {
+    if (!params.Has("matrix_in"))
+    {
+      throw std::runtime_error("If tmatrix_in is specified, matrix_in must be "
+          "specified!");
+    }
+
+    arma::mat tmat = params.Get<arma::mat>("tmatrix_in");
+    std::cerr << "tmat has size " << tmat.n_rows << " x " << tmat.n_cols << "\n";
+    arma::mat mat = params.Get<arma::mat>("matrix_in");
+    std::cerr << "mat has size " << mat.n_rows << " x " << mat.n_cols << "\n";
+
+    if (!arma::approx_equal(tmat.t(), mat, "reldiff", 0.001))
+    {
+      throw std::runtime_error("tmatrix_in transposed not equal to matrix_in!");
+    }
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and


### PR DESCRIPTION
Digging into #3324, I realized that none of our bindings (except command-line programs) have handling for parameters declared as `PARAM_TMATRIX_IN()` (i.e. a transposed matrix).  LARS happens to be the only binding that actually uses this parameter type, and so what happens is that in languages other than command-line bindings (such as Python), the user's data will be unexpectedly transposed.

This PR adds support for transposed matrices to Python, Go, R, and Julia bindings, which will in turn fix the strange behavior specific to LARS that was encountered in #3324 (and probably by other users).

For each language, this boils down to:

 * adding a test for a `PARAM_TMATRIX_IN` parameter
 * handling the `noTranspose` parameter from `ParamData` while generating the bindings
 * updating the glue code between languages so it can support transposing if needed

There are also a couple other tiny fixes in here:

 * fix some deprecation warnings from numpy in `matrix_utils.py`
 * fix CMake configuration so that `python_bindings_test` is not added unless `BUILD_TESTS` is `ON`
 * fix Go configuration so that `go_bindings_test` is not added unless `BUILD_TESTS` is `ON`