### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# Default image contents: https://hub.docker.com/r/mlpack/jenkins-amd64-debian
+# Choose different variants available at: https://hub.docker.com/u/mlpack
+ARG VARIANT=jenkins-amd64-debian
+FROM mlpack/${VARIANT}
+
+# Additional options here... 
+# RUN apt update && apt upgrade -y 
+
+# and so on...

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
 	"name": "MLPACK C++ Dev Container",
 	"build": {
 		"dockerfile": "Dockerfile",
-    // Update 'VARIANT' to pick a new MLPACK base image from
-    // https://hub.docker.com/u/mlpack
+		// Update 'VARIANT' to pick a new MLPACK base image from
+		// https://hub.docker.com/u/mlpack
 		"args": { "VARIANT": "jenkins-amd64-debian" }
 	},
 	// Configure tool-specific properties.
@@ -12,16 +12,16 @@
 		"vscode": {
 			"settings": {},
 			"extensions": [
-        "twxs.cmake",
-        "ms-vscode.cpptools",
-        "ms-vscode.cmake-tools",
-        "llvm-vs-code-extensions.vscode-clangd",
+				"twxs.cmake",
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools",
+				"llvm-vs-code-extensions.vscode-clangd",
 				"streetsidesoftware.code-spell-checker"
 			]
 		}
 	}
 
 	// Switch to using root as a remote user
-  // details: https://aka.ms/dev-containers-non-root.
+	// details: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "MLPACK C++ Dev Container",
+	"build": {
+		"dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a new MLPACK base image from
+    // https://hub.docker.com/u/mlpack
+		"args": { "VARIANT": "jenkins-amd64-debian" }
+	},
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+        "twxs.cmake",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "llvm-vs-code-extensions.vscode-clangd",
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	}
+
+	// Switch to using root as a remote user
+  // details: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,7 @@
 				"twxs.cmake",
 				"ms-vscode.cpptools",
 				"ms-vscode.cmake-tools",
-				"llvm-vs-code-extensions.vscode-clangd",
-				"streetsidesoftware.code-spell-checker"
+				"llvm-vs-code-extensions.vscode-clangd"
 			]
 		}
 	}


### PR DESCRIPTION
So, this adds a devcontainer image that has a few choice C++ extensions enabled (but not configured) for VS Code.

You can check it out on my forked repo here: 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/coatless-mlpack/mlpack/tree/add-devcontainer)

The video next shows creating the codespace from scratch and running cmake. It stops just before the build install step as I didn't see `jenkins` password. (For that reason, maybe we should opt for a different base image?) In total, the runtime is about 3 minutes.

https://github.com/mlpack/mlpack/assets/833642/a761feb3-2b97-4560-92d0-62e310728a36

