### PR TITLE
Fix call to preprocess_split() in generated documentation.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,10 @@
 ### mlpack ?.?.?
 ###### ????-??-??
+  * Fix `preprocess_split()` call in documentation for `LinearRegression` and
+    `AdaBoost` Python classes (#3563).
 
 ### mlpack 4.3.0
-###### 2023-11-22
+###### 2023-11-27
   * Fix include ordering issue for `LinearRegression` (#3541).
 
   * Fix L1 regularization in case where weight is zero (#3545).
@@ -19,9 +21,6 @@
 
   * Fix inconsistent use of the "input" parameter to the Backward method in ANNs
     (#3551).
-
-  * Fix `preprocess_split()` call in documentation for `LinearRegression` and
-    `AdaBoost` Python classes (#3563).
 
 ### mlpack 4.2.1
 ###### 2023-09-05

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,9 @@
   * Fix inconsistent use of the "input" parameter to the Backward method in ANNs
     (#3551).
 
+  * Fix `preprocess_split()` call in documentation for `LinearRegression` and
+    `AdaBoost` Python classes (#3563).
+
 ### mlpack 4.2.1
 ###### 2023-09-05
   * Reinforcement Learning: Gaussian noise (#3515).

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -413,12 +413,13 @@ inline std::string SplitTrainTest(const std::string& datasetName,
                                   const std::string& testLabels,
                                   const std::string& splitRatio)
 {
-  std::string splitString = ">>> ";
-  splitString += testDataset + ", " + testLabels + ", ";
-  splitString += trainDataset + ", " + trainLabels;
-  splitString += " = ";
-  splitString += "preprocess_split(input_=" + datasetName + ", input_labels=";
-  splitString += labelName + ", test_ratio=" + splitRatio + ")";
+  std::string splitString;
+  splitString += ">>> d = preprocess_split(input_=" + datasetName + ", input_labels=";
+  splitString += labelName + ", test_ratio=" + splitRatio + ")\n";
+  splitString += ">>> " + trainDataset + " = d['training']\n";
+  splitString += ">>> " + trainLabels + " = d['training_labels']\n";
+  splitString += ">>> " + testDataset + " = d['test']\n";
+  splitString += ">>> " + testLabels + " = d['test_labels']";
   return splitString;
 }
 

--- a/src/mlpack/methods/linear_regression/linear_regression_train_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_train_main.cpp
@@ -46,14 +46,14 @@ BINDING_EXAMPLE(
     GET_DATASET("X", "https://example.com") + "\n" +
     GET_DATASET("y", "https://example.com") + "\n" +
     SPLIT_TRAIN_TEST("X", "y", "X_train", "y_train", "X_test", "y_test", 
-    "0.2") + "\n" +
-    CREATE_OBJECT("model", "linear_regression") + "\n" +
-    CALL_METHOD("model", "train", "training", "X_train",
-        "training_responses", "y_train"));
+        "0.2") + "\n" +
+    CREATE_OBJECT("lr", "linear_regression") + "\n" +
+    CALL_METHOD("lr", "train", "training", "X_train", "training_responses",
+        "y_train"));
 
 // See also...
 BINDING_SEE_ALSO("Linear/ridge regression tutorial",
-       "@doc/tutorials/linear_regression.md");
+    "@doc/tutorials/linear_regression.md");
 
 PARAM_MATRIX_IN_REQ("training", "Matrix containing training set X (regressors).",
     "t");


### PR DESCRIPTION
This is a fix for #3556, in the Python bindings.  The generated documentation would print a line like

```py
X_test, y_test, X_train, y_train = preprocess_split(input_=X, input_labels=y)
```

but `preprocess_split()` returns a Python dict with several members.  Instead, this is what's necessary to get the training/test datasets:

```py
d = preprocessd_split(input_=X, input_labels=y)
X_train = d['training']
y_train = d['training_labels']
X_test = d['test']
y_test = d['test_labels']
```

These changes update the function that prints this documentation to use the second version.  I tested that the generated code runs successfully.