### PR TITLE
Fix `numClasses` member in `SoftmaxRegression::Train()`

### DIFF
--- a/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
@@ -190,6 +190,7 @@ double SoftmaxRegression::Train(const arma::mat& data,
 
   // Train the model.
   const double out = optimizer.Optimize(regressor, parameters);
+  this->numClasses = numClasses;
 
   Log::Info << "SoftmaxRegression::SoftmaxRegression(): final objective of "
             << "trained model is " << out << "." << std::endl;
@@ -211,6 +212,7 @@ double SoftmaxRegression::Train(const arma::mat& data,
 
   // Train the model.
   const double out = optimizer.Optimize(regressor, parameters, callbacks...);
+  this->numClasses = numClasses;
 
   Log::Info << "SoftmaxRegression::SoftmaxRegression(): final objective of "
             << "trained model is " << out << "." << std::endl;

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -672,3 +672,32 @@ TEST_CASE("SoftmaxRegressionComputeProbabilitiesAndLabelsTest",
     REQUIRE(testLabels(i) == labels(i));
   }
 }
+
+TEST_CASE("SoftmaxImmediateTrainTest", "[SoftmaxRegressionTest]")
+{
+  // Initialize a random dataset.
+  const size_t numClasses = 3;
+  const size_t inputSize = 10;
+  const size_t points = 500;
+  arma::mat data;
+  data.randu(inputSize, points);
+
+  // Create random class labels.
+  arma::Row<size_t> labels(points);
+  for (size_t i = 0; i < points; ++i)
+    labels(i) = RandInt(0, numClasses);
+
+  // Train without setting any parameters to the constructor.
+  SoftmaxRegression sr;
+  sr.Train(data, labels, numClasses);
+
+  // Now classify some points.
+  // This just makes sure that the model can successfully make predictions at
+  // all (i.e. no exception thrown).
+  arma::Row<size_t> predictions;
+  sr.Classify(data, predictions);
+
+  REQUIRE(predictions.n_elem == labels.n_elem);
+  REQUIRE(arma::all(predictions >= 0));
+  REQUIRE(arma::all(predictions <= 2));
+}


### PR DESCRIPTION
While using softmax regression for some experiments, I found that if I called `Train()` directly, instead of passing anything in the constructor, that subsequent calls to `Classify()` would fail.  The reason is that the `numClasses` member is not actually set in `Train()`, so I fixed that, and added a test that would have failed without the changes here, but now, it succeeds. :)