### PR TITLE
Reinforcement Learning: Deep Deterministic Policy Gradient 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Reinforcement Learning: Deep Deterministic Policy Gradient (#3494).
+  
   * Adapt C_ReLU, ReLU6, FlexibleReLU layer for new neural network API (#3445).
 
   * Fix PReLU, add integration test to it (#3473).

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -1,0 +1,195 @@
+/**
+ * @file methods/reinforcement_learning/ddpg.hpp
+ * @author Tarek Elsayed
+ *
+ * This file is the definition of DDPG class, which implements the
+ * Deep Deterministic Policy Gradient algorithm.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_RL_DDPG_HPP
+#define MLPACK_METHODS_RL_DDPG_HPP
+
+#include <mlpack/core.hpp>
+#include <ensmallen.hpp>
+#include <mlpack/methods/ann/ann.hpp>
+
+#include "replay/replay.hpp"
+#include "training_config.hpp"
+
+namespace mlpack {
+
+/**
+ * Implementation of Deep Deterministic Policy Gradient, a model-free 
+ * off-policy actor-critic based deep reinforcement learning algorithm.
+ *
+ * For more details, see the following:
+ * @code
+ * @misc{Lillicrap et al, 2015,
+ *  author    = {Timothy P. Lillicrap,
+ *               Jonathan J. Hunt,
+ *               Alexander Pritzel,
+ *               Nicolas Heess,
+ *               Tom Erez,
+ *               Yuval Tassa,
+ *               David Silver,
+ *               Daan Wierstra},
+ *  title     = {Continuous control with deep reinforcement learning},
+ *  year      = {2015},
+ *  url       = {https://arxiv.org/abs/1509.02971}
+ * }
+ * @endcode
+ *
+ * @tparam EnvironmentType The environment of the reinforcement learning task.
+ * @tparam NetworkType The network to compute action value.
+ * @tparam UpdaterType How to apply gradients when training.
+ * @tparam ReplayType Experience replay method.
+ */
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType = RandomReplay<EnvironmentType>
+>
+class DDPG
+{
+ public:
+  //! Convenient typedef for state.
+  using StateType = typename EnvironmentType::State;
+
+  //! Convenient typedef for action.
+  using ActionType = typename EnvironmentType::Action;
+
+  /**
+   * Create the DDPG object with given settings.
+   *
+   * If you want to pass in a parameter and discard the original parameter
+   * object, you can directly pass the parameter, as the constructor takes
+   * a reference. This avoids unnecessary copy.
+   *
+   * @param config Hyper-parameters for training.
+   * @param learningQNetwork The network to compute action value.
+   * @param policyNetwork The network to produce an action given a state.
+   * @param replayMethod Experience replay method.
+   * @param qNetworkUpdater How to apply gradients to Q network when training.
+   * @param policyNetworkUpdater How to apply gradients to policy network
+   *        when training.
+   * @param environment Reinforcement learning task.
+   */
+  DDPG(TrainingConfig& config,
+      QNetworkType& learningQNetwork,
+      PolicyNetworkType& policyNetwork,
+      ReplayType& replayMethod,
+      UpdaterType qNetworkUpdater = UpdaterType(),
+      UpdaterType policyNetworkUpdater = UpdaterType(),
+      EnvironmentType environment = EnvironmentType());
+
+  /**
+    * Clean memory.
+    */
+  ~DDPG();
+
+  /**
+   * Softly update the target networks` parameters from the learning networks`
+   * parameters.
+   * 
+   * @param rho How "softly" should the parameters be copied.
+   * */
+  void SoftUpdate(double rho);
+
+  /**
+   * Update the Q and policy networks.
+   * */
+  void Update();
+
+  /**
+   * Select an action, given an agent.
+   */
+  void SelectAction();
+
+  /**
+   * Execute an episode.
+   * @return Return of the episode.
+   */
+  double Episode();
+
+  //! Modify total steps from beginning.
+  size_t& TotalSteps() { return totalSteps; }
+  //! Get total steps from beginning.
+  const size_t& TotalSteps() const { return totalSteps; }
+
+  //! Modify the state of the agent.
+  StateType& State() { return state; }
+  //! Get the state of the agent.
+  const StateType& State() const { return state; }
+
+  //! Get the action of the agent.
+  const ActionType& Action() const { return action; }
+
+  //! Modify the training mode / test mode indicator.
+  bool& Deterministic() { return deterministic; }
+  //! Get the indicator of training mode / test mode.
+  const bool& Deterministic() const { return deterministic; }
+
+
+ private:
+  //! Locally-stored hyper-parameters.
+  TrainingConfig& config;
+
+  //! Locally-stored learning Q network.
+  QNetworkType& learningQNetwork;
+
+  //! Locally-stored target Q network.
+  QNetworkType targetQNetwork;
+
+  //! Locally-stored policy network.
+  PolicyNetworkType& policyNetwork;
+
+  //! Locally-stored target policy network.
+  PolicyNetworkType targetPNetwork;
+
+  //! Locally-stored experience method.
+  ReplayType& replayMethod;
+
+  //! Locally-stored updater.
+  UpdaterType qNetworkUpdater;
+  #if ENS_VERSION_MAJOR >= 2
+  typename UpdaterType::template Policy<arma::mat, arma::mat>*
+      qNetworkUpdatePolicy;
+  #endif
+
+  //! Locally-stored updater.
+  UpdaterType policyNetworkUpdater;
+  #if ENS_VERSION_MAJOR >= 2
+  typename UpdaterType::template Policy<arma::mat, arma::mat>*
+      policyNetworkUpdatePolicy;
+  #endif
+
+  //! Locally-stored reinforcement learning task.
+  EnvironmentType environment;
+
+  //! Total steps from the beginning of the task.
+  size_t totalSteps;
+
+  //! Locally-stored current state of the agent.
+  StateType state;
+
+  //! Locally-stored action of the agent.
+  ActionType action;
+
+  //! Locally-stored flag indicating training mode or test mode.
+  bool deterministic;
+
+  //! Locally-stored loss function.
+  MeanSquaredError lossFunction;
+};
+
+} // namespace mlpack
+
+// Include implementation
+#include "ddpg_impl.hpp"
+#endif

--- a/src/mlpack/methods/reinforcement_learning/ddpg.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg.hpp
@@ -44,7 +44,8 @@ namespace mlpack {
  * @endcode
  *
  * @tparam EnvironmentType The environment of the reinforcement learning task.
- * @tparam NetworkType The network to compute action value.
+ * @tparam QNetworkType The network used to estimate the critic's Q-values.
+ * @tparam PolicyNetworkType The network to compute action value.
  * @tparam UpdaterType How to apply gradients when training.
  * @tparam ReplayType Experience replay method.
  */

--- a/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/ddpg_impl.hpp
@@ -1,0 +1,337 @@
+/**
+ * @file methods/reinforcement_learning/ddpg_impl.hpp
+ * @author Tarek Elsayed
+ *
+ * This file is the implementation of DDPG class, which implements the
+ * Deep Deterministic Policy Gradient algorithm.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_RL_DDPG_IMPL_HPP
+#define MLPACK_METHODS_RL_DDPG_IMPL_HPP
+
+#include <mlpack/prereqs.hpp>
+
+#include "ddpg.hpp"
+
+namespace mlpack {
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::DDPG(TrainingConfig& config,
+       QNetworkType& learningQNetwork,
+       PolicyNetworkType& policyNetwork,
+       ReplayType& replayMethod,
+       UpdaterType qNetworkUpdater,
+       UpdaterType policyNetworkUpdater,
+       EnvironmentType environment):
+  config(config),
+  learningQNetwork(learningQNetwork),
+  policyNetwork(policyNetwork),
+  replayMethod(replayMethod),
+  qNetworkUpdater(std::move(qNetworkUpdater)),
+  #if ENS_VERSION_MAJOR >= 2
+  qNetworkUpdatePolicy(NULL),
+  #endif
+  policyNetworkUpdater(std::move(policyNetworkUpdater)),
+  #if ENS_VERSION_MAJOR >= 2
+  policyNetworkUpdatePolicy(NULL),
+  #endif
+  environment(std::move(environment)),
+  totalSteps(0),
+  deterministic(false)
+{
+  // Set up q-learning and policy networks.
+  targetPNetwork = policyNetwork;
+  targetQNetwork = learningQNetwork;
+
+  // Reset all the networks.
+  // Note: the q and policy networks have an if condition before reset.
+  // This is because we don't want to reset a loaded(possibly pretrained) model
+  // passed using this constructor.
+  const size_t envSampleSize = environment.InitialSample().Encode().n_elem;
+  if (policyNetwork.Parameters().n_elem != envSampleSize)
+    policyNetwork.Reset(envSampleSize);
+
+  targetPNetwork.Reset(envSampleSize);
+
+  const size_t networkSize = envSampleSize +
+      policyNetwork.Network()[policyNetwork.Network().size() - 1]->OutputSize();
+
+  if (learningQNetwork.Parameters().n_elem != networkSize)
+    learningQNetwork.Reset(networkSize);
+  
+  targetQNetwork.Reset(networkSize);
+
+  #if ENS_VERSION_MAJOR == 1
+  this->qNetworkUpdater.Initialize(learningQNetwork.Parameters().n_rows,
+                                   learningQNetwork.Parameters().n_cols);
+  #else
+  this->qNetworkUpdatePolicy = new typename UpdaterType::template
+      Policy<arma::mat, arma::mat>(this->qNetworkUpdater,
+                                   learningQNetwork.Parameters().n_rows,
+                                   learningQNetwork.Parameters().n_cols);
+  #endif
+
+  #if ENS_VERSION_MAJOR == 1
+  this->policyNetworkUpdater.Initialize(policyNetwork.Parameters().n_rows,
+                                        policyNetwork.Parameters().n_cols);
+  #else
+  this->policyNetworkUpdatePolicy = new typename UpdaterType::template
+      Policy<arma::mat, arma::mat>(this->policyNetworkUpdater,
+                                   policyNetwork.Parameters().n_rows,
+                                   policyNetwork.Parameters().n_cols);
+  #endif
+
+  // Copy over the learning networks to their respective target networks.
+  targetQNetwork.Parameters() = learningQNetwork.Parameters();
+  targetPNetwork.Parameters() = policyNetwork.Parameters();
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::~DDPG()
+{
+  #if ENS_VERSION_MAJOR >= 2
+  delete qNetworkUpdatePolicy;
+  delete policyNetworkUpdatePolicy;
+  #endif
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+void DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::SoftUpdate(double rho)
+{
+  targetQNetwork.Parameters() = (1 - rho) * targetQNetwork.Parameters() +
+      rho * learningQNetwork.Parameters();
+  targetPNetwork.Parameters() = (1 - rho) * targetPNetwork.Parameters() +
+      rho * policyNetwork.Parameters();
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+void DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::Update()
+{
+  // Sample from previous experience.
+  arma::mat sampledStates;
+  std::vector<ActionType> sampledActions;
+  arma::rowvec sampledRewards;
+  arma::mat sampledNextStates;
+  arma::irowvec isTerminal;
+
+  replayMethod.Sample(sampledStates, sampledActions, sampledRewards,
+      sampledNextStates, isTerminal);
+
+  // Critic network update.
+
+  // Use the target actor to obtain the next actions.
+  arma::mat nextStateActions;
+  targetPNetwork.Predict(sampledNextStates, nextStateActions);
+
+  arma::mat targetQInput = arma::join_vert(nextStateActions,
+      sampledNextStates);
+  arma::rowvec Q;
+  targetQNetwork.Predict(targetQInput, Q);
+  arma::rowvec nextQ = sampledRewards + config.Discount() 
+      * ((1 - isTerminal) % Q);
+
+  arma::mat sampledActionValues(action.size, sampledActions.size());
+  for (size_t i = 0; i < sampledActions.size(); i++)
+    sampledActionValues.col(i) = arma::conv_to<arma::colvec>::from
+                                 (sampledActions[i].action);
+  arma::mat learningQInput = arma::join_vert(sampledActionValues,
+      sampledStates);
+  learningQNetwork.Forward(learningQInput, Q);
+
+  arma::mat gradQLoss;
+  lossFunction.Backward(Q, nextQ, gradQLoss);
+
+  // Update the critic network.
+  arma::mat gradientQ;
+  learningQNetwork.Backward(learningQInput, gradQLoss, gradientQ);
+  #if ENS_VERSION_MAJOR == 1
+  qNetworkUpdater.Update(learningQNetwork.Parameters(), config.StepSize(),
+      gradientQ);
+  #else
+  qNetworkUpdatePolicy->Update(learningQNetwork.Parameters(),
+      config.StepSize(), gradientQ);
+  #endif
+
+  // Actor network update.
+
+  // Get the size of the first hidden layer in the Q network.
+  size_t hidden1 = learningQNetwork.Network()[0]->OutputSize();
+
+  arma::mat gradient;
+  for (size_t i = 0; i < sampledStates.n_cols; i++)
+  {
+    arma::mat grad, gradQ, q;
+    arma::colvec singleState = sampledStates.col(i);
+    arma::colvec singlePi;
+    policyNetwork.Forward(singleState, singlePi);
+    arma::colvec input = arma::join_vert(singlePi, singleState);
+    arma::mat weightLastLayer;
+
+    // Note that we can use an empty matrix for the backwards pass, since the
+    // networks use EmptyLoss.
+    learningQNetwork.Forward(input, q);
+    learningQNetwork.Backward(input, arma::mat("-1"), gradQ);
+    weightLastLayer = arma::reshape(learningQNetwork.Parameters().
+          rows(0, hidden1 * singlePi.n_rows - 1), hidden1, singlePi.n_rows);
+
+    arma::colvec gradQBias = gradQ(input.n_rows * hidden1, 0,
+        arma::size(hidden1, 1));
+    arma::mat gradPolicy = weightLastLayer.t() * gradQBias;
+    policyNetwork.Backward(singleState, gradPolicy, grad);
+    if (i == 0)
+    {
+      gradient.copy_size(grad);
+      gradient.fill(0.0);
+    }
+    gradient += grad;
+  }
+  gradient /= sampledStates.n_cols;
+
+  #if ENS_VERSION_MAJOR == 1
+  policyUpdater.Update(policyNetwork.Parameters(), config.StepSize(), gradient);
+  #else
+  policyNetworkUpdatePolicy->Update(policyNetwork.Parameters(),
+      config.StepSize(), gradient);
+  #endif
+
+  // Update target networks
+  if (totalSteps % config.TargetNetworkSyncInterval() == 0)
+    SoftUpdate(config.Rho());
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+void DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::SelectAction()
+{
+  // Get the action at current state, from policy.
+  arma::colvec outputAction;
+  policyNetwork.Predict(state.Encode(), outputAction);
+
+  if (!deterministic)
+  {
+    arma::colvec noise = arma::randn<arma::colvec>(outputAction.n_rows) * 0.1;
+    noise = arma::clamp(noise, -0.25, 0.25);
+    outputAction = outputAction + noise;
+  }
+  action.action = arma::conv_to<std::vector<double>>::from(outputAction);
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+double DDPG<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::Episode()
+{
+  // Get the initial state from environment.
+  state = environment.InitialSample();
+
+  // Track the steps in this episode.
+  size_t steps = 0;
+
+  // Track the return of this episode.
+  double totalReturn = 0.0;
+
+  // Running until get to the terminal state.
+  while (!environment.IsTerminal(state))
+  {
+    if (config.StepLimit() && steps >= config.StepLimit())
+      break;
+    SelectAction();
+
+    // Interact with the environment to advance to next state.
+    StateType nextState;
+    double reward = environment.Sample(state, action, nextState);
+
+    totalReturn += reward;
+    steps++;
+    totalSteps++;
+
+    // Store the transition for replay.
+    replayMethod.Store(state, action, reward, nextState,
+        environment.IsTerminal(nextState), config.Discount());
+
+    // Update current state.
+    state = nextState;
+
+    if (deterministic || totalSteps < config.ExplorationSteps())
+      continue;
+    for (size_t i = 0; i < config.UpdateInterval(); i++)
+      Update();
+  }
+  return totalReturn;
+}
+
+} // namespace mlpack
+#endif

--- a/src/mlpack/methods/reinforcement_learning/reinforcement_learning.hpp
+++ b/src/mlpack/methods/reinforcement_learning/reinforcement_learning.hpp
@@ -22,5 +22,6 @@
 #include "async_learning.hpp"
 #include "q_learning.hpp"
 #include "sac.hpp"
+#include "ddpg.hpp"
 
 #endif

--- a/src/mlpack/tests/q_learning_test.cpp
+++ b/src/mlpack/tests/q_learning_test.cpp
@@ -588,16 +588,12 @@ TEST_CASE("PendulumWithDDPG", "[QLearningTest]")
         policyNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
     policyNetwork.Add(new Linear(128));
     policyNetwork.Add(new ReLU());
-    policyNetwork.Add(new Linear(128));
-    policyNetwork.Add(new ReLU());
     policyNetwork.Add(new Linear(1));
     policyNetwork.Add(new TanH());
 
     // Set up Critic network.
     FFN<EmptyLoss, GaussianInitialization>
         qNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
-    qNetwork.Add(new Linear(128));
-    qNetwork.Add(new ReLU());
     qNetwork.Add(new Linear(128));
     qNetwork.Add(new ReLU());
     qNetwork.Add(new Linear(1));
@@ -620,15 +616,11 @@ TEST_CASE("DDPGForMultipleActions", "[QLearningTest]")
       policyNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
   policyNetwork.Add(new Linear(128));
   policyNetwork.Add(new ReLU());
-  policyNetwork.Add(new Linear(128));
-  policyNetwork.Add(new ReLU());
   policyNetwork.Add(new Linear(4));
   policyNetwork.Add(new TanH());
 
   FFN<EmptyLoss, GaussianInitialization>
       qNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
-  qNetwork.Add(new Linear(128));
-  qNetwork.Add(new ReLU());
   qNetwork.Add(new Linear(128));
   qNetwork.Add(new ReLU());
   qNetwork.Add(new Linear(1));


### PR DESCRIPTION
# Description

This pull request implements the DDPG (Deep Deterministic Policy Gradient) algorithm, along with 2 test cases. 

## Implementation details
DDPG is an actor-critic algorithm designed for continuous action spaces. It combines deep neural networks with deterministic policy gradients to learn optimal policies in a continuous control setting.

Implemented four networks:
- `policyNetwork` (actor network)
- `targetPNetwork` (target actor network)
- `learningQNetwork` (critic network)
- `targetQNetwork` (target critic network)

# How Has This Been Tested?

- [x] Included a Pendulum test that successfully passes on my machine. The average reward achieved in the Pendulum environment is approximately -500, indicating successful learning.
- [x] Additionally, added a test for continuous action spaces, which also passes.

The test configurations for DDPG are adapted from the SAC (Soft Actor-Critic) implementation since both DDPG and SAC are policy gradient off-policy algorithms. This ensures consistent evaluation and comparison of the algorithms.
