### PR TITLE
S01E05 Convert all the init methods from arma::mat to MatType

### DIFF
--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -160,7 +160,7 @@ struct GetRowType<arma::SpMat<eT>>
 template<typename MatType>
 struct GetColType
 {
-  typedef arma::Row<typename MatType::elem_type> type;
+  typedef arma::Col<typename MatType::elem_type> type;
 };
 
 template<typename eT>

--- a/src/mlpack/methods/ann/init_rules/const_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/const_init.hpp
@@ -37,8 +37,8 @@ class ConstInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template<typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
     if (W.is_empty())
       W.set_size(rows, cols);
@@ -51,8 +51,9 @@ class ConstInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;
@@ -68,8 +69,8 @@ class ConstInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -85,8 +86,9 @@ class ConstInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty cube." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -44,8 +44,8 @@ class GaussianInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W,
+  template<typename MatType>
+  void Initialize(MatType& W,
                   const size_t rows,
                   const size_t cols)
   {
@@ -60,8 +60,9 @@ class GaussianInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;
@@ -77,8 +78,8 @@ class GaussianInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT> & W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -95,8 +96,9 @@ class GaussianInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT> & W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -60,8 +60,8 @@ class HeInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template <typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template <typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
     // He initialization rule says to initialize weights with random
     // values taken from a gaussian distribution with mean = 0 and
@@ -82,8 +82,9 @@ class HeInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template <typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template <typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     // He initialization rule says to initialize weights with random
     // values taken from a gaussian distribution with mean = 0 and
@@ -107,8 +108,8 @@ class HeInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template <typename eT>
-  void Initialize(arma::Cube<eT> & W,
+  template <typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -126,8 +127,9 @@ class HeInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template <typename eT>
-  void Initialize(arma::Cube<eT> & W)
+  template <typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix" << std::endl;

--- a/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
@@ -65,8 +65,8 @@ class KathirvalavakumarSubavathiInitialization
    * @param data The input patterns.
    * @param s Parameter that defines the active region.
    */
-  template<typename eT>
-  KathirvalavakumarSubavathiInitialization(const arma::Mat<eT>& data,
+  template<typename MatType>
+  KathirvalavakumarSubavathiInitialization(const MatType& data,
                                            const double s) : s(s)
   {
     dataSum = arma::sum(data % data);
@@ -80,10 +80,11 @@ class KathirvalavakumarSubavathiInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template<typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
-    arma::Row<eT> b = s * arma::sqrt(3 / (rows * dataSum));
+    typedef typename GetRowType<MatType>::type RowType; 
+    RowType b = s * arma::sqrt(3 / (rows * dataSum));
     const double theta = b.min();
     RandomInitialization randomInit(-theta, theta);
     randomInit.Initialize(W, rows, cols);
@@ -95,10 +96,12 @@ class KathirvalavakumarSubavathiInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
-    arma::Row<eT> b = s * arma::sqrt(3 / (W.n_rows * dataSum));
+    typedef typename GetRowType<MatType>::type RowType; 
+    RowType b = s * arma::sqrt(3 / (W.n_rows * dataSum));
     const double theta = b.min();
     RandomInitialization randomInit(-theta, theta);
     randomInit.Initialize(W);
@@ -113,8 +116,8 @@ class KathirvalavakumarSubavathiInitialization
    * @param cols Number of columns.
    * @param slices Number of slices
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -132,8 +135,9 @@ class KathirvalavakumarSubavathiInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty cube." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -64,8 +64,8 @@ class LecunNormalInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template <typename eT>
-  void Initialize(arma::Mat<eT>& W,
+  template <typename MatType>
+  void Initialize(MatType& W,
                   const size_t rows,
                   const size_t cols)
   {
@@ -88,8 +88,9 @@ class LecunNormalInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template <typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template <typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     // He initialization rule says to initialize weights with random
     // values taken from a gaussian distribution with mean = 0 and
@@ -113,8 +114,8 @@ class LecunNormalInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template <typename eT>
-  void Initialize(arma::Cube<eT> & W,
+  template <typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -132,8 +133,9 @@ class LecunNormalInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template <typename eT>
-  void Initialize(arma::Cube<eT> & W)
+  template <typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty cube." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
@@ -71,8 +71,8 @@ class NguyenWidrowInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template<typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
     RandomInitialization randomInit(lowerBound, upperBound);
     randomInit.Initialize(W, rows, cols);
@@ -87,14 +87,15 @@ class NguyenWidrowInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     RandomInitialization randomInit(lowerBound, upperBound);
     randomInit.Initialize(W);
 
     double beta = 0.7 * std::pow(W.n_cols, 1.0 / W.n_rows);
-    W *= (beta / arma::norm(W));
+    W *= (beta / norm(W));
   }
 
   /**
@@ -106,8 +107,8 @@ class NguyenWidrowInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -125,8 +126,9 @@ class NguyenWidrowInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/oivs_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/oivs_init.hpp
@@ -79,8 +79,8 @@ class OivsInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template<typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
     RandomInitialization randomInit(-gamma, gamma);
     randomInit.Initialize(W, rows, cols);
@@ -93,8 +93,9 @@ class OivsInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     RandomInitialization randomInit(-gamma, gamma);
     randomInit.Initialize(W);
@@ -111,8 +112,8 @@ class OivsInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -130,8 +131,9 @@ class OivsInitialization
    *
    * @param W 3rd order tensor to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty cube." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
@@ -38,13 +38,14 @@ class OrthogonalInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template<typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
-    arma::Mat<eT> V;
-    arma::Col<eT> s;
+    MatType V;
+    typedef typename GetColType<MatType>::type ColType;
+    ColType s;
 
-    arma::svd_econ(W, s, V, arma::randu<arma::Mat<eT> >(rows, cols));
+    svd_econ(W, s, V, arma::randu<MatType>(rows, cols));
     W *= gain;
   }
 
@@ -54,13 +55,15 @@ class OrthogonalInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
-    arma::Mat<eT> V;
-    arma::Col<eT> s;
+    MatType V;
+    typedef typename GetColType<MatType>::type ColType;
+    ColType s;
 
-    arma::svd_econ(W, s, V, arma::randu<arma::Mat<eT> >(W.n_rows, W.n_cols));
+    svd_econ(W, s, V, arma::randu<MatType>(W.n_rows, W.n_cols));
     W *= gain;
   }
 
@@ -73,8 +76,8 @@ class OrthogonalInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -92,8 +95,9 @@ class OrthogonalInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty cube." << std::endl;

--- a/src/mlpack/methods/ann/init_rules/random_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/random_init.hpp
@@ -51,8 +51,8 @@ class RandomInitialization
    * @param rows Number of rows.
    * @param cols Number of columns.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W, const size_t rows, const size_t cols)
+  template<typename MatType>
+  void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
     if (W.is_empty())
       W.set_size(rows, cols);
@@ -67,8 +67,9 @@ class RandomInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Mat<eT>& W)
+  template<typename MatType>
+  void Initialize(MatType& W,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;
@@ -86,8 +87,8 @@ class RandomInitialization
    * @param cols Number of columns.
    * @param slices Number of slices.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W,
+  template<typename CubeType>
+  void Initialize(CubeType& W,
                   const size_t rows,
                   const size_t cols,
                   const size_t slices)
@@ -104,8 +105,9 @@ class RandomInitialization
    *
    * @param W Weight matrix to initialize.
    */
-  template<typename eT>
-  void Initialize(arma::Cube<eT>& W)
+  template<typename CubeType>
+  void Initialize(CubeType& W,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty cube." << std::endl;


### PR DESCRIPTION
This PR converts all the `arma::Mat<eT>` in the init methods to `MatType`.
This should be merged quickly.