### PR TITLE
[R] Remove configure script as sunos is no longer an issue

### DIFF
--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -289,11 +289,6 @@ if (BUILD_R_BINDINGS)
        DESTINATION
        "${CMAKE_CURRENT_BINARY_DIR}/mlpack/")
 
-  file(COPY
-       "${CMAKE_CURRENT_SOURCE_DIR}/mlpack/configure"
-       DESTINATION
-       "${CMAKE_CURRENT_BINARY_DIR}/mlpack/")
-
   # Do the actual build.
   add_custom_target(r_build ALL)
 

--- a/src/mlpack/bindings/R/mlpack/configure
+++ b/src/mlpack/bindings/R/mlpack/configure
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if test `uname` = "SunOS" ;
-then
-sed '1 s/$/ -ftrack-macro-expansion=0 -pipe --param ggc-min-expand=10 --param ggc-min-heapsize=8192/' ./src/Makevars > ./src/Makevars.tmp && cat ./src/Makevars.tmp > ./src/Makevars && rm ./src/Makevars.tmp
-fi
-
-exit 0


### PR DESCRIPTION
Looking over the R package files, I noticed the short (sweet and simple) `configure` script dealing with a special case for the Sun compilation that had been done for so long at CRAN.  But it is a thing of the past so this can be removed.

Now, it does no harm -- but repo clutter is still (a very minor form of) technical debt so I would remove it and suggest to do so here.