### PR TITLE
Cut-point optimization for {BestBinaryNumericSplit} -- Issue[884]

### DIFF
--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -117,7 +117,7 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
   for (size_t index = minimum; index < data.n_elem - minimum; ++index)
   {
     class_changed = (sortedLabels[index - 1] != sortedLabels[index]
-                  || (repeat && class_changed));
+        || (repeat && class_changed));
     repeat = data[sortedIndices[index - 1]] == data[sortedIndices[index]];
     eligible_cut = !repeat && class_changed;
     
@@ -135,7 +135,7 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       ++classCounts(sortedLabels[index - 1], 0);
     }
     if (!eligible_cut)
-        continue;
+      continue;
  
     // Calculate the gain for the left and right child.  Only use weights if
     // needed.

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -103,13 +103,15 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       ++classCounts(sortedLabels[i], 1);
   }
 
-  // Flags for validating whether the current sample index k is
-  // eligible as a cut point. {repeat} if the value at index k is
-  // part of a repeating sequence. {class_changed} if the class at 
-  // index k changed from k-1. {eligible_cut} if the value did not 
-  // repeat and the class changed, meaning index k is a boundary 
-  // point. See Fayyad and Irani (1992) for more details on eligible 
-  // cut points.
+  /**
+   * Flags for validating whether the current sample index k is
+   * eligible as a cut point. {repeat} if the value at index k is
+   * part of a repeating sequence. {class_changed} if the class at 
+   * index k changed from k-1. {eligible_cut} if the value did not 
+   * repeat and the class changed, meaning index k is a boundary 
+   * point. See Fayyad and Irani (1992) for more details on eligible 
+   * cut points.
+   */
   bool class_changed = false;
   bool repeat = false; 
   bool eligible_cut = false; 

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -112,16 +112,16 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
    * point. See Fayyad and Irani (1992) for more details on eligible 
    * cut points.
    */
-  bool class_changed = false;
+  bool classChanged = false;
   bool repeat = false; 
-  bool eligible_cut = false; 
+  bool eligibleCut = false; 
 
   for (size_t index = minimum; index < data.n_elem - minimum; ++index)
   {
-    class_changed = (sortedLabels[index - 1] != sortedLabels[index]
-        || (repeat && class_changed));
+    classChanged = (sortedLabels[index - 1] != sortedLabels[index]
+        || (repeat && classChanged));
     repeat = data[sortedIndices[index - 1]] == data[sortedIndices[index]];
-    eligible_cut = !repeat && class_changed;
+    eligibleCut = !repeat && classChanged;
     
     // Update class weight sums or counts.
     if (UseWeights)
@@ -136,7 +136,7 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       --classCounts(sortedLabels[index - 1], 1);
       ++classCounts(sortedLabels[index - 1], 0);
     }
-    if (!eligible_cut)
+    if (!eligibleCut)
       continue;
  
     // Calculate the gain for the left and right child.  Only use weights if


### PR DESCRIPTION
Added a cut-point optimization to {BestBinaryNumericSplit}, an optimization described by Fayyad, U.M. and Irani K.B. in "On the Handling of Continuous-Valued Attributes in Decision Tree Generation". Many more details can be found in the attached proposal for work on Issue[884].
[issue-884.pdf](https://github.com/mlpack/mlpack/files/14302229/issue-884.pdf)
