### PR TITLE
Add additional documentation about `data::Load()` and models

### DIFF
--- a/doc/tutorials/linear_regression.md
+++ b/doc/tutorials/linear_regression.md
@@ -388,6 +388,11 @@ LinearRegression lr;
 data::Load(filename, "lr_model", lr);
 ```
 
+Here, `"lr_model"` is the name given to the model.  The
+`mlpack_linear_regression` command-line program uses the default name `"model"`,
+so if you want to load a model in C++ that was created by the command-line
+program, be sure to use the name `"model"` when loading.
+
 ### Prediction
 
 Once you have generated or loaded a model using one of the aforementioned

--- a/doc/user/formats.md
+++ b/doc/user/formats.md
@@ -484,8 +484,9 @@ is in the `Range` class.  A more complex example is found in the
 Using the `mlpack::data::Load()` and `mlpack::data::Save()` classes is easy if
 the type being saved has a `serialize()` method implemented: simply call either
 function with a filename, a name for the object to save, and the object itself.
-The example below, for instance, creates an `Range` object and saves it as
-`range.txt`.  Then, that range is loaded from file into another `Range` object.
+The example below, for instance, creates an `Range` object and saves it
+with the name `"range"` as `range.txt`.  Then, that range is loaded from file
+into another `Range` object.
 
 ```c++
 // Create range and save it.
@@ -502,6 +503,10 @@ instance, a `LogisticRegression` object and attempt to load it as an `Range`
 object, the load will fail and an exception will be thrown.  (When the object is
 saved as binary (.bin), it is possible that the load will not fail, but instead
 load with mangled data, which is perhaps even worse!)
+
+Note that all models saved by command-line bindings are given the name
+`"model"` by default.  Use, e.g., `mlpack::data::Load("model.bin", "model", m)`
+to load a model saved by a command-line binding.
 
 ## Final Notes
 


### PR DESCRIPTION
This fixes the documentation issue pointed out in #3518.

I simply added some more discussion about what the name parameter is, both to the linear regression tutorial and to the appropriate section of the documentation on loading and saving.