### PR TITLE
Another cran fix round two

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,13 +15,15 @@
 
   * Add `ClassProbabilities()` member to `DecisionTree` so that the internal
     details of trees can be more easily inspected (#3511).
-  
+
   * Bipolar sigmoid activation function added and invertible functions 
     fixed (#3506).
 
   * Add auto-configured `mlpack/config.hpp` to contain configuration details of
     mlpack that are required at compile time.  STB detection is now done in this
     file with the `MLPACK_HAS_STB` macro (#3519).
+
+  * Fix CRAN package alias for R bindings (#3536).
 
 ### mlpack 4.2.0
 ###### 2023-06-14

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,7 +23,7 @@
     mlpack that are required at compile time.  STB detection is now done in this
     file with the `MLPACK_HAS_STB` macro (#3519).
 
-  * Fix CRAN package alias for R bindings (#3536).
+  * Fix CRAN package alias for R bindings (#3543).
 
 ### mlpack 4.2.0
 ###### 2023-06-14

--- a/src/mlpack/bindings/R/mlpack/R/package.R
+++ b/src/mlpack/bindings/R/mlpack/R/package.R
@@ -8,6 +8,7 @@
 #'
 #' @docType package
 #' @name mlpack
+#' @aliases mlpack-package
 #' @author mlpack Team
 #' @importFrom Rcpp evalCpp
 #' @useDynLib mlpack


### PR DESCRIPTION
Second attempt (see #3536)... this time on a correct branch. :)

I got another email from Kurt Hornik about something that needs to change in the R package:

```
Dear maintainer,

You have file 'mlpack/man/mlpack.Rd' with \docType{package}, likely
intended as a package overview help file, but without the appropriate
PKGNAME-package \alias as per "Documenting packages" in R-exts.

This seems to be the consequence of the breaking change

  Using @docType package no longer automatically adds a -package alias.
  Instead document _PACKAGE to get all the defaults for package
  documentation.

in roxygen2 7.0.0 (2019-11-12) having gone unnoticed, see
<https://github.com/r-lib/roxygen2/issues/1491>.

As explained in the issue, to get the desired PKGNAME-package \alias
back, you should either change to the new approach and document the new
special sentinel

  "_PACKAGE"

or manually add

  @aliases mlpack-package

if remaining with the old approach.

Please fix in your master sources as appropriate, and submit a fixed
version of your package within the next few months.

Best,
-k
```

I followed the second suggestion and just added @aliases mlpack-package. This change was made in the tarball of mlpack 4.2.1 that I submitted to CRAN, but I also wanted to get the fix in here for posterity.
