### PR TITLE
Add include files and configured pkgconfig file to Python distribution

### DIFF
--- a/CMake/ConfigureFileOnly.cmake
+++ b/CMake/ConfigureFileOnly.cmake
@@ -1,0 +1,11 @@
+# ConfigureFileOnly.cmake: generate an mlpack binding file given input
+# arguments, using the @ONLY option.
+#
+# This file depends on the following variables being set:
+#
+#  * GENERATE_CPP_IN: the .cpp.in file to configure.
+#  * GENERATE_CPP_OUT: the .cpp file we'll generate.
+#
+# Any other defined variables will be passed on to the file that is being
+# generated.
+configure_file(${GENERATE_CPP_IN} ${GENERATE_CPP_OUT} @ONLY)

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -158,6 +158,23 @@ add_custom_command(TARGET python_copy PRE_BUILD
         ${CMAKE_CURRENT_SOURCE_DIR}/setup_readme.md
         ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/)
 
+# Copy all mlpack headers for inclusion in the package.
+add_custom_command(TARGET python_copy PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory
+        ${CMAKE_SOURCE_DIR}/src/
+        ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/include/)
+
+# Generate pkgconfig file for easy use of included headers.
+add_custom_target(python_pkgconfig
+    COMMAND ${CMAKE_COMMAND}
+        -D GENERATE_CPP_IN=${CMAKE_SOURCE_DIR}/src/mlpack/bindings/python/mlpack.pc.in
+        -D GENERATE_CPP_OUT=${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/share/pkgconfig/mlpack.pc
+        -D PACKAGE_VERSION="${PACKAGE_VERSION}"
+        -P "${CMAKE_SOURCE_DIR}/CMake/ConfigureFileOnly.cmake"
+        BYPRODUCTS "${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/share/pkgconfig/mlpack.pc"
+        COMMENT "Configuring Python mlpack.pc...")
+add_dependencies(python_copy python_pkgconfig)
+
 if (BUILD_TESTS)
   foreach(test_file ${TEST_SOURCES})
     add_custom_command(TARGET python_copy PRE_BUILD

--- a/src/mlpack/bindings/python/mlpack.pc.in
+++ b/src/mlpack/bindings/python/mlpack.pc.in
@@ -1,0 +1,7 @@
+prefix=${pcfiledir}/../../
+includedir=${prefix}/include
+
+Name: mlpack
+Description: a flexible, fast machine learning library
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}

--- a/src/mlpack/bindings/python/setup.py.in
+++ b/src/mlpack/bindings/python/setup.py.in
@@ -116,6 +116,12 @@ else:
                       else '${DISABLE_CFLAGS}'.split(' ')) \
         for name in pyxs]
 
+# Find all include files.
+include_files = []
+for (path, directories, filenames) in os.walk('mlpack/include/'):
+  for filename in filenames:
+    include_files.append(os.path.join('..', path, filename))
+
 setup(name='mlpack',
       version='${PACKAGE_VERSION}',
       description='a flexible, fast machine learning library',
@@ -141,6 +147,8 @@ setup(name='mlpack',
       install_requires=['cython>=0.24', 'numpy', 'pandas'],
       package_dir={ '': '.' }, # Might be superfluous.
       packages=['mlpack'],
+      package_data={ 'mlpack': include_files + ['../mlpack/share/pkgconfig/mlpack.pc'] },
+      include_package_data=True,
       cmdclass={ 'build_ext': build_ext },
       ext_modules = modules,
       setup_requires=['cython', 'pytest-runner'],


### PR DESCRIPTION
This addresses #3544: with these changes, all of the mlpack headers and also a configured `mlpack.pc` (for pkgconfig) is distributed with the mlpack Python package.  Like [pybind11](https://github.com/pybind/pybind11), the headers are packaged in `mlpack/include/` and the pkgconfig file in `mlpack/share/pkgconfig/`.

I needed to add a version of `ConfigureFile.cmake` that included the `@ONLY` option for `configure_file()`, so that `mlpack.pc.in` and its use of bash variables did not get overwritten by CMake configuration.