### PR TITLE
Fix JacobianTest and CustomJacobianTest (Resolves #3470)

### DIFF
--- a/src/mlpack/tests/ann/ann_test_tools.hpp
+++ b/src/mlpack/tests/ann/ann_test_tools.hpp
@@ -74,7 +74,7 @@ double JacobianTest(ModuleType& module,
     derivTemp(i) = 1;
 
     arma::mat delta(input.n_rows, input.n_cols);
-    module.Backward(input, deriv, delta);
+    module.Backward(output, deriv, delta);
 
     jacobianB.col(i) = delta;
   }
@@ -125,7 +125,7 @@ double CustomJacobianTest(ModuleType& module,
     deriv(i) = 1;
 
     arma::mat delta(input.n_rows, input.n_cols);
-    module.Backward(input, deriv, delta);
+    module.Backward(output, deriv, delta);
 
     jacobianB.col(i) = delta;
   }


### PR DESCRIPTION
Use output of the Forward method instead of input. Fixes #3470 (See issue for more details).