### PR TITLE
Add binding of Matrix Completion and template to pca test

### DIFF
--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Utility macro to add bindings for all languages.
+﻿# Utility macro to add bindings for all languages.
 macro(add_all_bindings directory name type)
   add_category(${name} ${type})
   add_cli_executable(${directory} ${name})
@@ -37,6 +37,7 @@ add_all_bindings(local_coordinate_coding local_coordinate_coding
     "transformations")
 add_all_bindings(logistic_regression logistic_regression "classification")
 add_all_bindings(lsh lsh "geometry")
+add_all_bindings(matrix_completion matrix_completion "preprocessing")
 add_all_bindings(mean_shift mean_shift "clustering")
 add_all_bindings(naive_bayes nbc "classification")
 add_all_bindings(nca nca "transformations")

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -9,8 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef _MLPACK_METHODS_AMF_SIMPLERESIDUETERMINATION_HPP_INCLUDED
-#define _MLPACK_METHODS_AMF_SIMPLERESIDUETERMINATION_HPP_INCLUDED
+#ifndef _MLPACK_METHODS_AMF_SIMPLE_RESIDUE_TERMINATION_HPP_INCLUDED
+#define _MLPACK_METHODS_AMF_SIMPLE_RESIDUE_TERMINATION_HPP_INCLUDED
 
 #include <mlpack/prereqs.hpp>
 

--- a/src/mlpack/methods/amf/termination_policies/validation_rmse_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/validation_rmse_termination.hpp
@@ -9,8 +9,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef _MLPACK_METHODS_AMF_VALIDATIONRMSETERMINATION_HPP_INCLUDED
-#define _MLPACK_METHODS_AMF_VALIDATIONRMSETERMINATION_HPP_INCLUDED
+#ifndef _MLPACK_METHODS_AMF_VALIDATION_RMSE_TERMINATION_HPP_INCLUDED
+#define _MLPACK_METHODS_AMF_VALIDATION_RMSE_TERMINATION_HPP_INCLUDED
 
 #include <mlpack/prereqs.hpp>
 

--- a/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
+++ b/src/mlpack/methods/kernel_pca/kernel_pca_main.cpp
@@ -113,7 +113,8 @@ PARAM_INT_IN("new_dimensionality", "If not 0, reduce the dimensionality of "
 PARAM_FLAG("center", "If set, the transformed data will be centered about the "
     "origin.", "c");
 
-PARAM_FLAG("nystroem_method", "If set, the Nystroem method will be used.", "n");
+PARAM_FLAG("nystroem_method", "If set, the Nystroem method will be used else "
+           "Naive will be used.", "n");
 
 PARAM_STRING_IN("sampling", "Sampling scheme to use for the Nystroem method: "
     "'kmeans', 'random', 'ordered'", "s", "kmeans");

--- a/src/mlpack/methods/matrix_completion/matrix_completion.hpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion.hpp
@@ -38,7 +38,7 @@ namespace mlpack {
  *
  * @code
  * size_t m, n;         // size of unknown matrix
- * arma::umat indices;  // contains the known indices [2 x n_entries]
+ * arma::Mat<size_t> indices;  // contains the known indices [2 x n_entries]
  * arma::vec values;    // contains the known values [n_entries]
  * arma::mat recovered; // will contain the completed matrix
  *
@@ -65,7 +65,7 @@ class MatrixCompletion
    */
   MatrixCompletion(const size_t m,
                    const size_t n,
-                   const arma::umat& indices,
+                   const arma::Mat<size_t>& indices,
                    const arma::vec& values,
                    const size_t r);
 
@@ -83,7 +83,7 @@ class MatrixCompletion
    */
   MatrixCompletion(const size_t m,
                    const size_t n,
-                   const arma::umat& indices,
+                   const arma::Mat<size_t>& indices,
                    const arma::vec& values,
                    const arma::mat& initialPoint);
 
@@ -99,7 +99,7 @@ class MatrixCompletion
    */
   MatrixCompletion(const size_t m,
                    const size_t n,
-                   const arma::umat& indices,
+                   const arma::Mat<size_t>& indices,
                    const arma::vec& values);
 
   /**
@@ -123,7 +123,7 @@ class MatrixCompletion
   //! Number of columns in original matrix.
   size_t n;
   //! Matrix containing the indices of the known entries (has two rows).
-  arma::umat indices;
+  arma::Mat<size_t> indices;
   //! Vector containing the values of the known entries.
   arma::mat values;
 

--- a/src/mlpack/methods/matrix_completion/matrix_completion_impl.hpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion_impl.hpp
@@ -20,7 +20,7 @@ namespace mlpack {
 inline MatrixCompletion::MatrixCompletion(
     const size_t m,
     const size_t n,
-    const arma::umat& indices,
+    const arma::Mat<size_t>& indices,
     const arma::vec& values,
     const size_t r) :
     m(m),
@@ -36,7 +36,7 @@ inline MatrixCompletion::MatrixCompletion(
 inline MatrixCompletion::MatrixCompletion(
     const size_t m,
     const size_t n,
-    const arma::umat& indices,
+    const arma::Mat<size_t>& indices,
     const arma::vec& values,
     const arma::mat& initialPoint) :
     m(m),
@@ -52,7 +52,7 @@ inline MatrixCompletion::MatrixCompletion(
 inline MatrixCompletion::MatrixCompletion(
     const size_t m,
     const size_t n,
-    const arma::umat& indices,
+    const arma::Mat<size_t>& indices,
     const arma::vec& values) :
     m(m),
     n(n),

--- a/src/mlpack/methods/matrix_completion/matrix_completion_main.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion_main.cpp
@@ -1,0 +1,118 @@
+/**
+ * @file methods/matrix_completion/matrix_completion_main.cpp
+ * @author Adarsh Santoria
+ *
+ * Executable for Matrix Completion.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+
+#undef BINDING_NAME
+#define BINDING_NAME matrix_completion
+
+#include <mlpack/core/util/mlpack_main.hpp>
+
+#include "matrix_completion.hpp"
+
+// Program Name.
+BINDING_USER_NAME("Matrix Completion");
+
+// Short description.
+BINDING_SHORT_DESC(
+    "A thin wrapper around nuclear norm minimization to solve low rank "
+    "matrix completion problems.");
+
+// Long description.
+BINDING_LONG_DESC(
+    "An implementation of Matrix Completion.  "
+    "This implements the popular nuclear norm minimization heuristic for "
+    "low rank matrix completion problems and recover the recovery matrix. "
+    "\n\n"
+    "To work, this algorithm needs number of rows (specified by the " + 
+    PRINT_PARAM_STRING("rows") + " parameter), number of columns (specified by "
+    "the " + PRINT_PARAM_STRING("columns") + " parameter), indices  matrix of "
+    "size (2 x p) (specified by the " + PRINT_PARAM_STRING("indices") +
+    " parameter), values vector of length p (specified by the " +
+    PRINT_PARAM_STRING("values") + " parameter).  "
+    "\n\n"
+    "Optionally, the maximum rank of solution (specified by the " + 
+    PRINT_PARAM_STRING("rank") + " parameter) or initial_point matrix for the "
+    "SDP optimization (specified by the " + PRINT_PARAM_STRING("initial") + 
+    " parameter) can be used.  The recovered matrix containing the completed "
+    "matrix will be saved with the " + PRINT_PARAM_STRING("recover") + " output "
+    "parameter.");
+
+// Example.
+BINDING_EXAMPLE(
+    "For example, to run Matrix Completion on the indices matrix " + 
+    PRINT_DATASET("indices") + " with values vector " + PRINT_DATASET("values")
+    + ", the following command could be used: "
+    "\n\n" +
+    PRINT_CALL("matrix_completion", "rows", "columns", "indices", "values"));
+
+PARAM_INT_IN_REQ("rows", "Size of the neighborhood of similar users to "
+    "consider for each query user.", "r");
+PARAM_INT_IN_REQ("columns", "Rank of decomposed matrices (if 0, a heuristic is used to"
+    " estimate the rank).", "c");
+PARAM_UMATRIX_IN_REQ("indices", "Input dataset to run NCA on.", "i");
+PARAM_COL_IN_REQ("values", "Labels for input dataset.", "v");
+
+PARAM_INT_IN("rank", "Size of the neighborhood of similar users to "
+    "consider for each query user.", "k", 1);
+PARAM_MATRIX_IN("initial", "Input dataset to run NCA on.", "e");
+
+PARAM_MATRIX_OUT("recover", "Matrix to output distances into.", "o");
+
+PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
+
+using namespace arma;
+using namespace std;
+using namespace mlpack;
+using namespace mlpack::util;
+
+void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
+{
+  if (params.Get<int>("seed") != 0)
+    RandomSeed((size_t) params.Get<int>("seed"));
+  else
+    RandomSeed((size_t) std::time(NULL));
+
+  size_t rows = (size_t) params.Get<int>("rows");
+  size_t columns = (size_t) params.Get<int>("columns");
+
+  // Load data.
+  arma::Mat<size_t> indices = std::move(params.Get<arma::Mat<size_t>>("indices"));
+  arma::vec values = std::move(params.Get<arma::vec>("values"));
+
+  // Now create the MC object and recover the recovered matrix.
+  timers.Start("mc_recovery");
+
+  size_t rank = (size_t) params.Get<int>("rank");
+  arma::mat initial = std::move(params.Get<arma::mat>("initial"));
+  arma::mat recover;
+
+  if (params.Has("rank"))
+  {
+    MatrixCompletion mc(rows, columns,indices, values, rank);
+    mc.Recover(recover);
+  }
+  else if (params.Has("initial"))
+  {
+    MatrixCompletion mc(rows, columns,indices, values, initial);
+    mc.Recover(recover);
+  }
+  else
+  {
+    MatrixCompletion mc(rows, columns,indices, values);
+    mc.Recover(recover);
+  }
+  timers.Stop("mc_recovery");
+
+  // Save the output.
+  if (params.Has("recover"))
+    params.Get<arma::mat>("recover") = std::move(recover);
+}

--- a/src/mlpack/methods/matrix_completion/matrix_completion_main.cpp
+++ b/src/mlpack/methods/matrix_completion/matrix_completion_main.cpp
@@ -48,24 +48,22 @@ BINDING_LONG_DESC(
 
 // Example.
 BINDING_EXAMPLE(
-    "For example, to run Matrix Completion on the indices matrix " + 
-    PRINT_DATASET("indices") + " with values vector " + PRINT_DATASET("values")
-    + ", the following command could be used: "
+    "For example, to run Matrix Completion on the indices matrix with values "
+    "vector, the following command could be used: "
     "\n\n" +
     PRINT_CALL("matrix_completion", "rows", "columns", "indices", "values"));
 
-PARAM_INT_IN_REQ("rows", "Size of the neighborhood of similar users to "
-    "consider for each query user.", "r");
-PARAM_INT_IN_REQ("columns", "Rank of decomposed matrices (if 0, a heuristic is used to"
-    " estimate the rank).", "c");
-PARAM_UMATRIX_IN_REQ("indices", "Input dataset to run NCA on.", "i");
-PARAM_COL_IN_REQ("values", "Labels for input dataset.", "v");
+PARAM_INT_IN_REQ("rows", "Number of rows of original matrix.", "r");
+PARAM_INT_IN_REQ("columns", "Number of columns of original matrix.", "c");
+PARAM_UMATRIX_IN_REQ("indices", "Matrix containing the indices of the known "
+    "entries.", "i");
+PARAM_COL_IN_REQ("values", "Vector containing the values of the known entries.",
+    "v");
 
-PARAM_INT_IN("rank", "Size of the neighborhood of similar users to "
-    "consider for each query user.", "k", 1);
-PARAM_MATRIX_IN("initial", "Input dataset to run NCA on.", "e");
+PARAM_INT_IN("rank", "Maximum rank of solution.", "k", 1);
+PARAM_MATRIX_IN("initial", "Starting point for the SDP optimization.", "e");
 
-PARAM_MATRIX_OUT("recover", "Matrix to output distances into.", "o");
+PARAM_MATRIX_OUT("recover", "Completed matrix.", "o");
 
 PARAM_INT_IN("seed", "Random seed.  If 0, 'std::time(NULL)' is used.", "s", 0);
 

--- a/src/mlpack/tests/matrix_completion_test.cpp
+++ b/src/mlpack/tests/matrix_completion_test.cpp
@@ -31,7 +31,7 @@ using namespace mlpack;
 TEST_CASE("UniformMatrixCompletionSDP", "[MatrixCompletionTest]")
 {
   arma::mat Xorig, values;
-  arma::umat indices;
+  arma::Mat<size_t> indices;
 
   if (!data::Load("completion_X.csv", Xorig, false, false))
     FAIL("Cannot load dataset completion_X.csv");

--- a/src/mlpack/tests/pca_test.cpp
+++ b/src/mlpack/tests/pca_test.cpp
@@ -173,58 +173,22 @@ void PCAVarianceRetained()
 }
 
 /**
- * Compare the output of our exact PCA implementation with Armadillo's.
+ * Compare the output of all types of  PCA implementation with Armadillo's.
  */
-TEST_CASE("ArmaComparisonExactPCATest", "[PCATest]")
+TEMPLATE_TEST_CASE("ArmaComparisonPCATest", "[PCATest]", ExactSVDPolicy, 
+    RandomizedSVDPCAPolicy, QUICSVDPolicy, RandomizedBlockKrylovSVDPolicy)
 {
-  ArmaComparisonPCA<ExactSVDPolicy>();
+  ArmaComparisonPCA<TestType>();
 }
 
 /**
- * Compare the output of our randomized block krylov PCA implementation with
- * Armadillo's.
+ * Test that dimensionality reduction with all types of  PCA implementation
+ * works the same way MATLAB does.
  */
-TEST_CASE("ArmaComparisonRandomizedBlockKrylovPCATest", "[PCATest]")
+TEMPLATE_TEST_CASE("PCADimensionalityReductionTest", "[PCATest]", ExactSVDPolicy, 
+    RandomizedSVDPCAPolicy, RandomizedBlockKrylovSVDPolicy)
 {
-  RandomizedBlockKrylovSVDPolicy decomposition(5);
-  ArmaComparisonPCA<RandomizedBlockKrylovSVDPolicy>(false, decomposition);
-}
-
-/**
- * Compare the output of our randomized-SVD PCA implementation with Armadillo's.
- */
-TEST_CASE("ArmaComparisonRandomizedPCATest", "[PCATest]")
-{
-  ArmaComparisonPCA<RandomizedSVDPCAPolicy>();
-}
-
-/**
- * Test that dimensionality reduction with exact-svd PCA works the same way
- * MATLAB does (which should be correct!).
- */
-TEST_CASE("ExactPCADimensionalityReductionTest", "[PCATest]")
-{
-  PCADimensionalityReduction<ExactSVDPolicy>();
-}
-
-/**
- * Test that dimensionality reduction with randomized block krylov PCA works the
- * same way MATLAB does (which should be correct!).
- */
-TEST_CASE("RandomizedBlockKrylovPCADimensionalityReductionTest", "[PCATest]")
-{
-  RandomizedBlockKrylovSVDPolicy decomposition(5);
-  PCADimensionalityReduction<RandomizedBlockKrylovSVDPolicy>(false,
-      decomposition);
-}
-
-/**
- * Test that dimensionality reduction with randomized-svd PCA works the same way
- * MATLAB does (which should be correct!).
- */
-TEST_CASE("RandomizedPCADimensionalityReductionTest", "[PCATest]")
-{
-  PCADimensionalityReduction<RandomizedSVDPCAPolicy>();
+  PCADimensionalityReduction<TestType>();
 }
 
 /**


### PR DESCRIPTION
Tasks performed in the pr :-
1. Added binding of `Matrix Completion` and changed datatype of indicies from `umat` to `Mat<size_t>` due to no support for umat in binding.
2. Added template to pca test.
3. Some minor style fix.