### PR TITLE
Add mlpack/config.hpp and automatic CMake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ xcode*
 .vscode
 src/mlpack/core/util/gitversion.hpp
 src/mlpack/core/util/arma_config.hpp
-src/mlpack/config.hpp
 .idea
 cmake-build-*
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ xcode*
 .vscode
 src/mlpack/core/util/gitversion.hpp
 src/mlpack/core/util/arma_config.hpp
+src/mlpack/config.hpp
 .idea
 cmake-build-*
 *.pyc

--- a/CMake/FindStbImage.cmake
+++ b/CMake/FindStbImage.cmake
@@ -4,33 +4,44 @@
 # This module sets the following variables:
 #  STB_IMAGE_FOUND - set to true if the library is found
 #  STB_IMAGE_INCLUDE_DIR - list of required include directories
+#  STB_INCLUDE_NEEDS_STB_SUFFIX - whether or not the include files are under an
+#     stb/ directory; if "YES", then includes must be done as, e.g.,
+#     stb/stb_image.h.
 
 file(GLOB STB_IMAGE_SEARCH_PATHS
     ${CMAKE_BINARY_DIR}/deps/
     ${CMAKE_BINARY_DIR}/deps/stb)
-find_path(STB_IMAGE_INCLUDE_DIR
-    NAMES stb/stb_image.h stb/stb_image_write.h
-    PATHS ${STB_IMAGE_SEARCH_PATHS})
+find_path(STB_IMAGE_INCLUDE_DIR_1
+    NAMES stb_image.h stb_image_write.h
+    PATHS ${STB_IMAGE_SEARCH_PATHS} ${STB_IMAGE_INCLUDE_DIR})
 
-if(STB_IMAGE_INCLUDE_DIR)
+if(STB_IMAGE_INCLUDE_DIR_1)
   set(STB_IMAGE_FOUND YES)
+  set(STB_IMAGE_INCLUDE_DIR "${STB_IMAGE_INCLUDE_DIR_1}" CACHE PATH
+      "stb_image include directory")
+
+  # Either we found /usr/include/stb_image.h (or similar), or the user passed
+  # a directory in STB_IMAGE_SEARCH_PATHS that directly contains stb_image.h.
+  # In either of those cases, we want to include <stb_image.h>, not
+  # <stb/stb_image.h>.
+  set(STB_INCLUDE_NEEDS_STB_SUFFIX "NO")
 else ()
-  find_path(STB_IMAGE_INCLUDE_DIR
+  find_path(STB_IMAGE_INCLUDE_DIR_2
         NAMES stb_image.h stb_image_write.h
-        PATHS ${STB_IMAGE_SEARCH_PATHS})
+        PATHS ${STB_IMAGE_SEARCH_PATHS} ${STB_IMAGE_INCLUDE_DIR}
+        PATH_SUFFIXES stb/)
 
-  if(STB_IMAGE_INCLUDE_DIR)
+  if(STB_IMAGE_INCLUDE_DIR_2)
     set(STB_IMAGE_FOUND YES)
-  endif ()
-endif ()
+    set(STB_IMAGE_INCLUDE_DIR "${STB_IMAGE_INCLUDE_DIR_2}" CACHE PATH
+        "stb_image include directory")
 
-# Make sure that stb/ is the last part of the include directory, if it was
-# found.
-if (STB_IMAGE_INCLUDE_DIR)
-  string(REGEX MATCH ".*stb[/]?" STB_INCLUDE_HAS_TRAILING_STB
-      "${STB_IMAGE_INCLUDE_DIR}")
-  if (NOT STB_INCLUDE_HAS_TRAILING_STB)
-    set(STB_IMAGE_INCLUDE_DIR "${STB_IMAGE_INCLUDE_DIR}/stb/")
+    # Since we searched the same paths but allowed an stb/ suffix this time,
+    # then there is definitely a suffix.
+    set(STB_INCLUDE_NEEDS_STB_SUFFIX "YES")
+    # Strip the suffix.
+    string(REGEX REPLACE ".*stb[/]?$" "" STB_IMAGE_INCLUDE_DIR
+        "${STB_IMAGE_INCLUDE_DIR}")
   endif ()
 endif ()
 

--- a/CMake/TestStaticSTB.cmake
+++ b/CMake/TestStaticSTB.cmake
@@ -14,6 +14,12 @@ implementation that can be used from multiple translation units.
 
 if(NOT DEFINED CMAKE_HAS_WORKING_STATIC_STB)
   message(STATUS "Check that STB static implementation mode links correctly...")
+
+  set(TEST_CXX_DEFS "")
+  if (NOT STB_INCLUDE_NEEDS_STB_SUFFIX)
+    set(TEST_CXX_DEFS "-DMLPACK_HAS_NO_STB_DIR")
+  endif ()
+
   try_compile(CMAKE_HAS_WORKING_STATIC_STB
       ${CMAKE_BINARY_DIR}/CMakeFiles/CMakeTmp/
       SOURCES
@@ -21,12 +27,13 @@ if(NOT DEFINED CMAKE_HAS_WORKING_STATIC_STB)
         ${CMAKE_SOURCE_DIR}/CMake/stb/a.cpp
         ${CMAKE_SOURCE_DIR}/CMake/stb/b.cpp
       CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${STB_IMAGE_INCLUDE_DIR}"
+      COMPILE_DEFINITIONS "${TEST_CXX_DEFS}"
       OUTPUT_VARIABLE out)
   if (CMAKE_HAS_WORKING_STATIC_STB)
     message(STATUS "Check that STB static implementation mode links "
         "correctly... success")
     set(CMAKE_HAS_WORKING_STATIC_STB 1 CACHE INTERNAL
-	"Does STB static implementation mode link correctly")
+        "Does STB static implementation mode link correctly")
     file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
         "Determining if STB's static implementation can link correctly passed "
         "with the following output:\n${out}\n\n")

--- a/CMake/stb/a.cpp
+++ b/CMake/stb/a.cpp
@@ -6,8 +6,13 @@
 #define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 
-#include <stb_image.h>
-#include <stb_image_write.h>
+#ifdef MLPACK_HAS_NO_STB_DIR
+  #include <stb_image.h>
+  #include <stb_image_write.h>
+#else
+  #include <stb/stb_image.h>
+  #include <stb/stb_image_write.h>
+#endif
 
 void A::A()
 {

--- a/CMake/stb/b.cpp
+++ b/CMake/stb/b.cpp
@@ -6,8 +6,13 @@
 #define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 
-#include <stb_image.h>
-#include <stb_image_write.h>
+#ifdef MLPACK_HAS_NO_STB_DIR
+  #include <stb_image.h>
+  #include <stb_image_write.h>
+#else
+  #include <stb/stb_image.h>
+  #include <stb/stb_image_write.h>
+#endif
 
 void B::B()
 {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,18 +473,24 @@ endif ()
 # Modify config.hpp as necessary.
 file(READ ${CMAKE_SOURCE_DIR}/src/mlpack/config.hpp CONFIG_CONTENTS)
 if (BFD_DL_AVAILABLE)
-  string(REPLACE "// #define MLPACK_HAS_BFD_DL" "#define MLPACK_HAS_BFD_DL"
-      CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+  string(REGEX REPLACE "// #define MLPACK_HAS_BFD_DL\n"
+      "#define MLPACK_HAS_BFD_DL\n" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
 endif ()
 if (STB_AVAILABLE)
-  string(REPLACE "// #define MLPACK_HAS_STB" "#define MLPACK_HAS_STB"
-      CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+  string(REGEX REPLACE "// #define MLPACK_HAS_STB\n"
+      "#define MLPACK_HAS_STB\n" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+  if (NOT STB_INCLUDE_NEEDS_STB_SUFFIX)
+    string(REGEX REPLACE "// #define MLPACK_HAS_NO_STB_DIR\n"
+        "#define MLPACK_HAS_NO_STB_DIR\n" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+  endif ()
 endif ()
 if (USING_GIT)
-  string(REPLACE "// #define MLPACK_GIT_VERSION" "#define MLPACK_GIT_VERSION"
-      CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+  string(REGEX REPLACE "// #define MLPACK_GIT_VERSION\n"
+      "#define MLPACK_GIT_VERSION\n" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
 endif ()
-file(WRITE ${CMAKE_SOURCE_DIR}/src/mlpack/config.hpp "${CONFIG_CONTENTS}")
+file(WRITE ${CMAKE_BINARY_DIR}/include/mlpack/config-local.hpp "${CONFIG_CONTENTS}")
+include_directories(${CMAKE_BINARY_DIR}/include/)
+add_definitions(-DMLPACK_CUSTOM_CONFIG_FILE=mlpack/config-local.hpp)
 
 # Finally, add any cross-compilation support libraries (they may need to come
 # last).  If we are not cross-compiling, no changes will happen here.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,6 @@ if (DEBUG)
       set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${LIBBFD_LIBRARIES}
           ${LIBDL_LIBRARIES})
       set(BFD_DL_AVAILABLE "YES")
-      add_definitions(-DMLPACK_HAS_BFD_DL)
     else()
       message(WARNING "No libBFD and/or libDL has been found!")
     endif()
@@ -321,7 +320,6 @@ else()
 endif()
 
 if (STB_IMAGE_FOUND)
-  add_definitions(-DMLPACK_HAS_STB)
   set(STB_AVAILABLE "1")
   set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} "${STB_IMAGE_INCLUDE_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,7 @@ else()
 endif()
 
 if (STB_IMAGE_FOUND)
-  add_definitions(-DHAS_STB)
+  add_definitions(-DMLPACK_HAS_STB)
   set(STB_AVAILABLE "1")
   set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} "${STB_IMAGE_INCLUDE_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 # Debugging CFLAGS.  Turn optimizations off; turn debugging symbols on.
+set (BFD_DL_AVAILABLE "NO")
 if (DEBUG)
   if (NOT MSVC)
     add_definitions(-DDEBUG)
@@ -240,6 +241,7 @@ if (DEBUG)
           ${LIBDL_INCLUDE_DIRS})
       set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${LIBBFD_LIBRARIES}
           ${LIBDL_LIBRARIES})
+      set(BFD_DL_AVAILABLE "YES")
       add_definitions(-DMLPACK_HAS_BFD_DL)
     else()
       message(WARNING "No libBFD and/or libDL has been found!")
@@ -469,6 +471,22 @@ if (BUILD_CLI_EXECUTABLES AND UNIX)
         DESTINATION "${CMAKE_INSTALL_MANDIR}")
   endif ()
 endif ()
+
+# Modify config.hpp as necessary.
+file(READ ${CMAKE_SOURCE_DIR}/src/mlpack/config.hpp CONFIG_CONTENTS)
+if (BFD_DL_AVAILABLE)
+  string(REPLACE "// #define MLPACK_HAS_BFD_DL" "#define MLPACK_HAS_BFD_DL"
+      CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+endif ()
+if (STB_AVAILABLE)
+  string(REPLACE "// #define MLPACK_HAS_STB" "#define MLPACK_HAS_STB"
+      CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+endif ()
+if (USING_GIT)
+  string(REPLACE "// #define MLPACK_GIT_VERSION" "#define MLPACK_GIT_VERSION"
+      CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+endif ()
+file(WRITE ${CMAKE_SOURCE_DIR}/src/mlpack/config.hpp "${CONFIG_CONTENTS}")
 
 # Finally, add any cross-compilation support libraries (they may need to come
 # last).  If we are not cross-compiling, no changes will happen here.

--- a/src/mlpack/CMakeLists.txt
+++ b/src/mlpack/CMakeLists.txt
@@ -20,10 +20,15 @@ install(FILES
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/base.hpp"
+    # Note: config.hpp does not get installed from the source directory!
+    # The configured version gets installed.
     "${CMAKE_CURRENT_SOURCE_DIR}/core.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/namespace_compat.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/prereqs.hpp"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mlpack/")
+install(FILES "${CMAKE_BINARY_DIR}/include/mlpack/config-local.hpp"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mlpack"
+    RENAME "config.hpp")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/core" DESTINATION
     "${CMAKE_INSTALL_INCLUDEDIR}/mlpack")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/methods" DESTINATION

--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -44,7 +44,18 @@
 #endif
 
 // Include mlpack configuration.
-#include "config.hpp"
+#ifdef MLPACK_CUSTOM_CONFIG_FILE
+  // During the build process, CMake will generate a custom configuration file
+  // specific to the system.  When CMake is used to build mlpack, that custom
+  // file is used via the MLPACK_CUSTOM_CONFIG_FILE macro.  When mlpack is
+  // installed by CMake, the custom configuration file is installed as
+  // config.hpp, and MLPACK_CUSTOM_CONFIG_FILE is not set after installation.
+  #undef MLPACK_WRAP_INCLUDE
+  #define MLPACK_WRAP_INCLUDE(x) <x>
+  #include MLPACK_WRAP_INCLUDE(MLPACK_CUSTOM_CONFIG_FILE)
+#else
+  #include "config.hpp"
+#endif
 
 // Give ourselves a nice way to force functions to be inline if we need.
 #undef mlpack_force_inline

--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -43,17 +43,8 @@
   #define M_PI 3.141592653589793238462643383279
 #endif
 
-// MLPACK_COUT_STREAM is used to change the default stream for printing
-// purpose.
-#if !defined(MLPACK_COUT_STREAM)
- #define MLPACK_COUT_STREAM std::cout
-#endif
-
-// MLPACK_CERR_STREAM is used to change the stream for printing warnings
-// and errors.
-#if !defined(MLPACK_CERR_STREAM)
- #define MLPACK_CERR_STREAM std::cerr
-#endif
+// Include mlpack configuration.
+#include "config.hpp"
 
 // Give ourselves a nice way to force functions to be inline if we need.
 #undef mlpack_force_inline

--- a/src/mlpack/config.hpp
+++ b/src/mlpack/config.hpp
@@ -13,22 +13,56 @@
 #ifndef MLPACK_CONFIG_HPP
 #define MLPACK_CONFIG_HPP
 
+//
+// mlpack has the capability of providing backtraces when errors are encountered
+// using libbfd and libdl.  This support is only available on Linux.  If
+// MLPACK_HAS_BFD_DL is enabled, then when compiling an mlpack program with
+// debugging symbols (e.g. -DDEBUG), you must link with -lbfd and -ldl.
+//
 #ifndef MLPACK_HAS_BFD_DL
-/**
- * 
- */
 // #define MLPACK_HAS_BFD_DL
 #endif
 
+//
+// mlpack provides image loading and saving support via STB, if available.  STB
+// is an optional dependency of mlpack.  When STB is found on a system,
+// MLPACK_HAS_STB will be defined and the files `stb_image.h` and
+// `stb_image_write.h` are expected to be found in the compiler include path.
+//
 #ifndef MLPACK_HAS_STB
 // #define MLPACK_HAS_STB
 #endif
 
+//
+// If the version of mlpack is built from a git repository and is not an
+// official release, then MLPACK_GIT_VERSION will be defined.  This causes
+// mlpack::util::GetVersion() to return the git revision instead of the version
+// number.
+//
 #ifndef MLPACK_GIT_VERSION
 // #define MLPACK_GIT_VERSION
 #endif
 
-// These macros can be defined to disable support.
+//
+// MLPACK_COUT_STREAM is used to change the default stream for printing
+// non-error messages.
+//
+#if !defined(MLPACK_COUT_STREAM)
+ #define MLPACK_COUT_STREAM std::cout
+#endif
+
+//
+// MLPACK_CERR_STREAM is used to change the stream for printing warnings and
+// errors.
+//
+#if !defined(MLPACK_CERR_STREAM)
+ #define MLPACK_CERR_STREAM std::cerr
+#endif
+
+//
+// These macros can be defined to disable support that is defined above.  (This
+// is useful if you cannot or do not want to modify config.hpp.)
+//
 #ifdef MLPACK_DISABLE_STB
   #ifdef MLPACK_HAS_STB
     #undef MLPACK_HAS_STB

--- a/src/mlpack/config.hpp
+++ b/src/mlpack/config.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file config.hpp
+ *
+ * This file contains compile-time definitions that control what is supported in
+ * mlpack.  In general, this file is configured by CMake, but you can edit it if
+ * necessary.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_CONFIG_HPP
+#define MLPACK_CONFIG_HPP
+
+#ifndef MLPACK_HAS_BFD_DL
+/**
+ * 
+ */
+// #define MLPACK_HAS_BFD_DL
+#endif
+
+#ifndef MLPACK_HAS_STB
+// #define MLPACK_HAS_STB
+#endif
+
+#ifndef MLPACK_GIT_VERSION
+// #define MLPACK_GIT_VERSION
+#endif
+
+// These macros can be defined to disable support.
+#ifdef MLPACK_DISABLE_STB
+  #ifdef MLPACK_HAS_STB
+    #undef MLPACK_HAS_STB
+  #endif
+#endif
+
+#ifdef MLPACK_DISABLE_BFD_DL
+  #ifdef MLPACK_HAS_BFD_DL
+    #undef MLPACK_HAS_BFD_DL
+  #endif
+#endif
+
+#endif

--- a/src/mlpack/config.hpp
+++ b/src/mlpack/config.hpp
@@ -34,6 +34,16 @@
 #endif
 
 //
+// If STB support is available but the STB headers do not live in an stb/
+// directory, then MLPACK_HAS_NO_STB_DIR should be defined.
+//
+#ifdef MLPACK_HAS_STB
+#ifndef MLPACK_HAS_NO_STB_DIR
+// #define MLPACK_HAS_NO_STB_DIR
+#endif
+#endif
+
+//
 // If the version of mlpack is built from a git repository and is not an
 // official release, then MLPACK_GIT_VERSION will be defined.  This causes
 // mlpack::util::GetVersion() to return the git revision instead of the version
@@ -66,6 +76,12 @@
 #ifdef MLPACK_DISABLE_STB
   #ifdef MLPACK_HAS_STB
     #undef MLPACK_HAS_STB
+  #endif
+#endif
+
+#ifdef MLPACK_DISABLE_NO_STB_DIR
+  #ifdef MLPACK_HAS_NO_STB_DIR
+    #undef MLPACK_HAS_NO_STB_DIR
   #endif
 #endif
 

--- a/src/mlpack/core/data/image_info_impl.hpp
+++ b/src/mlpack/core/data/image_info_impl.hpp
@@ -30,7 +30,7 @@ inline const std::vector<std::string> SaveFileTypes()
 }
 }
 
-#ifdef HAS_STB // Compile this only if stb is present.
+#ifdef MLPACK_HAS_STB // Compile this only if stb is present.
 
 // In case it hasn't been included yet.
 #include "image_info.hpp"
@@ -65,7 +65,7 @@ inline bool ImageFormatSupported(const std::string& fileName, const bool save)
 } // namespace data
 } // namespace mlpack
 
-#endif // HAS_STB.
+#endif // MLPACK_HAS_STB.
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/load_image.hpp
+++ b/src/mlpack/core/data/load_image.hpp
@@ -15,7 +15,7 @@
 
 #include "image_info.hpp"
 
-#ifdef HAS_STB
+#ifdef MLPACK_HAS_STB
 
 // The definition of STB_IMAGE_IMPLEMENTATION means that the implementation will
 // be included here directly.
@@ -23,7 +23,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-#endif // HAS_STB
+#endif // MLPACK_HAS_STB
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/load_image.hpp
+++ b/src/mlpack/core/data/load_image.hpp
@@ -21,7 +21,11 @@
 // be included here directly.
 #define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
-#include <stb_image.h>
+#ifdef MLPACK_HAS_STB_DIR
+  #include <stb/stb_image.h>
+#else
+  #include <stb_image.h>
+#endif
 
 #endif // MLPACK_HAS_STB
 

--- a/src/mlpack/core/data/load_image_impl.hpp
+++ b/src/mlpack/core/data/load_image_impl.hpp
@@ -90,7 +90,7 @@ bool Load(const std::vector<std::string>& files,
   return true;
 }
 
-#ifdef HAS_STB
+#ifdef MLPACK_HAS_STB
 
 inline bool LoadImage(const std::string& filename,
                       arma::Mat<unsigned char>& matrix,
@@ -165,7 +165,7 @@ inline bool LoadImage(const std::string& filename,
   return true;
 }
 
-#else // HAS_STB
+#else // MLPACK_HAS_STB
 
 inline bool LoadImage(const std::string& /* filename */,
                       arma::Mat<unsigned char>& /* matrix */,

--- a/src/mlpack/core/data/save_image.hpp
+++ b/src/mlpack/core/data/save_image.hpp
@@ -14,13 +14,13 @@
 
 #include "image_info.hpp"
 
-#ifdef HAS_STB
+#ifdef MLPACK_HAS_STB
 
 #define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 
-#endif // HAS_STB
+#endif // MLPACK_HAS_STB
 
 namespace mlpack {
 namespace data {

--- a/src/mlpack/core/data/save_image.hpp
+++ b/src/mlpack/core/data/save_image.hpp
@@ -18,7 +18,11 @@
 
 #define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
-#include <stb_image_write.h>
+#ifdef MLPACK_HAS_STB_DIR
+  #include <stb/stb_image_write.h>
+#else
+  #include <stb_image_write.h>
+#endif
 
 #endif // MLPACK_HAS_STB
 

--- a/src/mlpack/core/data/save_image_impl.hpp
+++ b/src/mlpack/core/data/save_image_impl.hpp
@@ -75,7 +75,7 @@ bool Save(const std::vector<std::string>& files,
   return status;
 }
 
-#ifdef HAS_STB
+#ifdef MLPACK_HAS_STB
 
 inline bool SaveImage(const std::string& filename,
                       arma::Mat<unsigned char>& image,
@@ -166,7 +166,7 @@ inline bool SaveImage(const std::string& filename,
   return status;
 }
 
-#else // HAS_STB
+#else // MLPACK_HAS_STB
 
 inline bool SaveImage(const std::string& /* filename */,
                       arma::Mat<unsigned char>& /* image */,

--- a/src/mlpack/tests/image_load_test.cpp
+++ b/src/mlpack/tests/image_load_test.cpp
@@ -19,7 +19,7 @@ using namespace mlpack;
 using namespace mlpack::data;
 using namespace std;
 
-#ifdef HAS_STB // Compile this only if stb is present.
+#ifdef MLPACK_HAS_STB // Compile this only if stb is present.
 
 /**
  * Test if an image with an unsupported extension throws an expected
@@ -152,4 +152,4 @@ TEST_CASE("ImageInfoSerialization", "[ImageLoadTest]")
   REQUIRE(info.Quality() == binaryInfo.Quality());
 }
 
-#endif // HAS_STB.
+#endif // MLPACK_HAS_STB.

--- a/src/mlpack/tests/main_tests/image_converter_test.cpp
+++ b/src/mlpack/tests/main_tests/image_converter_test.cpp
@@ -22,7 +22,7 @@
 
 using namespace mlpack;
 
-#ifdef HAS_STB // Compile this only if stb is present.
+#ifdef MLPACK_HAS_STB // Compile this only if stb is present.
 
 BINDING_TEST_FIXTURE(ImageConverterTestFixture);
 
@@ -165,4 +165,4 @@ TEST_CASE_METHOD(ImageConverterTestFixture, "EmptyInputTest",
   REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);
 }
 
-#endif // HAS_STB.
+#endif // MLPACK_HAS_STB.


### PR DESCRIPTION
It turns out there are a couple loose ends leftover from the header-only conversion.  mlpack's old runtime library depended on a few macros that were specifically defined by CMake: `HAS_STB` and `MLPACK_GIT_VERSION`.  Those only needed to be set by CMake, because the functionality that depended on it lived only inside libmlpack.so.

However, now, that is not the case, and so these variables must be set properly for every compilation that includes mlpack.  #3514 exposed this problem.  Thus, what is necessary is a way of ensuring that system-specific defines are properly defined each time.

Inspired by Armadillo's solution of `config.hpp`, I set to work with that approach.  The general idea is that CMake modifies the "sample" `config.hpp` (in which nothing is enabled by default).  However, I did not use the approach directly.  Some technical details follow...

In Armadillo, CMake also copies all of the Armadillo header files to `tmp/include/`, and the generated `config.hpp` lives in that directory.  That actually presents a slight difficult for development, because if you modify Armadillo's sources, there is nothing to copy those updated sources to `tmp/include/`, and you have to remember to do that manually or re-run CMake, if you are hand-compiling some test program that uses, e.g., `-Itmp/include/` or something.  I wanted to avoid that situation for mlpack development---because we have so many contributors, that could be a potentially confusing pitfall.

The obvious next idea is to modify `config.hpp` directly in the source tree with CMake at configuration time.  That works, but then any `git commit -a` or similar that is done during development will pick up the changes in `config.hpp`---which should not be committed to the main repository, because the `config.hpp` in mlpack's repository should be as generic as possible (i.e. STB disabled by default, etc.).  `config.hpp` cannot be added to `.gitignore`, because it is a file that is in the repository.  I considered pre-commit and post-commit hooks to prevent `config.hpp` from being added, but concluded that in the end those approaches could present a lot of confusion to users.

The solution I ended up settling on is this:

 * CMake configures `config.hpp`, but outputs it to `build/include/mlpack/config-local.hpp`.
 * `mlpack/base.hpp`, which includes the configuration file, has support for a macro `MLPACK_CUSTOM_CONFIG_FILE`; if that is set, then instead of including `mlpack/config.hpp`, the custom file will be included.
 * Whenever CMake is building any mlpack program, binding, or test, it sets `MLPACK_CUSTOM_CONFIG_FILE=build/include/mlpack/config-local.hpp` so that the correct system-local configuration is used.
  * At install time, CMake installs `config-local.hpp` instead of the default `config.hpp`.  So the installation will have the system-local configuration.

If users want to use mlpack directly by unpacking the tarball, they can either set the configuration options manually during compilation, like one can do with Armadillo (e.g. compile with `-DMLPACK_HAS_STB`), or they can modify config.hpp themselves, or they can even use `MLPACK_CUSTOM_CONFIG_FILE` just like CMake does.

These are the configuration variables that mlpack currently automatically sets with CMake:

 * `MLPACK_HAS_BFD_DL`: this is for the backtrace support, only available on Linux when mlpack is compiled with debugging symbols.  Personally I would not be sad to see the backtrace code go, since it is relatively unused, but that's a different story.  I preserved it for now.

 * `MLPACK_HAS_STB`: this is the actual solution for #3514; the macro is renamed from `HAS_STB`.
 
 * `MLPACK_HAS_NO_STB_DIR`: this is a tricky piece.  STB is distributed on most Linux systems in a way where you typically do `#include <stb/stb_image.h>`.  But as STB is a header-only library with single-file includes, it is reasonable and somewhat expected for a user to manually download `stb_image.h` in a way where you instead would need to do `#include <stb_image.h>` (for instance, if they downloaded `stb_image.h` directly into `/usr/local/include/`).  If `MLPACK_HAS_NO_STB_DIR` is defined, `#include <stb_image.h>` will be used; if it is not defined (the default), `#include <stb/stb_image.h>` is used.  The default is chosen to match what most Linux systems will do.  I had to refactor the STB finding code to support this correctly, but I tried several combinations locally successfully (let's see what CI thinks!).
 
  * `MLPACK_GIT_VERSION`: if set, this just means that `mlpack::util::GetVersion()` will return a version indicator with the git revision, instead of an incorrect version number.  This is determined by CMake at configuration time.

I know that is a really long description.  There are still a couple tiny things to do once CI succeeds:

 - [ ] Update documentation in `README.md` to at least mention the config file briefly
 - [ ] Update `HISTORY.md`
 - [ ] Check through other build/dependency documentation to make sure it is consistent