### PR TITLE
Add license to hard_tanh.cpp test

### DIFF
--- a/src/mlpack/tests/ann/layer/hard_tanh.cpp
+++ b/src/mlpack/tests/ann/layer/hard_tanh.cpp
@@ -2,8 +2,12 @@
  * @file tests/ann/layer/hard_tanh.cpp
  * @author Vaibhav Pathak
  *
- * Tests the hard_tanh layer
+ * Tests the hard_tanh layer.
  *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
 #include <mlpack/core.hpp>


### PR DESCRIPTION
I noticed while trying to release a new version of mlpack that the test `hard_tanh.cpp` was missing a license---easy fix.

(We need to release a new version with the Armadillo warning fixes from #3405 for CRAN.  I guess I could hand-patch a version if someone has a particular reason to wait.)