### PR TITLE
Test and fix Backward/Deriv

### DIFF
--- a/src/mlpack/tests/ann/activation_functions_test.cpp
+++ b/src/mlpack/tests/ann/activation_functions_test.cpp
@@ -14,6 +14,7 @@
 #include <mlpack/methods/ann/ann.hpp>
 
 #include "../catch.hpp"
+#include "ann_test_tools.hpp"
 
 using namespace mlpack;
 
@@ -74,6 +75,10 @@ void CheckDerivativeCorrect(const arma::colvec input,
   {
     REQUIRE(derivatives.at(i) == Approx(target.at(i)).epsilon(1e-5));
   }
+
+  arma::mat inputTemp(input.n_elem, 1);
+  double maxRelativeError = ActivationJacobianTest<ActivationFunction>(inputTemp);
+  REQUIRE(maxRelativeError <= 1e-3);
 }
 
 /**

--- a/src/mlpack/tests/ann/ann_test_tools.hpp
+++ b/src/mlpack/tests/ann/ann_test_tools.hpp
@@ -167,6 +167,55 @@ double JacobianPerformanceTest(ModuleType& module,
   return arma::max(arma::max(arma::abs(centralDifference - delta)));
 }
 
+template<typename ActivationFunction>
+double ActivationJacobianTest(arma::mat& input,
+                              const double minValue = -2,
+                              const double maxValue = -1,
+                              const double pertubation = 1e-6)
+{
+  arma::mat output, outputA, outputB, jacobianA, jacobianB;
+  output.set_size(input.n_rows, input.n_cols);
+  outputA.set_size(input.n_rows, input.n_cols);
+  outputB.set_size(input.n_rows, input.n_cols);
+
+  RandomInitialization init(minValue, maxValue);
+  init.Initialize(input, input.n_rows, input.n_cols);
+  
+  ActivationFunction::Fn(input, output);
+  jacobianA = arma::zeros(input.n_elem, output.n_elem);
+  
+  for(size_t i = 0; i < input.n_elem; ++i)
+  {
+    double original = input(i);
+    input(i) = original - pertubation;
+    ActivationFunction::Fn(input, outputA);
+    input(i) = original + pertubation;
+    ActivationFunction::Fn(input, outputB);
+    input(i) = original;
+
+    outputB -= outputA;
+    outputB /= 2 * pertubation;
+    jacobianA.row(i) = outputB.t();
+  }
+
+  arma::mat deriv = arma::zeros(output.n_rows, output.n_cols);
+  jacobianB = arma::zeros(input.n_elem, output.n_elem);
+
+  for(size_t i = 0; i < deriv.n_elem; ++i)
+  {
+    deriv.zeros();
+    deriv(i) = 1;
+
+    arma::mat delta(input.n_rows, input.n_cols);
+    ActivationFunction::Deriv(output, delta);
+    delta %= deriv;
+
+    jacobianB.col(i) = delta;
+  }
+
+  return arma::max(arma::max(arma::abs(jacobianA - jacobianB)));
+}  
+
 // Simple numerical gradient checker.
 template<class FunctionType>
 double CheckGradient(FunctionType& function, const double eps = 1e-7)


### PR DESCRIPTION
### Background

The Backward/Deriv method has several times being misused or incorrectly implemented.(See #3471, #3469) So, to make it clear: 

 The `Backward` method of a layer(except loss functions) expects the first argument to be the output of the Forward method. The same is true for activation functions, in which `Deriv` method expects the first argument to be the output of `Fn`. 

To take an example of a correctly implemented function, let's look at LogisticFunction([logistic_function.hpp](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/ann/activation_functions/logistic_function.hpp)). Let's first look at the `Fn` method:
```
  57   template<typename InputVecType, typename OutputVecType>
  58   static void Fn(const InputVecType& x, OutputVecType& y)
  59   {
  60     y = (1.0 / (1 + arma::exp(-x)));
  61   }
```
Now look at the `Deriv` method:
```
  80   template<typename InputVecType, typename OutputVecType>
  81   static void Deriv(const InputVecType& y, OutputVecType& x)
  82   {
  83     x = y % (1.0 - y);
  84   }
```
Observe that derivative in the `Deriv` method is written in terms of output, **not** in terms of input. 

To put it mathematically,

If  $y=f(x)$ is the given function, then the derivative should be function of $y$ i.e. 
$$\frac{dy}{dx} = g(y)$$

In the example, our function $y=f(x)$ is defined as follows,
$$f(x) = \frac{1}{1 + e^{-x} }$$

Now, if we simply differentiate it w.r.t. $x$,
$$f'(x) = \frac{e^{-x}}{(1+e^{-x})^2}$$

If we arrange the terms, we can write the derivative as,
$$f'(x) = f(x)(1-f(x))$$
substitute f(x) with y,
$$\frac{dy}{dx} = y(1-y)$$
which is our required form of derivative. 


### Add test and fix issues

Since JacobianTest is fixed(#3471), all layers need to be tested against JacobianTest(and/or its siblings). After adding JacobianTest for activation functions, lots of the test failed. Also potentially, other layers may be buggy. 

The aim of this PR, is to: 
1. Add tests to the activation function, loss functions and the layers. 
2. Document known issues.
3. Fix issues.

The following layers/functions fail the JacobianTest and need to fix their Backward/Deriv method:

*(The list is WIP and may be updated)*

1. Softplus function
2.  Mish function
3. LiSHT function
4.  GELU function
5.  Elliot function
6.  Elish function
7.  Inverse Quadratic function
8.  Quadratic function
9.  Multiquad function
10.  Poisson1 function
11. Gaussion function
12. Hard Swish function
13. Tanh Exp
14. SILU function

