### PR TITLE
Test fixes

### DIFF
--- a/src/mlpack/tests/main.cpp
+++ b/src/mlpack/tests/main.cpp
@@ -19,17 +19,24 @@
 
 int main(int argc, char** argv)
 {
-  /**
-   * Uncomment these three lines if you want to test with different random seeds
-   * each run.  This is good for ensuring that a test's tolerance is sufficient
-   * across many different runs.
-   */
-  // size_t seed = std::time(NULL);
-  // mlpack::RandomSeed(seed);
+  Catch::Session session;
+  const int returnCode = session.applyCommandLine(argc, argv);
+  // Check for a command line error.
+  if (returnCode != 0)
+    return returnCode;
 
   std::cout << "mlpack version: " << mlpack::util::GetVersion() << std::endl;
   std::cout << "armadillo version: " << arma::arma_version::as_string()
       << std::endl;
 
-  return Catch::Session().run(argc, argv);
+  // Use Catch2 command-line to set the random seed.
+  // -rng-seed <'time'|number>
+  // If a number is provided this is used directly as the seed. Alternatively
+  // if the keyword 'time' is provided then the result of calling std::time(0)
+  // is used.
+  const size_t seed = session.config().rngSeed();
+  std::cout << "random seed: " << seed << std::endl;
+  mlpack::RandomSeed(seed);
+
+  return session.run();
 }


### PR DESCRIPTION
I wanted to fix two failing tests, but I couldn't reproduce one of them, so I'm still scratching my head about what to do there.

 * I found that `PReLUIntegrationTest` was not robust and failed often.  So I changed some tolerances and allowed multiple trials.  I don't think anything is actually wrong in the implementation.
 * Like ensmallen, I added support to specify the random seed in the command-line options to `mlpack_test`.  This should make it easier to test for robustness.

This plus a few other recent PRs should go a long way towards making the builds green again.

The other test I couldn't get is a `RADICAL` test, where somehow NaNs are sneaking in.