### PR TITLE
Reinforcement Learning: Twin Delayed Deep Deterministic Policy Gradient

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Reinforcement Learning: Twin Delayed Deep Deterministic 
+    Policy Gradient (#3512).
+
   * Reinforcement Learning: Ornstein-Uhlenbeck noise (#3499).
   
   * Reinforcement Learning: Deep Deterministic Policy Gradient (#3494).

--- a/src/mlpack/methods/reinforcement_learning/reinforcement_learning.hpp
+++ b/src/mlpack/methods/reinforcement_learning/reinforcement_learning.hpp
@@ -22,7 +22,8 @@
 #include "training_config.hpp"
 #include "async_learning.hpp"
 #include "q_learning.hpp"
-#include "sac.hpp"
 #include "ddpg.hpp"
+#include "td3.hpp"
+#include "sac.hpp"
 
 #endif

--- a/src/mlpack/methods/reinforcement_learning/td3.hpp
+++ b/src/mlpack/methods/reinforcement_learning/td3.hpp
@@ -1,0 +1,194 @@
+/**
+ * @file methods/reinforcement_learning/td3.hpp
+ * @author Tarek Elsayed
+ *
+ * This file is the definition of TD3 class, which implements the
+ * Twin Delayed Deep Deterministic Policy Gradient algorithm.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_RL_TD3_HPP
+#define MLPACK_METHODS_RL_TD3_HPP
+
+#include <mlpack/core.hpp>
+#include <ensmallen.hpp>
+#include <mlpack/methods/ann/ann.hpp>
+
+#include "replay/replay.hpp"
+#include "training_config.hpp"
+
+namespace mlpack {
+
+/**
+ * Implementation of Twin Delayed Deep Deterministic policy gradient, 
+ * a model-free off-policy actor-critic based algorithm.
+ *
+ * For more details, see the following:
+ * @code
+ * @misc{Fujimoto et al, 2018,
+ *  author    = {Scott Fujimoto,
+ *               Herke van Hoof,
+ *               David Meger},
+ *  title     = {Addressing Function Approximation Error in 
+ *               Actor-Critic Methods},
+ *  year      = {2018},
+ *  url       = {https://arxiv.org/abs/1802.09477}
+ * }
+ * @endcode
+ *
+ * @tparam EnvironmentType The environment of the reinforcement learning task.
+ * @tparam QNetworkType The network used to estimate the critic's Q-values.
+ * @tparam PolicyNetworkType The network to compute action value.
+ * @tparam UpdaterType How to apply gradients when training.
+ * @tparam ReplayType Experience replay method.
+ */
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType = RandomReplay<EnvironmentType>
+>
+class TD3
+{
+ public:
+  //! Convenient typedef for state.
+  using StateType = typename EnvironmentType::State;
+
+  //! Convenient typedef for action.
+  using ActionType = typename EnvironmentType::Action;
+
+  /**
+   * Create the TD3 object with given settings.
+   *
+   * If you want to pass in a parameter and discard the original parameter
+   * object, you can directly pass the parameter, as the constructor takes
+   * a reference. This avoids unnecessary copy.
+   *
+   * @param config Hyper-parameters for training.
+   * @param learningQNetwork The network to compute action value.
+   * @param policyNetwork The network to produce an action given a state.
+   * @param replayMethod Experience replay method.
+   * @param qNetworkUpdater How to apply gradients to Q network when training.
+   * @param policyNetworkUpdater How to apply gradients to policy network
+   *        when training.
+   * @param environment Reinforcement learning task.
+   */
+  TD3(TrainingConfig& config,
+      QNetworkType& learningQNetwork,
+      PolicyNetworkType& policyNetwork,
+      ReplayType& replayMethod,
+      UpdaterType qNetworkUpdater = UpdaterType(),
+      UpdaterType policyNetworkUpdater = UpdaterType(),
+      EnvironmentType environment = EnvironmentType());
+
+  /**
+    * Clean memory.
+    */
+  ~TD3();
+
+  /**
+   * Softly update the target networks` parameters from the learning networks`
+   * parameters.
+   * 
+   * @param rho How "softly" should the parameters be copied.
+   * */
+  void SoftUpdate(double rho);
+
+  /**
+   * Update the Q and policy networks.
+   * */
+  void Update();
+
+  /**
+   * Select an action, given an agent.
+   */
+  void SelectAction();
+
+  /**
+   * Execute an episode.
+   * @return Return of the episode.
+   */
+  double Episode();
+
+  //! Modify total steps from beginning.
+  size_t& TotalSteps() { return totalSteps; }
+  //! Get total steps from beginning.
+  const size_t& TotalSteps() const { return totalSteps; }
+
+  //! Modify the state of the agent.
+  StateType& State() { return state; }
+  //! Get the state of the agent.
+  const StateType& State() const { return state; }
+
+  //! Get the action of the agent.
+  const ActionType& Action() const { return action; }
+
+  //! Modify the training mode / test mode indicator.
+  bool& Deterministic() { return deterministic; }
+  //! Get the indicator of training mode / test mode.
+  const bool& Deterministic() const { return deterministic; }
+
+
+ private:
+  //! Locally-stored hyper-parameters.
+  TrainingConfig& config;
+
+  //! Locally-stored learning Q1 and Q2 network.
+  QNetworkType& learningQ1Network;
+  QNetworkType learningQ2Network;
+
+  //! Locally-stored target Q1 and Q2 network.
+  QNetworkType targetQ1Network;
+  QNetworkType targetQ2Network;
+
+  //! Locally-stored policy network.
+  PolicyNetworkType& policyNetwork;
+
+  //! Locally-stored target policy network.
+  PolicyNetworkType targetPNetwork;
+
+  //! Locally-stored experience method.
+  ReplayType& replayMethod;
+
+  //! Locally-stored updater.
+  UpdaterType qNetworkUpdater;
+  #if ENS_VERSION_MAJOR >= 2
+  typename UpdaterType::template Policy<arma::mat, arma::mat>*
+      qNetworkUpdatePolicy;
+  #endif
+
+  //! Locally-stored updater.
+  UpdaterType policyNetworkUpdater;
+  #if ENS_VERSION_MAJOR >= 2
+  typename UpdaterType::template Policy<arma::mat, arma::mat>*
+      policyNetworkUpdatePolicy;
+  #endif
+
+  //! Locally-stored reinforcement learning task.
+  EnvironmentType environment;
+
+  //! Total steps from the beginning of the task.
+  size_t totalSteps;
+
+  //! Locally-stored current state of the agent.
+  StateType state;
+
+  //! Locally-stored action of the agent.
+  ActionType action;
+
+  //! Locally-stored flag indicating training mode or test mode.
+  bool deterministic;
+
+  //! Locally-stored loss function.
+  MeanSquaredError lossFunction;
+};
+
+} // namespace mlpack
+
+// Include implementation
+#include "td3_impl.hpp"
+#endif

--- a/src/mlpack/methods/reinforcement_learning/td3_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/td3_impl.hpp
@@ -1,0 +1,362 @@
+/**
+ * @file methods/reinforcement_learning/td3_impl.hpp
+ * @author Tarek Elsayed
+ *
+ * This file is the implementation of TD3 class, which implements the
+ * Twin Delayed Deep Deterministic Policy Gradient algorithm.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_RL_td3_IMPL_HPP
+#define MLPACK_METHODS_RL_td3_IMPL_HPP
+
+#include <mlpack/prereqs.hpp>
+
+#include "td3.hpp"
+
+namespace mlpack {
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::TD3(TrainingConfig& config,
+       QNetworkType& learningQ1Network,
+       PolicyNetworkType& policyNetwork,
+       ReplayType& replayMethod,
+       UpdaterType qNetworkUpdater,
+       UpdaterType policyNetworkUpdater,
+       EnvironmentType environment):
+  config(config),
+  learningQ1Network(learningQ1Network),
+  policyNetwork(policyNetwork),
+  replayMethod(replayMethod),
+  qNetworkUpdater(std::move(qNetworkUpdater)),
+  #if ENS_VERSION_MAJOR >= 2
+  qNetworkUpdatePolicy(NULL),
+  #endif
+  policyNetworkUpdater(std::move(policyNetworkUpdater)),
+  #if ENS_VERSION_MAJOR >= 2
+  policyNetworkUpdatePolicy(NULL),
+  #endif
+  environment(std::move(environment)),
+  totalSteps(0),
+  deterministic(false)
+{ 
+  // Set up q-learning and policy networks.
+  targetPNetwork = policyNetwork;
+  targetQ1Network = learningQ1Network;
+  learningQ2Network = learningQ1Network;
+  targetQ2Network = learningQ2Network;
+
+  // Reset all the networks.
+  // Note: the q and policy networks have an if condition before reset.
+  // This is because we don't want to reset a loaded(possibly pretrained) model
+  // passed using this constructor.
+  const size_t envSampleSize = environment.InitialSample().Encode().n_elem;
+  if (policyNetwork.Parameters().n_elem != envSampleSize)
+    policyNetwork.Reset(envSampleSize);
+
+  targetPNetwork.Reset(envSampleSize);
+
+  const size_t networkSize = envSampleSize +
+      policyNetwork.Network()[policyNetwork.Network().size() - 1]->OutputSize();
+
+  if (learningQ1Network.Parameters().n_elem != networkSize)
+  {
+    learningQ1Network.Reset(networkSize);
+    learningQ2Network.Reset(networkSize);
+  }
+  targetQ1Network.Reset(networkSize);
+  targetQ2Network.Reset(networkSize);
+
+  #if ENS_VERSION_MAJOR == 1
+  this->qNetworkUpdater.Initialize(learningQ1Network.Parameters().n_rows,
+                                   learningQ1Network.Parameters().n_cols);
+  #else
+  this->qNetworkUpdatePolicy = new typename UpdaterType::template
+      Policy<arma::mat, arma::mat>(this->qNetworkUpdater,
+                                   learningQ1Network.Parameters().n_rows,
+                                   learningQ1Network.Parameters().n_cols);
+  #endif
+
+  #if ENS_VERSION_MAJOR == 1
+  this->policyNetworkUpdater.Initialize(policyNetwork.Parameters().n_rows,
+                                        policyNetwork.Parameters().n_cols);
+  #else
+  this->policyNetworkUpdatePolicy = new typename UpdaterType::template
+      Policy<arma::mat, arma::mat>(this->policyNetworkUpdater,
+                                   policyNetwork.Parameters().n_rows,
+                                   policyNetwork.Parameters().n_cols);
+  #endif
+
+  // Copy over the learning networks to their respective target networks.
+  targetQ1Network.Parameters() = learningQ1Network.Parameters();
+  targetQ2Network.Parameters() = learningQ2Network.Parameters();
+  targetPNetwork.Parameters() = policyNetwork.Parameters();
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::~TD3()
+{
+  #if ENS_VERSION_MAJOR >= 2
+  delete qNetworkUpdatePolicy;
+  delete policyNetworkUpdatePolicy;
+  #endif
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+void TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::SoftUpdate(double rho)
+{
+  targetQ1Network.Parameters() = (1 - rho) * targetQ1Network.Parameters() +
+      rho * learningQ1Network.Parameters();
+  targetQ2Network.Parameters() = (1 - rho) * targetQ2Network.Parameters() +
+      rho * learningQ2Network.Parameters();
+  targetPNetwork.Parameters() = (1 - rho) * targetPNetwork.Parameters() +
+      rho * policyNetwork.Parameters();
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+void TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::Update()
+{
+  // Sample from previous experience.
+  arma::mat sampledStates;
+  std::vector<ActionType> sampledActions;
+  arma::rowvec sampledRewards;
+  arma::mat sampledNextStates;
+  arma::irowvec isTerminal;
+
+  replayMethod.Sample(sampledStates, sampledActions, sampledRewards,
+      sampledNextStates, isTerminal);
+
+  // Critic network update.
+
+  // Use the target actor to obtain the next actions.
+  arma::mat nextStateActions;
+  targetPNetwork.Predict(sampledNextStates, nextStateActions);
+
+  // Compute the estimated next Q-values using the target Q-networks.
+  arma::mat targetQInput = arma::join_vert(nextStateActions,
+      sampledNextStates);
+  arma::rowvec Q1, Q2;
+  targetQ1Network.Predict(targetQInput, Q1);
+  targetQ2Network.Predict(targetQInput, Q2);
+  arma::rowvec nextQ = sampledRewards + config.Discount() * ((1 - isTerminal)
+      % arma::min(Q1, Q2));
+
+  arma::mat sampledActionValues(action.size, sampledActions.size());
+  for (size_t i = 0; i < sampledActions.size(); i++)
+    sampledActionValues.col(i) = arma::conv_to<arma::colvec>::from
+                                 (sampledActions[i].action);
+  arma::mat learningQInput = arma::join_vert(sampledActionValues,
+      sampledStates);
+  learningQ1Network.Forward(learningQInput, Q1);
+  learningQ2Network.Forward(learningQInput, Q2);
+
+  arma::mat gradQ1Loss, gradQ2Loss;
+  lossFunction.Backward(Q1, nextQ, gradQ1Loss);
+  lossFunction.Backward(Q2, nextQ, gradQ2Loss);
+
+  // Sum both losses
+  arma::mat combinedLoss = gradQ1Loss + gradQ2Loss;
+
+  // Update the critic networks.
+  arma::mat gradientQ1, gradientQ2;
+  learningQ1Network.Backward(learningQInput, combinedLoss, gradientQ1);
+  learningQ2Network.Backward(learningQInput, combinedLoss, gradientQ2);
+  #if ENS_VERSION_MAJOR == 1
+  qNetworkUpdater.Update(learningQ1Network.Parameters(), config.StepSize(),
+      gradientQ1);
+  #else
+  qNetworkUpdatePolicy->Update(learningQ1Network.Parameters(),
+      config.StepSize(), gradientQ1);
+  #endif
+  #if ENS_VERSION_MAJOR == 1
+  qNetworkUpdater.Update(learningQ2Network.Parameters(), config.StepSize(),
+      gradientQ2);
+  #else
+  qNetworkUpdatePolicy->Update(learningQ2Network.Parameters(),
+      config.StepSize(), gradientQ2);
+  #endif
+
+  // Actor network update.
+
+  if (totalSteps % config.TargetNetworkSyncInterval() == 0)
+  {
+    // Get the size of the first hidden layer in the Q network.
+    size_t hidden1 = learningQ1Network.Network()[0]->OutputSize();
+
+    arma::mat gradient;
+    for (size_t i = 0; i < sampledStates.n_cols; i++)
+    {
+        arma::mat grad, gradQ, q;
+        arma::colvec singleState = sampledStates.col(i);
+        arma::colvec singlePi;
+        policyNetwork.Forward(singleState, singlePi);
+        arma::colvec input = arma::join_vert(singlePi, singleState);
+        arma::mat weightLastLayer;
+
+        // Note that we can use an empty matrix for the backwards pass, since the
+        // networks use EmptyLoss.
+        learningQ1Network.Forward(input, q);
+        learningQ1Network.Backward(input, arma::mat("-1"), gradQ);
+        weightLastLayer = arma::reshape(learningQ1Network.Parameters().
+            rows(0, hidden1 * singlePi.n_rows - 1), hidden1, singlePi.n_rows);
+
+        arma::colvec gradQBias = gradQ(input.n_rows * hidden1, 0,
+            arma::size(hidden1, 1));
+        arma::mat gradPolicy = weightLastLayer.t() * gradQBias;
+        policyNetwork.Backward(singleState, gradPolicy, grad);
+        if (i == 0)
+        {
+            gradient.copy_size(grad);
+            gradient.fill(0.0);
+        }
+        gradient += grad;
+    }
+    gradient /= sampledStates.n_cols;
+
+    #if ENS_VERSION_MAJOR == 1
+    policyUpdater.Update(policyNetwork.Parameters(), config.StepSize(), gradient);
+    #else
+    policyNetworkUpdatePolicy->Update(policyNetwork.Parameters(),
+        config.StepSize(), gradient);
+    #endif
+
+    // Update target networks
+    SoftUpdate(config.Rho());
+  }
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+void TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::SelectAction()
+{
+  // Get the action at current state, from policy.
+  arma::colvec outputAction;
+  policyNetwork.Predict(state.Encode(), outputAction);
+
+  if (!deterministic)
+  {
+    arma::colvec noise = arma::randn<arma::colvec>(outputAction.n_rows) * 0.1;
+    noise = arma::clamp(noise, -0.25, 0.25);
+    outputAction = outputAction + noise;
+  }
+  action.action = arma::conv_to<std::vector<double>>::from(outputAction);
+}
+
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+double TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::Episode()
+{
+  // Get the initial state from environment.
+  state = environment.InitialSample();
+
+  // Track the steps in this episode.
+  size_t steps = 0;
+
+  // Track the return of this episode.
+  double totalReturn = 0.0;
+
+  // Running until get to the terminal state.
+  while (!environment.IsTerminal(state))
+  {
+    if (config.StepLimit() && steps >= config.StepLimit())
+      break;
+    SelectAction();
+
+    // Interact with the environment to advance to next state.
+    StateType nextState;
+    double reward = environment.Sample(state, action, nextState);
+
+    totalReturn += reward;
+    steps++;
+    totalSteps++;
+
+    // Store the transition for replay.
+    replayMethod.Store(state, action, reward, nextState,
+        environment.IsTerminal(nextState), config.Discount());
+
+    // Update current state.
+    state = nextState;
+
+    if (deterministic || totalSteps < config.ExplorationSteps())
+      continue;
+    for (size_t i = 0; i < config.UpdateInterval(); i++)
+      Update();
+  }
+  return totalReturn;
+}
+
+} // namespace mlpack
+#endif

--- a/src/mlpack/tests/q_learning_test.cpp
+++ b/src/mlpack/tests/q_learning_test.cpp
@@ -693,3 +693,89 @@ TEST_CASE("OUNoiseTest", "[QLearningTest]")
   bool isNotEqual = arma::any(sample != state);
   REQUIRE(isNotEqual);
 }
+
+//! Test TD3 on Pendulum task.
+TEST_CASE("PendulumWithTD3", "[QLearningTest]")
+{
+  // It isn't guaranteed that the network will converge in the specified number
+  // of iterations using random weights.
+  bool converged = false;
+  for (size_t trial = 0; trial < 8; ++trial)
+  {
+    Log::Debug << "Trial number: " << trial << std::endl;
+    // Set up the replay method.
+    RandomReplay<Pendulum> replayMethod(32, 10000);
+
+    TrainingConfig config;
+    config.StepSize() = 0.001;
+    config.TargetNetworkSyncInterval() = 2;
+    config.UpdateInterval() = 3;
+
+    // Set up Actor network.
+    FFN<EmptyLoss, GaussianInitialization>
+        policyNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
+    policyNetwork.Add(new Linear(128));
+    policyNetwork.Add(new ReLU());
+    policyNetwork.Add(new Linear(1));
+    policyNetwork.Add(new TanH());
+
+    // Set up Critic network.
+    FFN<EmptyLoss, GaussianInitialization>
+        qNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
+    qNetwork.Add(new Linear(128));
+    qNetwork.Add(new ReLU());
+    qNetwork.Add(new Linear(1));
+
+    // Set up Twin Delayed Deep Deterministic policy gradient agent.
+    TD3<Pendulum, decltype(qNetwork), decltype(policyNetwork), AdamUpdate>
+        agent(config, qNetwork, policyNetwork, replayMethod);
+
+    converged = testAgent<decltype(agent)>(agent, -900, 500, 10);
+    if (converged)
+      break;
+  }
+  REQUIRE(converged);
+}
+
+//! A test to ensure TD3 works with multiple actions in action space.
+TEST_CASE("TD3ForMultipleActions", "[QLearningTest]")
+{
+  FFN<EmptyLoss, GaussianInitialization>
+      policyNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
+  policyNetwork.Add(new Linear(128));
+  policyNetwork.Add(new ReLU());
+  policyNetwork.Add(new Linear(4));
+  policyNetwork.Add(new TanH());
+
+  FFN<EmptyLoss, GaussianInitialization>
+      qNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
+  qNetwork.Add(new Linear(128));
+  qNetwork.Add(new ReLU());
+  qNetwork.Add(new Linear(1));
+
+  // Set up the replay method.
+  RandomReplay<ContinuousActionEnv<3, 4>> replayMethod(32, 10000);
+
+  TrainingConfig config;
+  config.StepSize() = 0.001;
+  config.TargetNetworkSyncInterval() = 2;
+  config.UpdateInterval() = 3;
+
+  // Set up the TD3 agent.
+  TD3<ContinuousActionEnv<3, 4>, decltype(qNetwork), decltype(policyNetwork),
+      AdamUpdate>
+      agent(config, qNetwork, policyNetwork, replayMethod);
+
+  agent.State().Data() = arma::randu<arma::colvec>
+      (ContinuousActionEnv<3, 4>::State::dimension, 1);
+  agent.SelectAction();
+
+  // Test to check if the action dimension given by the agent is correct.
+  REQUIRE(agent.Action().action.size() == 4);
+
+  replayMethod.Store(agent.State(), agent.Action(), 1, agent.State(), 1, 0.99);
+  agent.TotalSteps()++;
+  agent.Update();
+  // If the agent is able to reach this point of the test, it is assured
+  // that the agent can handle multiple actions in continuous space.
+}


### PR DESCRIPTION
# Description

This pull request implements the TD3 (Twin Delayed Deep Deterministic Policy Gradient) algorithm, along with 2 test cases. 

## Implementation details
TD3 (Twin Delayed Deep Deterministic Policy Gradient) is a reinforcement learning algorithm designed for continuous action spaces. It builds upon DDPG and introduces twin critics and delayed updates to improve stability and performance. 

Implemented 6 networks:
- `policyNetwork` (actor network)
- `targetPNetwork` (target actor network)
- `learningQ1Network` (first critic network)
- `targetQ1Network` (first target critic network)
- `learningQ2Network` (second critic network)
- `targetQ2Network` (second target critic network)

# How Has This Been Tested?

- [x] Included a Pendulum test that successfully passes with different configuration values. 
    - With TargetNetworkSyncInterval = 1 ——> -1081.52
    - With TargetNetworkSyncInterval = 2 ——> -508.788
    - With TargetNetworkSyncInterval = 3 ——> -1209.31
- [x] Additionally, added a test for continuous action spaces, which also passes.

The networks for the 2 tests are the same for DDPG and SAC for comparison.