### PR TITLE
Float -- episode 1 

### DIFF
--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -468,7 +468,7 @@ typename MatType::elem_type FFN<
   res += EvaluateWithGradient(parameters, 0, gradient, 1);
   for (size_t i = 1; i < predictors.n_cols; ++i)
   {
-    arma::mat tmpGradient(gradient.n_rows, gradient.n_cols);
+    MatType tmpGradient(gradient.n_rows, gradient.n_cols);
     res += EvaluateWithGradient(parameters, i, tmpGradient, 1);
     gradient += tmpGradient;
   }

--- a/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm_impl.hpp
@@ -216,26 +216,26 @@ void BatchNormType<MatType>::Forward(
     // Calculate mean and variance over all channels.
     MatType mean = arma::sum(arma::sum(inputTemp, 2), 0) / m;
     variance = arma::sum(arma::sum(arma::pow(
-        inputTemp.each_slice() - arma::repmat<MatType>(mean,
+        inputTemp.each_slice() - arma::repmat(mean,
         inputSize, 1), 2), 2), 0) / m;
 
-    outputTemp.each_slice() -= arma::repmat<MatType>(mean, inputSize, 1);
+    outputTemp.each_slice() -= arma::repmat(mean, inputSize, 1);
 
     // Used in backward propagation.
     inputMean.set_size(arma::size(inputTemp));
     inputMean = outputTemp;
 
     // Normalize output.
-    outputTemp.each_slice() /= arma::sqrt(arma::repmat<MatType>(variance,
+    outputTemp.each_slice() /= arma::sqrt(arma::repmat(variance,
         inputSize, 1) + eps);
 
     // Re-used in backward propagation.
     normalized.set_size(arma::size(inputTemp));
     normalized = outputTemp;
 
-    outputTemp.each_slice() %= arma::repmat<MatType>(gamma.t(),
+    outputTemp.each_slice() %= arma::repmat(gamma.t(),
         inputSize, 1);
-    outputTemp.each_slice() += arma::repmat<MatType>(beta.t(),
+    outputTemp.each_slice() += arma::repmat(beta.t(),
         inputSize, 1);
 
     count += 1;
@@ -260,13 +260,13 @@ void BatchNormType<MatType>::Forward(
         const_cast<MatType&>(output).memptr(), inputSize, size,
         batchSize * higherDimension, false, false);
 
-    outputTemp.each_slice() -= arma::repmat<MatType>(runningMean.t(),
+    outputTemp.each_slice() -= arma::repmat(runningMean.t(),
         inputSize, 1);
-    outputTemp.each_slice() /= arma::sqrt(arma::repmat<MatType>(runningVariance.t(),
+    outputTemp.each_slice() /= arma::sqrt(arma::repmat(runningVariance.t(),
         inputSize, 1) + eps);
-    outputTemp.each_slice() %= arma::repmat<MatType>(gamma.t(),
+    outputTemp.each_slice() %= arma::repmat(gamma.t(),
         inputSize, 1);
-    outputTemp.each_slice() += arma::repmat<MatType>(beta.t(),
+    outputTemp.each_slice() += arma::repmat(beta.t(),
         inputSize, 1);
   }
 }
@@ -292,7 +292,7 @@ void BatchNormType<MatType>::Backward(
 
   // Step 1: dl / dxhat.
   arma::Cube<typename MatType::elem_type> norm =
-      gyTemp.each_slice() % arma::repmat<MatType>(gamma.t(), inputSize, 1);
+      gyTemp.each_slice() % arma::repmat(gamma.t(), inputSize, 1);
 
   // Step 2: sum dl / dxhat * (x - mu) * -0.5 * stdInv^3.
   MatType temp = arma::sum(arma::sum(norm % inputMean, 2), 0);
@@ -300,17 +300,17 @@ void BatchNormType<MatType>::Backward(
 
   // Step 3: dl / dxhat * 1 / stdInv + variance * 2 * (x - mu) / m +
   // dl / dmu * 1 / m.
-  gTemp = (norm.each_slice() % arma::repmat<MatType>(stdInv,
+  gTemp = (norm.each_slice() % arma::repmat(stdInv,
       inputSize, 1)) +
-      ((inputMean.each_slice() % arma::repmat<MatType>(vars, inputSize, 1) * 2.0) / m);
+      ((inputMean.each_slice() % arma::repmat(vars, inputSize, 1) * 2.0) / m);
 
   // Step 4: sum (dl / dxhat * -1 / stdInv) + variance *
   // sum (-2 * (x - mu)) / m.
   MatType normTemp = arma::sum(arma::sum((norm.each_slice() %
-      arma::repmat<MatType>(-stdInv, inputSize, 1)) + 
-      (inputMean.each_slice() % arma::repmat<MatType>(vars, inputSize, 1) * (-2.0) / m),
+      arma::repmat(-stdInv, inputSize, 1)) + 
+      (inputMean.each_slice() % arma::repmat(vars, inputSize, 1) * (-2.0) / m),
       2), 0) / m;
-  gTemp.each_slice() += arma::repmat<MatType>(normTemp, inputSize, 1);
+  gTemp.each_slice() += arma::repmat(normTemp, inputSize, 1);
 }
 
 template<typename MatType>

--- a/src/mlpack/methods/ann/layer/c_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/c_relu_impl.hpp
@@ -68,13 +68,14 @@ template<typename MatType>
 void CReLUType<MatType>::Forward(
     const MatType& input, MatType& output)
 {
+  typename MatType::elem_type zero = 0.0;
   #pragma omp for
   for (size_t i = 0; i < (size_t) input.n_cols; ++i)
   {
     for (size_t j = 0; j < (size_t) input.n_rows; ++j)
     {
-      output(j, i) = std::max(input(j, i), 0.0);
-      output(j + input.n_rows, i) = std::max(-input(j, i), 0.0);
+      output(j, i) = std::max(input(j, i), zero);
+      output(j + input.n_rows, i) = std::max(-input(j, i), zero);
     }
   }
 }

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -374,10 +374,10 @@ class ConvolutionType : public Layer<MatType>
   arma::Cube<typename MatType::elem_type> gradientTemp;
 
   //! Locally-stored padding layer.
-  Padding padding;
+  PaddingType<MatType> padding;
 
   //! Locally-stored padding layer for backward pass.
-  Padding paddingBackward;
+  PaddingType<MatType> paddingBackward;
 
   //! Type of padding.
   std::string paddingType;

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -573,7 +573,7 @@ void ConvolutionType<
     InitializeSamePadding();
   }
 
-  padding = Padding(padWLeft, padWRight, padHTop, padHBottom);
+  padding = PaddingType<MatType>(padWLeft, padWRight, padHTop, padHBottom);
   padding.InputDimensions() = this->inputDimensions;
   padding.ComputeOutputDimensions();
 
@@ -600,7 +600,7 @@ void ConvolutionType<
   apparentHeight = (this->outputDimensions[1] - 1) * strideHeight +
       kernelHeight;
 
-  paddingBackward = Padding(0, padding.OutputDimensions()[0] -
+  paddingBackward = PaddingType<MatType>(0, padding.OutputDimensions()[0] -
       apparentWidth, 0, padding.OutputDimensions()[1] - apparentHeight);
   paddingBackward.InputDimensions() = std::vector<size_t>({ apparentWidth,
       apparentHeight, inMaps * higherInDimensions });

--- a/src/mlpack/methods/ann/layer/grouped_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution.hpp
@@ -390,10 +390,10 @@ class GroupedConvolutionType : public Layer<MatType>
   arma::Cube<typename MatType::elem_type> gradientTemp;
 
   //! Locally-stored padding layer.
-  Padding padding;
+  PaddingType<MatType> padding;
 
   //! Locally-stored padding layer for backward pass.
-  Padding paddingBackward;
+  PaddingType<MatType> paddingBackward;
 
   //! Type of padding.
   std::string paddingType;

--- a/src/mlpack/methods/ann/layer/grouped_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution_impl.hpp
@@ -612,7 +612,7 @@ void GroupedConvolutionType<
     InitializeSamePadding();
   }
 
-  padding = Padding(padWLeft, padWRight, padHTop, padHBottom);
+  padding = PaddingType<MatType>(padWLeft, padWRight, padHTop, padHBottom);
   padding.InputDimensions() = this->inputDimensions;
   padding.ComputeOutputDimensions();
 
@@ -650,7 +650,7 @@ void GroupedConvolutionType<
   apparentHeight = (this->outputDimensions[1] - 1) * strideHeight + 
       kernelHeight;
 
-  paddingBackward = Padding(0, padding.OutputDimensions()[0] -
+  paddingBackward = PaddingType<MatType>(0, padding.OutputDimensions()[0] -
       apparentWidth, 0, padding.OutputDimensions()[1] - apparentHeight);
   paddingBackward.InputDimensions() = std::vector<size_t>({ apparentWidth,
       apparentHeight, inMaps * higherInDimensions });

--- a/src/mlpack/methods/ann/layer/leaky_relu.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu.hpp
@@ -47,7 +47,7 @@ class LeakyReLUType : public Layer<MatType>
    *
    * @param alpha Non zero gradient.
    */
-  LeakyReLUType(const double alpha = 0.03);
+  LeakyReLUType(const typename MatType::elem_type alpha = 0.03);
 
   //! Clone the LeakyReLUType object. This handles polymorphism correctly.
   LeakyReLUType* Clone() const { return new LeakyReLUType(*this); }
@@ -85,9 +85,9 @@ class LeakyReLUType : public Layer<MatType>
   void Backward(const MatType& input, const MatType& gy, MatType& g);
 
   //! Get the non zero gradient.
-  double const& Alpha() const { return alpha; }
+  typename MatType::elem_type const& Alpha() const { return alpha; }
   //! Modify the non zero gradient.
-  double& Alpha() { return alpha; }
+  typename MatType::elem_type& Alpha() { return alpha; }
 
   //! Serialize the layer.
   template<typename Archive>
@@ -95,7 +95,7 @@ class LeakyReLUType : public Layer<MatType>
 
  private:
   //! Leakyness Parameter in the range 0 <alpha< 1
-  double alpha;
+  typename MatType::elem_type alpha;
 }; // class LeakyReLUType
 
 // Convenience typedefs.

--- a/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu_impl.hpp
@@ -20,7 +20,7 @@
 namespace mlpack {
 
 template<typename MatType>
-LeakyReLUType<MatType>::LeakyReLUType(const double alpha) :
+LeakyReLUType<MatType>::LeakyReLUType(const typename MatType::elem_type alpha) :
     Layer<MatType>(),
     alpha(alpha)
 {

--- a/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling_impl.hpp
@@ -376,7 +376,7 @@ void MeanPoolingType<MatType>::Unpooling(
           rowEnd = output.n_rows - 1;
         }
 
-        arma::mat OutputArea = output(arma::span(i, rowEnd), arma::span(j, colEnd));
+        MatType OutputArea = output(arma::span(i, rowEnd), arma::span(j, colEnd));
 
         unpooledError = arma::Mat<typename MatType::elem_type>(OutputArea.n_rows, OutputArea.n_cols);
         unpooledError.fill(error(rowidx, colidx) / OutputArea.n_elem);

--- a/src/mlpack/methods/ann/layer/serialization.hpp
+++ b/src/mlpack/methods/ann/layer/serialization.hpp
@@ -76,5 +76,6 @@
     CEREAL_REGISTER_TYPE(mlpack::FTSwishType<__VA_ARGS__>); \
 
 CEREAL_REGISTER_MLPACK_LAYERS(arma::mat);
+CEREAL_REGISTER_MLPACK_LAYERS(arma::fmat);
 
 #endif

--- a/src/mlpack/methods/ann/layer/serialization.hpp
+++ b/src/mlpack/methods/ann/layer/serialization.hpp
@@ -76,6 +76,5 @@
     CEREAL_REGISTER_TYPE(mlpack::FTSwishType<__VA_ARGS__>); \
 
 CEREAL_REGISTER_MLPACK_LAYERS(arma::mat);
-CEREAL_REGISTER_MLPACK_LAYERS(arma::fmat);
 
 #endif


### PR DESCRIPTION
This PR allows to compile mnist_simple with `arma::fmat` instead of the standard `arma::mat`

@rcurtin feel free to review, I only tested mnist_simple. If necessary for the other will be a new episode of Float PRs

The duck is helpful with these complex errors, it took much less time than expected this time. 