### PR TITLE
Coot 12, refactor, `arma::min`, `arma::imbue` and some other bugs

### DIFF
--- a/src/mlpack/core/data/scaler_methods/max_abs_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/max_abs_scaler.hpp
@@ -54,7 +54,7 @@ class MaxAbsScaler
   template<typename MatType>
   void Fit(const MatType& input)
   {
-    itemMin = arma::min(input, 1);
+    itemMin = min(input, 1);
     itemMax = arma::max(input, 1);
     scale = arma::max(arma::abs(itemMin), arma::abs(itemMax));
     // Handling zeros in scale vector.

--- a/src/mlpack/core/data/scaler_methods/mean_normalization.hpp
+++ b/src/mlpack/core/data/scaler_methods/mean_normalization.hpp
@@ -55,7 +55,7 @@ class MeanNormalization
   void Fit(const MatType& input)
   {
     itemMean = arma::mean(input, 1);
-    itemMin = arma::min(input, 1);
+    itemMin = min(input, 1);
     itemMax = arma::max(input, 1);
     scale = itemMax - itemMin;
     // Handling zeros in scale vector.

--- a/src/mlpack/core/data/scaler_methods/min_max_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/min_max_scaler.hpp
@@ -73,7 +73,7 @@ class MinMaxScaler
   template<typename MatType>
   void Fit(const MatType& input)
   {
-    itemMin = arma::min(input, 1);
+    itemMin = min(input, 1);
     itemMax = arma::max(input, 1);
     scale = itemMax - itemMin;
     // Handle zeros in scale vector.

--- a/src/mlpack/core/tree/binary_space_tree/rp_tree_max_split_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/rp_tree_max_split_impl.hpp
@@ -59,7 +59,7 @@ bool RPTreeMaxSplit<BoundType, MatType>::GetSplitVal(
     values[k] = dot(data.col(samples[k]), direction);
 
   const ElemType maximum = arma::max(values);
-  const ElemType minimum = arma::min(values);
+  const ElemType minimum = min(values);
   if (minimum == maximum)
     return false;
 

--- a/src/mlpack/core/tree/binary_space_tree/rp_tree_mean_split_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/rp_tree_mean_split_impl.hpp
@@ -95,7 +95,7 @@ bool RPTreeMeanSplit<BoundType, MatType>::GetDotMedian(
     values[k] = dot(data.col(samples[k]), direction);
 
   const ElemType maximum = arma::max(values);
-  const ElemType minimum = arma::min(values);
+  const ElemType minimum = min(values);
   if (minimum == maximum)
     return false;
 
@@ -129,7 +129,7 @@ bool RPTreeMeanSplit<BoundType, MatType>::GetMeanMedian(
   }
 
   const ElemType maximum = arma::max(values);
-  const ElemType minimum = arma::min(values);
+  const ElemType minimum = min(values);
   if (minimum == maximum)
     return false;
 

--- a/src/mlpack/core/tree/cellbound_impl.hpp
+++ b/src/mlpack/core/tree/cellbound_impl.hpp
@@ -882,7 +882,7 @@ CellBound<MetricType, ElemType>::operator|=(const MatType& data)
 {
   Log::Assert(data.n_rows == dim);
 
-  arma::Col<ElemType> mins(arma::min(data, 1));
+  arma::Col<ElemType> mins(min(data, 1));
   arma::Col<ElemType> maxs(arma::max(data, 1));
 
   minWidth = std::numeric_limits<ElemType>::max();

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree_impl.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree_impl.hpp
@@ -520,7 +520,7 @@ inline void CosineTree::CosineNodeSplit()
   // Compute maximum and minimum cosine values.
   double cosineMax, cosineMin;
   cosineMax = arma::max(cosines % (cosines < 1));
-  cosineMin = arma::min(cosines);
+  cosineMin = min(cosines);
 
   std::vector<size_t> leftIndices, rightIndices;
 

--- a/src/mlpack/core/util/using.hpp
+++ b/src/mlpack/core/util/using.hpp
@@ -20,6 +20,7 @@ namespace mlpack {
   /* using for armadillo namespace*/
   using arma::conv_to;
   using arma::exp;
+  using arma::distr_param;
   using arma::dot;
   using arma::join_cols;
   using arma::join_rows;
@@ -46,6 +47,7 @@ namespace mlpack {
   /* using for bandicoot namespace*/
   using coot::conv_to;
   using coot::exp;
+  using coot::distr_param;
   using coot::dot;
   using coot::join_cols;
   using coot::join_rows;

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -52,7 +52,7 @@ class GaussianInitialization
     if (W.is_empty())
       W.set_size(rows, cols);
 
-    W = randn<MatType>(rows, cols, distr_param(0.0, std::sqrt(variance)));
+    W = randn<MatType>(rows, cols) * std::sqrt(variance);
   }
 
   /**
@@ -67,8 +67,7 @@ class GaussianInitialization
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;
 
-    W = randn<MatType>(W.n_rows, W.n_cols,
-        distr_param(mean, std::sqrt(variance)));
+    W = randn<MatType>(W.n_rows, W.n_cols) * std::sqrt(variance);
   }
 
   /**

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -53,7 +53,7 @@ class GaussianInitialization
     if (W.is_empty())
       W.set_size(rows, cols);
 
-    W = randn<MatType>(rows, cols) * stddev;
+    W = randn<MatType>(rows, cols) * stddev + mean;
   }
 
   /**
@@ -68,7 +68,7 @@ class GaussianInitialization
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;
 
-    W = randn<MatType>(W.n_rows, W.n_cols) * stddev;
+    W = randn<MatType>(W.n_rows, W.n_cols) * stddev + mean;
   }
 
   /**

--- a/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/gaussian_init.hpp
@@ -52,7 +52,7 @@ class GaussianInitialization
     if (W.is_empty())
       W.set_size(rows, cols);
 
-    W.imbue( [&]() { return arma::as_scalar(RandNormal(mean, variance)); } );
+    W = randn<MatType>(rows, cols, distr_param(0.0, std::sqrt(variance)));
   }
 
   /**
@@ -67,7 +67,8 @@ class GaussianInitialization
     if (W.is_empty())
       Log::Fatal << "Cannot initialize an empty matrix." << std::endl;
 
-    W.imbue( [&]() { return arma::as_scalar(RandNormal(mean, variance)); } );
+    W = randn<MatType>(W.n_rows, W.n_cols,
+        distr_param(mean, std::sqrt(variance)));
   }
 
   /**

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -73,7 +73,7 @@ class HeInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c^2) * V(X).
-    W.imbue( [&]() { return std::sqrt(variance) * arma::randn(); } );
+    W = randn<MatType>(rows, cols, distr_param(0.0, std::sqrt(variance)));
   }
 
   /**
@@ -96,7 +96,8 @@ class HeInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c^2) * V(X).
-    W.imbue( [&]() { return std::sqrt(variance) * arma::randn(); } );
+    W = randn<MatType>(W.n_rows, W.n_cols, 
+        distr_param(0.0, std::sqrt(variance)));
   }
 
   /**

--- a/src/mlpack/methods/ann/init_rules/he_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/he_init.hpp
@@ -73,7 +73,7 @@ class HeInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c^2) * V(X).
-    W = randn<MatType>(rows, cols, distr_param(0.0, std::sqrt(variance)));
+    W = randn<MatType>(rows, cols) * std::sqrt(variance);
   }
 
   /**
@@ -96,8 +96,7 @@ class HeInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c^2) * V(X).
-    W = randn<MatType>(W.n_rows, W.n_cols, 
-        distr_param(0.0, std::sqrt(variance)));
+    W = randn<MatType>(W.n_rows, W.n_cols) * std::sqrt(variance);
   }
 
   /**

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -79,7 +79,7 @@ class LecunNormalInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c ^ 2) * V(X).
-    W = randn<MatType>(rows, cols, distr_param(0.0, std::sqrt(variance)));
+    W = randn<MatType>(rows, cols) * std::sqrt(variance);
   }
 
   /**
@@ -102,8 +102,7 @@ class LecunNormalInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c ^ 2) * V(X).
-    W = randn<MatType>(W.n_rows, W.n_cols, 
-        distr_param(0.0, std::sqrt(variance)));
+    W = randn<MatType>(W.n_rows, W.n_cols) * std::sqrt(variance);
   }
 
   /**

--- a/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/lecun_normal_init.hpp
@@ -69,7 +69,7 @@ class LecunNormalInitialization
                   const size_t rows,
                   const size_t cols)
   {
-    // He initialization rule says to initialize weights with random
+    // Lecun initialization rule says to initialize weights with random
     // values taken from a gaussian distribution with mean = 0 and
     // standard deviation = sqrt(1 / rows), i.e. variance = (1 / rows).
     const double variance = 1.0 / ((double) rows);
@@ -79,7 +79,7 @@ class LecunNormalInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c ^ 2) * V(X).
-    W.imbue( [&]() { return std::sqrt(variance) * arma::randn(); } );
+    W = randn<MatType>(rows, cols, distr_param(0.0, std::sqrt(variance)));
   }
 
   /**
@@ -92,7 +92,7 @@ class LecunNormalInitialization
   void Initialize(MatType& W,
       const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
-    // He initialization rule says to initialize weights with random
+    // Lecun initialization rule says to initialize weights with random
     // values taken from a gaussian distribution with mean = 0 and
     // standard deviation = sqrt(1 / rows), i.e. variance = (1 / rows).
     const double variance = 1.0 / (double) W.n_rows;
@@ -102,7 +102,8 @@ class LecunNormalInitialization
 
     // Multipling a random variable X with variance V(X) by some factor c,
     // then the variance V(cX) = (c ^ 2) * V(X).
-    W.imbue( [&]() { return std::sqrt(variance) * arma::randn(); } );
+    W = randn<MatType>(W.n_rows, W.n_cols, 
+        distr_param(0.0, std::sqrt(variance)));
   }
 
   /**

--- a/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu_impl.hpp
@@ -127,7 +127,7 @@ void PReLUType<MatType>::Gradient(
 {
   MatType zeros = arma::zeros<MatType>(input.n_rows, input.n_cols);
   gradient.set_size(1, 1);
-  gradient(0) = accu(error % arma::min(zeros, input)) / input.n_cols;
+  gradient(0) = accu(error % min(zeros, input)) / input.n_cols;
 }
 
 template<typename MatType>

--- a/src/mlpack/methods/ann/layer/softmin_impl.hpp
+++ b/src/mlpack/methods/ann/layer/softmin_impl.hpp
@@ -63,7 +63,7 @@ void SoftminType<MatType>::Forward(
     MatType& output)
 {
   MatType softminInput = exp(-(input.each_row() -
-      arma::min(input, 0)));
+      min(input, 0)));
   output = softminInput.each_row() / sum(softminInput, 0);
 }
 

--- a/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
+++ b/src/mlpack/methods/approx_kfn/approx_kfn_main.cpp
@@ -338,7 +338,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
 
       const double averageError = sum(exactDistances.row(0) /
           distances.row(0)) / distances.n_cols;
-      const double minError = arma::min(exactDistances.row(0) /
+      const double minError = min(exactDistances.row(0) /
           distances.row(0));
       const double maxError = max(exactDistances.row(0) /
           distances.row(0));

--- a/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/all_categorical_split_impl.hpp
@@ -53,7 +53,7 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
 
   // If each child will have the minimum number of points in it, we can split.
   // Otherwise we can't.
-  if (arma::min(counts) < minimumLeafSize)
+  if (min(counts) < minimumLeafSize)
     return DBL_MAX;
 
   // Calculate the gain of the split.  First we have to calculate the labels
@@ -150,7 +150,7 @@ double AllCategoricalSplit<FitnessFunction>::SplitIfBetter(
 
   // If each child will have the minimum number of points in it, we can split.
   // Otherwise we can't.
-  if (arma::min(counts) < minimumLeafSize)
+  if (min(counts) < minimumLeafSize)
     return DBL_MAX;
 
   // Calculate the gain of the split.  First we have to calculate the labels

--- a/src/mlpack/methods/decision_tree/random_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/random_binary_numeric_split_impl.hpp
@@ -42,7 +42,7 @@ double RandomBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     return DBL_MAX; // It can't be outperformed.
 
   typename VecType::elem_type maxValue = max(data);
-  typename VecType::elem_type minValue = arma::min(data);
+  typename VecType::elem_type minValue = min(data);
 
   // Sanity check: if the maximum element is the same as the minimum, we
   // can't split in this dimension.
@@ -162,7 +162,7 @@ double RandomBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     return DBL_MAX; // It can't be outperformed.
 
   typename VecType::elem_type maxValue = max(data);
-  typename VecType::elem_type minValue = arma::min(data);
+  typename VecType::elem_type minValue = min(data);
 
   // Sanity check: if the maximum element is the same as the minimum, we
   // can't split in this dimension.

--- a/src/mlpack/methods/det/dtree_impl.hpp
+++ b/src/mlpack/methods/det/dtree_impl.hpp
@@ -332,7 +332,7 @@ DTree<MatType, TagType>::DTree(MatType & data) :
     start(0),
     end(data.n_cols),
     maxVals(arma::max(data, 1)),
-    minVals(arma::min(data, 1)),
+    minVals(min(data, 1)),
     splitDim(size_t(-1)),
     splitValue(std::numeric_limits<ElemType>::max()),
     subtreeLeavesLogNegError(-DBL_MAX),

--- a/src/mlpack/methods/kmeans/elkan_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/elkan_kmeans_impl.hpp
@@ -76,7 +76,7 @@ double ElkanKMeans<MetricType, MatType>::Iterate(const arma::mat& centroids,
 
   // Now find the closest cluster to each other cluster.  We multiply by 0.5 so
   // that this is equivalent to s(c) for each cluster c.
-  minClusterDistances = 0.5 * arma::min(clusterDistances).t();
+  minClusterDistances = 0.5 * min(clusterDistances).t();
 
   // Now loop over all points, and see which ones need to be updated.
   for (size_t i = 0; i < dataset.n_cols; ++i)

--- a/src/mlpack/methods/lmnn/constraints_impl.hpp
+++ b/src/mlpack/methods/lmnn/constraints_impl.hpp
@@ -26,7 +26,7 @@ Constraints<MetricType>::Constraints(
     precalculated(false)
 {
   // Ensure a valid k is passed.
-  size_t minCount = arma::min(arma::histc(labels, arma::unique(labels)));
+  size_t minCount = min(arma::histc(labels, arma::unique(labels)));
 
   if (minCount < k + 1)
   {

--- a/src/mlpack/methods/lmnn/lmnn_function_impl.hpp
+++ b/src/mlpack/methods/lmnn/lmnn_function_impl.hpp
@@ -64,7 +64,7 @@ LMNNFunction<MetricType>::LMNNFunction(const arma::mat& dataset,
   oldTransformationCounts.push_back(dataset.n_cols);
 
   // Check if we can impose bounds over impostors.
-  size_t minCount = arma::min(arma::histc(labels, arma::unique(labels)));
+  size_t minCount = min(arma::histc(labels, arma::unique(labels)));
   if (minCount <= k + 1)
   {
     // Initialize target neighbors & impostors.

--- a/src/mlpack/methods/lmnn/lmnn_main.cpp
+++ b/src/mlpack/methods/lmnn/lmnn_main.cpp
@@ -343,7 +343,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   else if (normalize)
   {
     // Find the minimum and maximum values for each dimension.
-    arma::vec ranges = max(data, 1) - arma::min(data, 1);
+    arma::vec ranges = max(data, 1) - min(data, 1);
     for (size_t d = 0; d < ranges.n_elem; ++d)
       if (ranges[d] == 0.0)
         ranges[d] = 1; // A range of 0 produces NaN later on.

--- a/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
+++ b/src/mlpack/methods/preprocess/preprocess_describe_main.cpp
@@ -201,7 +201,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
 
     // f at the front of the variable names means "feature".
     const double fMax = max(feature);
-    const double fMin = arma::min(feature);
+    const double fMin = min(feature);
     const double fMean = arma::mean(feature);
     const double fStd = arma::stddev(feature, population);
 

--- a/src/mlpack/methods/reinforcement_learning/environment/mountain_car.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/mountain_car.hpp
@@ -187,7 +187,7 @@ class MountainCar
     State state;
     stepsPerformed = 0;
     state.Velocity() = 0.0;
-    state.Position() = arma::as_scalar(arma::randu(1)) * 0.2 - 0.6;
+    state.Position() = randu() * 0.2 - 0.6;
     return state;
   }
 

--- a/src/mlpack/methods/reinforcement_learning/sac_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/sac_impl.hpp
@@ -183,7 +183,7 @@ void SAC<
   targetQ1Network.Predict(targetQInput, Q1);
   targetQ2Network.Predict(targetQInput, Q2);
   arma::rowvec nextQ = sampledRewards + config.Discount() * ((1 - isTerminal)
-      % arma::min(Q1, Q2));
+      % min(Q1, Q2));
 
   arma::mat sampledActionValues(action.size, sampledActions.size());
   for (size_t i = 0; i < sampledActions.size(); i++)

--- a/src/mlpack/methods/reinforcement_learning/td3_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/td3_impl.hpp
@@ -190,7 +190,7 @@ void TD3<
   targetQ1Network.Predict(targetQInput, Q1);
   targetQ2Network.Predict(targetQInput, Q2);
   arma::rowvec nextQ = sampledRewards + config.Discount() * ((1 - isTerminal)
-      % arma::min(Q1, Q2));
+      % min(Q1, Q2));
 
   arma::mat sampledActionValues(action.size, sampledActions.size());
   for (size_t i = 0; i < sampledActions.size(); i++)

--- a/src/mlpack/tests/ann/layer/parametric_relu.cpp
+++ b/src/mlpack/tests/ann/layer/parametric_relu.cpp
@@ -117,7 +117,7 @@ TEST_CASE("PReLUIntegrationTest", "[ANNLayerTest]")
   model.Add<Linear>(3);
   model.Add<PReLU>(0.01);
   model.Add<Linear>(1);
-
+  model.InputDimensions() = std::vector<size_t>({trainData.n_rows});
   // Sometimes the model may not optimize correctly, so we allow a few trials.
   bool success = false;
   for (size_t trial = 0; trial < 3; ++trial)

--- a/src/mlpack/tests/ann/layer/parametric_relu.cpp
+++ b/src/mlpack/tests/ann/layer/parametric_relu.cpp
@@ -117,7 +117,7 @@ TEST_CASE("PReLUIntegrationTest", "[ANNLayerTest]")
   model.Add<Linear>(3);
   model.Add<PReLU>(0.01);
   model.Add<Linear>(1);
-  model.InputDimensions() = std::vector<size_t>({trainData.n_rows});
+
   // Sometimes the model may not optimize correctly, so we allow a few trials.
   bool success = false;
   for (size_t trial = 0; trial < 3; ++trial)

--- a/src/mlpack/tests/ann/loss_functions_test.cpp
+++ b/src/mlpack/tests/ann/loss_functions_test.cpp
@@ -187,7 +187,7 @@ TEST_CASE("SimpleKLDivergenceTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(accu(output)) == Approx(-0.484392).epsilon(1e-3);
+  REQUIRE(accu(output) == Approx(-0.484392).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
@@ -456,7 +456,7 @@ TEST_CASE("SimpleEarthMoverDistanceLayerTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input3, target3, output);
-  REQUIRE(accu(output)) == Approx(-0.168867).epsilon(1e-3);
+  REQUIRE(accu(output) == Approx(-0.168867).epsilon(1e-3));
   REQUIRE(output.n_rows == input3.n_rows);
   REQUIRE(output.n_cols == input3.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);

--- a/src/mlpack/tests/ann/loss_functions_test.cpp
+++ b/src/mlpack/tests/ann/loss_functions_test.cpp
@@ -50,8 +50,7 @@ TEST_CASE("HuberLossTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(arma::as_scalar(accu(output)) ==
-                Approx(-0.8032).epsilon(1e-3));
+  REQUIRE(accu(output) == Approx(-0.8032).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
@@ -69,8 +68,7 @@ TEST_CASE("HuberLossTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(arma::as_scalar(accu(output)) ==
-            Approx(-0.0669333).epsilon(1e-3));
+  REQUIRE(accu(output) == Approx(-0.0669333).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
@@ -171,7 +169,7 @@ TEST_CASE("SimpleKLDivergenceTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(arma::as_scalar(accu(output)) == Approx(-5.8127).epsilon(1e-3));
+  REQUIRE(accu(output) == Approx(-5.8127).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
@@ -189,7 +187,7 @@ TEST_CASE("SimpleKLDivergenceTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(arma::as_scalar(accu(output)) == Approx(-0.484392).epsilon(1e-3));
+  REQUIRE(accu(output)) == Approx(-0.484392).epsilon(1e-3);
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
@@ -221,8 +219,7 @@ TEST_CASE("SimpleMeanSquaredLogarithmicErrorTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input, target, output);
-  REQUIRE(arma::as_scalar(accu(output)) ==
-      Approx(-10.5619).epsilon(1e-3));
+  REQUIRE(accu(output) == Approx(-10.5619).epsilon(1e-3));
   REQUIRE(output.n_rows == input.n_rows);
   REQUIRE(output.n_cols == input.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);
@@ -459,8 +456,7 @@ TEST_CASE("SimpleEarthMoverDistanceLayerTest", "[LossFunctionsTest]")
 
   // Test the Backward function.
   module.Backward(input3, target3, output);
-  REQUIRE(arma::as_scalar(accu(output)) == 
-      Approx(-0.168867).epsilon(1e-3));
+  REQUIRE(accu(output)) == Approx(-0.168867).epsilon(1e-3);
   REQUIRE(output.n_rows == input3.n_rows);
   REQUIRE(output.n_cols == input3.n_cols);
   CheckMatrices(output, expectedOutput, 0.1);

--- a/src/mlpack/tests/ann/recurrent_network_test.cpp
+++ b/src/mlpack/tests/ann/recurrent_network_test.cpp
@@ -36,23 +36,21 @@ void GenerateNoisySines(arma::cube& data,
 {
   arma::colvec x =  arma::linspace<arma::colvec>(0, points - 1, points) /
       points * 20.0;
-  arma::colvec y1 = arma::sin(x + arma::as_scalar(arma::randu(1)) * 3.0);
-  arma::colvec y2 = arma::sin(x / 2.0 + arma::as_scalar(arma::randu(1)) * 3.0);
+  arma::colvec y1 = arma::sin(x + randu() * 3.0);
+  arma::colvec y2 = arma::sin(x / 2.0 + randu() * 3.0);
 
   data = arma::zeros(1 /* single dimension */, sequences * 2, points);
   labels = arma::zeros(2 /* 2 classes */, sequences * 2);
 
   for (size_t seq = 0; seq < sequences; seq++)
   {
-    arma::vec sequence = arma::randu(points) * noise + y1 +
-        arma::as_scalar(arma::randu(1) - 0.5) * noise;
+    arma::vec sequence = randu(points) * noise + y1 + (randu() - 0.5) * noise;
     for (size_t i = 0; i < points; ++i)
       data(0, seq, i) = sequence[i];
 
     labels(0, seq) = 1;
 
-    sequence = arma::randu(points) * noise + y2 +
-        arma::as_scalar(arma::randu(1) - 0.5) * noise;
+    sequence = randu(points) * noise + y2 + (randu() - 0.5) * noise;
     for (size_t i = 0; i < points; ++i)
       data(0, sequences + seq, i) = sequence[i];
 

--- a/src/mlpack/tests/cosine_tree_test.cpp
+++ b/src/mlpack/tests/cosine_tree_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("CosineNodeCosineSplit", "[CosineTreeTest]")
       // CosineNodeSplit may differ from cosineMax below, so we have to handle
       // minor differences.
       double cosineMax = arma::max(cosines % (cosines < 1.0 + precision));
-      double cosineMin = arma::min(cosines);
+      double cosineMin = min(cosines);
       // If max(cosines) is close to 1.0 cosineMax and cosineMax2 may
       // differ significantly.
       double cosineMax2 = arma::max(cosines % (cosines < 1.0 - precision));


### PR DESCRIPTION
Hi,

There is still one single test that is failing and I am not able to figure out where the issue is coming from. Here is the test failure:

```
./bin/mlpack_test
mlpack version: mlpack git-a62b12d4ed
armadillo version: 12.6.1 (Cortisol Retox)
random seed: 0
terminate called after throwing an instance of 'std::logic_error'
  what():  as_scalar(): expression must evaluate to exactly one element

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mlpack_test is a Catch v2.13.10 host application.
Run with -? for options

-------------------------------------------------------------------------------
OneStepQLearningTest
-------------------------------------------------------------------------------
/meta/mlpack/src/mlpack/tests/ann/async_learning_test.cpp:21
...............................................................................

/meta/mlpack/src/mlpack/tests/ann/async_learning_test.cpp:21: FAILED:
due to a fatal error condition:
  SIGABRT - Abort (abnormal termination) signal

===============================================================================
test cases:     204 |     203 passed | 1 failed
assertions: 1070829 | 1070828 passed | 1 failed

[3]    3152935 IOT instruction (core dumped)  ./bin/mlpack_test

```

The issue here is that there are two as_scalar that are left in methods that could be used here, and both of them are being used correctly, (evaluate a vector and return a scalar).

I am also pretty sure that in a lot of places we can remove `arma::as_scalar` since it is used for no reason