### PR TITLE
Update adaboost_impl.hpp for better Weight initialization

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -94,10 +94,16 @@ double AdaBoost<WeakLearnerType, MatType>::Train(
       predictedLabels.n_cols);
 
   // Load the initial weights into a 2-D matrix.
-  const double initWeight = 1.0 / double(data.n_cols * numClasses);
+  //D(l)(k) is 1/2n where l is the label of the kth data point
+  //For all l other than that is 1/2n(k-1)
+  const double initWeightnotlabel = 1.0 / double(2*data.n_cols * (numClasses-1));
+  const double initWeightlabel = 1.0 / double(2*data.n_cols)
   arma::mat D(numClasses, data.n_cols);
-  D.fill(initWeight);
-
+  D.fill(initWeightnotlabel);
+  for(size_t i=0;i<D.n_cols;++i)
+  {
+  D.col(i)(labels(i)) = initWeight2;
+  }    
   // Weights are stored in this row vector.
   arma::rowvec weights(predictedLabels.n_cols);
 


### PR DESCRIPTION
According to the new implementation of adaboost.mh its better to use 1/2n for weigh initialization of datapoints on the actual label of the datapoint and 1/2n (k-1) for others labels of that data point 

The idea behind this scheme is that it will create K well-balanced one-against-all binary classification problems as given by  section 2.1 expression 3 of https://arxiv.org/pdf/1312.6086.pdf and 2.0 page 3 expression 2 of http://proceedings.mlr.press/v7/busa09/busa09.pdf 