### PR TITLE
Fix include ordering for `LinearRegression`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Fix include ordering issue for `LinearRegression` (#3541).
 
 ### mlpack 4.2.1
 ###### 2023-09-05

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -10,8 +10,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_CORE_DISTRIBUTIONS_REGRESSION_DISTRIBUTION_HPP
-#define MLPACK_CORE_DISTRIBUTIONS_REGRESSION_DISTRIBUTION_HPP
+#ifndef MLPACK_CORE_DISTS_REGRESSION_DISTRIBUTION_HPP
+#define MLPACK_CORE_DISTS_REGRESSION_DISTRIBUTION_HPP
 
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/dists/gaussian_distribution.hpp>

--- a/src/mlpack/core/dists/regression_distribution_impl.hpp
+++ b/src/mlpack/core/dists/regression_distribution_impl.hpp
@@ -10,9 +10,8 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-
-#ifndef MLPACK_CORE_DISTRIBUTIONS_REGRESSION_DISTRIBUTION_IMPL_HPP
-#define MLPACK_CORE_DISTRIBUTIONS_REGRESSION_DISTRIBUTION_IMPL_HPP
+#ifndef MLPACK_CORE_DISTS_REGRESSION_DISTRIBUTION_IMPL_HPP
+#define MLPACK_CORE_DISTS_REGRESSION_DISTRIBUTION_IMPL_HPP
 
 #include "regression_distribution.hpp"
 

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -13,7 +13,11 @@
 #ifndef MLPACK_METHODS_LINEAR_REGRESSION_LINEAR_REGRESSION_HPP
 #define MLPACK_METHODS_LINEAR_REGRESSION_LINEAR_REGRESSION_HPP
 
-#include <mlpack/core.hpp>
+// Because RegressionDistribution uses LinearRegression internally, we need to
+// make sure we define LinearRegression fully before we define
+// RegressionDistribution.  Therefore we have to include the prereqs first, and
+// include the core later.
+#include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 
@@ -167,5 +171,8 @@ class LinearRegression
 
 // Include implementation.
 #include "linear_regression_impl.hpp"
+
+// Now that LinearRegression is defined, we can include the core.
+#include <mlpack/core.hpp>
 
 #endif // MLPACK_METHODS_LINEAR_REGRESSION_HPP


### PR DESCRIPTION
In #3540 @kiner-shah pointed out that it is possible to create a circular include loop!  I was surprised by this, but the reason is that the `RegressionDistribution` class (in `src/mlpack/core/dists/`) depends on the `LinearRegression` class (in `src/mlpack/methods/`).  This is the only situation where something in `core/` includes something in `methods/`, and as a result, if you just happen to only include `linear_regression.hpp`, you get a problem.

Anyway, one solution is to have `linear_regression.hpp` only include `mlpack/prereqs.hpp` (which does not include the `dists/`), and then include `mlpack/core.hpp` after `LinearRegression` is defined.

After this PR, the following slightly more complex example compiles:

```c++
include <mlpack/methods/linear_regression.hpp>

using namespace mlpack;

int main()
{
  LinearRegression r;
}
```