### PR TITLE
Fix python test duplicate filename error

### DIFF
--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -158,11 +158,16 @@ add_custom_command(TARGET python_copy PRE_BUILD
         ${CMAKE_CURRENT_SOURCE_DIR}/setup_readme.md
         ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/)
 
-# Copy all mlpack headers for inclusion in the package.
+# Copy all mlpack headers for inclusion in the package, but remove the bindings/
+# and tests/ directories as they should not be included.
 add_custom_command(TARGET python_copy PRE_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory
         ${CMAKE_SOURCE_DIR}/src/
         ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/include/)
+add_custom_command(TARGET python_copy PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} ARGS -E rm -r
+        ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/include/mlpack/bindings/
+        ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/include/mlpack/tests/)
 
 # Generate pkgconfig file for easy use of included headers.
 add_custom_target(python_pkgconfig


### PR DESCRIPTION
This fixes the failing Python tests in #3565, #3578, and #3564 (and other builds).  The error comes from #3579, where I mistakenly merged the PR even though some tests were failing.  Oops...

The actual failure being fixed is this:

```
_________________ ERROR collecting tests/dataset_info_test.py __________________
import file mismatch:
imported module 'dataset_info_test' has this __file__ attribute:
  /home/vsts/work/1/s/build/src/mlpack/bindings/python/mlpack/include/mlpack/bindings/python/tests/dataset_info_test.py
which is not the same as the test file we want to collect:
  /home/vsts/work/1/s/build/src/mlpack/bindings/python/tests/dataset_info_test.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
```

which is a result of the Python bindings tests existing multiple times in the Python package, because we simply copy the `mlpack/` directory (including `mlpack/bindings/`) to the Python package root.

The fix is just to remove `mlpack/bindings/` and `mlpack/tests/`, since those aren't a part of the mlpack headers that were meant to be included in #3579.