### PR TITLE
S01E07 Adding the last missing part from `arma::Mat` to `MatType` and from `arma::Cube` to `CubeType`

### DIFF
--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -220,9 +220,12 @@ struct GetDenseMatType<arma::SpMat<eT>>
 // Get the cube type corresponding to a given MatType.
 
 template<typename MatType>
-struct GetCubeType
+struct GetCubeType;
+
+template<typename eT>
+struct GetCubeType<arma::Mat<eT>>
 {
-  typedef arma::Cube<typename MatType::elem_type> type;
+  typedef arma::Cube<eT> type;
 };
 
 // Get the sparse matrix type corresponding to a given MatType.

--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -225,12 +225,6 @@ struct GetCubeType
   typedef arma::Cube<typename MatType::elem_type> type;
 };
 
-template<typename eT>
-struct GetCubeType<arma::Mat<eT>>
-{
-  typedef arma::Cube<eT> type;
-};
-
 // Get the sparse matrix type corresponding to a given MatType.
 
 template<typename MatType>

--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -217,6 +217,20 @@ struct GetDenseMatType<arma::SpMat<eT>>
   typedef arma::Mat<eT> type;
 };
 
+// Get the cube type corresponding to a given MatType.
+
+template<typename MatType>
+struct GetCubeType
+{
+  typedef arma::Cube<typename MatType::elem_type> type;
+};
+
+template<typename eT>
+struct GetCubeType<arma::Mat<eT>>
+{
+  typedef arma::Cube<eT> type;
+};
+
 // Get the sparse matrix type corresponding to a given MatType.
 
 template<typename MatType>

--- a/src/mlpack/methods/ann/activation_functions/identity_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/identity_function.hpp
@@ -44,9 +44,10 @@ class IdentityFunction
    * @param x Input data.
    * @param y The resulting output activation.
    */
-  template<typename VecType>
-  static void Fn(const VecType& x, VecType& y,
-      const typename std::enable_if_t<IsVector<VecType>::value>* = 0)
+  template<typename InputVecType, typename OutputVecType>
+  static void Fn(const InputVecType& x, OutputVecType& y,
+      const typename std::enable_if_t<IsVector<InputVecType>::value>* = 0,
+      const typename std::enable_if_t<IsVector<OutputVecType>::value>* = 0)
   {
     y = x;
   }

--- a/src/mlpack/methods/ann/activation_functions/identity_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/identity_function.hpp
@@ -44,8 +44,9 @@ class IdentityFunction
    * @param x Input data.
    * @param y The resulting output activation.
    */
-  template<typename InputVecType, typename OutputVecType>
-  static void Fn(const InputVecType& x, OutputVecType& y)
+  template<typename VecType>
+  static void Fn(const VecType& x, VecType& y,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0)
   {
     y = x;
   }
@@ -82,8 +83,9 @@ class IdentityFunction
    * @param y Input activations.
    * @param dy The resulting derivatives.
    */
-  template<typename eT>
-  static void Deriv(const arma::Cube<eT>& y, arma::Cube<eT>& x)
+  template<typename CubeType>
+  static void Deriv(const CubeType& y, CubeType& x,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     x.ones(y.n_rows, y.n_cols, y.n_slices);
   }

--- a/src/mlpack/methods/ann/activation_functions/swish_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/swish_function.hpp
@@ -47,8 +47,9 @@ class SwishFunction
    * @param x Input data.
    * @param y The resulting output activation.
    */
-  template<typename eT>
-  static void Fn(const arma::Mat<eT>& x, arma::Mat<eT>& y)
+  template<typename MatType>
+  static void Fn(const MatType& x, MatType& y,
+     const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0) 
   {
     y = x / (1.0 + arma::exp(-x));
   }
@@ -59,8 +60,9 @@ class SwishFunction
    * @param x Input data.
    * @param y The resulting output activation.
    */
-  template<typename InputVecType, typename OutputVecType>
-  static void Fn(const InputVecType& x, OutputVecType& y)
+  template<typename VecType>
+  static void Fn(const VecType& x, VecType& y,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0)
   {
     y.set_size(arma::size(x));
 

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -73,6 +73,8 @@ template <
 class ConvolutionType : public Layer<MatType>
 {
  public:
+  //! Get the CubeType from MatType
+  typedef typename GetCubeType<MatType>::type CubeType;
   //! Create the ConvolutionType object.
   ConvolutionType();
 
@@ -196,12 +198,12 @@ class ConvolutionType : public Layer<MatType>
   MatType& Parameters() { return weights; }
 
   //! Get the weight of the layer as a cube.
-  arma::Cube<typename MatType::elem_type> const& Weight() const
+  CubeType const& Weight() const
   {
     return weight;
   }
   //! Modify the weight of the layer as a cube.
-  arma::Cube<typename MatType::elem_type>& Weight() { return weight; }
+  CubeType& Weight() { return weight; }
 
   //! Get the bias of the layer.
   MatType const& Bias() const { return bias; }
@@ -298,14 +300,15 @@ class ConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  template<typename eT>
-  void Rotate180(const arma::Cube<eT>& input, arma::Cube<eT>& output)
+  template<typename CubeType>
+  void Rotate180(const CubeType& input, CubeType& output,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
-    output = arma::Cube<eT>(input.n_rows, input.n_cols, input.n_slices);
+    output = CubeType(input.n_rows, input.n_cols, input.n_slices);
 
     // * left-right flip, up-down flip */
     for (size_t s = 0; s < output.n_slices; s++)
-      output.slice(s) = arma::fliplr(arma::flipud(input.slice(s)));
+      output.slice(s) = fliplr(flipud(input.slice(s)));
   }
 
   /**
@@ -314,11 +317,11 @@ class ConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  template<typename eT>
-  void Rotate180(const arma::Mat<eT>& input, arma::Mat<eT>& output)
+  void Rotate180(const MatType& input, MatType& output,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     // * left-right flip, up-down flip */
-    output = arma::fliplr(arma::flipud(input));
+    output = fliplr(flipud(input));
   }
 
   //! Locally-stored number of output channels.
@@ -358,22 +361,22 @@ class ConvolutionType : public Layer<MatType>
   MatType weights;
 
   //! Locally-stored weight object.
-  arma::Cube<typename MatType::elem_type> weight;
+  CubeType weight;
 
   //! Locally-stored bias term object.
   MatType bias;
 
   //! Locally-stored transformed output parameter.
-  arma::Cube<typename MatType::elem_type> outputTemp;
+  CubeType outputTemp;
 
   //! Locally-stored transformed padded input parameter.
   MatType inputPadded;
 
   //! Locally-stored transformed error parameter.
-  arma::Cube<typename MatType::elem_type> gTemp;
+  CubeType gTemp;
 
   //! Locally-stored transformed gradient parameter.
-  arma::Cube<typename MatType::elem_type> gradientTemp;
+  CubeType gradientTemp;
 
   //! Locally-stored padding layer.
   PaddingType<MatType> padding;

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -73,8 +73,8 @@ template <
 class ConvolutionType : public Layer<MatType>
 {
  public:
-  //! Get the CubeType from MatType
   typedef typename GetCubeType<MatType>::type CubeType;
+
   //! Create the ConvolutionType object.
   ConvolutionType();
 
@@ -301,8 +301,7 @@ class ConvolutionType : public Layer<MatType>
    * @param output The rotated output.
    */
   template<typename CubeType>
-  void Rotate180(const CubeType& input, CubeType& output,
-      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
+  void Rotate180(const CubeType& input, CubeType& output)
   {
     output = CubeType(input.n_rows, input.n_cols, input.n_slices);
 
@@ -317,8 +316,7 @@ class ConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  void Rotate180(const MatType& input, MatType& output,
-      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
+  void Rotate180(const MatType& input, MatType& output)
   {
     // * left-right flip, up-down flip */
     output = fliplr(flipud(input));

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -300,7 +300,6 @@ class ConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  template<typename CubeType>
   void Rotate180(const CubeType& input, CubeType& output)
   {
     output = CubeType(input.n_rows, input.n_cols, input.n_slices);

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -313,7 +313,7 @@ void ConvolutionType<
     padding.Forward(input, inputPadded);
   }
 
-  arma::Cube<typename MatType::elem_type> inputTemp;
+  CubeType inputTemp;
   MakeAlias(inputTemp,
       const_cast<MatType&>(usingPadding ? inputPadded : input).memptr(),
       paddedRows, paddedCols, inMaps * higherInDimensions * batchSize);
@@ -375,7 +375,7 @@ void ConvolutionType<
     const MatType& gy,
     MatType& g)
 {
-  arma::Cube<typename MatType::elem_type> mappedError;
+  CubeType mappedError;
   MakeAlias(mappedError, ((MatType&) gy).memptr(), this->outputDimensions[0],
       this->outputDimensions[1], higherInDimensions * maps * batchSize);
 
@@ -387,11 +387,11 @@ void ConvolutionType<
       (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0);
 
   // To perform the backward pass, we need to rotate all the filters.
-  arma::Cube<typename MatType::elem_type> rotatedFilters(weight.n_rows,
+  CubeType rotatedFilters(weight.n_rows,
       weight.n_cols, weight.n_slices);
 
   // To perform the backward pass, we need to dilate all the mappedError.
-  arma::Cube<typename MatType::elem_type> dilatedMappedError;
+  CubeType dilatedMappedError;
   if (strideHeight == 1 && strideWidth == 1)
   {
     MakeAlias(dilatedMappedError, mappedError.memptr(),
@@ -424,7 +424,7 @@ void ConvolutionType<
 
   MatType output(apparentWidth * apparentHeight * inMaps * higherInDimensions,
       batchSize, arma::fill::zeros);
-  arma::Cube<typename MatType::elem_type> outputCube;
+  CubeType outputCube;
   MakeAlias(outputCube, output.memptr(), apparentWidth, apparentHeight,
       inMaps * higherInDimensions * batchSize);
 
@@ -456,7 +456,7 @@ void ConvolutionType<
   }
   MatType temp(padding.OutputDimensions()[0] * padding.OutputDimensions()[1] *
       inMaps * higherInDimensions, batchSize);
-  arma::Cube<typename MatType::elem_type> tempCube;
+  CubeType tempCube;
   MakeAlias(tempCube, temp.memptr(), padding.OutputDimensions()[0],
       padding.OutputDimensions()[1], inMaps * higherInDimensions * batchSize);
   paddingBackward.Forward(output, temp);
@@ -490,7 +490,7 @@ void ConvolutionType<
     const MatType& error,
     MatType& gradient)
 {
-  arma::Cube<typename MatType::elem_type> mappedError;
+  CubeType mappedError;
   MakeAlias(mappedError, ((MatType&) error).memptr(),
       this->outputDimensions[0], this->outputDimensions[1],
       higherInDimensions * maps * batchSize);
@@ -502,13 +502,13 @@ void ConvolutionType<
   const size_t paddedRows = this->inputDimensions[0] + padWLeft + padWRight;
   const size_t paddedCols = this->inputDimensions[1] + padHTop + padHBottom;
 
-  arma::Cube<typename MatType::elem_type> inputTemp(
+  CubeType inputTemp(
       const_cast<MatType&>(usingPadding ? inputPadded : input).memptr(),
       paddedRows, paddedCols, inMaps * batchSize, false, false);
 
   MatType temp(apparentWidth * apparentHeight * inMaps * higherInDimensions,
       batchSize);
-  arma::Cube<typename MatType::elem_type> tempCube;
+  CubeType tempCube;
   MakeAlias(tempCube, temp.memptr(), apparentWidth, apparentHeight,
       inMaps * higherInDimensions * batchSize);
   paddingBackward.Backward(input, {} /* unused */, usingPadding ? inputPadded : input, temp);

--- a/src/mlpack/methods/ann/layer/grouped_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution.hpp
@@ -77,8 +77,8 @@ template <
 class GroupedConvolutionType : public Layer<MatType>
 {
  public:
-  //! Get the CubeType from MatType
   typedef typename GetCubeType<MatType>::type CubeType;
+
   //! Create the GroupedConvolutionType object.
   GroupedConvolutionType();
 
@@ -313,8 +313,7 @@ class GroupedConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  void Rotate180(const CubeType& input, CubeType& output,
-      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
+  void Rotate180(const CubeType& input, CubeType& output)
   {
     output = CubeType(input.n_rows, input.n_cols, input.n_slices);
 
@@ -329,8 +328,7 @@ class GroupedConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  void Rotate180(const MatType& input, MatType& output,
-      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
+  void Rotate180(const MatType& input, MatType& output)
   {
     // * left-right flip, up-down flip */
     output = fliplr(flipud(input));

--- a/src/mlpack/methods/ann/layer/grouped_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution.hpp
@@ -77,6 +77,8 @@ template <
 class GroupedConvolutionType : public Layer<MatType>
 {
  public:
+  //! Get the CubeType from MatType
+  typedef typename GetCubeType<MatType>::type CubeType;
   //! Create the GroupedConvolutionType object.
   GroupedConvolutionType();
 
@@ -204,12 +206,12 @@ class GroupedConvolutionType : public Layer<MatType>
   MatType& Parameters() { return weights; }
 
   //! Get the weight of the layer as a cube.
-  arma::Cube<typename MatType::elem_type> const& Weight() const
+  CubeType const& Weight() const
   {
     return weight;
   }
   //! Modify the weight of the layer as a cube.
-  arma::Cube<typename MatType::elem_type>& Weight() { return weight; }
+  CubeType& Weight() { return weight; }
 
   //! Get the bias of the layer.
   MatType const& Bias() const { return bias; }
@@ -311,14 +313,14 @@ class GroupedConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  template<typename eT>
-  void Rotate180(const arma::Cube<eT>& input, arma::Cube<eT>& output)
+  void Rotate180(const CubeType& input, CubeType& output,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
-    output = arma::Cube<eT>(input.n_rows, input.n_cols, input.n_slices);
+    output = CubeType(input.n_rows, input.n_cols, input.n_slices);
 
     // * left-right flip, up-down flip */
     for (size_t s = 0; s < output.n_slices; s++)
-      output.slice(s) = arma::fliplr(arma::flipud(input.slice(s)));
+      output.slice(s) = fliplr(flipud(input.slice(s)));
   }
 
   /**
@@ -327,11 +329,11 @@ class GroupedConvolutionType : public Layer<MatType>
    * @param input The input data to be rotated.
    * @param output The rotated output.
    */
-  template<typename eT>
-  void Rotate180(const arma::Mat<eT>& input, arma::Mat<eT>& output)
+  void Rotate180(const MatType& input, MatType& output,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     // * left-right flip, up-down flip */
-    output = arma::fliplr(arma::flipud(input));
+    output = fliplr(flipud(input));
   }
 
   //! Locally-stored number of output channels.
@@ -374,22 +376,22 @@ class GroupedConvolutionType : public Layer<MatType>
   MatType weights;
 
   //! Locally-stored weight object.
-  arma::Cube<typename MatType::elem_type> weight;
+  CubeType weight;
 
   //! Locally-stored bias term object.
   MatType bias;
 
   //! Locally-stored transformed output parameter.
-  arma::Cube<typename MatType::elem_type> outputTemp;
+  CubeType outputTemp;
 
   //! Locally-stored transformed padded input parameter.
   MatType inputPadded;
 
   //! Locally-stored transformed error parameter.
-  arma::Cube<typename MatType::elem_type> gTemp;
+  CubeType gTemp;
 
   //! Locally-stored transformed gradient parameter.
-  arma::Cube<typename MatType::elem_type> gradientTemp;
+  CubeType gradientTemp;
 
   //! Locally-stored padding layer.
   PaddingType<MatType> padding;

--- a/src/mlpack/methods/ann/layer/grouped_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution_impl.hpp
@@ -323,7 +323,7 @@ void GroupedConvolutionType<
     padding.Forward(input, inputPadded);
   }
 
-  arma::Cube<typename MatType::elem_type> inputTemp;
+  CubeType inputTemp;
   MakeAlias(inputTemp,
       const_cast<MatType&>(usingPadding ? inputPadded : input).memptr(),
       paddedRows, paddedCols, inMaps * higherInDimensions * batchSize);
@@ -393,7 +393,7 @@ void GroupedConvolutionType<
     const MatType& gy,
     MatType& g)
 {
-  arma::Cube<typename MatType::elem_type> mappedError;
+  CubeType mappedError;
   MakeAlias(mappedError, ((MatType&) gy).memptr(), this->outputDimensions[0],
       this->outputDimensions[1], higherInDimensions * maps * batchSize);
 
@@ -405,7 +405,7 @@ void GroupedConvolutionType<
       (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0);
 
   // To perform the backward pass, we need to rotate all the filters.
-  arma::Cube<typename MatType::elem_type> rotatedFilters(weight.n_rows,
+  CubeType rotatedFilters(weight.n_rows,
       weight.n_cols, weight.n_slices);
 
   #pragma omp parallel for
@@ -415,7 +415,7 @@ void GroupedConvolutionType<
   }
 
   // To perform the backward pass, we need to dilate all the mappedError.
-  arma::Cube<typename MatType::elem_type> dilatedMappedError;
+  CubeType dilatedMappedError;
   if (strideHeight == 1 && strideWidth == 1)
   {
     MakeAlias(dilatedMappedError, mappedError.memptr(),
@@ -442,7 +442,7 @@ void GroupedConvolutionType<
 
   MatType output(apparentWidth * apparentHeight * inMaps * higherInDimensions,
       batchSize, arma::fill::zeros);
-  arma::Cube<typename MatType::elem_type> outputCube;
+  CubeType outputCube;
   MakeAlias(outputCube, output.memptr(), apparentWidth, apparentHeight,
       inMaps * higherInDimensions * batchSize);
 
@@ -483,7 +483,7 @@ void GroupedConvolutionType<
 
   MatType temp(padding.OutputDimensions()[0] * padding.OutputDimensions()[1] *
       inMaps * higherInDimensions, batchSize);
-  arma::Cube<typename MatType::elem_type> tempCube;
+  CubeType tempCube;
   MakeAlias(tempCube, temp.memptr(), padding.OutputDimensions()[0],
       padding.OutputDimensions()[1], inMaps * higherInDimensions * batchSize);
   paddingBackward.Forward(output, temp);
@@ -517,7 +517,7 @@ void GroupedConvolutionType<
     const MatType& error,
     MatType& gradient)
 {
-  arma::Cube<typename MatType::elem_type> mappedError;
+  CubeType mappedError;
   MakeAlias(mappedError, ((MatType&) error).memptr(),
       this->outputDimensions[0], this->outputDimensions[1],
       higherInDimensions * maps * batchSize);
@@ -529,13 +529,13 @@ void GroupedConvolutionType<
   const size_t paddedRows = this->inputDimensions[0] + padWLeft + padWRight;
   const size_t paddedCols = this->inputDimensions[1] + padHTop + padHBottom;
 
-  arma::Cube<typename MatType::elem_type> inputTemp(
+  CubeType inputTemp(
       const_cast<MatType&>(usingPadding ? inputPadded : input).memptr(),
       paddedRows, paddedCols, inMaps * batchSize, false, false);
 
   MatType temp(apparentWidth * apparentHeight * inMaps * higherInDimensions,
       batchSize);
-  arma::Cube<typename MatType::elem_type> tempCube;
+  CubeType tempCube;
   MakeAlias(tempCube, temp.memptr(), apparentWidth, apparentHeight,
       inMaps * higherInDimensions * batchSize);
   paddingBackward.Backward(input, {} /* unused */, usingPadding ? inputPadded : input, temp);

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
@@ -111,8 +111,7 @@ class PoissonNLLLossType
 
  private:
   //! Check if the probabilities lie in the range [0, 1].
-  template<typename eT>
-  void CheckProbs(const arma::Mat<eT>& probs)
+  void CheckProbs(const MatType& probs)
   {
     for (size_t i = 0; i < probs.size(); ++i)
     {


### PR DESCRIPTION
This PR addresses the last part of converting `arma::Mat`  and `arma::Cube` to `MatType` and `CubeType` in the ANN code base. In the next PR we will start addressing `arma::Col`
