### PR TITLE
Reduce random failures for DecisionTreeRegressor tests

### DIFF
--- a/src/mlpack/tests/decision_tree_regressor_test.cpp
+++ b/src/mlpack/tests/decision_tree_regressor_test.cpp
@@ -924,84 +924,61 @@ TEST_CASE("CategoricalMADGainWeightedBuildTest", "[DecisionTreeRegressorTest]")
 
   // Make sure we get reasonable rmse.
   const double rmse = RMSE(predictions, testResponses);
-  REQUIRE(rmse < 1.05);
-}
-
-/**
- * Test that the decision tree generalizes reasonably.
- */
-TEST_CASE("SimpleGeneralizationTest_", "[DecisionTreeRegressorTest]")
-{
-  // Loading data.
-  data::DatasetInfo info;
-  arma::mat trainData, testData;
-  arma::rowvec trainResponses, testResponses;
-  LoadBostonHousingDataset(trainData, testData, trainResponses, testResponses,
-      info);
-  arma::rowvec weights = arma::ones<arma::rowvec>(trainResponses.n_elem);
-
-  // Build decision tree.
-  DecisionTreeRegressor<> d(trainData, info, trainResponses);
-  DecisionTreeRegressor<> wd(trainData, info, trainResponses, weights);
-
-  // Get the predicted test responses.
-  arma::rowvec predictions;
-  d.Predict(testData, predictions);
-
-  REQUIRE(predictions.n_elem == testData.n_cols);
-
-  // Figure out rmse.
-  double rmse = RMSE(predictions, testResponses);
-  REQUIRE(rmse < 6.1);
-
-  // Reset the predictions.
-  predictions.zeros();
-  wd.Predict(testData, predictions);
-
-  REQUIRE(predictions.n_elem == testData.n_cols);
-
-  // Figure out rmse.
-  rmse = RMSE(predictions, testResponses);
-  REQUIRE(rmse < 6.1);
+  REQUIRE(rmse < 1.25);
 }
 
 /**
  * Test that the decision tree generalizes reasonably when built on float data.
  */
-TEST_CASE("SimpleGeneralizationFMatTest_", "[DecisionTreeRegressorTest]")
+TEMPLATE_TEST_CASE("SimpleGeneralizationTest_",
+    "[DecisionTreeRegressorTest]", float, double)
 {
-  // Loading data.
-  data::DatasetInfo info;
-  arma::fmat trainData, testData;
-  arma::rowvec trainLabels, testLabels;
-  LoadBostonHousingDataset(trainData, testData, trainLabels, testLabels, info);
+  typedef TestType ElemType;
 
-  // Initialize an all-ones weight matrix.
-  arma::rowvec weights(trainLabels.n_cols, arma::fill::ones);
+  // Allow three trials.
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    // Loading data.
+    data::DatasetInfo info;
+    arma::Mat<ElemType> trainData, testData;
+    arma::Row<ElemType> trainResponses, testResponses;
+    LoadBostonHousingDataset(trainData, testData, trainResponses, testResponses,
+        info);
 
-  // Build decision tree.
-  DecisionTreeRegressor<> d(trainData, trainLabels);
-  DecisionTreeRegressor<> wd(trainData, trainLabels, weights);
+    // Initialize an all-ones weight matrix.
+    arma::rowvec weights(trainResponses.n_cols, arma::fill::ones);
 
-  // Get the predicted test labels.
-  arma::rowvec predictions;
-  d.Predict(testData, predictions);
+    // Build decision tree.
+    DecisionTreeRegressor<> d(trainData, trainResponses);
+    DecisionTreeRegressor<> wd(trainData, trainResponses, weights);
 
-  REQUIRE(predictions.n_elem == testData.n_cols);
+    // Get the predicted test labels.
+    arma::Row<ElemType> predictions;
+    d.Predict(testData, predictions);
 
-  // Figure out the rmse.
-  double rmse = RMSE(predictions, testLabels);
-  REQUIRE(rmse < 6.0);
+    REQUIRE(predictions.n_elem == testData.n_cols);
 
-  // Reset the prediction.
-  predictions.zeros();
-  wd.Predict(testData, predictions);
+    // Figure out the rmse.
+    ElemType rmse = RMSE(predictions, testResponses);
 
-  REQUIRE(predictions.n_elem == testData.n_cols);
+    // Reset the prediction.
+    predictions.zeros();
+    wd.Predict(testData, predictions);
 
-  // Figure out the rmse.
-  double wdrmse = RMSE(predictions, testLabels);
-  REQUIRE(wdrmse < 6.0);
+    REQUIRE(predictions.n_elem == testData.n_cols);
+
+    // Figure out the rmse.
+    ElemType wdrmse = RMSE(predictions, testResponses);
+
+    if (rmse <= 6.2 && wdrmse <= 6.2)
+    {
+      success = true;
+      break;
+    }
+  }
+
+  REQUIRE(success == true);
 }
 
 /**
@@ -1011,42 +988,53 @@ TEST_CASE("SimpleGeneralizationFMatTest_", "[DecisionTreeRegressorTest]")
  */
 TEST_CASE("WeightedDecisionTreeTest_", "[DecisionTreeRegressorTest]")
 {
-  // Loading data.
-  data::DatasetInfo info;
-  arma::mat trainData, testData;
-  arma::rowvec trainResponses, testResponses;
-  LoadBostonHousingDataset(trainData, testData, trainResponses, testResponses,
-      info);
+  // Allow three trials for success.
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    // Loading data.
+    data::DatasetInfo info;
+    arma::mat trainData, testData;
+    arma::rowvec trainResponses, testResponses;
+    LoadBostonHousingDataset(trainData, testData, trainResponses, testResponses,
+        info);
 
-  // Add some noise.
-  arma::mat noise(trainData.n_rows, 100, arma::fill::randu);
-  arma::rowvec noiseResponses(100);
-  for (size_t i = 0; i < noiseResponses.n_elem; ++i)
-    noiseResponses[i] = 15 + Random(0, 10); // Random response.
+    // Add some noise.
+    arma::mat noise(trainData.n_rows, 100, arma::fill::randu);
+    arma::rowvec noiseResponses(100);
+    for (size_t i = 0; i < noiseResponses.n_elem; ++i)
+      noiseResponses[i] = 15 + Random(0, 10); // Random response.
 
-  // Concatenate data matrices.
-  arma::mat data = arma::join_rows(trainData, noise);
-  arma::rowvec fullResponses = arma::join_rows(trainResponses, noiseResponses);
+    // Concatenate data matrices.
+    arma::mat data = arma::join_rows(trainData, noise);
+    arma::rowvec fullResponses = arma::join_rows(trainResponses,
+        noiseResponses);
 
-  // Now set weights.
-  arma::rowvec weights(trainData.n_cols + 100);
-  for (size_t i = 0; i < trainData.n_cols; ++i)
-    weights[i] = Random(0.9, 1.0);
-  for (size_t i = trainData.n_cols; i < trainData.n_cols + 100; ++i)
-    weights[i] = Random(0.0, 0.01); // Low weights for false points.
+    // Set weights.
+    arma::rowvec weights(trainData.n_cols + 100);
+    for (size_t i = 0; i < trainData.n_cols; ++i)
+      weights[i] = Random(0.9, 1.0);
+    for (size_t i = trainData.n_cols; i < trainData.n_cols + 100; ++i)
+      weights[i] = Random(0.0, 0.01); // Low weights for false points.
 
-  // Now build the decision tree.
-  DecisionTreeRegressor<> d(data, fullResponses, weights);
+    // Now build the decision tree.
+    DecisionTreeRegressor<> d(data, fullResponses, weights);
 
-  // Now we can check that we get good performance on the test set.
-  arma::rowvec predictions;
-  d.Predict(testData, predictions);
+    // Now we can check that we get good performance on the test set.
+    arma::rowvec predictions;
+    d.Predict(testData, predictions);
 
-  REQUIRE(predictions.n_elem == testData.n_cols);
+    REQUIRE(predictions.n_elem == testData.n_cols);
 
-  // Figure out the rmse.
-  double rmse = RMSE(predictions, testResponses);
-  REQUIRE(rmse < 6.0);
+    // Figure out the rmse.
+    double rmse = RMSE(predictions, testResponses);
+    if (rmse < 6.2)
+    {
+      success = true;
+      break;
+    }
+  }
+  REQUIRE(success == true);
 }
 
 /**
@@ -1056,40 +1044,52 @@ TEST_CASE("WeightedDecisionTreeTest_", "[DecisionTreeRegressorTest]")
  */
 TEST_CASE("WeightedDecisionTreeMADGainTest", "[DecisionTreeRegressorTest]")
 {
-  // Loading data.
-  data::DatasetInfo info;
-  arma::mat trainData, testData;
-  arma::rowvec trainResponses, testResponses;
-  LoadBostonHousingDataset(trainData, testData, trainResponses, testResponses,
-      info);
+  // Allow multiple trials, if needed.
+  bool success = false;
+  for (size_t trial = 0; trial < 5; ++trial)
+  {
+    // Loading data.
+    data::DatasetInfo info;
+    arma::mat trainData, testData;
+    arma::rowvec trainResponses, testResponses;
+    LoadBostonHousingDataset(trainData, testData, trainResponses, testResponses,
+        info);
 
-  // Add some noise.
-  arma::mat noise(trainData.n_rows, 100, arma::fill::randu);
-  arma::rowvec noiseResponses(100);
-  for (size_t i = 0; i < noiseResponses.n_elem; ++i)
-    noiseResponses[i] = 15 + Random(0, 10); // Random response.
+    // Add some noise.
+    arma::mat noise(trainData.n_rows, 100, arma::fill::randu);
+    arma::rowvec noiseResponses(100);
+    for (size_t i = 0; i < noiseResponses.n_elem; ++i)
+      noiseResponses[i] = 15 + Random(0, 10); // Random response.
 
-  // Concatenate data matrices.
-  arma::mat data = arma::join_rows(trainData, noise);
-  arma::rowvec fullResponses = arma::join_rows(trainResponses, noiseResponses);
+    // Concatenate data matrices.
+    arma::mat data = arma::join_rows(trainData, noise);
+    arma::rowvec fullResponses = arma::join_rows(trainResponses,
+        noiseResponses);
 
-  // Now set weights.
-  arma::rowvec weights(trainData.n_cols + 100);
-  for (size_t i = 0; i < trainData.n_cols; ++i)
-    weights[i] = Random(0.9, 1.0);
-  for (size_t i = trainData.n_cols; i < trainData.n_cols + 100; ++i)
-    weights[i] = Random(0.0, 0.01); // Low weights for false points.
+    // Now set weights.
+    arma::rowvec weights(trainData.n_cols + 100);
+    for (size_t i = 0; i < trainData.n_cols; ++i)
+      weights[i] = Random(0.9, 1.0);
+    for (size_t i = trainData.n_cols; i < trainData.n_cols + 100; ++i)
+      weights[i] = Random(0.0, 0.01); // Low weights for false points.
 
-  // Now build the decision tree using MADGain.
-  DecisionTreeRegressor<MADGain> d(data, fullResponses, weights);
+    // Now build the decision tree using MADGain.
+    DecisionTreeRegressor<MADGain> d(data, fullResponses, weights);
 
-  // Now we can check that we get good performance on the test set.
-  arma::rowvec predictions;
-  d.Predict(testData, predictions);
+    // Now we can check that we get good performance on the test set.
+    arma::rowvec predictions;
+    d.Predict(testData, predictions);
 
-  REQUIRE(predictions.n_elem == testData.n_cols);
+    REQUIRE(predictions.n_elem == testData.n_cols);
 
-  // Figure out the rmse.
-  double rmse = RMSE(predictions, testResponses);
-  REQUIRE(rmse < 6.5);
+    // Figure out the rmse.
+    double rmse = RMSE(predictions, testResponses);
+    if (rmse < 6.6)
+    {
+      success = true;
+      break;
+    }
+  }
+
+  REQUIRE(success == true);
 }

--- a/src/mlpack/tests/test_function_tools.hpp
+++ b/src/mlpack/tests/test_function_tools.hpp
@@ -30,11 +30,11 @@ using namespace mlpack;
  * @param shuffledResponses Matrix object to store the shuffled responses into.
  */
 inline void LogisticRegressionTestData(arma::mat& data,
-                                arma::mat& testData,
-                                arma::mat& shuffledData,
-                                arma::Row<size_t>& responses,
-                                arma::Row<size_t>& testResponses,
-                                arma::Row<size_t>& shuffledResponses)
+                                       arma::mat& testData,
+                                       arma::mat& shuffledData,
+                                       arma::Row<size_t>& responses,
+                                       arma::Row<size_t>& testResponses,
+                                       arma::Row<size_t>& shuffledResponses)
 {
   // Generate a two-Gaussian dataset.
   GaussianDistribution g1(arma::vec("1.0 1.0 1.0"), arma::eye<arma::mat>(3, 3));
@@ -79,15 +79,15 @@ inline void LogisticRegressionTestData(arma::mat& data,
   }
 }
 
-template<typename MatType>
+template<typename MatType, typename ResponsesType>
 void LoadBostonHousingDataset(MatType& trainData,
                               MatType& testData,
-                              arma::rowvec& trainResponses,
-                              arma::rowvec& testResponses,
+                              ResponsesType& trainResponses,
+                              ResponsesType& testResponses,
                               data::DatasetInfo& info)
 {
   MatType dataset;
-  arma::rowvec responses;
+  ResponsesType responses;
 
   // Defining categorical deimensions.
   info.SetDimensionality(13);
@@ -103,10 +103,11 @@ void LoadBostonHousingDataset(MatType& trainData,
       trainResponses, testResponses, 0.3);
 }
 
-inline double RMSE(const arma::Row<double>& predictions,
-                   const arma::Row<double>& trueResponses)
+template<typename ElemType>
+inline ElemType RMSE(const arma::Row<ElemType>& predictions,
+                     const arma::Row<ElemType>& trueResponses)
 {
-  double mse = arma::accu(arma::square(predictions - trueResponses)) /
+  ElemType mse = arma::accu(arma::square(predictions - trueResponses)) /
       predictions.n_elem;
   return sqrt(mse);
 }


### PR DESCRIPTION
This allows multiple trials for the `DecisionTreeRegressor` tests.  I found them to be failing at the rate of about one every hundred times.  With these fixes, I saw no failures at all with 1000 different random seeds.

I also combined one of the tests that had both an `fmat` and a `mat` version into a single test using `TEMPLATE_TEST_CASE()`.  That required some slight changes to some of the test tools.