### PR TITLE
Updating preprocess_split_main_cpp #3556

### DIFF
--- a/src/mlpack/methods/preprocess/preprocess_split_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_split_main.cpp
@@ -163,16 +163,8 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     Log::Info << "Test data contains "
         << get<1>(value).n_cols << " points." << endl;
 
-    if (params.Has("training"))
-      params.Get<arma::mat>("training") = std::move(get<0>(value));
-    if (params.Has("test"))
-      params.Get<arma::mat>("test") = std::move(get<1>(value));
-    if (params.Has("training_labels"))
-      params.Get<arma::Mat<size_t>>("training_labels") =
-          std::move(get<2>(value));
-    if (params.Has("test_labels"))
-      params.Get<arma::Mat<size_t>>("test_labels") =
-          std::move(get<3>(value));
+    return std::move(get<0>(value)), std::move(get<1>(value)),
+           std::move(get<2>(value)), std::move(get<3>(value));
   }
   else // We have no labels, so just split the dataset.
   {
@@ -185,9 +177,6 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     Log::Info << "Test data contains " << get<1>(value).n_cols << " points."
         << endl;
 
-    if (params.Has("training"))
-      params.Get<arma::mat>("training") = std::move(get<0>(value));
-    if (params.Has("test"))
-      params.Get<arma::mat>("test") = std::move(get<1>(value));
+    return std::move(get<0>(value)), std::move(get<1>(value));
   }
 }


### PR DESCRIPTION
Related to the issue: #3556 
`output = preprocess_split(input_=dataset, input_labels=labels, test_ratio=0.2)`
Now the output will be a dictionary. output['test'], output['test_labels'], output['training'], and output['training_labels'] will give us a numpy matrix of test data, test labels, train data, and train labels respectively. Now, the updates are being done such that,
X_test, y_test, X_train, y_train = preprocess_split(input_=dataset, input_labels=labels, test_ratio=0.2), where X_test, y_test, X_train, y_train are the numpy matrix of test data, test labels, train data, and train labels respectively.