### PR TITLE
Fix L1 regularization in case where weight is zero

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 ###### ????-??-??
   * Fix include ordering issue for `LinearRegression` (#3541).
 
+  * Fix L1 regularization in case where weight is zero (#3545)
+
 ### mlpack 4.2.1
 ###### 2023-09-05
   * Reinforcement Learning: Gaussian noise (#3515).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 ###### ????-??-??
   * Fix include ordering issue for `LinearRegression` (#3541).
 
-  * Fix L1 regularization in case where weight is zero (#3545)
+  * Fix L1 regularization in case where weight is zero (#3545).
 
 ### mlpack 4.2.1
 ###### 2023-09-05

--- a/src/mlpack/methods/ann/regularizer/lregularizer_impl.hpp
+++ b/src/mlpack/methods/ann/regularizer/lregularizer_impl.hpp
@@ -37,7 +37,7 @@ template<>
 template<typename MatType>
 void LRegularizer<1>::Evaluate(const MatType& weight, MatType& gradient)
 {
-  gradient += arma::vectorise(factor * weight / arma::abs(weight));
+  gradient += arma::vectorise(factor * arma::sign(weight));
 }
 
 // L2-Regularizer specializations.


### PR DESCRIPTION
In the case where there was a 0 in the weights, the L1Regularizer would produce a nonfinite value in the gradient due to a divide-by-zero.  This code was just attempting to implement the "sign" function, so replaced it with that.