### PR TITLE
avoid deprecation warnings in Armadillo 11.4.4+

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 
   * Fix DBSCAN handling of non-core points (#3346).
 
+  * Avoid deprecation warnings in Armadillo 11.4.4+ (#3405).
+
 ### mlpack 4.0.1
 ###### 2022-12-23
   * Fix mapping of categorical data for Julia bindings (#3305).

--- a/src/mlpack/core/data/save_impl.hpp
+++ b/src/mlpack/core/data/save_impl.hpp
@@ -101,10 +101,10 @@ bool Save(const std::string& filename,
 #ifdef ARMA_USE_HDF5
     // We can't save with streams for HDF5.
     const bool success = (saveType == FileType::HDF5Binary) ?
-        tmp.quiet_save(filename, ToArmaFileType(saveType)) :
-        tmp.quiet_save(stream, ToArmaFileType(saveType));
+        tmp.save(filename, ToArmaFileType(saveType)) :
+        tmp.save(stream, ToArmaFileType(saveType));
 #else
-    const bool success = tmp.quiet_save(stream, ToArmaFileType(saveType));
+    const bool success = tmp.save(stream, ToArmaFileType(saveType));
 #endif
     if (!success)
     {
@@ -122,10 +122,10 @@ bool Save(const std::string& filename,
 #ifdef ARMA_USE_HDF5
     // We can't save with streams for HDF5.
     const bool success = (saveType == FileType::HDF5Binary) ?
-        matrix.quiet_save(filename, ToArmaFileType(saveType)) :
-        matrix.quiet_save(stream, ToArmaFileType(saveType));
+        matrix.save(filename, ToArmaFileType(saveType)) :
+        matrix.save(stream, ToArmaFileType(saveType));
 #else
-    const bool success = matrix.quiet_save(stream, ToArmaFileType(saveType));
+    const bool success = matrix.save(stream, ToArmaFileType(saveType));
 #endif
     if (!success)
     {
@@ -236,7 +236,7 @@ bool Save(const std::string& filename,
     tmp = trans(matrix);
   }
 
-  const bool success = tmp.quiet_save(stream, ToArmaFileType(saveType));
+  const bool success = tmp.save(stream, ToArmaFileType(saveType));
   if (!success)
   {
     Timer::Stop("saving_data");

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("WrongExtensionWrongLoad", "[LoadSaveTest]")
                    "4 8;";
 
   arma::mat testTrans = trans(test);
-  REQUIRE(testTrans.quiet_save("test_file.csv", arma::arma_binary) == true);
+  REQUIRE(testTrans.save("test_file.csv", arma::arma_binary) == true);
 
   // Now reload through our interface.
   REQUIRE(data::Load("test_file.csv", test) == false);
@@ -79,7 +79,7 @@ TEST_CASE("WrongExtensionCorrectLoad", "[LoadSaveTest]")
                    "4 8;";
 
   arma::mat testTrans = trans(test);
-  REQUIRE(testTrans.quiet_save("test_file.csv", arma::arma_binary) == true);
+  REQUIRE(testTrans.save("test_file.csv", arma::arma_binary) == true);
 
   // Now reload through our interface.
   REQUIRE(
@@ -924,7 +924,7 @@ TEST_CASE("LoadArmaBinaryTest", "[LoadSaveTest]")
                    "4 8;";
 
   arma::mat testTrans = trans(test);
-  REQUIRE(testTrans.quiet_save("test_file.bin", arma::arma_binary)
+  REQUIRE(testTrans.save("test_file.bin", arma::arma_binary)
       == true);
 
   // Now reload through our interface.
@@ -1001,7 +1001,7 @@ TEST_CASE("LoadRawBinaryTest", "[LoadSaveTest]")
                    "7 8;";
 
   arma::mat testTrans = trans(test);
-  REQUIRE(testTrans.quiet_save("test_file.bin", arma::raw_binary)
+  REQUIRE(testTrans.save("test_file.bin", arma::raw_binary)
       == true);
 
   // Now reload through our interface.
@@ -1028,7 +1028,7 @@ TEST_CASE("LoadPGMBinaryTest", "[LoadSaveTest]")
                    "4 8;";
 
   arma::mat testTrans = trans(test);
-  REQUIRE(testTrans.quiet_save("test_file.pgm", arma::pgm_binary)
+  REQUIRE(testTrans.save("test_file.pgm", arma::pgm_binary)
       == true);
 
   // Now reload through our interface.
@@ -1080,13 +1080,13 @@ TEST_CASE("LoadHDF5Test", "[LoadSaveTest]")
                    "3 7;"
                    "4 8;";
   arma::mat testTrans = trans(test);
-  REQUIRE(testTrans.quiet_save("test_file.h5", arma::hdf5_binary)
+  REQUIRE(testTrans.save("test_file.h5", arma::hdf5_binary)
       == true);
-  REQUIRE(testTrans.quiet_save("test_file.hdf5", arma::hdf5_binary)
+  REQUIRE(testTrans.save("test_file.hdf5", arma::hdf5_binary)
       == true);
-  REQUIRE(testTrans.quiet_save("test_file.hdf", arma::hdf5_binary)
+  REQUIRE(testTrans.save("test_file.hdf", arma::hdf5_binary)
       == true);
-  REQUIRE(testTrans.quiet_save("test_file.he5", arma::hdf5_binary)
+  REQUIRE(testTrans.save("test_file.he5", arma::hdf5_binary)
       == true);
 
   // Now reload through our interface.


### PR DESCRIPTION
Change all instances of `.quiet_save()` to `.save()`.  This is to avoid compile-time deprecation warnings.

The functions `.quiet_save()` and `.quiet_load()` have been deprecated since Armadillo 11.4.4.

Since Armadillo 10.4, the default degree of warning messages has been reduced, so that failed saving / loading no longer emits warnings.

(The warning level can be manually changed via the [ARMA_WARN_LEVEL](https://arma.sourceforge.net/docs.html#config_hpp) option).
