### PR TITLE
Python binding installation fixes

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -27,7 +27,7 @@ steps:
     if [ "$(binding)" == "python" ]; then
       export PYBIN=$(which python)
       $PYBIN -m pip install --upgrade pip
-      $PYBIN -m pip install --upgrade --ignore-installed setuptools cython pandas
+      $PYBIN -m pip install --upgrade --ignore-installed setuptools cython pandas wheel
     fi
 
     if [ "a$(julia.version)" != "a" ]; then

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ With that in mind, if you would still like to manually build the mlpack Python
 bindings, first make sure that the following Python packages are installed:
 
  - setuptools
+ - wheel
  - cython >= 0.24
  - numpy
  - pandas >= 0.15.0

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -70,18 +70,22 @@ find_python_module(pandas 0.15.0)
 if (NOT PY_PANDAS)
   set(PY_NOT_FOUND_MSG "${PY_NOT_FOUND_MSG}\n    - pandas")
 endif ()
+find_python_module(wheel)
+if (NOT PY_WHEEL)
+  set(PY_NOT_FOUND_MSG "${PY_NOT_FOUND_MSG}\n    - wheel")
+endif ()
 
 ## We need to check here if Python and other dependencies is even available, as
 ## it is require to build python-bindings.
 if (FORCE_BUILD_PYTHON_BINDINGS)
   if (NOT PYTHON_EXECUTABLE OR NOT PY_DISTUTILS OR NOT PY_CYTHON OR NOT PY_NUMPY
-      OR NOT PY_PANDAS)
+      OR NOT PY_PANDAS OR NOT PY_WHEEL)
     unset(BUILD_PYTHON_BINDINGS CACHE)
     message(FATAL_ERROR "\nCould not Build Python Bindings; the following modules are not available: ${PY_NOT_FOUND_MSG}")
   endif()
 else()
   if (NOT PYTHON_EXECUTABLE OR NOT PY_DISTUTILS OR NOT PY_CYTHON OR NOT PY_NUMPY
-      OR NOT PY_PANDAS)
+      OR NOT PY_PANDAS OR NOT PY_WHEEL)
     unset(BUILD_PYTHON_BINDINGS CACHE)
     not_found_return("Not building Python bindings; the following modules are not available: ${PY_NOT_FOUND_MSG}")
   endif()

--- a/src/mlpack/bindings/python/PythonInstall.cmake
+++ b/src/mlpack/bindings/python/PythonInstall.cmake
@@ -5,16 +5,19 @@
 if (DEFINED ENV{DESTDIR})
   execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install
           --prefix=${PYTHON_INSTALL_PREFIX}
-          --root=$ENV{DESTDIR} .
+          --root=$ENV{DESTDIR}
+          --no-index --no-deps --no-build-isolation -f ./ .
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 elseif (WIN32)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install .
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install
+          --no-index --no-deps --no-build-isolation -f ./ .
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 else ()
   execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install
-          --prefix=${PYTHON_INSTALL_PREFIX} .
+          --prefix=${PYTHON_INSTALL_PREFIX}
+          --no-index --no-deps --no-build-isolation -f ./ .
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/"
       RESULT_VARIABLE setup_res)
 endif ()


### PR DESCRIPTION
This addresses some of the issues in #3500 by disabling network access during the Python installation step.  (e.g., we are now doing `python -m pip install --no-index --no-deps`.  A quick explanation of the changes:

 * Adding the `--no-index` option disables searching PyPI for dependencies during installation.
 * Adding the `--no-deps` option is likely unnecessary but disallows the installation of any dependencies; so, we will only install mlpack (which is what we want).
 * By default, pip creates a new temporary Python environment to do the installation in, and installs all build requirements of the packages there---and *then* it does the installation.  However, if no network access is available, then you need to either make all the build requirements available as wheels... or add `--no-build-isolation` so that the environment used is whatever the default environment is.
  * The `wheel` package has apparently been split out from the core Python packages.  That probably happened a while ago, but without `--no-index` and `--no-deps`, I never noticed because pip would just go install it.

These changes were tested and applied to the Fedora package; I think they will also help @barak with packaging for Debian.