### PR TITLE
Shorten filename for CRAN tar limits

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
@@ -1,5 +1,5 @@
 /**
- * @file methods/reinforcement_learning/environment/continuous_double_pole_cart.hpp
+ * @file methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
  * @author Rahul Ganesh Prabhu
  *
  * This file is an implementation of Continuous Double Pole Cart Balancing
@@ -11,8 +11,8 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#ifndef MLPACK_METHODS_RL_ENVIRONMENT_CONTINUOUS_DOUBLE_POLE_CART_HPP
-#define MLPACK_METHODS_RL_ENVIRONMENT_CONTINUOUS_DOUBLE_POLE_CART_HPP
+#ifndef MLPACK_METHODS_RL_ENVIRONMENT_CONT_DOUBLE_POLE_CART_HPP
+#define MLPACK_METHODS_RL_ENVIRONMENT_CONT_DOUBLE_POLE_CART_HPP
 
 #include <mlpack/prereqs.hpp>
 

--- a/src/mlpack/methods/reinforcement_learning/environment/environment.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/environment.hpp
@@ -15,7 +15,7 @@
 #include "env_type.hpp"
 #include "acrobot.hpp"
 #include "cart_pole.hpp"
-#include "continuous_double_pole_cart.hpp"
+#include "cont_double_pole_cart.hpp"
 #include "continuous_mountain_car.hpp"
 #include "double_pole_cart.hpp"
 #include "ftn.hpp"


### PR DESCRIPTION
I should probably comment to point out that this PR is not a joke.  As much as I'd like it to be.  I'll do my best to keep my editorializing to a minimum.  Ah, too late.

I submitted mlpack 4.2.0 to CRAN.  It failed the checks: https://win-builder.r-project.org/incoming_pretest/mlpack_4.2.0_20230623_145416/Debian/00check.log

```
Found the following non-portable file path:
  mlpack/inst/include/mlpack/methods/reinforcement_learning/environment/continuous_double_pole_cart.hpp

Tarballs are only required to store paths of up to 100 bytes and cannot
store those of more than 256 bytes, with restrictions including to 100
bytes for the final component.
```

The filename is too long, so people running R on Soviet-era PDP clones with only-standards-compliant-and-nothing-more `tar` versions could have problems.  This is a big issue and so this PR addresses that.