### PR TITLE
Add random splitting for categorical features for decision trees.

### DIFF
--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -24,6 +24,7 @@
 #include "random_binary_numeric_split.hpp"
 
 #include "all_categorical_split.hpp"
+#include "random_categorical_split.hpp"
 
 #include "all_dimension_select.hpp"
 #include "random_dimension_select.hpp"

--- a/src/mlpack/methods/decision_tree/random_categorical_split.hpp
+++ b/src/mlpack/methods/decision_tree/random_categorical_split.hpp
@@ -1,0 +1,137 @@
+/**
+ * @file methods/decision_tree/random_categorical_split.hpp
+ * @author Adarsh Santoria
+ *
+ * This file defines a tree splitter that split a categorical feature into random 
+ * categories.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_DECISION_TREE_RANDOM_CATEGORICAL_SPLIT_HPP
+#define MLPACK_METHODS_DECISION_TREE_RANDOM_CATEGORICAL_SPLIT_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+
+/**
+ * The RandomCategoricalSplit is a splitting function that will split categorical
+ * features into random children. This is a generic splitting
+ * strategy and can be used for both regression and classification trees.
+ * 
+ * @tparam FitnessFunction Fitness function to evaluate gain with.
+ */
+template<typename FitnessFunction>
+class RandomCategoricalSplit
+{
+ public:
+  // No extra info needed for split.
+  class AuxiliarySplitInfo { };
+
+  /**
+   * Check if we can split a node.  If we can split a node in a way that
+   * improves on 'bestGain', then we return the improved gain.  Otherwise we
+   * return the value 'bestGain'.  If a split is made, then splitInfo and
+   * aux may be modified.  For this particular split type, aux will be empty
+   * and splitInfo will store the number of children of the node.
+   *
+   * This overload is used only for classification.
+   *
+   * @param bestGain Best gain seen so far (we'll only split if we find gain
+   *      better than this).
+   * @param data The dimension of data points to check for a split in.
+   * @param numCategories Number of categories in the categorical data.
+   * @param labels Labels for each point.
+   * @param numClasses Number of classes in the dataset.
+   * @param weights Weights associated with labels.
+   * @param minimumLeafSize Minimum number of points in a leaf node for
+   *      splitting.
+   * @param splitInfo Stores split information on a successful split.
+   * @param minimumGainSplit Minimum  gain split.
+   * @param aux Auxiliary split information, which may be modified on a
+   *      successful split.
+   */
+  template<bool UseWeights, typename VecType, typename LabelsType,
+           typename WeightVecType>
+  static double SplitIfBetter(
+      const double bestGain,
+      const VecType& data,
+      const size_t numCategories,
+      const LabelsType& labels,
+      const size_t numClasses,
+      const WeightVecType& weights,
+      const size_t minimumLeafSize,
+      const double minimumGainSplit,
+      arma::vec& splitInfo,
+      AuxiliarySplitInfo& aux);
+
+  /**
+   * Check if we can split a node.  If we can split a node in a way that
+   * improves on 'bestGain', then we return the improved gain.  Otherwise we
+   * return the value 'bestGain'.  If a split is made, then splitInfo and
+   * aux may be modified.  For this particular split type, aux will be empty
+   * and splitInfo will store the number of children of the node.
+   *
+   * This overload is used only for regression.
+   *
+   * @param bestGain Best gain seen so far (we'll only split if we find gain
+   *      better than this).
+   * @param data The dimension of data points to check for a split in.
+   * @param numCategories Number of categories in the categorical data.
+   * @param responses Responses for each point.
+   * @param weights Weights associated with responses.
+   * @param minimumLeafSize Minimum number of points in a leaf node for
+   *      splitting.
+   * @param splitInfo Stores split information on a successful split.
+   * @param minimumGainSplit Minimum  gain split.
+   * @param aux Auxiliary split information, which may be modified on a
+   *      successful split.
+   * @param fitnessFunction The FitnessFunction object instance. It it used to
+   *      evaluate the gain for the split.
+   */
+  template<bool UseWeights, typename VecType, typename ResponsesType,
+           typename WeightVecType>
+  static double SplitIfBetter(
+      const double bestGain,
+      const VecType& data,
+      const size_t numCategories,
+      const ResponsesType& responses,
+      const WeightVecType& weights,
+      const size_t minimumLeafSize,
+      const double minimumGainSplit,
+      double& splitInfo,
+      AuxiliarySplitInfo& aux,
+      FitnessFunction& fitnessFunction);
+
+  /**
+   * Return the number of children in the split.
+   *
+   * @param splitInfo Auxiliary information for the split.
+   * @param * (aux) Auxiliary information for the split (Unused).
+   */
+  static size_t NumChildren(const double& splitInfo,
+                            const AuxiliarySplitInfo& /* aux */);
+
+  /**
+   * Calculate the direction a point should percolate to.
+   *
+   * @param point the Point to use.
+   * @param splitInfo Auxiliary information for the split.
+   * @param * (aux) Auxiliary information for the split (Unused).
+   */
+  template<typename ElemType>
+  static size_t CalculateDirection(
+      const ElemType& point,
+      const double& splitInfo,
+      const AuxiliarySplitInfo& /* aux */);
+};
+
+} // namespace mlpack
+
+// Include implementation.
+#include "random_categorical_split_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/decision_tree/random_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/random_categorical_split_impl.hpp
@@ -1,0 +1,256 @@
+/**
+ * @file methods/decision_tree/random_categorical_split_impl.hpp
+ * @author Adarsh Santoria
+ *
+ * Implementation of the RandomCategoricalSplit categorical split class.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_DECISION_TREE_RANDOM_CATEGORICAL_SPLIT_IMPL_HPP
+#define MLPACK_METHODS_DECISION_TREE_RANDOM_CATEGORICAL_SPLIT_IMPL_HPP
+
+namespace mlpack {
+
+// Overload used in classification.
+template<typename FitnessFunction>
+template<bool UseWeights, typename VecType, typename LabelsType,
+         typename WeightVecType>
+double RandomCategoricalSplit<FitnessFunction>::SplitIfBetter(
+    const double bestGain,
+    const VecType& data,
+    const size_t numCategories,
+    const LabelsType& labels,
+    const size_t numClasses,
+    const WeightVecType& weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    arma::vec& splitInfo,
+    AuxiliarySplitInfo& /* aux */)
+{
+  const double epsilon = 1e-7; // Tolerance for floating-point errors.
+
+  // Count the number of elements in each potential child.
+  arma::Col<size_t> counts(numCategories, arma::fill::zeros);
+  for (size_t i = 0; i < data.n_elem; ++i)
+    counts[(size_t) data[i]]++;
+  
+  // Calculate the gain of the split.  First we have to calculate the labels
+  // that would be assigned to each child.
+  arma::uvec childPositions(numCategories, arma::fill::zeros);
+  std::vector<arma::Row<size_t>> childLabels(numCategories);
+  std::vector<arma::Row<double>> childWeights(numCategories);
+
+  for (size_t i = 0; i < numCategories; ++i)
+  {
+    // Labels and weights should have same length.
+    childLabels[i].zeros(counts[i]);
+    if (UseWeights)
+      childWeights[i].zeros(counts[i]);
+  }
+
+  // Extract labels for each child.
+  for (size_t i = 0; i < data.n_elem; ++i)
+  {
+    const size_t category = (size_t)data[i];
+
+    if (UseWeights)
+      childWeights[category][childPositions[category]] = weights[i];
+    childLabels[category][childPositions[category]++] = labels[i];
+  }
+
+  // Shuffling the childs
+  arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
+    numCategories - 1, numCategories));
+
+  // Picking two random Pivot to make 2 subsets and take their union
+  size_t randomPivot1 = Random(1, numCategories - 1);
+  size_t randomPivot2 = Random(randomPivot1, numCategories - 1);
+
+  // Making new Variables containing childs of union of the subsets
+  arma::Col<size_t> newCounts(randomPivot1 + numCategories - randomPivot2);
+  std::vector<arma::Row<size_t>> 
+    newLabels(randomPivot1 + numCategories - randomPivot2);
+  std::vector<arma::Row<double>> 
+    newWeights(randomPivot1 + numCategories - randomPivot2);
+  arma::vec newWeightSums(randomPivot1 + numCategories - randomPivot2);
+
+  double sumWeight = 0.0;
+  size_t totalCounts = 0;
+  for (size_t i = 0, j = 0; i < numCategories; ++i){
+    if(i < randomPivot1 || i >= randomPivot2)
+    {
+      if (UseWeights)
+      {
+        newWeights[j] = childWeights[ordering[i]];
+        newWeightSums[j] = accu(childWeights[ordering[i]]);
+        sumWeight += newWeightSums[j];
+      }
+      newCounts[j] = counts[ordering[i]];
+      totalCounts += counts[ordering[i]];
+      newLabels[j++] = childLabels[ordering[i]];
+    }
+  }
+
+  // If each child will have the minimum number of points in it, we can split.
+  // Otherwise we can't.
+  if (arma::min(newCounts) < minimumLeafSize)
+    return DBL_MAX;
+
+  double overallGain = 0.0;
+  for (size_t i = 0; i < newCounts.n_elem; ++i)
+  {
+    // Calculate the gain of this child.
+    const double childPct = UseWeights ?
+        double(newWeightSums[i]) / sumWeight :
+        double(newCounts[i]) / double(totalCounts);
+    const double childGain = FitnessFunction::template Evaluate<UseWeights>(
+        newLabels[i], numClasses, newWeights[i]);
+
+    overallGain += childPct * childGain;
+  }
+
+  if (overallGain > bestGain + minimumGainSplit + epsilon)
+  {
+    // This is better, so store it in splitInfo and return.
+    splitInfo.set_size(1);
+    splitInfo[0] = randomPivot1 + numCategories - randomPivot2;
+    return overallGain;
+  }
+
+  // Otherwise there was no improvement.
+  return DBL_MAX;
+}
+
+// Overload used in regression.
+template<typename FitnessFunction>
+template<bool UseWeights, typename VecType, typename ResponsesType,
+         typename WeightVecType>
+double RandomCategoricalSplit<FitnessFunction>::SplitIfBetter(
+    const double bestGain,
+    const VecType& data,
+    const size_t numCategories,
+    const ResponsesType& responses,
+    const WeightVecType& weights,
+    const size_t minimumLeafSize,
+    const double minimumGainSplit,
+    double& splitInfo,
+    AuxiliarySplitInfo& /* aux */,
+    FitnessFunction& fitnessFunction)
+{
+  const double epsilon = 1e-7; // Tolerance for floating-point errors.
+
+  // Count the number of elements in each potential child.
+  arma::Col<size_t> counts(numCategories, arma::fill::zeros);
+  for (size_t i = 0; i < data.n_elem; ++i)
+    counts[(size_t) data[i]]++;
+  
+  // Calculate the gain of the split.  First we have to calculate the responses
+  // that would be assigned to each child.
+  arma::uvec childPositions(numCategories, arma::fill::zeros);
+  std::vector<arma::Row<size_t>> childResponses(numCategories);
+  std::vector<arma::Row<double>> childWeights(numCategories);
+
+  for (size_t i = 0; i < numCategories; ++i)
+  {
+    // Responses and weights should have same length.
+    childResponses[i].zeros(counts[i]);
+    if (UseWeights)
+      childWeights[i].zeros(counts[i]);
+  }
+
+  // Extract responses for each child.
+  for (size_t i = 0; i < data.n_elem; ++i)
+  {
+    const size_t category = (size_t)data[i];
+
+    if (UseWeights)
+      childWeights[category][childPositions[category]] = weights[i];
+    childResponses[category][childPositions[category]++] = responses[i];
+  }
+
+  // Shuffling the childs
+  arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
+    numCategories - 1, numCategories));
+
+  // Picking two random Pivot to make 2 subsets and take their union
+  size_t randomPivot1 = Random(1, numCategories - 1);
+  size_t randomPivot2 = Random(randomPivot1,numCategories - 1);
+
+  // Making new Variables containing childs of union of the subsets
+  arma::Col<size_t> newCounts(randomPivot1 + numCategories - randomPivot2);
+  std::vector<arma::Row<size_t>> 
+    newResponses(randomPivot1 + numCategories - randomPivot2);
+  std::vector<arma::Row<double>> 
+    newWeights(randomPivot1 + numCategories - randomPivot2);
+  arma::vec newWeightSums(randomPivot1 + numCategories - randomPivot2);
+
+  double sumWeight = 0.0;
+  size_t totalCounts = 0;
+  for (size_t i = 0, j = 0; i < numCategories; ++i){
+    if(i < randomPivot1 || i >= randomPivot2)
+    {
+      if (UseWeights)
+      {
+        newWeights[j] = childWeights[ordering[i]];
+        newWeightSums[j] = accu(childWeights[ordering[i]]);
+        sumWeight += newWeightSums[j];
+      }
+      newCounts[j] = counts[ordering[i]];
+      totalCounts += counts[ordering[i]];
+      newResponses[j++] = childResponses[ordering[i]];
+    }
+  }
+
+  // If each child will have the minimum number of points in it, we can split.
+  // Otherwise we can't.
+  if (arma::min(newCounts) < minimumLeafSize)
+    return DBL_MAX;
+
+  double overallGain = 0.0;
+  for (size_t i = 0; i < newCounts.n_elem; ++i)
+  {
+    // Calculate the gain of this child.
+    const double childPct = UseWeights ?
+        double(newWeightSums[i]) / sumWeight :
+        double(newCounts[i]) / double(totalCounts);
+    const double childGain = FitnessFunction::template Evaluate<UseWeights>(
+        newResponses[i], newWeights[i]);
+
+    overallGain += childPct * childGain;
+  }
+
+  if (overallGain > bestGain + minimumGainSplit + epsilon)
+  {
+    // This is better, so store it in splitInfo and return.
+    splitInfo = randomPivot1 + numCategories - randomPivot2;
+    return overallGain;
+  }
+
+  // Otherwise there was no improvement.
+  return DBL_MAX;
+}
+
+template<typename FitnessFunction>
+size_t RandomCategoricalSplit<FitnessFunction>::NumChildren(
+    const double& splitInfo,
+    const AuxiliarySplitInfo& /* aux */)
+{
+  return (size_t) splitInfo;
+}
+
+template<typename FitnessFunction>
+template<typename ElemType>
+size_t RandomCategoricalSplit<FitnessFunction>::CalculateDirection(
+    const ElemType& point,
+    const double& /* splitInfo */,
+    const AuxiliarySplitInfo& /* aux */)
+{
+  return (size_t) point;
+}
+
+} // namespace mlpack
+
+#endif


### PR DESCRIPTION
An attempt to solve #884.

The changes made in this PR are:-
1.  Add implementation of `RandomCategoricalSplit` for decision tree.

Reference Paper used - [link](http://orbi.ulg.be/bitstream/2268/9357/1/geurts-mlj-advance.pdf)