### PR TITLE
Add Quic_SVD method in CF

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+
+  * Add QUIC_SVD method in CF (#3404).
+
   * Bugfix for non-square convolution kernels (#3376).
 
   * Fix a few missing includes in `<mlpack.hpp>` (#3374).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,5 @@
 ### mlpack ?.?.?
 ###### ????-??-??
-
-  * Add QUIC_SVD method in CF (#3404).
-
   * Bugfix for non-square convolution kernels (#3376).
 
   * Fix a few missing includes in `<mlpack.hpp>` (#3374).

--- a/src/mlpack/methods/cf/decomposition_policies/decomposition_policies.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/decomposition_policies.hpp
@@ -20,5 +20,6 @@
 #include "svd_complete_method.hpp"
 #include "svd_incomplete_method.hpp"
 #include "svdplusplus_method.hpp"
+#include "quic_svd_method.hpp"
 
 #endif

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -1,0 +1,174 @@
+/**
+ * @file methods/cf/decomposition_policies/quic_svd_method.hpp
+ * @author Adarsh Santoria
+ *
+ * Implementation of the quic svd method for use in
+ * Collaborative Fitlering.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_CF_DECOMPOSITION_POLICIES_QUIC_SVD_METHOD_HPP
+#define MLPACK_METHODS_CF_DECOMPOSITION_POLICIES_QUIC_SVD_METHOD_HPP
+
+#include <mlpack/prereqs.hpp>
+#include <mlpack/methods/quic_svd/quic_svd.hpp>
+
+namespace mlpack {
+
+/**
+ * Implementation of the Quic SVD policy to act as a wrapper when
+ * accessing Quic SVD from within CFType.
+ *
+ * An example of how to use QuicSVDPolicy in CF is shown below:
+ *
+ * @code
+ * extern arma::mat data; // data is a (user, item, rating) table.
+ * // Users for whom recommendations are generated.
+ * extern arma::Col<size_t> users;
+ * arma::Mat<size_t> recommendations; // Resulting recommendations.
+ *
+ * CFType<QuicSVDPolicy> cf(data);
+ *
+ * // Generate 10 recommendations for all users.
+ * cf.GetRecommendations(10, recommendations);
+ * @endcode
+ */
+class QuicSVDPolicy
+{
+ public:
+  /**
+   * Use quic SVD method to perform collaborative filtering
+   */
+  QuicSVDPolicy()
+  {
+    /* Nothing to do here */
+  }
+
+  /**
+   * Apply Collaborative Filtering to the provided data set using the
+   * quic SVD.
+   *
+   * @param * (data) Data matrix: dense matrix (coordinate lists)
+   *    or sparse matrix(cleaned).
+   * @param cleanedData item user table in form of sparse matrix.
+   * @param * (rank) Rank parameter for matrix factorization.
+   * @param * (maxIterations) Maximum number of iterations.
+   * @param * (minResidue) Residue required to terminate.
+   * @param * (mit) Whether to terminate only when maxIterations is reached.
+   */
+  template<typename MatType>
+  void Apply(const MatType& data,
+             const arma::sp_mat& /* cleanedData */,
+             const size_t /* rank */,
+             const size_t /* maxIterations */,
+             const double /* minResidue */,
+             const bool /* mit */)
+  {
+    arma::mat sigma;
+
+    // Do singular value decomposition using the quic SVD algorithm.
+    QUIC_SVD quicsvd;
+    quicsvd.Apply(data, w, h, sigma);
+
+   if (data.n_cols < data.n_rows)
+  {
+    arma::mat tempMat = w;
+    w = h;
+    h = tempMat;
+  }
+
+    // Take transpose of the matrix h as required by CF class.
+    h = arma::trans(h);
+  }
+
+  /**
+   * Return predicted rating given user ID and item ID.
+   *
+   * @param user User ID.
+   * @param item Item ID.
+   */
+  double GetRating(const size_t user, const size_t item) const
+  {
+    double rating = arma::as_scalar(w.row(item) * h.col(user));
+    return rating;
+  }
+
+  /**
+   * Get predicted ratings for a user.
+   *
+   * @param user User ID.
+   * @param rating Resulting rating vector.
+   */
+  void GetRatingOfUser(const size_t user, arma::vec& rating) const
+  {
+    rating = w * h.col(user);
+  }
+
+  /**
+   * Get the neighborhood and corresponding similarities for a set of users.
+   *
+   * @tparam NeighborSearchPolicy The policy to perform neighbor search.
+   *
+   * @param users Users whose neighborhood is to be computed.
+   * @param numUsersForSimilarity The number of neighbors returned for
+   *     each user.
+   * @param neighborhood Neighbors represented by user IDs.
+   * @param similarities Similarity between each user and each of its
+   *     neighbors.
+   */
+  template<typename NeighborSearchPolicy>
+  void GetNeighborhood(const arma::Col<size_t>& users,
+                       const size_t numUsersForSimilarity,
+                       arma::Mat<size_t>& neighborhood,
+                       arma::mat& similarities) const
+  {
+    // We want to avoid calculating the full rating matrix, so we will do
+    // nearest neighbor search only on the H matrix, using the observation that
+    // if the rating matrix X = W*H, then d(X.col(i), X.col(j)) = d(W H.col(i),
+    // W H.col(j)).  This can be seen as nearest neighbor search on the H
+    // matrix with the Mahalanobis distance where M^{-1} = W^T W.  So, we'll
+    // decompose M^{-1} = L L^T (the Cholesky decomposition), and then multiply
+    // H by L^T. Then we can perform nearest neighbor search.
+    arma::mat l = arma::chol(w.t() * w);
+    arma::mat stretchedH = l * h; // Due to the Armadillo API, l is L^T.
+
+    // Temporarily store feature vector of queried users.
+    arma::mat query(stretchedH.n_rows, users.n_elem);
+    // Select feature vectors of queried users.
+    for (size_t i = 0; i < users.n_elem; ++i)
+      query.col(i) = stretchedH.col(users(i));
+
+    NeighborSearchPolicy neighborSearch(stretchedH);
+    neighborSearch.Search(
+        query, numUsersForSimilarity, neighborhood, similarities);
+  }
+
+  //! Get the Item Matrix.
+  const arma::mat& W() const { return w; }
+  //! Get the User Matrix.
+  const arma::mat& H() const { return h; }
+
+  /**
+   * Serialization.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */)
+  {
+    ar(CEREAL_NVP(w));
+    ar(CEREAL_NVP(h));
+  }
+
+ private:
+  //! Item matrix.
+  arma::mat w;
+  //! User matrix.
+  arma::mat h;
+};
+
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -52,9 +52,9 @@ class QuicSVDPolicy
    * Apply Collaborative Filtering to the provided data set using the
    * quic SVD.
    *
-   * @param * (data) Data matrix: dense matrix (coordinate lists)
+   * @param data Data matrix: dense matrix (coordinate lists)
    *    or sparse matrix(cleaned).
-   * @param cleanedData item user table in form of sparse matrix.
+   * @param * (cleanedData) item user table in form of sparse matrix.
    * @param * (rank) Rank parameter for matrix factorization.
    * @param * (maxIterations) Maximum number of iterations.
    * @param * (minResidue) Residue required to terminate.

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -52,17 +52,17 @@ class QuicSVDPolicy
    * Apply Collaborative Filtering to the provided data set using the
    * quic SVD.
    *
-   * @param data Data matrix: dense matrix (coordinate lists)
+   * @param * (data) Data matrix: dense matrix (coordinate lists)
    *    or sparse matrix(cleaned).
-   * @param * (cleanedData) item user table in form of sparse matrix.
+   * @param cleanedData item user table in form of sparse matrix.
    * @param * (rank) Rank parameter for matrix factorization.
    * @param * (maxIterations) Maximum number of iterations.
    * @param * (minResidue) Residue required to terminate.
    * @param * (mit) Whether to terminate only when maxIterations is reached.
    */
   template<typename MatType>
-  void Apply(const MatType& data,
-             const arma::sp_mat& /* cleanedData */,
+  void Apply(const MatType& /* data */,
+             const arma::sp_mat& cleanedData,
              const size_t /* rank */,
              const size_t /* maxIterations */,
              const double /* minResidue */,
@@ -70,16 +70,11 @@ class QuicSVDPolicy
   {
     arma::mat sigma;
 
+    arma::mat data(cleanedData);
+
     // Do singular value decomposition using the quic SVD algorithm.
     QUIC_SVD quicsvd;
     quicsvd.Apply(data, w, h, sigma);
-
-    if (data.n_cols < data.n_rows)
-    {
-      arma::mat tempMat = w;
-      w = h;
-      h = tempMat;
-    }
 
     // Take transpose of the matrix h as required by CF class.
     h = arma::trans(h);

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -20,7 +20,7 @@
 namespace mlpack {
 
 /**
- * Implementation of the Quic SVD policy to act as a wrapper when
+ * Implementation of the QUIC-SVD policy to act as a wrapper when
  * accessing Quic SVD from within CFType.
  *
  * An example of how to use QuicSVDPolicy in CF is shown below:

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -70,6 +70,7 @@ class QuicSVDPolicy
   {
     arma::mat sigma;
 
+    // Preprocessed data converted to mat format
     arma::mat data(cleanedData);
 
     // Do singular value decomposition using the quic SVD algorithm.

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -74,12 +74,12 @@ class QuicSVDPolicy
     QUIC_SVD quicsvd;
     quicsvd.Apply(data, w, h, sigma);
 
-   if (data.n_cols < data.n_rows)
-  {
-    arma::mat tempMat = w;
-    w = h;
-    h = tempMat;
-  }
+    if (data.n_cols < data.n_rows)
+    {
+      arma::mat tempMat = w;
+      w = h;
+      h = tempMat;
+    }
 
     // Take transpose of the matrix h as required by CF class.
     h = arma::trans(h);

--- a/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
+++ b/src/mlpack/methods/cf/decomposition_policies/quic_svd_method.hpp
@@ -23,7 +23,7 @@ namespace mlpack {
  * Implementation of the QUIC-SVD policy to act as a wrapper when
  * accessing Quic SVD from within CFType.
  *
- * An example of how to use QuicSVDPolicy in CF is shown below:
+ * An example of how to use QUIC_SVDPolicy in CF is shown below:
  *
  * @code
  * extern arma::mat data; // data is a (user, item, rating) table.
@@ -31,19 +31,19 @@ namespace mlpack {
  * extern arma::Col<size_t> users;
  * arma::Mat<size_t> recommendations; // Resulting recommendations.
  *
- * CFType<QuicSVDPolicy> cf(data);
+ * CFType<QUIC_SVDPolicy> cf(data);
  *
  * // Generate 10 recommendations for all users.
  * cf.GetRecommendations(10, recommendations);
  * @endcode
  */
-class QuicSVDPolicy
+class QUIC_SVDPolicy
 {
  public:
   /**
    * Use quic SVD method to perform collaborative filtering
    */
-  QuicSVDPolicy()
+  QUIC_SVDPolicy()
   {
     /* Nothing to do here */
   }
@@ -76,6 +76,9 @@ class QuicSVDPolicy
     // Do singular value decomposition using the quic SVD algorithm.
     QUIC_SVD quicsvd;
     quicsvd.Apply(data, w, h, sigma);
+
+    // Sigma matrix is multiplied to w.
+    w = w * sigma;
 
     // Take transpose of the matrix h as required by CF class.
     h = arma::trans(h);

--- a/src/mlpack/methods/quic_svd/quic_svd.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd.hpp
@@ -43,7 +43,7 @@ namespace mlpack {
  * const double delta = 0.1 // Lower error bound for Monte Carlo estimate.
  *
  * // Make a QuicSVD object.
- * QuicSVD qSVD();
+ * QUIC_SVD qSVD();
  * 
  * arma::mat u, v, sigma; // Matrices for the factors. data = u * sigma * v.t()
  *

--- a/src/mlpack/methods/quic_svd/quic_svd.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd.hpp
@@ -46,7 +46,7 @@ namespace mlpack {
  * QuicSVD qSVD();
  * 
  * arma::mat u, v, sigma; // Matrices for the factors. data = u * sigma * v.t()
- * 
+ *
  * // Use the Apply() method to get a factorization.
  * qSVD.Apply(data, u, v, sigma, epsilon, delta);
  * @endcode

--- a/src/mlpack/methods/quic_svd/quic_svd.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd.hpp
@@ -72,7 +72,7 @@ class QUIC_SVD
            const double delta = 0.1);
 
  /**
-   * Create object for the randomized SVD method.
+   * Create object for the QUIC-SVD method.
    *
    * @param epsilon Error tolerance fraction for calculated subspace.
    * @param delta Cumulative probability for Monte Carlo error lower bound.

--- a/src/mlpack/methods/quic_svd/quic_svd.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd.hpp
@@ -42,21 +42,20 @@ namespace mlpack {
  * const double epsilon = 0.01; // Relative error limit of data in subspace.
  * const double delta = 0.1 // Lower error bound for Monte Carlo estimate.
  *
+ * // Make a QuicSVD object.
+ * QuicSVD qSVD();
+ * 
  * arma::mat u, v, sigma; // Matrices for the factors. data = u * sigma * v.t()
- *
- * // Get the factorization in the constructor.
- * QUIC_SVD(data, u, v, sigma, epsilon, delta);
+ * 
+ * // Use the Apply() method to get a factorization.
+ * qSVD.Apply(data, u, v, sigma, epsilon, delta);
  * @endcode
  */
 class QUIC_SVD
 {
  public:
   /**
-   * Constructor which implements the QUIC-SVD algorithm. The function calls the
-   * CosineTree constructor to create a subspace basis, where the original
-   * matrix's projection has minimum reconstruction error. The constructor then
-   * uses the ExtractSVD() function to calculate the SVD of the original dataset
-   * in that subspace.
+   * Create object for the randomized SVD method.
    *
    * @param dataset Matrix for which SVD is calculated.
    * @param u First unitary matrix.
@@ -72,6 +71,35 @@ class QUIC_SVD
            const double epsilon = 0.03,
            const double delta = 0.1);
 
+ /**
+   * Create object for the randomized SVD method.
+   *
+   * @param epsilon Error tolerance fraction for calculated subspace.
+   * @param delta Cumulative probability for Monte Carlo error lower bound.
+   */
+  QUIC_SVD(const double epsilon = 0.03,
+           const double delta = 0.1);
+
+ /**
+   * The function calls the CosineTree constructor to create a subspace basis,
+   * where the original matrix's projection has minimum reconstruction error. 
+   * The constructor then uses the ExtractSVD() function to calculate the SVD 
+   * of the original dataset in that subspace.
+   *
+   * @param dataset Matrix for which SVD is calculated.
+   * @param u First unitary matrix.
+   * @param v Second unitary matrix.
+   * @param sigma Diagonal matrix of singular values.
+   * @param epsilon Error tolerance fraction for calculated subspace.
+   * @param delta Cumulative probability for Monte Carlo error lower bound.
+   */
+  void Apply(const arma::mat& dataset,
+             arma::mat& u,
+             arma::mat& v,
+             arma::mat& sigma,
+             const double epsilon = 0.03,
+             const double delta = 0.1);
+
   /**
    * This function uses the vector subspace created using a cosine tree to
    * calculate an approximate SVD of the original matrix.
@@ -80,11 +108,12 @@ class QUIC_SVD
    * @param v Second unitary matrix.
    * @param sigma Diagonal matrix of singular values.
    */
-  void ExtractSVD(arma::mat& u, arma::mat& v, arma::mat& sigma);
+  void ExtractSVD(const arma::mat& dataset,
+                  arma::mat& u, 
+                  arma::mat& v, 
+                  arma::mat& sigma);
 
  private:
-  //! Matrix for which cosine tree is constructed.
-  const arma::mat& dataset;
   //! Subspace basis of the input dataset.
   arma::mat basis;
 };

--- a/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
@@ -23,8 +23,25 @@ inline QUIC_SVD::QUIC_SVD(
     arma::mat& v,
     arma::mat& sigma,
     const double epsilon,
-    const double delta) :
-    dataset(dataset)
+    const double delta)
+{
+  Apply(dataset, u, v, sigma, epsilon, delta);
+}
+
+inline QUIC_SVD::QUIC_SVD(
+    const double epsilon,
+    const double delta)
+{
+  /* Nothing to do here */
+}
+
+inline void QUIC_SVD::Apply(
+    const arma::mat& dataset,
+    arma::mat& u,
+    arma::mat& v,
+    arma::mat& sigma,
+    const double epsilon,
+    const double delta)
 {
   // Since columns are sample in the implementation, the matrix is transposed if
   // necessary for maximum speedup.
@@ -42,10 +59,11 @@ inline QUIC_SVD::QUIC_SVD(
 
   // Use the ExtractSVD algorithm mentioned in the paper to extract the SVD of
   // the original dataset in the obtained subspace.
-  ExtractSVD(u, v, sigma);
+  ExtractSVD(dataset,u, v, sigma);
 }
 
-inline void QUIC_SVD::ExtractSVD(arma::mat& u,
+inline void QUIC_SVD::ExtractSVD(const arma::mat& dataset,
+                                 arma::mat& u,
                                  arma::mat& v,
                                  arma::mat& sigma)
 {

--- a/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
@@ -82,6 +82,9 @@ inline void QUIC_SVD::ExtractSVD(const arma::mat& dataset,
   arma::vec sigmaBar;
   arma::svd(uBar, sigmaBar, vBar, projectedMatSquared);
 
+  // vBar was tarnsposed of vBar
+  vBar = arma::trans(vBar);
+
   // Calculate the approximate SVD of the original matrix, using the SVD of the
   // squared projected matrix.
   v = basis * vBar;

--- a/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
@@ -59,7 +59,7 @@ inline void QUIC_SVD::Apply(
 
   // Use the ExtractSVD algorithm mentioned in the paper to extract the SVD of
   // the original dataset in the obtained subspace.
-  ExtractSVD(dataset,u, v, sigma);
+  ExtractSVD(dataset, u, v, sigma);
 }
 
 inline void QUIC_SVD::ExtractSVD(const arma::mat& dataset,

--- a/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
+++ b/src/mlpack/methods/quic_svd/quic_svd_impl.hpp
@@ -82,9 +82,6 @@ inline void QUIC_SVD::ExtractSVD(const arma::mat& dataset,
   arma::vec sigmaBar;
   arma::svd(uBar, sigmaBar, vBar, projectedMatSquared);
 
-  // vBar was tarnsposed of vBar
-  vBar = arma::trans(vBar);
-
   // Calculate the approximate SVD of the original matrix, using the SVD of the
   // squared projected matrix.
   v = basis * vBar;

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -567,8 +567,8 @@ TEMPLATE_TEST_CASE("CFBatchPredictTest", "[CFTest]",
  * some methods
  */
 TEMPLATE_TEST_CASE("TrainTest_1", "[CFTest]",
-  RandomizedSVDPolicy, BatchSVDPolicy, NMFPolicy, SVDCompletePolicy,
-  SVDIncompletePolicy, QUIC_SVDPolicy)
+    RandomizedSVDPolicy, BatchSVDPolicy, NMFPolicy, SVDCompletePolicy,
+    SVDIncompletePolicy, QUIC_SVDPolicy)
 {
   TestType decomposition;
   Train(decomposition);

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -1055,8 +1055,8 @@ TEST_CASE("SerializationSVDIncompleteTest", "[CFTest]")
 }
 
 /**
- * Ensure we can load and save the CF model using Quic SVD Incremental.
-//  */
+ * Ensure we can load and save the CF model using Quic SVD Policy.
+ */
 TEST_CASE("SerializationQSVDTest", "[CFTest]")
 {
   Serialization<QuicSVDPolicy>();

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -611,8 +611,8 @@ TEMPLATE_TEST_CASE("SerializationTest", "[CFTest]",
  * all types of Normalization except default.
  */
 TEMPLATE_TEST_CASE("CFPredictNormalization", "[CFTest]",
-  OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
-  ZScoreNormalization)
+    OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
+    ZScoreNormalization)
 {
   CFPredict<NMFPolicy, TestType>(2.0);
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -644,8 +644,8 @@ TEST_CASE("CFPredictNoNormalization", "[CFTest]")
  * for all types of Normalization except default.
  */
 TEMPLATE_TEST_CASE("RecommendationAccuracyNormalizationTest", "[CFTest]",
-  OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
-  ZScoreNormalization)
+    OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
+    ZScoreNormalization)
 {
   RecommendationAccuracy<NMFPolicy, TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -496,230 +496,37 @@ void Serialization()
 
 /**
  * Make sure that correct number of recommendations are generated when query
- * set for randomized SVD.
+ * set for all methods.
  */
-TEST_CASE("CFGetRecommendationsAllUsersRandSVDTest", "[CFTest]")
+TEMPLATE_TEST_CASE("CFGetRecommendationsAllUsersTest", "[CFTest]",
+  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+  QUIC_SVDPolicy)
 {
-  GetRecommendationsAllUsers<RandomizedSVDPolicy>();
+  GetRecommendationsAllUsers<TestType>();
 }
 
 /**
- * Make sure that correct number of recommendations are generated when query
- * set for regularized SVD.
+ * Make sure that the recommendations are generated for queried users
+ * for all methods.
  */
-TEST_CASE("CFGetRecommendationsAllUsersRegSVDTest", "[CFTest]")
+TEMPLATE_TEST_CASE("CFGetRecommendationsQueriedUsersTest", "[CFTest]",
+  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+  QUIC_SVDPolicy)
 {
-  GetRecommendationsAllUsers<RegSVDPolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for Batch SVD.
- */
-
-TEST_CASE("CFGetRecommendationsAllUsersBatchSVDTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<BatchSVDPolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for NMF.
- */
-TEST_CASE("CFGetRecommendationsAllUsersNMFTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<NMFPolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for SVD Complete Incremental method.
- */
-TEST_CASE("CFGetRecommendationsAllUsersSVDCompleteTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<SVDCompletePolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for SVD Incomplete Incremental method.
- */
-TEST_CASE("CFGetRecommendationsAllUsersSVDIncompleteTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<SVDIncompletePolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for Bias SVD method.
- */
-TEST_CASE("CFGetRecommendationsAllUsersBiasSVDTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<BiasSVDPolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for SVDPlusPlus method.
- */
-TEST_CASE("CFGetRecommendationsAllUsersSVDPPTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<SVDPlusPlusPolicy>();
-}
-
-/**
- * Make sure that correct number of recommendations are generated when query
- * set for Quic SVD method.
- */
-TEST_CASE("CFGetRecommendationsAllUsersQSVDTest", "[CFTest]")
-{
-  GetRecommendationsAllUsers<QuicSVDPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for randomized SVD.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserRandSVDTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<RandomizedSVDPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for regularized SVD.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserRegSVDTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<RegSVDPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for batch SVD.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserBatchSVDTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<BatchSVDPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for NMF.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserNMFTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<NMFPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for SVD Complete Incremental method.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserSVDCompleteTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<SVDCompletePolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for SVD Incomplete Incremental method.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserSVDIncompleteTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<SVDIncompletePolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for Bias SVD method.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserBiasSVDTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<BiasSVDPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for SVDPlusPlus method.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserSVDPPTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<SVDPlusPlusPolicy>();
-}
-
-/**
- * Make sure that the recommendations are generated for queried users only
- * for Quic SVD method.
- */
-TEST_CASE("CFGetRecommendationsQueriedUserQSVDTest", "[CFTest]")
-{
-  GetRecommendationsQueriedUser<QuicSVDPolicy>();
+  GetRecommendationsQueriedUser<TestType>();
 }
 
 /**
  * Make sure recommendations that are generated are reasonably accurate
- * for randomized SVD.
+ * for all methods except SVDPlusPlus method.
  */
-TEST_CASE("RecommendationAccuracyRandSVDTest", "[CFTest]")
+TEMPLATE_TEST_CASE("RecommendationAccuracyTest", "[CFTest]",
+  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, QUIC_SVDPolicy)
 {
-  RecommendationAccuracy<RandomizedSVDPolicy>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for regularized SVD.
- */
-TEST_CASE("RecommendationAccuracyRegSVDTest", "[CFTest]")
-{
-  RecommendationAccuracy<RegSVDPolicy>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for batch SVD.
- */
-TEST_CASE("RecommendationAccuracyBatchSVDTest", "[CFTest]")
-{
-  RecommendationAccuracy<BatchSVDPolicy>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for NMF.
- */
-TEST_CASE("RecommendationAccuracyNMFTest", "[CFTest]")
-{
-  RecommendationAccuracy<NMFPolicy>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for SVD Complete Incremental method.
- */
-TEST_CASE("RecommendationAccuracySVDCompleteTest", "[CFTest]")
-{
-  RecommendationAccuracy<SVDCompletePolicy>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for SVD Incomplete Incremental method.
- */
-TEST_CASE("RecommendationAccuracySVDIncompleteTest", "[CFTest]")
-{
-  RecommendationAccuracy<SVDIncompletePolicy>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for Bias SVD method.
- */
-TEST_CASE("RecommendationAccuracyBiasSVDTest", "[CFTest]")
-{
-  // This algorithm seems to be far less effective than others.
-  // We therefore allow failures on 44% of the runs.
-  RecommendationAccuracy<BiasSVDPolicy>(22);
+  RecommendationAccuracy<TestType>();
 }
 
 /**
@@ -733,369 +540,81 @@ TEST_CASE("RecommendationAccuracyBiasSVDTest", "[CFTest]")
 //   RecommendationAccuracy<SVDPlusPlusPolicy>();
 // }
 
-// Make sure that Predict() is returning reasonable results for randomized SVD.
-TEST_CASE("CFPredictRandSVDTest", "[CFTest]")
+/**
+ * Make sure that Predict() is returning reasonable results for all methods.
+ */
+TEMPLATE_TEST_CASE("CFPredictTest", "[CFTest]",
+  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+  QUIC_SVDPolicy)
 {
-  CFPredict<RandomizedSVDPolicy>();
-}
-
-// Make sure that Predict() is returning reasonable results for regularized SVD.
-TEST_CASE("CFPredictRegSVDTest", "[CFTest]")
-{
-  CFPredict<RegSVDPolicy>();
-}
-
-// Make sure that Predict() is returning reasonable results for batch SVD.
-TEST_CASE("CFPredictBatchSVDTest", "[CFTest]")
-{
-  CFPredict<BatchSVDPolicy>();
-}
-
-// Make sure that Predict() is returning reasonable results for NMF.
-TEST_CASE("CFPredictNMFTest", "[CFTest]")
-{
-  CFPredict<NMFPolicy>();
+  CFPredict<TestType>();
 }
 
 /**
- * Make sure that Predict() is returning reasonable results for SVD Complete
- * Incremental method.
+ * Compare batch Predict() and individual Predict() for all methods.
  */
-TEST_CASE("CFPredictSVDCompleteTest", "[CFTest]")
+TEMPLATE_TEST_CASE("CFBatchPredictTest", "[CFTest]",
+  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+  QUIC_SVDPolicy)
 {
-  CFPredict<SVDCompletePolicy>();
+  BatchPredict<TestType>();
 }
 
 /**
- * Make sure that Predict() is returning reasonable results for SVD Incomplete
- * Incremental method.
+ * Make sure we can train an already-trained model and it works okay for 
+ * some methods
  */
-TEST_CASE("CFPredictSVDIncompleteTest", "[CFTest]")
+TEMPLATE_TEST_CASE("TrainTest_1", "[CFTest]",
+  RandomizedSVDPolicy, BatchSVDPolicy, NMFPolicy, SVDCompletePolicy,
+  SVDIncompletePolicy, QUIC_SVDPolicy)
 {
-  CFPredict<SVDIncompletePolicy>();
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for Bias SVD
- * method.
- */
-TEST_CASE("CFPredictBiasSVDTest", "[CFTest]")
-{
-  CFPredict<BiasSVDPolicy>();
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for SVDPlusPlus
- * method.
- */
-TEST_CASE("CFPredictSVDPPTest", "[CFTest]")
-{
-  CFPredict<SVDPlusPlusPolicy>();
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for Quic SVD
- * method.
- */
-TEST_CASE("CFPredictQSVDTest", "[CFTest]")
-{
-  CFPredict<QuicSVDPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for randomized SVD.
-TEST_CASE("CFBatchPredictRandSVDTest", "[CFTest]")
-{
-  BatchPredict<RandomizedSVDPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for regularized SVD.
-TEST_CASE("CFBatchPredictRegSVDTest", "[CFTest]")
-{
-  BatchPredict<RegSVDPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for batch SVD.
-TEST_CASE("CFBatchPredictBatchSVDTest", "[CFTest]")
-{
-  BatchPredict<BatchSVDPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for NMF.
-TEST_CASE("CFBatchPredictNMFTest", "[CFTest]")
-{
-  BatchPredict<NMFPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for
-// SVD Complete Incremental method.
-TEST_CASE("CFBatchPredictSVDCompleteTest", "[CFTest]")
-{
-  BatchPredict<SVDCompletePolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for
-// SVD Incomplete Incremental method.
-TEST_CASE("CFBatchPredictSVDIncompleteTest", "[CFTest]")
-{
-  BatchPredict<SVDIncompletePolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for
-// Bias SVD method.
-TEST_CASE("CFBatchPredictBiasSVDTest", "[CFTest]")
-{
-  BatchPredict<BiasSVDPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for
-// SVDPlusPlus method.
-TEST_CASE("CFBatchPredictSVDPPTest", "[CFTest]")
-{
-  BatchPredict<SVDPlusPlusPolicy>();
-}
-
-// Compare batch Predict() and individual Predict() for
-// Quic SVD method.
-TEST_CASE("CFBatchPredictQSVDTest", "[CFTest]")
-{
-  BatchPredict<QuicSVDPolicy>();
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * randomized SVD.
- */
-TEST_CASE("TrainRandSVDTest", "[CFTest]")
-{
-  RandomizedSVDPolicy decomposition;
+  TestType decomposition;
   Train(decomposition);
 }
 
 /**
- * Make sure we can train an already-trained model and it works okay for
- * regularized SVD.
+ * Make sure we can train an already-trained model and it works okay for 
+ * some methods
  */
-TEST_CASE("TrainRegSVDTest", "[CFTest]")
+TEMPLATE_TEST_CASE("TrainTest_2", "[CFTest]",
+  RegSVDPolicy, BiasSVDPolicy, SVDPlusPlusPolicy)
 {
-  RegSVDPolicy decomposition;
-  TrainWithCoordinateList(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * batch SVD.
- */
-TEST_CASE("TrainBatchSVDTest", "[CFTest]")
-{
-  BatchSVDPolicy decomposition;
-  Train(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * NMF.
- */
-TEST_CASE("TrainNMFTest", "[CFTest]")
-{
-  NMFPolicy decomposition;
-  Train(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * SVD Complete Incremental method.
- */
-TEST_CASE("TrainSVDCompleteTest", "[CFTest]")
-{
-  SVDCompletePolicy decomposition;
-  Train(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * SVD Incomplete Incremental method.
- */
-TEST_CASE("TrainSVDIncompleteTest", "[CFTest]")
-{
-  SVDIncompletePolicy decomposition;
-  Train(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * BiasSVD method.
- */
-TEST_CASE("TrainBiasSVDTest", "[CFTest]")
-{
-  BiasSVDPolicy decomposition;
-  TrainWithCoordinateList(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * SVDPlusPlus method.
- */
-TEST_CASE("TrainSVDPPTest", "[CFTest]")
-{
-  SVDPlusPlusPolicy decomposition;
-  TrainWithCoordinateList(decomposition);
-}
-
-/**
- * Make sure we can train an already-trained model and it works okay for
- * Quic SVD method.
- */
-TEST_CASE("TrainQSVDTest", "[CFTest]")
-{
-  QuicSVDPolicy decomposition;
+  TestType decomposition;
   TrainWithCoordinateList(decomposition);
 }
 
 /**
  * Make sure we can train a model after using the empty constructor when
- * using randomized SVD.
+ * using any of the method.
  */
-TEST_CASE("EmptyConstructorTrainRandSVDTest", "[CFTest]")
+TEMPLATE_TEST_CASE("EmptyConstructorTrainTest", "[CFTest]",
+  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, QUIC_SVDPolicy)
 {
-  EmptyConstructorTrain<RandomizedSVDPolicy>();
+  EmptyConstructorTrain<TestType>();
 }
 
 /**
- * Make sure we can train a model after using the empty constructor when
- * using regularized SVD.
+ * Ensure we can load and save the CF model using any of the method.
  */
-TEST_CASE("EmptyConstructorTrainRegSVDTest", "[CFTest]")
+TEMPLATE_TEST_CASE("SerializationTest", "[CFTest]",
+  RandomizedSVDPolicy, BatchSVDPolicy, NMFPolicy, SVDCompletePolicy,
+  SVDIncompletePolicy, QUIC_SVDPolicy)
 {
-  EmptyConstructorTrain<RegSVDPolicy>();
-}
-
-/**
- * Make sure we can train a model after using the empty constructor when
- * using batch SVD.
- */
-TEST_CASE("EmptyConstructorTrainBatchSVDTest", "[CFTest]")
-{
-  EmptyConstructorTrain<BatchSVDPolicy>();
-}
-
-/**
- * Make sure we can train a model after using the empty constructor when
- * using NMF.
- */
-TEST_CASE("EmptyConstructorTrainNMFTest", "[CFTest]")
-{
-  EmptyConstructorTrain<NMFPolicy>();
-}
-
-/**
- * Make sure we can train a model after using the empty constructor when
- * using SVD Complete Incremental method.
- */
-TEST_CASE("EmptyConstructorTrainSVDCompleteTest", "[CFTest]")
-{
-  EmptyConstructorTrain<SVDCompletePolicy>();
-}
-
-/**
- * Make sure we can train a model after using the empty constructor when
- * using SVD Incomplete Incremental method.
- */
-TEST_CASE("EmptyConstructorTrainSVDIncompleteTest", "[CFTest]")
-{
-  EmptyConstructorTrain<SVDIncompletePolicy>();
-}
-
-/**
- * Make sure we can train a model after using the empty constructor when
- * using Quic SVD method.
- */
-TEST_CASE("EmptyConstructorTrainQSVDTest", "[CFTest]")
-{
-  EmptyConstructorTrain<QuicSVDPolicy>();
-}
-
-/**
- * Ensure we can load and save the CF model using randomized SVD policy.
- */
-TEST_CASE("SerializationRandSVDTest", "[CFTest]")
-{
-  Serialization<RandomizedSVDPolicy>();
-}
-
-/**
- * Ensure we can load and save the CF model using batch SVD policy.
- */
-TEST_CASE("SerializationBatchSVDTest", "[CFTest]")
-{
-  Serialization<BatchSVDPolicy>();
-}
-
-/**
- * Ensure we can load and save the CF model using NMF policy.
- */
-TEST_CASE("SerializationNMFTest", "[CFTest]")
-{
-  Serialization<NMFPolicy>();
-}
-
-/**
- * Ensure we can load and save the CF model using SVD Complete Incremental.
- */
-TEST_CASE("SerializationSVDCompleteTest", "[CFTest]")
-{
-  Serialization<SVDCompletePolicy>();
-}
-
-/**
- * Ensure we can load and save the CF model using SVD Incomplete Incremental.
- */
-TEST_CASE("SerializationSVDIncompleteTest", "[CFTest]")
-{
-  Serialization<SVDIncompletePolicy>();
-}
-
-/**
- * Ensure we can load and save the CF model using Quic SVD Policy.
- */
-TEST_CASE("SerializationQSVDTest", "[CFTest]")
-{
-  Serialization<QuicSVDPolicy>();
+  Serialization<TestType>();
 }
 
 /**
  * Make sure that Predict() is returning reasonable results for NMF and
- * OverallMeanNormalization.
+ * all types of Normalization except default.
  */
-TEST_CASE("CFPredictOverallMeanNormalization", "[CFTest]")
+TEMPLATE_TEST_CASE("CFPredictNormalization", "[CFTest]",
+  OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
+  ZScoreNormalization)
 {
-  CFPredict<NMFPolicy, OverallMeanNormalization>(2.0);
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for NMF and
- * UserMeanNormalization.
- */
-TEST_CASE("CFPredictUserMeanNormalization", "[CFTest]")
-{
-  CFPredict<NMFPolicy, UserMeanNormalization>(2.0);
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for NMF and
- * ItemMeanNormalization.
- */
-TEST_CASE("CFPredictItemMeanNormalization", "[CFTest]")
-{
-  CFPredict<NMFPolicy, ItemMeanNormalization>(2.0);
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for NMF and
- * ZScoreNormalization.
- */
-TEST_CASE("CFPredictZScoreNormalization", "[CFTest]")
-{
-  CFPredict<NMFPolicy, ZScoreNormalization>(2.0);
+  CFPredict<NMFPolicy, TestType>(2.0);
 }
 
 /**
@@ -1122,38 +641,13 @@ TEST_CASE("CFPredictNoNormalization", "[CFTest]")
 
 /**
  * Make sure recommendations that are generated are reasonably accurate
- * for OverallMeanNormalization.
+ * for all types of Normalization except default.
  */
-TEST_CASE("RecommendationAccuracyOverallMeanNormalizationTest", "[CFTest]")
+TEMPLATE_TEST_CASE("RecommendationAccuracyNormalizationTest", "[CFTest]",
+  OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
+  ZScoreNormalization)
 {
-  RecommendationAccuracy<NMFPolicy, OverallMeanNormalization>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for UserMeanNormalization.
- */
-TEST_CASE("RecommendationAccuracyUserMeanNormalizationTest", "[CFTest]")
-{
-  RecommendationAccuracy<NMFPolicy, UserMeanNormalization>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for ItemMeanNormalization.
- */
-TEST_CASE("RecommendationAccuracyItemMeanNormalizationTest", "[CFTest]")
-{
-  RecommendationAccuracy<NMFPolicy, ItemMeanNormalization>();
-}
-
-/**
- * Make sure recommendations that are generated are reasonably accurate
- * for ZScoreNormalization.
- */
-TEST_CASE("RecommendationAccuracyZScoreNormalizationTest", "[CFTest]")
-{
-  RecommendationAccuracy<NMFPolicy, ZScoreNormalization>();
+  RecommendationAccuracy<NMFPolicy, TestType>();
 }
 
 /**
@@ -1170,35 +664,14 @@ TEST_CASE("RecommendationAccuracyCombinedNormalizationTest", "[CFTest]")
 }
 
 /**
- * Ensure we can load and save the CF model using OverallMeanNormalization.
+ * Ensure we can load and save the CF model using any type of Normalization 
+ * except default.
  */
-TEST_CASE("SerializationOverallMeanNormalizationTest", "[CFTest]")
+TEMPLATE_TEST_CASE("SerializationNormalizationTest", "[CFTest]",
+  OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
+  ZScoreNormalization)
 {
-  Serialization<NMFPolicy, OverallMeanNormalization>();
-}
-
-/**
- * Ensure we can load and save the CF model using UserMeanNormalization.
- */
-TEST_CASE("SerializationUserMeanNormalizationTest", "[CFTest]")
-{
-  Serialization<NMFPolicy, UserMeanNormalization>();
-}
-
-/**
- * Ensure we can load and save the CF model using ItemMeanNormalization.
- */
-TEST_CASE("SerializationItemMeanNormalizationTest", "[CFTest]")
-{
-  Serialization<NMFPolicy, ItemMeanNormalization>();
-}
-
-/**
- * Ensure we can load and save the CF model using ZScoreMeanNormalization.
- */
-TEST_CASE("SerializationZScoreNormalizationTest", "[CFTest]")
-{
-  Serialization<NMFPolicy, ZScoreNormalization>();
+  Serialization<NMFPolicy, TestType>();
 }
 
 /**
@@ -1214,54 +687,24 @@ TEST_CASE("SerializationCombinedNormalizationTest", "[CFTest]")
 }
 
 /**
- * Make sure that Predict() is returning reasonable results for
- * EuclideanSearch.
+ * Make sure that Predict() is returning reasonable results for all search
+ * except default.
  */
-TEST_CASE("CFPredictEuclideanSearch", "[CFTest]")
+TEMPLATE_TEST_CASE("CFPredictSearch", "[CFTest]",
+  EuclideanSearch, CosineSearch, PearsonSearch)
 {
-  CFPredict<NMFPolicy, OverallMeanNormalization, EuclideanSearch>(2.0);
+  CFPredict<NMFPolicy, OverallMeanNormalization, TestType>(2.0);
 }
 
 /**
  * Make sure that Predict() is returning reasonable results for
- * CosineSearch.
+ * some Interpolations.
  */
-TEST_CASE("CFPredictCosineSearch", "[CFTest]")
+TEMPLATE_TEST_CASE("CFPredictAverageInterpolation", "[CFTest]",
+  AverageInterpolation, SimilarityInterpolation)
 {
-  CFPredict<NMFPolicy, OverallMeanNormalization, CosineSearch>(2.0);
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for
- * PearsonSearch.
- */
-TEST_CASE("CFPredictPearsonSearch", "[CFTest]")
-{
-  CFPredict<NMFPolicy, OverallMeanNormalization, PearsonSearch>(2.0);
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for
- * AverageInterpolation.
- */
-TEST_CASE("CFPredictAverageInterpolation", "[CFTest]")
-{
-  CFPredict<NMFPolicy,
-            OverallMeanNormalization,
-            EuclideanSearch,
-            AverageInterpolation>(2.0);
-}
-
-/**
- * Make sure that Predict() is returning reasonable results for
- * SimilarityInterpolation.
- */
-TEST_CASE("CFPredictSimilarityInterpolation", "[CFTest]")
-{
-  CFPredict<NMFPolicy,
-            OverallMeanNormalization,
-            EuclideanSearch,
-            SimilarityInterpolation>(2.0);
+  CFPredict<NMFPolicy, OverallMeanNormalization, EuclideanSearch,
+    TestType>(2.0);
 }
 
 /**

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -701,7 +701,7 @@ TEMPLATE_TEST_CASE("CFPredictSearch", "[CFTest]",
  * some Interpolations.
  */
 TEMPLATE_TEST_CASE("CFPredictAverageInterpolation", "[CFTest]",
-  AverageInterpolation, SimilarityInterpolation)
+    AverageInterpolation, SimilarityInterpolation)
 {
   CFPredict<NMFPolicy, OverallMeanNormalization, EuclideanSearch,
     TestType>(2.0);

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -600,8 +600,8 @@ TEMPLATE_TEST_CASE("EmptyConstructorTrainTest", "[CFTest]",
  * Ensure we can load and save the CF model using any of the method.
  */
 TEMPLATE_TEST_CASE("SerializationTest", "[CFTest]",
-  RandomizedSVDPolicy, BatchSVDPolicy, NMFPolicy, SVDCompletePolicy,
-  SVDIncompletePolicy, QUIC_SVDPolicy)
+    RandomizedSVDPolicy, BatchSVDPolicy, NMFPolicy, SVDCompletePolicy,
+    SVDIncompletePolicy, QUIC_SVDPolicy)
 {
   Serialization<TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -568,6 +568,15 @@ TEST_CASE("CFGetRecommendationsAllUsersSVDPPTest", "[CFTest]")
 }
 
 /**
+ * Make sure that correct number of recommendations are generated when query
+ * set for Quic SVD method.
+ */
+TEST_CASE("CFGetRecommendationsAllUsersQSVDTest", "[CFTest]")
+{
+  GetRecommendationsAllUsers<QuicSVDPolicy>();
+}
+
+/**
  * Make sure that the recommendations are generated for queried users only
  * for randomized SVD.
  */
@@ -637,6 +646,15 @@ TEST_CASE("CFGetRecommendationsQueriedUserBiasSVDTest", "[CFTest]")
 TEST_CASE("CFGetRecommendationsQueriedUserSVDPPTest", "[CFTest]")
 {
   GetRecommendationsQueriedUser<SVDPlusPlusPolicy>();
+}
+
+/**
+ * Make sure that the recommendations are generated for queried users only
+ * for Quic SVD method.
+ */
+TEST_CASE("CFGetRecommendationsQueriedUserQSVDTest", "[CFTest]")
+{
+  GetRecommendationsQueriedUser<QuicSVDPolicy>();
 }
 
 /**
@@ -775,6 +793,15 @@ TEST_CASE("CFPredictSVDPPTest", "[CFTest]")
   CFPredict<SVDPlusPlusPolicy>();
 }
 
+/**
+ * Make sure that Predict() is returning reasonable results for Quic SVD
+ * method.
+ */
+TEST_CASE("CFPredictQSVDTest", "[CFTest]")
+{
+  CFPredict<QuicSVDPolicy>();
+}
+
 // Compare batch Predict() and individual Predict() for randomized SVD.
 TEST_CASE("CFBatchPredictRandSVDTest", "[CFTest]")
 {
@@ -825,6 +852,13 @@ TEST_CASE("CFBatchPredictBiasSVDTest", "[CFTest]")
 TEST_CASE("CFBatchPredictSVDPPTest", "[CFTest]")
 {
   BatchPredict<SVDPlusPlusPolicy>();
+}
+
+// Compare batch Predict() and individual Predict() for
+// Quic SVD method.
+TEST_CASE("CFBatchPredictQSVDTest", "[CFTest]")
+{
+  BatchPredict<QuicSVDPolicy>();
 }
 
 /**
@@ -908,6 +942,16 @@ TEST_CASE("TrainSVDPPTest", "[CFTest]")
 }
 
 /**
+ * Make sure we can train an already-trained model and it works okay for
+ * Quic SVD method.
+ */
+TEST_CASE("TrainQSVDTest", "[CFTest]")
+{
+  QuicSVDPolicy decomposition;
+  TrainWithCoordinateList(decomposition);
+}
+
+/**
  * Make sure we can train a model after using the empty constructor when
  * using randomized SVD.
  */
@@ -962,6 +1006,15 @@ TEST_CASE("EmptyConstructorTrainSVDIncompleteTest", "[CFTest]")
 }
 
 /**
+ * Make sure we can train a model after using the empty constructor when
+ * using Quic SVD method.
+ */
+TEST_CASE("EmptyConstructorTrainQSVDTest", "[CFTest]")
+{
+  EmptyConstructorTrain<QuicSVDPolicy>();
+}
+
+/**
  * Ensure we can load and save the CF model using randomized SVD policy.
  */
 TEST_CASE("SerializationRandSVDTest", "[CFTest]")
@@ -999,6 +1052,14 @@ TEST_CASE("SerializationSVDCompleteTest", "[CFTest]")
 TEST_CASE("SerializationSVDIncompleteTest", "[CFTest]")
 {
   Serialization<SVDIncompletePolicy>();
+}
+
+/**
+ * Ensure we can load and save the CF model using Quic SVD Incremental.
+//  */
+TEST_CASE("SerializationQSVDTest", "[CFTest]")
+{
+  Serialization<QuicSVDPolicy>();
 }
 
 /**

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -579,7 +579,7 @@ TEMPLATE_TEST_CASE("TrainTest_1", "[CFTest]",
  * some methods
  */
 TEMPLATE_TEST_CASE("TrainTest_2", "[CFTest]",
-  RegSVDPolicy, BiasSVDPolicy, SVDPlusPlusPolicy)
+    RegSVDPolicy, BiasSVDPolicy, SVDPlusPlusPolicy)
 {
   TestType decomposition;
   TrainWithCoordinateList(decomposition);

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -499,9 +499,9 @@ void Serialization()
  * set for all methods.
  */
 TEMPLATE_TEST_CASE("CFGetRecommendationsAllUsersTest", "[CFTest]",
-  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
-  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
-  QUIC_SVDPolicy)
+    RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+    SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+    QUIC_SVDPolicy)
 {
   GetRecommendationsAllUsers<TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -704,7 +704,7 @@ TEMPLATE_TEST_CASE("CFPredictAverageInterpolation", "[CFTest]",
     AverageInterpolation, SimilarityInterpolation)
 {
   CFPredict<NMFPolicy, OverallMeanNormalization, EuclideanSearch,
-    TestType>(2.0);
+      TestType>(2.0);
 }
 
 /**

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -668,8 +668,8 @@ TEST_CASE("RecommendationAccuracyCombinedNormalizationTest", "[CFTest]")
  * except default.
  */
 TEMPLATE_TEST_CASE("SerializationNormalizationTest", "[CFTest]",
-  OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
-  ZScoreNormalization)
+    OverallMeanNormalization, UserMeanNormalization, ItemMeanNormalization,
+    ZScoreNormalization)
 {
   Serialization<NMFPolicy, TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -544,9 +544,9 @@ TEMPLATE_TEST_CASE("RecommendationAccuracyTest", "[CFTest]",
  * Make sure that Predict() is returning reasonable results for all methods.
  */
 TEMPLATE_TEST_CASE("CFPredictTest", "[CFTest]",
-  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
-  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
-  QUIC_SVDPolicy)
+    RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+    SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+    QUIC_SVDPolicy)
 {
   CFPredict<TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -523,8 +523,8 @@ TEMPLATE_TEST_CASE("CFGetRecommendationsQueriedUsersTest", "[CFTest]",
  * for all methods except SVDPlusPlus method.
  */
 TEMPLATE_TEST_CASE("RecommendationAccuracyTest", "[CFTest]",
-  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
-  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, QUIC_SVDPolicy)
+    RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+    SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, QUIC_SVDPolicy)
 {
   RecommendationAccuracy<TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -555,9 +555,9 @@ TEMPLATE_TEST_CASE("CFPredictTest", "[CFTest]",
  * Compare batch Predict() and individual Predict() for all methods.
  */
 TEMPLATE_TEST_CASE("CFBatchPredictTest", "[CFTest]",
-  RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
-  SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
-  QUIC_SVDPolicy)
+    RandomizedSVDPolicy, RegSVDPolicy, BatchSVDPolicy, NMFPolicy,
+    SVDCompletePolicy, SVDIncompletePolicy, BiasSVDPolicy, SVDPlusPlusPolicy,
+    QUIC_SVDPolicy)
 {
   BatchPredict<TestType>();
 }

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -691,7 +691,7 @@ TEST_CASE("SerializationCombinedNormalizationTest", "[CFTest]")
  * except default.
  */
 TEMPLATE_TEST_CASE("CFPredictSearch", "[CFTest]",
-  EuclideanSearch, CosineSearch, PearsonSearch)
+    EuclideanSearch, CosineSearch, PearsonSearch)
 {
   CFPredict<NMFPolicy, OverallMeanNormalization, TestType>(2.0);
 }


### PR DESCRIPTION
As mentioned in #3398, Quic_SVD method is added in CF and some standard changes in 'methods/quic_svd` are performed so that it can be used in cf.