### PR TITLE
Add ClassProbabilities() member to DecisionTree.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,12 @@
 ### mlpack ?.?.?
 ###### ????-??-??
   * Reinforcement Learning: Ornstein-Uhlenbeck noise (#3499).
-  
+
   * Reinforcement Learning: Deep Deterministic Policy Gradient (#3494).
-  
+
+  * Add `ClassProbabilities()` member to `DecisionTree` so that the internal
+    details of trees can be more easily inspected (#3511).
+
 ### mlpack 4.2.0
 ###### 2023-06-14
   * Adapt C_ReLU, ReLU6, FlexibleReLU layer for new neural network API (#3445).

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -470,6 +470,11 @@ class DecisionTree :
   //! trained tree).
   size_t SplitDimension() const { return splitDimension; }
 
+  //! Get the class probabilities, if this is a leaf node in the trained tree.
+  //! Note that if this is not a leaf, then this may contain arbitrary
+  //! information used by the split in the tree!
+  const arma::vec& ClassProbabilities() const { return classProbabilities; }
+
   /**
    * Given a point and that this node is not a leaf, calculate the index of the
    * child node this point would go towards.  This method is primarily used by


### PR DESCRIPTION
This handles #3509 by adding `DecisionTree::ClassProbabilities()`, plus a note that these are only class probabilities when the node is a leaf and not an internal node.  This could be useful not just for obtaining class probabilities but also information about the split.