### PR TITLE
Add -lgfortran and -lquadmath when statically linking OpenBLAS on Linux

### DIFF
--- a/CMake/FindArmadillo.cmake
+++ b/CMake/FindArmadillo.cmake
@@ -94,6 +94,20 @@ if(NOT _ARMA_USE_WRAPPER OR MSVC)
       endif()
     endif()
 
+    # On Linux, when statically linking against OpenBLAS, we must also manually
+    # link against -lgfortran and -lquadmath.  See
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/23693 for more
+    # information.  When that issue is fixed, we may be able to remove this
+    # section.
+    if (NOT BUILD_SHARED_LIBS AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+      string(TOLOWER "${LAPACK_LIBRARIES}" _lower_lapack_libs)
+      string(FIND "${_lower_lapack_libs}" "openblas" _openblas_found_index)
+      if (${_openblas_found_index} GREATER_EQUAL 0)
+	message(STATUS "Using static OpenBLAS on Linux; adding -lgfortran and -lquadmath...")
+	set(LAPACK_LIBRARIES "${LAPACK_LIBRARIES};gfortran;quadmath")
+      endif ()
+    endif ()
+
     if(LAPACK_FOUND)
       set(_ARMA_SUPPORT_LIBRARIES "${_ARMA_SUPPORT_LIBRARIES}" "${LAPACK_LIBRARIES}")
     endif()


### PR DESCRIPTION
See #3351.  I did some digging and found that on a fresh Ubuntu 22.04 container, configuring and compiling with CMake failed:

```
cmake -DDOWNLOAD_DEPENDENCIES=ON -DBUILD_SHARED_LIBS=OFF ../
make mlpack_bayesian_linear_regression
```

This would fail to link against both libgfortran and libquadmath symbols.

I found a [relevant CMake issue](https://gitlab.kitware.com/cmake/cmake/-/issues/23693) but it has not been fixed---and I am not sure it will be---so a manual workaround seems necessary.