### PR TITLE
Added size and dimension check for Perceptron 

### DIFF
--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -13,6 +13,7 @@
 #define MLPACK_METHODS_PERCEPTRON_PERCEPTRON_IMPL_HPP
 
 #include "perceptron.hpp"
+#include <mlpack/core/util/size_checks.hpp>
 
 namespace mlpack {
 
@@ -134,6 +135,9 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   arma::vec tempLabelMat;
   arma::uword maxIndex = 0;
   predictedLabels.set_size(test.n_cols);
+  
+  size_t dimension = weights.n_rows;
+  util::CheckSameDimensionality(test,dimension,"Dimension Mismatch");
 
   // Could probably be faster if done in batch.
   for (size_t i = 0; i < test.n_cols; ++i)
@@ -164,6 +168,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Train(
     const size_t numClasses,
     const arma::rowvec& instanceWeights)
 {
+  util::CheckSameSizes(data,labels,"Size Mismatch");
   // Do we need to resize the weights?
   if (weights.n_elem != numClasses)
   {

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -136,6 +136,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   arma::uword maxIndex = 0;
   predictedLabels.set_size(test.n_cols);
   
+  // Input data dimension should match with test data dimension.
   size_t dimension = weights.n_rows;
   util::CheckSameDimensionality(test,dimension,"Dimension Mismatch");
 
@@ -168,6 +169,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Train(
     const size_t numClasses,
     const arma::rowvec& instanceWeights)
 {
+  // Training data and labels should have same size.
   util::CheckSameSizes(data,labels,"Size Mismatch");
   // Do we need to resize the weights?
   if (weights.n_elem != numClasses)

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -138,7 +138,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   
   // Input data dimension should match with test data dimension.
   size_t dimension = weights.n_rows;
-  util::CheckSameDimensionality(test,dimension,"Dimension Mismatch");
+  util::CheckSameDimensionality(test,dimension,"Perceptron::Classify()");
 
   // Could probably be faster if done in batch.
   for (size_t i = 0; i < test.n_cols; ++i)
@@ -170,7 +170,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Train(
     const arma::rowvec& instanceWeights)
 {
   // Training data and labels should have same size.
-  util::CheckSameSizes(data,labels,"Size Mismatch");
+  util::CheckSameSizes(data,labels,"Perceptron::Train()");
   // Do we need to resize the weights?
   if (weights.n_elem != numClasses)
   {


### PR DESCRIPTION
An attempt to implement sanity check for Perceptron method as mentioned in #2820.
I have not implemented the sanity check inside bindings since it already contains a more efficient size check. However, it is missing for C++ code itself. 

Thanks,
Adi
