### PR TITLE
Add missing file to git commit for release script

### DIFF
--- a/scripts/release-mlpack.sh
+++ b/scripts/release-mlpack.sh
@@ -158,6 +158,7 @@ git checkout -b release-$MAJOR.$MINOR.$PATCH;
 
 git add src/mlpack/core/util/version.hpp \
     doc/user/sample_ml_app.md \
+    doc/examples/sample-ml-app/README.txt \
     doc/examples/sample-ml-app/sample-ml-app/sample-ml-app.vcxproj \
     CMakeLists.txt \
     README.md \


### PR DESCRIPTION
When I ran the release script for 4.2.0, the file `doc/examples/sample-ml-app/README.txt` was not checked in.  This PR just fixes that.