### PR TITLE
Remove other uses of /Zc:__cplusplus in the documentation.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@
 
   * Use HTTPS for all auto-downloaded dependencies (#3550).
 
-  * More robust detection of C++17 mode in the MSVC "compiler" (#3555).
+  * More robust detection of C++17 mode in the MSVC "compiler" (#3555, #3557).
 
 ### mlpack 4.2.1
 ###### 2023-09-05

--- a/doc/examples/sample-ml-app/sample-ml-app/sample-ml-app.vcxproj
+++ b/doc/examples/sample-ml-app/sample-ml-app/sample-ml-app.vcxproj
@@ -107,7 +107,7 @@
       <AdditionalIncludeDirectories>C:\mlpack\armadillo-11.4.1\include;C:\mlpack\mlpack-4.2.1\include\;C:\mlpack\cereal-1.3.2\include;C:\mlpack\ensmallen-2.19.0\include\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <OpenMPSupport>false</OpenMPSupport>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/doc/user/build_windows.md
+++ b/doc/user/build_windows.md
@@ -36,8 +36,8 @@ an existing one). The library is immediately ready to be included
 (via preprocessor directives) and used in your project without additional
 configuration.
 
-Note that when building mlpack, the `/std:c++17` and `/Zc:__cplusplus` options
-are required for Visual Studio.
+Note that when building mlpack, the `/std:c++17` option is required for Visual
+Studio.
 
 ## Build Environment
 

--- a/doc/user/sample_ml_app.md
+++ b/doc/user/sample_ml_app.md
@@ -43,10 +43,10 @@ this issue, disable "Conformance Mode" under C/C++ > Language.
 *Note*: you may need to change the paths of the include directories or libraries
 above, given how you installed the dependencies.
 
-*Note*: mlpack requires that the `/std:c++17` and `/Zc:__cplusplus` options be
-set for the Visual Studio compiler.  This is done by default in the provided
-example, but for your own projects, make sure that these options are set,
-otherwise compilation will fail.
+*Note*: mlpack requires that the `/std:c++17` option be set for the Visual
+Studio compiler.  This is done by default in the provided example, but for your
+own projects, make sure that these options are set, otherwise compilation will
+fail.
 
 ## The App's Goal
 


### PR DESCRIPTION
This is just a follow-up to #3555, since that option is no longer required for MSVC.