### PR TITLE
Update R package description to more recent mlpack 4 paper

### DIFF
--- a/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
+++ b/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
@@ -5,8 +5,8 @@ Date: @PACKAGE_DATE@
 Authors@R: @AUTHORS_R@
 Description: A fast, flexible machine learning library, written in C++, that
              aims to provide fast, extensible implementations of cutting-edge
-             machine learning algorithms.  See also Curtin et al. (2018)
-             <doi:10.21105/joss.00726>.
+             machine learning algorithms.  See also Curtin et al. (2023)
+             <doi:10.21105/joss.05026>.
 SystemRequirements: A C++14 compiler. Version 5 or later of GCC will be fine.
 License: BSD_3_clause + file LICENSE
 Depends: R (>= 4.0.0)


### PR DESCRIPTION
This is just a simple change to `DESCRIPTION` that references the new mlpack 4 paper instead of the somewhat older mlpack 3 paper.