### PR TITLE
Add serialize to init rules (in ann)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
   * Fix bug in LogSoftMax derivative (#3469).
 
+  * Add `serialize` method to `GaussianInitialization`, `KathirvalavakumarSubavathiInitialization`, `KathirvalavakumarSubavathiInitialization`, `NguyenWidrowInitialization`, and `OrthogonalInitialization` (#3483).
+
 ### mlpack 4.1.0
 ###### 2023-04-26
 

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -104,6 +104,16 @@ class GaussianInitialization
     for (size_t i = 0; i < W.n_slices; ++i)
       Initialize(W.slice(i));
   }
+ 
+  /**
+   * Serialize the initialization.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */)
+  {
+    ar(CEREAL_NVP(mean));
+    ar(CEREAL_NVP(variance));
+  }
 
  private:
   //! Mean of the gaussian.

--- a/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
@@ -141,6 +141,16 @@ class KathirvalavakumarSubavathiInitialization
     for (size_t i = 0; i < W.n_slices; ++i)
       Initialize(W.slice(i));
   }
+ 
+  /**
+   * Serialize the initialization.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */)
+  {
+    ar(CEREAL_NVP(dataSum));
+    ar(CEREAL_NVP(s));
+  }
 
  private:
   //! Parameter that defines the sum of elements in each column.

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -141,6 +141,12 @@ class LecunNormalInitialization
     for (size_t i = 0; i < W.n_slices; ++i)
       Initialize(W.slice(i));
   }
+
+  /**
+   * Serialize the initialization.  (Nothing to serialize for this one.)
+   */
+  template<typename Archive>
+  void serialize(Archive& /* ar */, const uint32_t /* version */) { }
 }; // class LecunNormalInitialization
 
 } // namespace mlpack

--- a/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
@@ -134,6 +134,16 @@ class NguyenWidrowInitialization
     for (size_t i = 0; i < W.n_slices; ++i)
       Initialize(W.slice(i));
   }
+ 
+  /**
+   * Serialize the initialization.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */)
+  {
+    ar(CEREAL_NVP(lowerBound));
+    ar(CEREAL_NVP(upperBound));
+  }
 
  private:
   //! The number used as lower bound.

--- a/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
@@ -101,6 +101,15 @@ class OrthogonalInitialization
     for (size_t i = 0; i < W.n_slices; ++i)
       Initialize(W.slice(i));
   }
+ 
+  /**
+   * Serialize the initialization.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */)
+  {
+    ar(CEREAL_NVP(gain));
+  }
 
  private:
   //! The number used as gain.


### PR DESCRIPTION
Several initialization classes were missing the serialize method. Without it neural networks that use these init rules cannot be serialized.