### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,76 +24,76 @@ jobs:
       r_bindings: ${{ steps.mlpack_version.outputs.mlpack_r_package }}
 
     steps:
-        - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-        - name: Extract mlpack version
-          id: mlpack_version
-          run: |
-            MLPACK_VERSION_MAJOR=$(grep -i ".*#define MLPACK_VERSION_MAJOR.*" src/mlpack/core/util/version.hpp | grep -o "[0-9]*")
-            MLPACK_VERSION_MINOR=$(grep -i ".*#define MLPACK_VERSION_MINOR.*" src/mlpack/core/util/version.hpp | grep -o "[0-9]*")
-            MLPACK_VERSION_PATCH=$(grep -i ".*#define MLPACK_VERSION_PATCH.*" src/mlpack/core/util/version.hpp | grep -o "[0-9]*")
-            MLPACK_VERSION_VALUE=${MLPACK_VERSION_MAJOR}.${MLPACK_VERSION_MINOR}.${MLPACK_VERSION_PATCH}
-            echo ::set-output name=mlpack_r_package::$(echo mlpack_"$MLPACK_VERSION_VALUE".tar.gz)
+      - name: Extract mlpack version
+        id: mlpack_version
+        run: |
+          MLPACK_VERSION_MAJOR=$(grep -i ".*#define MLPACK_VERSION_MAJOR.*" src/mlpack/core/util/version.hpp | grep -o "[0-9]*")
+          MLPACK_VERSION_MINOR=$(grep -i ".*#define MLPACK_VERSION_MINOR.*" src/mlpack/core/util/version.hpp | grep -o "[0-9]*")
+          MLPACK_VERSION_PATCH=$(grep -i ".*#define MLPACK_VERSION_PATCH.*" src/mlpack/core/util/version.hpp | grep -o "[0-9]*")
+          MLPACK_VERSION_VALUE=${MLPACK_VERSION_MAJOR}.${MLPACK_VERSION_MINOR}.${MLPACK_VERSION_PATCH}
+          echo "mlpack_r_package=$(echo mlpack_"$MLPACK_VERSION_VALUE".tar.gz)" >> $GITHUB_OUTPUT
 
-        # Setup Pandoc 
-        - uses: r-lib/actions/setup-pandoc@v2
+      # Setup Pandoc
+      - uses: r-lib/actions/setup-pandoc@v2
 
-        # Setup R actions
-        - uses: r-lib/actions/setup-r@v2
+      # Setup R actions
+      - uses: r-lib/actions/setup-r@v2
 
-        - name: Query dependencies
-          run: |
-            cp src/mlpack/bindings/R/mlpack/DESCRIPTION.in DESCRIPTION
-            Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps(dependencies = TRUE), 'depends.Rds')"
+      - name: Query dependencies
+        run: |
+          cp src/mlpack/bindings/R/mlpack/DESCRIPTION.in DESCRIPTION
+          Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps(dependencies = TRUE), 'depends.Rds')"
 
-        - name: Cache R packages
-          if: runner.os != 'Windows' && runner.os != 'macOS'
-          uses: actions/cache@v3
-          with:
-            path: ${{ env.R_LIBS_USER }}
-            key: ${{ runner.os }}-r-release-${{ hashFiles('depends.Rds') }}
-            restore-keys: ${{ runner.os }}-r-release-
+      - name: Cache R packages
+        if: runner.os != 'Windows' && runner.os != 'macOS'
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-release-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ runner.os }}-r-release-
 
-        - name: Install Build Dependencies
-          run: |
-            sudo apt-get update
-            # We don't install cereal via apt, because the Debian packagers
-            # split the rapidjson dependency into a separate package.  We will
-            # bundle the cereal sources with the R package, so we want them to
-            # be exactly the upstream sources (with rapidjson included).
-            sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libensmallen-dev libhdf5-dev libarmadillo-dev libcurl4-openssl-dev
-            wget https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz
-            tar -xvzpf v1.3.2.tar.gz
-            # These directives cause warnings on CRAN:
-            # https://github.com/USCiLab/cereal/blob/master/include/cereal/external/base64.hpp#L28-L31
-            # The command below comments them out.
-            sed -i 's|#pragma|// #pragma|' cereal-1.3.2/include/cereal/external/base64.hpp
+      - name: Install Build Dependencies
+        run: |
+          sudo apt-get update
+          # We don't install cereal via apt, because the Debian packagers
+          # split the rapidjson dependency into a separate package.  We will
+          # bundle the cereal sources with the R package, so we want them to
+          # be exactly the upstream sources (with rapidjson included).
+          sudo apt-get install -y --allow-unauthenticated libopenblas-dev liblapack-dev g++ libensmallen-dev libhdf5-dev libarmadillo-dev libcurl4-openssl-dev
+          wget https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz
+          tar -xvzpf v1.3.2.tar.gz
+          # These directives cause warnings on CRAN:
+          # https://github.com/USCiLab/cereal/blob/master/include/cereal/external/base64.hpp#L28-L31
+          # The command below comments them out.
+          sed -i 's|#pragma|// #pragma|' cereal-1.3.2/include/cereal/external/base64.hpp
 
-        - name: Install R-bindings dependencies
-          run: |
-            remotes::install_deps(dependencies = TRUE)
-            remotes::install_cran("roxygen2")
-            remotes::install_cran("pkgbuild")
-          shell: Rscript {0}
+      - name: Install R-bindings dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("roxygen2")
+          remotes::install_cran("pkgbuild")
+        shell: Rscript {0}
 
-        - name: CMake
-          run: |
-            mkdir build
-            cd build && cmake -DDEBUG=OFF -DPROFILE=OFF -DBUILD_CLI_EXECUTABLES=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=ON -DDOWNLOAD_DEPENDENCIES=ON -DBUILD_TESTS=ON -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/ ..
+      - name: CMake
+        run: |
+          mkdir build
+          cd build && cmake -DDEBUG=OFF -DPROFILE=OFF -DBUILD_CLI_EXECUTABLES=OFF -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_JULIA_BINDINGS=OFF -DBUILD_GO_BINDINGS=OFF -DBUILD_R_BINDINGS=ON -DDOWNLOAD_DEPENDENCIES=ON -DBUILD_TESTS=ON -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/ ..
 
-        - name: Build
-          run: |
-            cd build && make
+      - name: Build
+        run: |
+          cd build && make
 
-        - name: Run tests via ctest
-          run: |
-            cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+      - name: Run tests via ctest
+        run: |
+          cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
 
-        - name: Upload R packages
-          uses: actions/upload-artifact@v3
-          with:
-              name: mlpack_r_tarball
-              path: build/src/mlpack/bindings/R/${{ steps.mlpack_version.outputs.mlpack_r_package }}
+      - name: Upload R packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: mlpack_r_tarball
+          path: build/src/mlpack/bindings/R/${{ steps.mlpack_version.outputs.mlpack_r_package }}
 
   R-CMD-check:
     needs: jobR
@@ -106,9 +106,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {os: windows-latest, r: 'release', name: 'Windows R'}
-        - {os: macOS-latest, r: 'release', name: 'macOS R'}
-        - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release', name: 'Linux R'}
+          - { os: windows-latest, r: "release", name: "Windows R" }
+          - { os: macOS-latest, r: "release", name: "macOS R" }
+          - {
+              os: ubuntu-latest,
+              r: "devel",
+              http-user-agent: "release",
+              name: "Linux R",
+            }
 
     env:
       MAKEFLAGS: "-j 2"
@@ -146,8 +151,8 @@ jobs:
       - name: Install check dependencies
         if: runner.os != 'Windows' && runner.os != 'macOS'
         run: |
-            sudo apt-get update
-            sudo apt-get install -y --allow-unauthenticated libcurl4-openssl-dev
+          sudo apt-get update
+          sudo apt-get install -y --allow-unauthenticated libcurl4-openssl-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update-catch.yaml
+++ b/.github/workflows/update-catch.yaml
@@ -6,7 +6,7 @@ name: Update Catch
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 10 1/16 * *'
+    - cron: "0 10 1/16 * *"
 permissions:
   contents: read
 
@@ -16,7 +16,7 @@ jobs:
       contents: write # for peter-evans/create-pull-request to create branch
       pull-requests: write # for peter-evans/create-pull-request to create a PR
     if: ${{ false }}
-#    if: ${{ github.repository == 'mlpack/mlpack' }}
+    #    if: ${{ github.repository == 'mlpack/mlpack' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
           # Ping version information upstream.
           CATCH_RELEASE_JSON=$(curl -sL https://api.github.com/repos/catchorg/Catch2/releases/latest)
           CATCH_RELEASE_VERSION=$(jq -r ".tag_name" <<< "$CATCH_RELEASE_JSON" | tr -d v)
-          echo ::set-output name=release_tag::$(echo $CATCH_RELEASE_VERSION)
+          echo "release_tag=$(echo $CATCH_RELEASE_VERSION)" >> $GITHUB_OUTPUT
           # Extract out version information from git repository.
           CATCH_VERSION_MAJOR=$(grep -i ".*#define CATCH_VERSION_MAJOR.*" src/mlpack/tests/catch.hpp | grep -o "[0-9]*")
           CATCH_VERSION_MINOR=$(grep -i ".*#define CATCH_VERSION_MINOR.*" src/mlpack/tests/catch.hpp | grep -o "[0-9]*")
@@ -34,7 +34,7 @@ jobs:
           # Combine values to match release tag information.
           CATCH_VERSION_VALUE=${CATCH_VERSION_MAJOR}.${CATCH_VERSION_MINOR}.${CATCH_VERSION_PATCH}
           # Set the current release tag.
-          echo ::set-output name=current_tag::$(echo $CATCH_VERSION_VALUE)
+          echo "current_tag=$(echo $CATCH_VERSION_VALUE)" >> $GITHUB_OUTPUT
 
       - name: Update Catch
         if: steps.catch-header.outputs.current_tag != steps.catch-header.outputs.release_tag

--- a/.github/workflows/update-cli11.yaml
+++ b/.github/workflows/update-cli11.yaml
@@ -2,15 +2,15 @@ name: Update CLI11
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 10 1/16 * *'
+    - cron: "0 10 1/16 * *"
 permissions:
   contents: read
 
 jobs:
   updateCLI11:
     permissions:
-      contents: write  # for peter-evans/create-pull-request to create branch
-      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+      contents: write # for peter-evans/create-pull-request to create branch
+      pull-requests: write # for peter-evans/create-pull-request to create a PR
     if: ${{ github.repository == 'mlpack/mlpack' }}
     runs-on: ubuntu-latest
     steps:
@@ -21,11 +21,11 @@ jobs:
           # Ping version information upstream.
           CLI11_RELEASE_JSON=$(curl -sL https://api.github.com/repos/CLIUtils/CLI11/releases/latest)
           CLI11_RELEASE_VERSION=$(jq -r ".tag_name" <<< "$CLI11_RELEASE_JSON" | tr -d v)
-          echo ::set-output name=release_tag::$(echo $CLI11_RELEASE_VERSION)
+          echo "release_tag=$(echo $CLI11_RELEASE_VERSION)" >> $GITHUB_OUTPUT
           # Extract out version information from git repository.
           CLI11_VERSION_VALUE=$(grep -i ".*#define CLI11_VERSION.*" src/mlpack/bindings/cli/third_party/CLI/CLI11.hpp | grep -Po "(\d+\.)+\d+")
           # Set the current release tag.
-          echo ::set-output name=current_tag::$(echo $CLI11_VERSION_VALUE)
+          echo "current_tag=$(echo $CLI11_VERSION_VALUE)" >> $GITHUB_OUTPUT
 
       - name: Update CLI11
         if: steps.cli11-header.outputs.current_tag != steps.cli11-header.outputs.release_tag


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

