### PR TITLE
Use qualified std::move() to fix clang warnings for CRAN

### DIFF
--- a/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
+++ b/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
@@ -121,11 +121,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   // the 3rd row will be multiplied by two.
   if (params.Has("matrix_in"))
   {
-    arma::mat out = move(params.Get<arma::mat>("matrix_in"));
+    arma::mat out = std::move(params.Get<arma::mat>("matrix_in"));
     out.shed_row(4);
     out.row(2) *= 2.0;
 
-    params.Get<arma::mat>("matrix_out") = move(out);
+    params.Get<arma::mat>("matrix_out") = std::move(out);
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and
@@ -133,70 +133,70 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   if (params.Has("umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(params.Get<arma::Mat<size_t>>("umatrix_in"));
+        std::move(params.Get<arma::Mat<size_t>>("umatrix_in"));
     out.shed_row(4);
     out.row(2) *= 2;
 
-    params.Get<arma::Mat<size_t>>("umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("umatrix_out") = std::move(out);
   }
 
   // An input column or row should have all elements multiplied by two.
   if (params.Has("col_in"))
   {
-    arma::vec out = move(params.Get<arma::vec>("col_in"));
+    arma::vec out = std::move(params.Get<arma::vec>("col_in"));
     out *= 2.0;
 
-    params.Get<arma::vec>("col_out") = move(out);
+    params.Get<arma::vec>("col_out") = std::move(out);
   }
 
   if (params.Has("ucol_in"))
   {
     arma::Col<size_t> out =
-        move(params.Get<arma::Col<size_t>>("ucol_in"));
+        std::move(params.Get<arma::Col<size_t>>("ucol_in"));
     out += 1;
 
-    params.Get<arma::Col<size_t>>("ucol_out") = move(out);
+    params.Get<arma::Col<size_t>>("ucol_out") = std::move(out);
   }
 
   if (params.Has("row_in"))
   {
-    arma::rowvec out = move(params.Get<arma::rowvec>("row_in"));
+    arma::rowvec out = std::move(params.Get<arma::rowvec>("row_in"));
     out *= 2.0;
 
-    params.Get<arma::rowvec>("row_out") = move(out);
+    params.Get<arma::rowvec>("row_out") = std::move(out);
   }
 
   if (params.Has("urow_in"))
   {
     arma::Row<size_t> out =
-        move(params.Get<arma::Row<size_t>>("urow_in"));
+        std::move(params.Get<arma::Row<size_t>>("urow_in"));
     out += 1;
 
-    params.Get<arma::Row<size_t>>("urow_out") = move(out);
+    params.Get<arma::Row<size_t>>("urow_out") = std::move(out);
   }
 
   // Vector arguments should have the last element removed.
   if (params.Has("vector_in"))
   {
-    vector<int> out = move(params.Get<vector<int>>("vector_in"));
+    vector<int> out = std::move(params.Get<vector<int>>("vector_in"));
     out.pop_back();
 
-    params.Get<vector<int>>("vector_out") = move(out);
+    params.Get<vector<int>>("vector_out") = std::move(out);
   }
 
   if (params.Has("str_vector_in"))
   {
-    vector<string> out = move(params.Get<vector<string>>("str_vector_in"));
+    vector<string> out = std::move(params.Get<vector<string>>("str_vector_in"));
     out.pop_back();
 
-    params.Get<vector<string>>("str_vector_out") = move(out);
+    params.Get<vector<string>>("str_vector_out") = std::move(out);
   }
 
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
     typedef tuple<data::DatasetInfo, arma::mat> TupleType;
-    TupleType tuple = move(params.Get<TupleType>("matrix_and_info_in"));
+    TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);
     arma::mat& m = std::get<1>(tuple);
@@ -222,7 +222,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
       }
     }
 
-    params.Get<arma::mat>("matrix_and_info_out") = move(m);
+    params.Get<arma::mat>("matrix_and_info_out") = std::move(m);
   }
 
   // If we got a request to build a model, then build it.

--- a/src/mlpack/bindings/go/tests/test_go_binding_main.cpp
+++ b/src/mlpack/bindings/go/tests/test_go_binding_main.cpp
@@ -117,11 +117,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   // the 3rd row will be multiplied by two.
   if (params.Has("matrix_in"))
   {
-    arma::mat out = move(params.Get<arma::mat>("matrix_in"));
+    arma::mat out = std::move(params.Get<arma::mat>("matrix_in"));
     out.shed_row(4);
     out.row(2) *= 2.0;
 
-    params.Get<arma::mat>("matrix_out") = move(out);
+    params.Get<arma::mat>("matrix_out") = std::move(out);
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and
@@ -129,70 +129,70 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   if (params.Has("umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(params.Get<arma::Mat<size_t>>("umatrix_in"));
+        std::move(params.Get<arma::Mat<size_t>>("umatrix_in"));
     out.shed_row(4);
     out.row(2) *= 2;
 
-    params.Get<arma::Mat<size_t>>("umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("umatrix_out") = std::move(out);
   }
 
   // An input column or row should have all elements multiplied by two.
   if (params.Has("col_in"))
   {
-    arma::vec out = move(params.Get<arma::vec>("col_in"));
+    arma::vec out = std::move(params.Get<arma::vec>("col_in"));
     out *= 2.0;
 
-    params.Get<arma::vec>("col_out") = move(out);
+    params.Get<arma::vec>("col_out") = std::move(out);
   }
 
   if (params.Has("ucol_in"))
   {
     arma::Col<size_t> out =
-        move(params.Get<arma::Col<size_t>>("ucol_in"));
+        std::move(params.Get<arma::Col<size_t>>("ucol_in"));
     out *= 2;
 
-    params.Get<arma::Col<size_t>>("ucol_out") = move(out);
+    params.Get<arma::Col<size_t>>("ucol_out") = std::move(out);
   }
 
   if (params.Has("row_in"))
   {
-    arma::rowvec out = move(params.Get<arma::rowvec>("row_in"));
+    arma::rowvec out = std::move(params.Get<arma::rowvec>("row_in"));
     out *= 2.0;
 
-    params.Get<arma::rowvec>("row_out") = move(out);
+    params.Get<arma::rowvec>("row_out") = std::move(out);
   }
 
   if (params.Has("urow_in"))
   {
     arma::Row<size_t> out =
-        move(params.Get<arma::Row<size_t>>("urow_in"));
+        std::move(params.Get<arma::Row<size_t>>("urow_in"));
     out *= 2;
 
-    params.Get<arma::Row<size_t>>("urow_out") = move(out);
+    params.Get<arma::Row<size_t>>("urow_out") = std::move(out);
   }
 
   // Vector arguments should have the last element removed.
   if (params.Has("vector_in"))
   {
-    vector<int> out = move(params.Get<vector<int>>("vector_in"));
+    vector<int> out = std::move(params.Get<vector<int>>("vector_in"));
     out.pop_back();
 
-    params.Get<vector<int>>("vector_out") = move(out);
+    params.Get<vector<int>>("vector_out") = std::move(out);
   }
 
   if (params.Has("str_vector_in"))
   {
-    vector<string> out = move(params.Get<vector<string>>("str_vector_in"));
+    vector<string> out = std::move(params.Get<vector<string>>("str_vector_in"));
     out.pop_back();
 
-    params.Get<vector<string>>("str_vector_out") = move(out);
+    params.Get<vector<string>>("str_vector_out") = std::move(out);
   }
 
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
     typedef tuple<data::DatasetInfo, arma::mat> TupleType;
-    TupleType tuple = move(params.Get<TupleType>("matrix_and_info_in"));
+    TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);
     arma::mat& m = std::get<1>(tuple);
@@ -218,7 +218,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
       }
     }
 
-    params.Get<arma::mat>("matrix_and_info_out") = move(m);
+    params.Get<arma::mat>("matrix_and_info_out") = std::move(m);
   }
 
   // If we got a request to build a model, then build it.

--- a/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
+++ b/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
@@ -119,11 +119,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   // the 3rd row will be multiplied by two.
   if (params.Has("matrix_in"))
   {
-    arma::mat out = move(params.Get<arma::mat>("matrix_in"));
+    arma::mat out = std::move(params.Get<arma::mat>("matrix_in"));
     out.shed_row(4);
     out.row(2) *= 2.0;
 
-    params.Get<arma::mat>("matrix_out") = move(out);
+    params.Get<arma::mat>("matrix_out") = std::move(out);
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and
@@ -131,70 +131,70 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   if (params.Has("umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(params.Get<arma::Mat<size_t>>("umatrix_in"));
+        std::move(params.Get<arma::Mat<size_t>>("umatrix_in"));
     out.shed_row(4);
     out.row(2) *= 2;
 
-    params.Get<arma::Mat<size_t>>("umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("umatrix_out") = std::move(out);
   }
 
   // An input column or row should have all elements multiplied by two.
   if (params.Has("col_in"))
   {
-    arma::vec out = move(params.Get<arma::vec>("col_in"));
+    arma::vec out = std::move(params.Get<arma::vec>("col_in"));
     out *= 2.0;
 
-    params.Get<arma::vec>("col_out") = move(out);
+    params.Get<arma::vec>("col_out") = std::move(out);
   }
 
   if (params.Has("ucol_in"))
   {
     arma::Col<size_t> out =
-        move(params.Get<arma::Col<size_t>>("ucol_in"));
+        std::move(params.Get<arma::Col<size_t>>("ucol_in"));
     out *= 2;
 
-    params.Get<arma::Col<size_t>>("ucol_out") = move(out);
+    params.Get<arma::Col<size_t>>("ucol_out") = std::move(out);
   }
 
   if (params.Has("row_in"))
   {
-    arma::rowvec out = move(params.Get<arma::rowvec>("row_in"));
+    arma::rowvec out = std::move(params.Get<arma::rowvec>("row_in"));
     out *= 2.0;
 
-    params.Get<arma::rowvec>("row_out") = move(out);
+    params.Get<arma::rowvec>("row_out") = std::move(out);
   }
 
   if (params.Has("urow_in"))
   {
     arma::Row<size_t> out =
-        move(params.Get<arma::Row<size_t>>("urow_in"));
+        std::move(params.Get<arma::Row<size_t>>("urow_in"));
     out *= 2;
 
-    params.Get<arma::Row<size_t>>("urow_out") = move(out);
+    params.Get<arma::Row<size_t>>("urow_out") = std::move(out);
   }
 
   // Vector arguments should have the last element removed.
   if (params.Has("vector_in"))
   {
-    vector<int> out = move(params.Get<vector<int>>("vector_in"));
+    vector<int> out = std::move(params.Get<vector<int>>("vector_in"));
     out.pop_back();
 
-    params.Get<vector<int>>("vector_out") = move(out);
+    params.Get<vector<int>>("vector_out") = std::move(out);
   }
 
   if (params.Has("str_vector_in"))
   {
-    vector<string> out = move(params.Get<vector<string>>("str_vector_in"));
+    vector<string> out = std::move(params.Get<vector<string>>("str_vector_in"));
     out.pop_back();
 
-    params.Get<vector<string>>("str_vector_out") = move(out);
+    params.Get<vector<string>>("str_vector_out") = std::move(out);
   }
 
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
     typedef tuple<data::DatasetInfo, arma::mat> TupleType;
-    TupleType tuple = move(params.Get<TupleType>("matrix_and_info_in"));
+    TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);
     arma::mat& m = std::get<1>(tuple);
@@ -224,7 +224,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
       }
     }
 
-    params.Get<arma::mat>("matrix_and_info_out") = move(m);
+    params.Get<arma::mat>("matrix_and_info_out") = std::move(m);
   }
 
   // If we got a request to build a model, then build it.

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -140,11 +140,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   // the 3rd row will be multiplied by two.
   if (params.Has("matrix_in"))
   {
-    arma::mat out = move(params.Get<arma::mat>("matrix_in"));
+    arma::mat out = std::move(params.Get<arma::mat>("matrix_in"));
     out.shed_row(4);
     out.row(2) *= 2.0;
 
-    params.Get<arma::mat>("matrix_out") = move(out);
+    params.Get<arma::mat>("matrix_out") = std::move(out);
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and
@@ -152,89 +152,89 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   if (params.Has("umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(params.Get<arma::Mat<size_t>>("umatrix_in"));
+        std::move(params.Get<arma::Mat<size_t>>("umatrix_in"));
     out.shed_row(4);
     out.row(2) *= 2;
 
-    params.Get<arma::Mat<size_t>>("umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("umatrix_out") = std::move(out);
   }
 
   // An input matrix (pandas.Series) should have all elements multiplied by two.
   if (params.Has("smatrix_in"))
   {
-    arma::mat out = move(params.Get<arma::mat>("smatrix_in"));
+    arma::mat out = std::move(params.Get<arma::mat>("smatrix_in"));
     out *= 2.0;
 
-    params.Get<arma::mat>("smatrix_out") = move(out);
+    params.Get<arma::mat>("smatrix_out") = std::move(out);
   }
 
   // An input matrix (pandas.Series) should have all elements multiplied by two.
   if (params.Has("s_umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(params.Get<arma::Mat<size_t>>("s_umatrix_in"));
+        std::move(params.Get<arma::Mat<size_t>>("s_umatrix_in"));
     out *= 2;
 
-    params.Get<arma::Mat<size_t>>("s_umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("s_umatrix_out") = std::move(out);
   }
 
   // An input column or row should have all elements multiplied by two.
   if (params.Has("col_in"))
   {
-    arma::vec out = move(params.Get<arma::vec>("col_in"));
+    arma::vec out = std::move(params.Get<arma::vec>("col_in"));
     out *= 2.0;
 
-    params.Get<arma::vec>("col_out") = move(out);
+    params.Get<arma::vec>("col_out") = std::move(out);
   }
 
   if (params.Has("ucol_in"))
   {
     arma::Col<size_t> out =
-        move(params.Get<arma::Col<size_t>>("ucol_in"));
+        std::move(params.Get<arma::Col<size_t>>("ucol_in"));
     out *= 2;
 
-    params.Get<arma::Col<size_t>>("ucol_out") = move(out);
+    params.Get<arma::Col<size_t>>("ucol_out") = std::move(out);
   }
 
   if (params.Has("row_in"))
   {
-    arma::rowvec out = move(params.Get<arma::rowvec>("row_in"));
+    arma::rowvec out = std::move(params.Get<arma::rowvec>("row_in"));
     out *= 2.0;
 
-    params.Get<arma::rowvec>("row_out") = move(out);
+    params.Get<arma::rowvec>("row_out") = std::move(out);
   }
 
   if (params.Has("urow_in"))
   {
     arma::Row<size_t> out =
-        move(params.Get<arma::Row<size_t>>("urow_in"));
+        std::move(params.Get<arma::Row<size_t>>("urow_in"));
     out *= 2;
 
-    params.Get<arma::Row<size_t>>("urow_out") = move(out);
+    params.Get<arma::Row<size_t>>("urow_out") = std::move(out);
   }
 
   // Vector arguments should have the last element removed.
   if (params.Has("vector_in"))
   {
-    vector<int> out = move(params.Get<vector<int>>("vector_in"));
+    vector<int> out = std::move(params.Get<vector<int>>("vector_in"));
     out.pop_back();
 
-    params.Get<vector<int>>("vector_out") = move(out);
+    params.Get<vector<int>>("vector_out") = std::move(out);
   }
 
   if (params.Has("str_vector_in"))
   {
-    vector<string> out = move(params.Get<vector<string>>("str_vector_in"));
+    vector<string> out = std::move(params.Get<vector<string>>("str_vector_in"));
     out.pop_back();
 
-    params.Get<vector<string>>("str_vector_out") = move(out);
+    params.Get<vector<string>>("str_vector_out") = std::move(out);
   }
 
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
     typedef tuple<data::DatasetInfo, arma::mat> TupleType;
-    TupleType tuple = move(params.Get<TupleType>("matrix_and_info_in"));
+    TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);
     arma::mat& m = std::get<1>(tuple);
@@ -260,7 +260,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
       }
     }
 
-    params.Get<arma::mat>("matrix_and_info_out") = move(m);
+    params.Get<arma::mat>("matrix_and_info_out") = std::move(m);
   }
 
   // If we got a request to build a model, then build it.

--- a/src/mlpack/tests/io_test.cpp
+++ b/src/mlpack/tests/io_test.cpp
@@ -1100,8 +1100,8 @@ TEST_CASE("MatrixAndDatasetInfoTest", "[IOTest]")
       "MatrixAndDatasetInfoTest");
 
   // Get the dataset and info.
-  DatasetInfo info = move(get<0>(p.Get<TupleType>("dataset")));
-  arma::mat dataset = move(get<1>(p.Get<TupleType>("dataset")));
+  DatasetInfo info = std::move(get<0>(p.Get<TupleType>("dataset")));
+  arma::mat dataset = std::move(get<1>(p.Get<TupleType>("dataset")));
 
   REQUIRE(info.Dimensionality() == 3);
 

--- a/src/mlpack/tests/main_tests/det_test.cpp
+++ b/src/mlpack/tests/main_tests/det_test.cpp
@@ -86,7 +86,7 @@ TEST_CASE_METHOD(DETTestFixture, "DETParamBoundTest",
 
   // Test for folds.
 
-  SetInputParam("training", move(trainingData));
+  SetInputParam("training", std::move(trainingData));
   SetInputParam("folds", (int) -1);
 
   REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);

--- a/src/mlpack/tests/main_tests/range_search_test.cpp
+++ b/src/mlpack/tests/main_tests/range_search_test.cpp
@@ -57,7 +57,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RangeSearchInputModelNoQuery",
   if (!data::Load("iris.csv", inputData))
     FAIL("Unable to load dataset iris.csv!");
 
-  SetInputParam("reference", move(inputData));
+  SetInputParam("reference", std::move(inputData));
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
   SetInputParam("distances_file", distanceFile);
@@ -96,7 +96,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RangeSearchDifferentTree",
   if (!data::Load("iris.csv", inputData))
     FAIL("Unable to load dataset iris.csv!");
 
-  SetInputParam("reference", move(inputData));
+  SetInputParam("reference", std::move(inputData));
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
   SetInputParam("distances_file", distanceFile);
@@ -125,7 +125,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RangeSearchBothReferenceAndModel",
   if (!data::Load("iris_test.csv", queryData))
     FAIL("Unable to load dataset iris_test.csv!");
 
-  SetInputParam("reference", move(inputData));
+  SetInputParam("reference", std::move(inputData));
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
   SetInputParam("distances_file", distanceFile);
@@ -134,8 +134,8 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RangeSearchBothReferenceAndModel",
 
   RUN_BINDING();
 
-  SetInputParam("input_model", move(params.Get<RSModel*>("output_model")));
-  SetInputParam("query", move(queryData));
+  SetInputParam("input_model", std::move(params.Get<RSModel*>("output_model")));
+  SetInputParam("query", std::move(queryData));
 
   REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);
 
@@ -174,7 +174,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RangeSearchTest",
   vector<vector<size_t>> neighbors;
   vector<vector<double>> distances;
 
-  SetInputParam("reference", move(x));
+  SetInputParam("reference", std::move(x));
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
   SetInputParam("distances_file", distanceFile);
@@ -219,7 +219,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RangeSeachTestwithQuery",
   double minVal = 0, maxVal = 5;
 
   SetInputParam("query", queryData);
-  SetInputParam("reference", move(x));
+  SetInputParam("reference", std::move(x));
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
   SetInputParam("distances_file", distanceFile);
@@ -256,7 +256,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "ModelCheck",
   if (!data::Load("iris_test.csv", queryData))
     FAIL("Unable to load dataset iris_test.csv!");
 
-  SetInputParam("reference", move(inputData));
+  SetInputParam("reference", std::move(inputData));
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
   SetInputParam("distances_file", distanceFile);
@@ -275,7 +275,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "ModelCheck",
   ResetSettings();
 
   SetInputParam("input_model", outputModel);
-  SetInputParam("query", move(queryData));
+  SetInputParam("query", std::move(queryData));
 
   RUN_BINDING();
 
@@ -455,7 +455,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "RandomBasisTesting",
 
   RUN_BINDING();
 
-  RSModel* outputModel = move(params.Get<RSModel*>("output_model"));
+  RSModel* outputModel = std::move(params.Get<RSModel*>("output_model"));
 
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
@@ -504,7 +504,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "NaiveModeTest",
 
   neighbors = ReadData<size_t>(neighborsFile);
   distances = ReadData<double>(distanceFile);
-  RSModel* outputModel = move(params.Get<RSModel*>("output_model"));
+  RSModel* outputModel = std::move(params.Get<RSModel*>("output_model"));
 
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);
@@ -559,7 +559,7 @@ TEST_CASE_METHOD(RangeSearchTestFixture, "SingleModeTest",
 
   neighbors = ReadData<size_t>(neighborsFile);
   distances = ReadData<double>(distanceFile);
-  RSModel* outputModel = move(params.Get<RSModel*>("output_model"));
+  RSModel* outputModel = std::move(params.Get<RSModel*>("output_model"));
 
   SetInputParam("min", minVal);
   SetInputParam("max", maxVal);


### PR DESCRIPTION
I received an email from Brian Ripley:

```
clang 15 is warning:

In file included from test_r_binding.cpp:9:
./mlpack/bindings/R/tests//test_r_binding_main.cpp:99:21: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
    arma::mat out = move(params.Get<arma::mat>("matrix_in"));
                    ^
                    std::

...

Please correct before 2023-01-15 to safely retain your package on CRAN.
```

I can't understand the motivation of such a warning, even when there is a `using namespace std`, but anyway, whatever, here's a change that makes all uses of `std::move()` qualified, so that CRAN can be happy.