### PR TITLE
[R] Remove extra gcc-specific options from Makevars.win

### DIFF
--- a/src/mlpack/bindings/R/mlpack/src/Makevars.win
+++ b/src/mlpack/bindings/R/mlpack/src/Makevars.win
@@ -1,3 +1,3 @@
-PKG_CXXFLAGS = -I. -I../inst/include $(SHLIB_OPENMP_CXXFLAGS) -ftrack-macro-expansion=0 -pipe --param ggc-min-expand=10 --param ggc-min-heapsize=8192
+PKG_CXXFLAGS = -I. -I../inst/include $(SHLIB_OPENMP_CXXFLAGS)
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 CXX_STD = CXX17


### PR DESCRIPTION
CC: @coatless @eddelbuettel @kalibera

This is an experimental PR to try and remove the GCC-specific options from `Makevars.win`.  @kalibera pointed out via email that the R package build fails on Windows when using LLVM, because the `track-macro-expansion=0` compiler option isn't available in LLVM.  If we wanted, we could make the option conditional, but @kalibera noted that the build was actually faster under gcc without those options.  So, let's see what happens here.

Those options were originally added to decrease RAM usage so that the CRAN Windows workers would build successfully (if I remember right), but perhaps they aren't needed anymore.

First we can try this PR here, and if this succeeds, I can port these tiny changes to the existing mlpack CRAN package and see if CRAN still builds them successfully.

The usual disclaimer is that I am not an R expert and will defer to others' input and advice here! :smile: 