### PR TITLE
Fix Windows Azure MSI build and loosen some test tolerances

### DIFF
--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -160,7 +160,7 @@ steps:
 
     # Build the MSI installer.
     cd dist\win-installer\mlpack-win-installer
-    & 'C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe' `
+    & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe' `
         -t:rebuild `
         -p:Configuration=Release `
         -p:TreatWarningsAsErrors=True `

--- a/src/mlpack/tests/cf_test.cpp
+++ b/src/mlpack/tests/cf_test.cpp
@@ -138,7 +138,7 @@ void GetRecommendationsQueriedUser()
  */
 template<typename DecompositionPolicy,
          typename NormalizationType = NoNormalization>
-void RecommendationAccuracy(const size_t allowedFailures = 17)
+void RecommendationAccuracy(const size_t allowedFailures = 20)
 {
   DecompositionPolicy decomposition;
 


### PR DESCRIPTION
I noticed while going to release a patch version of mlpack that Azure Pipelines is not succeeding at building the MSI installer.  I think it is just a path issue, so let's see if this fixes it.

I also loosened some tolerances for some CFTest failures I was observing (they happened about 5% of the time).  If I see more random test failures in this PR, I'll fix them too.