### PR TITLE
Remove last references to doxygen in the documentation.

### DIFF
--- a/doc/developer/bindings.md
+++ b/doc/developer/bindings.md
@@ -164,7 +164,7 @@ BINDING_SEE_ALSO("Mean Shift, Mode Seeking, and Clustering (pdf)",
         "http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.510.1222"
         "&rep=rep1&type=pdf");
 BINDING_SEE_ALSO("mlpack::mean_shift::MeanShift C++ class documentation",
-        "@doxygen/classmlpack_1_1meanshift_1_1MeanShift.html");
+        "@src/mlpack/methods/mean_shift/mean_shift.hpp");
 
 // Define parameters for the executable.
 

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -276,7 +276,5 @@ other functionality is available.
 Some of this functionality is demonstrated in the
 [examples repository](https://github.com/mlpack/examples).
 
-A full list of all classes and functions that mlpack implements can be found in
-the
-[Doxygen documentation](https://www.mlpack.org/doc/stable/doxygen/index.html),
-or simply by browsing the well-commented source code.
+A full list of all classes and functions that mlpack implements can be found by
+browsing the well-commented source code.


### PR DESCRIPTION
This comes out of https://github.com/mlpack/mlpack.org/issues/59 --- I just took a look in the codebase for the word "doxygen", and removed it.  We don't use Doxygen anymore to document our code, so these references are out of date.