### PR TITLE
Add extra mlpack/ path so Cython properly detects .pyx files.

### DIFF
--- a/.ci/ci.yaml
+++ b/.ci/ci.yaml
@@ -41,18 +41,18 @@ jobs:
     matrix:
       Plain:
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_TESTS=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
-        python.version: '3.7'
+        python.version: '3.8'
       Python:
         binding: 'python'
-        python.version: '3.7'
+        python.version: '3.8'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_TESTS=ON -DBUILD_PYTHON_BINDINGS=ON -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
       Julia:
-        python.version: '3.7'
+        python.version: '3.8'
         julia.version: '1.6.3'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_TESTS=ON -DBUILD_JULIA_BINDINGS=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=OFF'
       Go:
         binding: 'go'
-        python.version: '3.7'
+        python.version: '3.8'
         go.version: '1.11.0'
         CMakeArgs: '-DDEBUG=ON -DPROFILE=OFF -DBUILD_TESTS=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=ON -DBUILD_R_BINDINGS=OFF'
 

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -18,7 +18,7 @@ steps:
 
     if [ "$(binding)" == "python" ]; then
       pip install --upgrade pip
-      pip install cython numpy pandas zipp configparser
+      pip install cython numpy pandas zipp configparser wheel
     fi
 
     if [ "a$(julia.version)" != "a" ]; then

--- a/src/mlpack/bindings/python/get_arma_type.hpp
+++ b/src/mlpack/bindings/python/get_arma_type.hpp
@@ -3,8 +3,8 @@
  * @author Ryan Curtin
  *
  * Return "mat", "col", or "row" depending on the type of the given Armadillo
- * object.  This is so that the correct overload of arma_numpy.numpy_to_<type>()
- * can be called.
+ * object.  This is so that the correct overload of numpy_to_<type>() can be
+ * called.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -102,7 +102,7 @@ inline std::string GetCythonType(
   else if (T::is_col)
     type = "Col";
 
-  return "arma." + type + "[" + GetCythonType<typename T::elem_type>(d) + "]";
+  return type + "[" + GetCythonType<typename T::elem_type>(d) + "]";
 }
 
 template<typename T>

--- a/src/mlpack/bindings/python/mlpack/arma_numpy.pxd
+++ b/src/mlpack/bindings/python/mlpack/arma_numpy.pxd
@@ -18,55 +18,55 @@ import numpy
 
 numpy.import_array()
 
-cimport arma
+from .arma cimport Mat, Row, Col
 from libcpp cimport bool
 
 """
 Convert a numpy ndarray to a matrix.
 """
-cdef arma.Mat[double]* numpy_to_mat_d(numpy.ndarray[numpy.double_t, ndim=2] X, \
-                                      bool takeOwnership) except +
-cdef arma.Mat[size_t]* numpy_to_mat_s(numpy.ndarray[numpy.npy_intp, ndim=2] X, \
-                                      bool takeOwnership) except +
+cdef Mat[double]* numpy_to_mat_d(numpy.ndarray[numpy.double_t, ndim=2] X, \
+                                 bool takeOwnership) except +
+cdef Mat[size_t]* numpy_to_mat_s(numpy.ndarray[numpy.npy_intp, ndim=2] X, \
+                                 bool takeOwnership) except +
 
 """
 Convert an Armadillo object to a numpy ndarray of the given type.
 """
-cdef numpy.ndarray[numpy.double_t, ndim=2] mat_to_numpy_d(arma.Mat[double]& X) \
+cdef numpy.ndarray[numpy.double_t, ndim=2] mat_to_numpy_d(Mat[double]& X) \
     except +
-cdef numpy.ndarray[numpy.npy_intp, ndim=2] mat_to_numpy_s(arma.Mat[size_t]& X) \
+cdef numpy.ndarray[numpy.npy_intp, ndim=2] mat_to_numpy_s(Mat[size_t]& X) \
     except +
 
 """
 Convert a numpy one-dimensional ndarray to a row of the given type.
 """
-cdef arma.Row[double]* numpy_to_row_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
-                                      bool takeOwnership) except +
-cdef arma.Row[size_t]* numpy_to_row_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
-                                      bool takeOwnership) except +
+cdef Row[double]* numpy_to_row_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
+                                 bool takeOwnership) except +
+cdef Row[size_t]* numpy_to_row_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
+                                 bool takeOwnership) except +
 
 """
 Convert an Armadillo row vector to a one-dimensional numpy ndarray of the
 given type.
 """
-cdef numpy.ndarray[numpy.double_t, ndim=1] row_to_numpy_d(arma.Row[double]& X) \
+cdef numpy.ndarray[numpy.double_t, ndim=1] row_to_numpy_d(Row[double]& X) \
     except +
-cdef numpy.ndarray[numpy.npy_intp, ndim=1] row_to_numpy_s(arma.Row[size_t]& X) \
+cdef numpy.ndarray[numpy.npy_intp, ndim=1] row_to_numpy_s(Row[size_t]& X) \
     except +
 
 """
 Convert a numpy one-dimensional ndarray to a column vector of the given type.
 """
-cdef arma.Col[double]* numpy_to_col_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
-                                      bool takeOwnership) except +
-cdef arma.Col[size_t]* numpy_to_col_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
-                                      bool takeOwnership) except +
+cdef Col[double]* numpy_to_col_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
+                                 bool takeOwnership) except +
+cdef Col[size_t]* numpy_to_col_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
+                                 bool takeOwnership) except +
 
 """
 Convert an Armadillo column vector to a one-dimensional numpy ndarray of the
 given type.
 """
-cdef numpy.ndarray[numpy.double_t, ndim=1] col_to_numpy_d(arma.Col[double]& X) \
+cdef numpy.ndarray[numpy.double_t, ndim=1] col_to_numpy_d(Col[double]& X) \
     except +
-cdef numpy.ndarray[numpy.npy_intp, ndim=1] col_to_numpy_s(arma.Col[size_t]& X) \
+cdef numpy.ndarray[numpy.npy_intp, ndim=1] col_to_numpy_s(Col[size_t]& X) \
     except +

--- a/src/mlpack/bindings/python/mlpack/arma_numpy.pyx
+++ b/src/mlpack/bindings/python/mlpack/arma_numpy.pyx
@@ -23,7 +23,7 @@ import numpy
 
 numpy.import_array()
 
-cimport arma
+from .arma cimport Mat, Row, Col
 from libcpp cimport bool
 
 import platform
@@ -39,15 +39,15 @@ cdef extern from "numpy/arrayobject.h":
 cdef extern from "<mlpack/bindings/python/mlpack/arma_util.hpp>":
   void SetMemState[T](T& m, int state)
   size_t GetMemState[T](T& m)
-  double* GetMemory(arma.Mat[double]& m)
-  double* GetMemory(arma.Col[double]& m)
-  double* GetMemory(arma.Row[double]& m)
-  size_t* GetMemory(arma.Mat[size_t]& m)
-  size_t* GetMemory(arma.Col[size_t]& m)
-  size_t* GetMemory(arma.Row[size_t]& m)
+  double* GetMemory(Mat[double]& m)
+  double* GetMemory(Col[double]& m)
+  double* GetMemory(Row[double]& m)
+  size_t* GetMemory(Mat[size_t]& m)
+  size_t* GetMemory(Col[size_t]& m)
+  size_t* GetMemory(Row[size_t]& m)
 
-cdef arma.Mat[double]* numpy_to_mat_d(numpy.ndarray[numpy.double_t, ndim=2] X, \
-                                      bool takeOwnership) except +:
+cdef Mat[double]* numpy_to_mat_d(numpy.ndarray[numpy.double_t, ndim=2] X, \
+                                 bool takeOwnership) except +:
   """
   Convert a numpy ndarray to a matrix.  The memory will still be owned by numpy.
   """
@@ -58,18 +58,18 @@ cdef arma.Mat[double]* numpy_to_mat_d(numpy.ndarray[numpy.double_t, ndim=2] X, \
     X = X.copy(order="C")
     takeOwnership = True
 
-  cdef arma.Mat[double]* m = new arma.Mat[double](<double*> PyArray_DATA(X),
+  cdef Mat[double]* m = new Mat[double](<double*> PyArray_DATA(X),
       PyArray_SHAPE(X)[1], PyArray_SHAPE(X)[0], isWin, False)
 
   # Take ownership of the memory, if we need to and we are not on Windows.
   if takeOwnership and not isWin:
     PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
-    SetMemState[arma.Mat[double]](m[0], 0)
+    SetMemState[Mat[double]](m[0], 0)
 
   return m
 
-cdef arma.Mat[size_t]* numpy_to_mat_s(numpy.ndarray[numpy.npy_intp, ndim=2] X, \
-                                      bool takeOwnership) except +:
+cdef Mat[size_t]* numpy_to_mat_s(numpy.ndarray[numpy.npy_intp, ndim=2] X, \
+                                 bool takeOwnership) except +:
   """
   Convert a numpy ndarray to a matrix.  The memory will still be owned by numpy.
   """
@@ -81,17 +81,17 @@ cdef arma.Mat[size_t]* numpy_to_mat_s(numpy.ndarray[numpy.npy_intp, ndim=2] X, \
     X = X.copy(order="C")
     takeOwnership = True
 
-  cdef arma.Mat[size_t]* m = new arma.Mat[size_t](<size_t*> PyArray_DATA(X),
+  cdef Mat[size_t]* m = new Mat[size_t](<size_t*> PyArray_DATA(X),
       PyArray_SHAPE(X)[1], PyArray_SHAPE(X)[0], isWin, False)
 
   # Take ownership of the memory, if we need to.
   if takeOwnership and not isWin:
     PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
-    SetMemState[arma.Mat[size_t]](m[0], 0)
+    SetMemState[Mat[size_t]](m[0], 0)
 
   return m
 
-cdef numpy.ndarray[numpy.double_t, ndim=2] mat_to_numpy_d(arma.Mat[double]& X) \
+cdef numpy.ndarray[numpy.double_t, ndim=2] mat_to_numpy_d(Mat[double]& X) \
     except +:
   """
   Convert an Armadillo object to a numpy ndarray.
@@ -106,13 +106,13 @@ cdef numpy.ndarray[numpy.double_t, ndim=2] mat_to_numpy_d(arma.Mat[double]& X) \
     output = output.copy(order="C")
 
   # Transfer memory ownership, if needed.
-  if GetMemState[arma.Mat[double]](X) == 0 and not isWin:
-    SetMemState[arma.Mat[double]](X, 1)
+  if GetMemState[Mat[double]](X) == 0 and not isWin:
+    SetMemState[Mat[double]](X, 1)
     PyArray_ENABLEFLAGS(output, numpy.NPY_ARRAY_OWNDATA)
 
   return output
 
-cdef numpy.ndarray[numpy.npy_intp, ndim=2] mat_to_numpy_s(arma.Mat[size_t]& X) \
+cdef numpy.ndarray[numpy.npy_intp, ndim=2] mat_to_numpy_s(Mat[size_t]& X) \
     except +:
   """
   Convert an Armadillo object to a numpy ndarray.
@@ -127,14 +127,14 @@ cdef numpy.ndarray[numpy.npy_intp, ndim=2] mat_to_numpy_s(arma.Mat[size_t]& X) \
     output = output.copy(order="C")
 
   # Transfer memory ownership, if needed.
-  if GetMemState[arma.Mat[size_t]](X) == 0 and not isWin:
-    SetMemState[arma.Mat[size_t]](X, 1)
+  if GetMemState[Mat[size_t]](X) == 0 and not isWin:
+    SetMemState[Mat[size_t]](X, 1)
     PyArray_ENABLEFLAGS(output, numpy.NPY_ARRAY_OWNDATA)
 
   return output
 
-cdef arma.Row[double]* numpy_to_row_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
-                                      bool takeOwnership) except +:
+cdef Row[double]* numpy_to_row_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
+                                 bool takeOwnership) except +:
   """
   Convert a numpy one-dimensional ndarray to a row.  The memory will still be
   owned by numpy.
@@ -147,18 +147,18 @@ cdef arma.Row[double]* numpy_to_row_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
     X = X.copy(order="C")
     takeOwnership = True
 
-  cdef arma.Row[double]* m = new arma.Row[double](<double*> PyArray_DATA(X),
+  cdef Row[double]* m = new Row[double](<double*> PyArray_DATA(X),
     PyArray_SHAPE(X)[0], isWin, False)
 
   # Transfer memory ownership, if needed.
   if takeOwnership and not isWin:
     PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
-    SetMemState[arma.Row[double]](m[0], 0)
+    SetMemState[Row[double]](m[0], 0)
 
   return m
 
-cdef arma.Row[size_t]* numpy_to_row_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
-                                      bool takeOwnership) except +:
+cdef Row[size_t]* numpy_to_row_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
+                                 bool takeOwnership) except +:
   """
   Convert a numpy one-dimensional ndarray to a row.  The memory will still be
   owned by numpy.
@@ -171,17 +171,17 @@ cdef arma.Row[size_t]* numpy_to_row_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
     X = X.copy(order="C")
     takeOwnership = True
 
-  cdef arma.Row[size_t]* m = new arma.Row[size_t](<size_t*> PyArray_DATA(X),
+  cdef Row[size_t]* m = new Row[size_t](<size_t*> PyArray_DATA(X),
       PyArray_SHAPE(X)[0], isWin, False)
 
   # Transfer memory ownership, if needed.
   if takeOwnership and not isWin:
     PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
-    SetMemState[arma.Row[size_t]](m[0], 0)
+    SetMemState[Row[size_t]](m[0], 0)
 
   return m
 
-cdef numpy.ndarray[numpy.double_t, ndim=1] row_to_numpy_d(arma.Row[double]& X) \
+cdef numpy.ndarray[numpy.double_t, ndim=1] row_to_numpy_d(Row[double]& X) \
     except +:
   """
   Convert an Armadillo row vector to a one-dimensional numpy ndarray.
@@ -194,13 +194,13 @@ cdef numpy.ndarray[numpy.double_t, ndim=1] row_to_numpy_d(arma.Row[double]& X) \
     output = output.copy(order="C")
 
   # Transfer memory ownership, if needed.
-  if GetMemState[arma.Row[double]](X) == 0 and not isWin:
-    SetMemState[arma.Row[double]](X, 1)
+  if GetMemState[Row[double]](X) == 0 and not isWin:
+    SetMemState[Row[double]](X, 1)
     PyArray_ENABLEFLAGS(output, numpy.NPY_ARRAY_OWNDATA)
 
   return output
 
-cdef numpy.ndarray[numpy.npy_intp, ndim=1] row_to_numpy_s(arma.Row[size_t]& X) \
+cdef numpy.ndarray[numpy.npy_intp, ndim=1] row_to_numpy_s(Row[size_t]& X) \
     except +:
   """
   Convert an Armadillo row vector to a one-dimensional numpy ndarray.
@@ -214,13 +214,37 @@ cdef numpy.ndarray[numpy.npy_intp, ndim=1] row_to_numpy_s(arma.Row[size_t]& X) \
     output = output.copy(order="C")
 
   # Transfer memory ownership, if needed.
-  if GetMemState[arma.Row[size_t]](X) == 0 and not isWin:
-    SetMemState[arma.Row[size_t]](X, 1)
+  if GetMemState[Row[size_t]](X) == 0 and not isWin:
+    SetMemState[Row[size_t]](X, 1)
     PyArray_ENABLEFLAGS(output, numpy.NPY_ARRAY_OWNDATA)
 
   return output
 
-cdef arma.Col[double]* numpy_to_col_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
+cdef Col[double]* numpy_to_col_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
+                                 bool takeOwnership) except +:
+  """
+  Convert a numpy one-dimensional ndarray to a column vector.  The memory will
+  still be owned by numpy.
+  """
+  cdef int flags = PyArray_FLAGS(X)
+  if not (flags & numpy.NPY_ARRAY_C_CONTIGUOUS) or \
+    (not (flags & numpy.NPY_ARRAY_OWNDATA) and not isWin):
+    # If needed, make a copy where we own the memory, except on Windows where
+    # we never copy.
+    X = X.copy(order="C")
+    takeOwnership = True
+
+  cdef Col[double]* m = new Col[double](<double*> PyArray_DATA(X),
+      PyArray_SHAPE(X)[0], isWin, False)
+
+  # Transfer memory ownership, if needed.
+  if takeOwnership and not isWin:
+    PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
+    SetMemState[Col[double]](m[0], 0)
+
+  return m
+
+cdef Col[size_t]* numpy_to_col_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
                                       bool takeOwnership) except +:
   """
   Convert a numpy one-dimensional ndarray to a column vector.  The memory will
@@ -234,41 +258,17 @@ cdef arma.Col[double]* numpy_to_col_d(numpy.ndarray[numpy.double_t, ndim=1] X, \
     X = X.copy(order="C")
     takeOwnership = True
 
-  cdef arma.Col[double]* m = new arma.Col[double](<double*> PyArray_DATA(X),
+  cdef Col[size_t]* m = new Col[size_t](<size_t*> PyArray_DATA(X), 
       PyArray_SHAPE(X)[0], isWin, False)
 
   # Transfer memory ownership, if needed.
   if takeOwnership and not isWin:
     PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
-    SetMemState[arma.Col[double]](m[0], 0)
+    SetMemState[Col[size_t]](m[0], 0)
 
   return m
 
-cdef arma.Col[size_t]* numpy_to_col_s(numpy.ndarray[numpy.npy_intp, ndim=1] X, \
-                                      bool takeOwnership) except +:
-  """
-  Convert a numpy one-dimensional ndarray to a column vector.  The memory will
-  still be owned by numpy.
-  """
-  cdef int flags = PyArray_FLAGS(X)
-  if not (flags & numpy.NPY_ARRAY_C_CONTIGUOUS) or \
-    (not (flags & numpy.NPY_ARRAY_OWNDATA) and not isWin):
-    # If needed, make a copy where we own the memory, except on Windows where
-    # we never copy.
-    X = X.copy(order="C")
-    takeOwnership = True
-
-  cdef arma.Col[size_t]* m = new arma.Col[size_t](<size_t*> PyArray_DATA(X), 
-      PyArray_SHAPE(X)[0], isWin, False)
-
-  # Transfer memory ownership, if needed.
-  if takeOwnership and not isWin:
-    PyArray_CLEARFLAGS(X, numpy.NPY_ARRAY_OWNDATA)
-    SetMemState[arma.Col[size_t]](m[0], 0)
-
-  return m
-
-cdef numpy.ndarray[numpy.double_t, ndim=1] col_to_numpy_d(arma.Col[double]& X) \
+cdef numpy.ndarray[numpy.double_t, ndim=1] col_to_numpy_d(Col[double]& X) \
     except +:
   """
   Convert an Armadillo column vector to a one-dimensional numpy ndarray.
@@ -281,13 +281,13 @@ cdef numpy.ndarray[numpy.double_t, ndim=1] col_to_numpy_d(arma.Col[double]& X) \
     output = output.copy(order="C")
 
   # Transfer memory ownership, if needed.
-  if GetMemState[arma.Col[double]](X) == 0 and not isWin:
-    SetMemState[arma.Col[double]](X, 1)
+  if GetMemState[Col[double]](X) == 0 and not isWin:
+    SetMemState[Col[double]](X, 1)
     PyArray_ENABLEFLAGS(output, numpy.NPY_ARRAY_OWNDATA)
 
   return output
 
-cdef numpy.ndarray[numpy.npy_intp, ndim=1] col_to_numpy_s(arma.Col[size_t]& X) \
+cdef numpy.ndarray[numpy.npy_intp, ndim=1] col_to_numpy_s(Col[size_t]& X) \
     except +:
   """
   Convert an Armadillo column vector to a one-dimensional numpy ndarray.
@@ -300,8 +300,8 @@ cdef numpy.ndarray[numpy.npy_intp, ndim=1] col_to_numpy_s(arma.Col[size_t]& X) \
     output = output.copy(order="C")
 
   # Transfer memory ownership, if needed.
-  if GetMemState[arma.Col[size_t]](X) == 0 and not isWin:
-    SetMemState[arma.Col[size_t]](X, 1)
+  if GetMemState[Col[size_t]](X) == 0 and not isWin:
+    SetMemState[Col[size_t]](X, 1)
     PyArray_ENABLEFLAGS(output, numpy.NPY_ARRAY_OWNDATA)
 
   return output

--- a/src/mlpack/bindings/python/mlpack/io.pxd
+++ b/src/mlpack/bindings/python/mlpack/io.pxd
@@ -15,7 +15,7 @@ http://www.opensource.org/licenses/BSD-3-Clause for more information.
 cimport cython
 from libcpp.string cimport string
 from libcpp cimport bool
-from params cimport Params
+from .params cimport Params
 
 cdef extern from "<mlpack/core/util/io.hpp>" namespace "mlpack" nogil:
   cdef cppclass IO:

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -269,7 +269,7 @@ void PrintInputProcessing(
    *   if param_name_tuple[0].shape[0] == 1 or
    *       param_name_tuple[0].shape[1] == 1:
    *     param_name_tuple[0].shape = (param_name_tuple[0].size,)
-   *   param_name_mat = arma_numpy.numpy_to_mat_s(param_name_tuple[0],
+   *   param_name_mat = numpy_to_mat_s(param_name_tuple[0],
    *       param_name_tuple[1])
    *   SetParam[mat](p, \<const string\> 'param_name', dereference(param_name_mat), True)
    *   p.SetPassed(\<const string\> 'param_name')
@@ -299,7 +299,7 @@ void PrintInputProcessing(
           << std::endl;
       std::cout << prefix << "      " << name << "_tuple[0].shape = ("
           << d.name << "_tuple[0].size,)" << std::endl;
-      std::cout << prefix << "  " << name << "_mat = arma_numpy.numpy_to_"
+      std::cout << prefix << "  " << name << "_mat = numpy_to_"
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << name
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
@@ -319,7 +319,7 @@ void PrintInputProcessing(
           << ") < 2:" << std::endl;
       std::cout << prefix << "    " << name << "_tuple[0].shape = (" << name
           << "_tuple[0].shape[0], 1)" << std::endl;
-      std::cout << prefix << "  " << name << "_mat = arma_numpy.numpy_to_"
+      std::cout << prefix << "  " << name << "_mat = numpy_to_"
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << name
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
@@ -343,7 +343,7 @@ void PrintInputProcessing(
           << name << "_tuple[0].shape[1] == 1:" << std::endl;
       std::cout << prefix << "    " << name << "_tuple[0].shape = ("
           << name << "_tuple[0].size,)" << std::endl;
-      std::cout << prefix << name << "_mat = arma_numpy.numpy_to_"
+      std::cout << prefix << name << "_mat = numpy_to_"
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << name
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
@@ -362,7 +362,7 @@ void PrintInputProcessing(
           << std::endl;
       std::cout << prefix << "  " << name << "_tuple[0].shape = (" << name
           << "_tuple[0].shape[0], 1)" << std::endl;
-      std::cout << prefix << name << "_mat = arma_numpy.numpy_to_"
+      std::cout << prefix << name << "_mat = numpy_to_"
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << name
           << "_tuple[0], " << name << "_tuple[1])" << std::endl;
       std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
@@ -475,7 +475,7 @@ void PrintInputProcessing(
    *   param_name_tuple = to_matrix_with_info(param_name)
    *   if len(param_name_tuple[0].shape) < 2:
    *     param_name_tuple[0].shape = (param_name_tuple[0].size,)
-   *   param_name_mat = arma_numpy.numpy_to_matrix_d(param_name_tuple[0])
+   *   param_name_mat = numpy_to_matrix_d(param_name_tuple[0])
    *   SetParamWithInfo[mat](p, \<const string\> 'param_name',
    *       dereference(param_name_mat), 
    *       \<const cbool*\> PyArray_DATA(param_name_dims))
@@ -496,11 +496,11 @@ void PrintInputProcessing(
         << ") < 2:" << std::endl;
     std::cout << prefix << "    " << name << "_tuple[0].shape = (" << name
         << "_tuple[0].shape[0], 1)" << std::endl;
-    std::cout << prefix << "  " << name << "_mat = arma_numpy.numpy_to_mat_d("
+    std::cout << prefix << "  " << name << "_mat = numpy_to_mat_d("
         << name << "_tuple[0], " << name << "_tuple[1])" << std::endl;
     std::cout << prefix << "  " << name << "_dims = " << name
         << "_tuple[2]" << std::endl;
-    std::cout << prefix << "  SetParamWithInfo[arma.Mat[double]](p, <const "
+    std::cout << prefix << "  SetParamWithInfo[Mat[double]](p, <const "
         << "string> '" << d.name << "', dereference(" << name << "_mat), "
         << "<const cbool*> PyArray_DATA(" << name << "_dims))" << std::endl;
     std::cout << prefix << "  p.SetPassed(<const string> '" << d.name
@@ -518,11 +518,11 @@ void PrintInputProcessing(
         << ") < 2:" << std::endl;
     std::cout << prefix << "  " << name << "_tuple[0].shape = (" << name
         << "_tuple[0].shape[0], 1)" << std::endl;
-    std::cout << prefix << name << "_mat = arma_numpy.numpy_to_mat_d("
+    std::cout << prefix << name << "_mat = numpy_to_mat_d("
         << name << "_tuple[0], " << name << "_tuple[1])" << std::endl;
     std::cout << prefix << name << "_dims = " << name << "_tuple[2]"
         << std::endl;
-    std::cout << prefix << "SetParamWithInfo[arma.Mat[double]](p, <const "
+    std::cout << prefix << "SetParamWithInfo[Mat[double]](p, <const "
         << "string> '" << d.name << "', dereference(" << name << "_mat), "
         << "<const cbool*> PyArray_DATA(" << name << "_dims))" << std::endl;
     std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -97,28 +97,26 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result = arma_numpy.mat_to_numpy_X(p.Get[mat]("name"))
+     * result = mat_to_numpy_X(p.Get[mat]("name"))
      *
      * where X indicates the type to convert to.
      */
-    std::cout << prefix << "result = arma_numpy." << GetArmaType<T>()
-        << "_to_numpy_" << GetNumpyTypeChar<T>() << "(p.Get["
-        << GetCythonType<T>(d) << "](\"" << d.name << "\"))" << std::endl;
+    std::cout << prefix << "result = " << GetArmaType<T>() << "_to_numpy_"
+        << GetNumpyTypeChar<T>() << "(p.Get[" << GetCythonType<T>(d) << "](\""
+        << d.name << "\"))" << std::endl;
   }
   else
   {
     /**
      * This gives us code like:
      *
-     * result['param_name'] =
-     *     arma_numpy.mat_to_numpy_X(p.Get[mat]('name')
+     * result['param_name'] = mat_to_numpy_X(p.Get[mat]('name')
      *
      * where X indicates the type to convert to.
      */
-    std::cout << prefix << "result['" << d.name
-        << "'] = arma_numpy." << GetArmaType<T>() << "_to_numpy_"
-        << GetNumpyTypeChar<T>() << "(p.Get[" << GetCythonType<T>(d)
-        << "]('" << d.name << "'))" << std::endl;
+    std::cout << prefix << "result['" << d.name << "'] = " << GetArmaType<T>()
+        << "_to_numpy_" << GetNumpyTypeChar<T>() << "(p.Get["
+        << GetCythonType<T>(d) << "]('" << d.name << "'))" << std::endl;
   }
 }
 
@@ -143,11 +141,11 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result = arma_numpy.mat_to_numpy_X(GetParamWithInfo[mat](p, 'name'))
+     * result = mat_to_numpy_X(GetParamWithInfo[mat](p, 'name'))
      */
-    std::cout << prefix << "result = arma_numpy.mat_to_numpy_"
+    std::cout << prefix << "result = mat_to_numpy_"
         << GetNumpyTypeChar<arma::mat>()
-        << "(GetParamWithInfo[arma.Mat[double]](p, '" << d.name << "'))"
+        << "(GetParamWithInfo[Mat[double]](p, '" << d.name << "'))"
         << std::endl;
   }
   else
@@ -155,12 +153,11 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result['param_name'] =
-     *     arma_numpy.mat_to_numpy_X(GetParamWithInfo[mat](p, 'name'))
+     * result['param_name'] = mat_to_numpy_X(GetParamWithInfo[mat](p, 'name'))
      */
     std::cout << prefix << "result['" << d.name
-        << "'] = arma_numpy.mat_to_numpy_" << GetNumpyTypeChar<arma::mat>()
-        << "(GetParamWithInfo[arma.Mat[double]](p, '" << d.name << "'))"
+        << "'] = mat_to_numpy_" << GetNumpyTypeChar<arma::mat>()
+        << "(GetParamWithInfo[Mat[double]](p, '" << d.name << "'))"
         << std::endl;
   }
 }

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -73,19 +73,22 @@ void PrintPYX(const util::BindingDetails& doc,
   // First, we must generate the header comment.
 
   // Now import all the necessary packages.
-  cout << "cimport arma" << endl;
-  cout << "cimport arma_numpy" << endl;
-  cout << "from io cimport IO" << endl;
-  cout << "from params cimport Params" << endl;
-  cout << "from timers cimport Timers" << endl;
-  cout << "from io cimport SetParam, SetParamPtr, SetParamWithInfo, "
+  cout << "from .arma cimport Mat, Row, Col" << endl;
+  cout << "from .arma_numpy cimport numpy_to_mat_d, numpy_to_mat_s, "
+      << "mat_to_numpy_d, mat_to_numpy_s, numpy_to_row_d, numpy_to_row_s, "
+      << "row_to_numpy_d, row_to_numpy_s, numpy_to_col_d, numpy_to_col_s, "
+      << "col_to_numpy_d, col_to_numpy_s" << endl;
+  cout << "from .io cimport IO" << endl;
+  cout << "from .params cimport Params" << endl;
+  cout << "from .timers cimport Timers" << endl;
+  cout << "from .io cimport SetParam, SetParamPtr, SetParamWithInfo, "
       << "GetParamPtr" << endl;
-  cout << "from io cimport EnableVerbose, DisableVerbose, DisableBacktrace, "
+  cout << "from .io cimport EnableVerbose, DisableVerbose, DisableBacktrace, "
       << "ResetTimers, EnableTimers" << endl;
-  cout << "from matrix_utils import to_matrix, to_matrix_with_info" << endl;
-  cout << "from preprocess_json_params import process_params_out, "
+  cout << "from .matrix_utils import to_matrix, to_matrix_with_info" << endl;
+  cout << "from .preprocess_json_params import process_params_out, "
       << "process_params_in" << endl;
-  cout << "from serialization cimport SerializeIn, SerializeOut, "
+  cout << "from .serialization cimport SerializeIn, SerializeOut, "
       << "SerializeOutJSON, SerializeInJSON" << endl;
   cout << endl;
   cout << "import numpy as np" << endl;

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -86,7 +86,8 @@ else:
                   language='c++',
                   include_dirs=[ \
                       np.get_include(), \
-                      '${OUTPUT_DIR}/src/mlpack/bindings/python/'] +
+                      '${OUTPUT_DIR}/src/mlpack/bindings/python/',
+                      '${OUTPUT_DIR}/src/mlpack/bindings/python/mlpack/'] +
                       '${CYTHON_INCLUDE_DIRECTORIES}'.replace(' ', ';')
                                                      .replace('\;', ' ')
                                                      .split(';'),
@@ -104,7 +105,8 @@ else:
                   language='c++',
                   include_dirs=[ \
                       np.get_include(), \
-                      '${OUTPUT_DIR}/src/mlpack/bindings/python/'] +
+                      '${OUTPUT_DIR}/src/mlpack/bindings/python/',
+                      '${OUTPUT_DIR}/src/mlpack/bindings/python/mlpack/'] +
                       '${CYTHON_INCLUDE_DIRECTORIES}'.replace(' ', ';')
                                                      .replace('\;', ' ')
                                                      .split(';'),

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -86,8 +86,7 @@ else:
                   language='c++',
                   include_dirs=[ \
                       np.get_include(), \
-                      '${OUTPUT_DIR}/src/mlpack/bindings/python/',
-                      '${OUTPUT_DIR}/src/mlpack/bindings/python/mlpack/'] +
+                      '${OUTPUT_DIR}/src/mlpack/bindings/python/'] +
                       '${CYTHON_INCLUDE_DIRECTORIES}'.replace(' ', ';')
                                                      .replace('\;', ' ')
                                                      .split(';'),
@@ -105,8 +104,7 @@ else:
                   language='c++',
                   include_dirs=[ \
                       np.get_include(), \
-                      '${OUTPUT_DIR}/src/mlpack/bindings/python/',
-                      '${OUTPUT_DIR}/src/mlpack/bindings/python/mlpack/'] +
+                      '${OUTPUT_DIR}/src/mlpack/bindings/python/'] +
                       '${CYTHON_INCLUDE_DIRECTORIES}'.replace(' ', ';')
                                                      .replace('\;', ' ')
                                                      .split(';'),


### PR DESCRIPTION
This is a bugfix for https://bugzilla.redhat.com/show_bug.cgi?id=2226015.
Newer versions of Cython don't seem to properly detect all the `.pxd`s during Python binding compilation.

I am not 100% sure what the reason for this is, but in any case, adding the `mlpack/` directory specifically to the list of `include_dirs` causes Cython to correctly detect the `.pxd` files.