### PR TITLE
Comment out pragmas in base64.hpp to fix CRAN warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,10 @@ jobs:
             sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libensmallen-dev libhdf5-dev libarmadillo-dev libcurl4-openssl-dev
             wget https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz
             tar -xvzpf v1.3.2.tar.gz
+            # These directives cause warnings on CRAN:
+            # https://github.com/USCiLab/cereal/blob/master/include/cereal/external/base64.hpp#L28-L31
+            # The command below comments them out.
+            sed -i 's|#pragma|// #pragma|' cereal-1.3.2/external/base64.hpp
 
         - name: Install R-bindings dependencies
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
             # These directives cause warnings on CRAN:
             # https://github.com/USCiLab/cereal/blob/master/include/cereal/external/base64.hpp#L28-L31
             # The command below comments them out.
-            sed -i 's|#pragma|// #pragma|' cereal-1.3.2/external/base64.hpp
+            sed -i 's|#pragma|// #pragma|' cereal-1.3.2/include/cereal/external/base64.hpp
 
         - name: Install R-bindings dependencies
           run: |


### PR DESCRIPTION
While submitting mlpack 4.0.1 to CRAN, after the changes in #3345 that bundle cereal, I found that the file `base64.hpp` caused some CRAN warnings.  The code in question is here:

https://github.com/USCiLab/cereal/blob/master/include/cereal/external/base64.hpp#L28-L31

So, I just added it to the Github action that builds the R package to comment that bit out.