### PR TITLE
[R] Update roxygen2 package-level documentation entry

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,11 @@
 
   * Remove `round()` implementation for old MSVC compilers (#3570).
 
-  * Added inline plugin to the R bindings to allow for other R packages to link to headers (#3626, h/t @cgiachalis).
+  * [R] Added inline plugin to the R bindings to allow for other R packages to link to headers (#3626, h/t @cgiachalis).
+
+  * [R] Removed extra gcc-specific options from `Makevars.win`  (#3627, h/t @kalibera).
+
+  * [R] Changed roxygen package-level documentation from using `@docType package` to `"_PACKAGE"`. (#3636)
 
 ### mlpack 4.3.0
 ###### 2023-11-27

--- a/src/mlpack/bindings/R/mlpack/R/package.R
+++ b/src/mlpack/bindings/R/mlpack/R/package.R
@@ -5,11 +5,9 @@
 #' learning algorithms. mlpack provides these algorithms as simple command-line
 #' programs, C++ classes and bindings for : Python, Julia, Go and R which can
 #' then be integrated into larger-scale machine learning solutions.
-#'
-#' @docType package
+#' 
 #' @name mlpack
 #' @aliases mlpack-package
-#' @author mlpack Team
 #' @importFrom Rcpp evalCpp
 #' @useDynLib mlpack
-NULL
+"_PACKAGE"


### PR DESCRIPTION
Fixes deprecation of `@docType package` by using `"_PACKAGE"`.

```
✖ package.R:15: `@docType "package"` is deprecated.
ℹ Please document "_PACKAGE" instead.
```