### PR TITLE
fix internal links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ variety of other needs.
 </div>
 <br>
 
-## 0. Contents and Quick Links
+## 0. Contents
 
  1. [Citation details](#1-citation-details)
  2. [Dependencies](#2-dependencies)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ variety of other needs.
 
  1. [Citation details](#1-citation-details)
  2. [Dependencies](#2-dependencies)
- 3. [Installing and using mlpack in C++](#3-installing-and-using-mlpack-in-c++)
+ 3. [Installing and using mlpack in C++](#3-installing-and-using-mlpack-in-c)
  4. [Building mlpack bindings to other languages](#4-building-mlpack-bindings-to-other-languages)
      1. [Command-line programs](#4i-command-line-programs)
      2. [Python bindings](#4ii-python-bindings)

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ variety of other needs.
 
  1. [Citation details](#1-citation-details)
  2. [Dependencies](#2-dependencies)
- 3. [Installing and using mlpack in C++](#4-installing-and-using-mlpack-in-c++)
- 4. [Building mlpack bindings to other languages](#5-building-mlpack-bindings-to-other-languages)
+ 3. [Installing and using mlpack in C++](#3-installing-and-using-mlpack-in-c++)
+ 4. [Building mlpack bindings to other languages](#4-building-mlpack-bindings-to-other-languages)
      1. [Command-line programs](#4i-command-line-programs)
      2. [Python bindings](#4ii-python-bindings)
      3. [R bindings](#4iii-r-bindings)


### PR DESCRIPTION
- fix internal links
- take into account markdown limitations in the names of internal links (eg. "++" is not doable, so "C++" becomes "C")
- remove second "Quick Links" to reduce confusion with first "Quick Links" (on line 40)