### PR TITLE
remove unused define

### DIFF
--- a/src/mlpack/core.hpp
+++ b/src/mlpack/core.hpp
@@ -61,9 +61,4 @@
   #include <omp.h>
 #endif
 
-// Use Armadillo's C++ version detection.
-#ifdef ARMA_USE_CXX11
-  #define MLPACK_USE_CX11
-#endif
-
 #endif


### PR DESCRIPTION
Remove the `MLPACK_USE_CX11` define, which is never used.

Related to https://github.com/mlpack/mlpack/pull/3380#issuecomment-1404111240
