### PR TITLE
Handle adjacent floating-point values in `BestBinaryNumericSplit`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,11 +9,17 @@
 
   * Remove `round()` implementation for old MSVC compilers (#3570).
 
-  * [R] Added inline plugin to the R bindings to allow for other R packages to link to headers (#3626, h/t @cgiachalis).
+  * [R] Added inline plugin to the R bindings to allow for other R packages to
+    link to headers (#3626, h/t @cgiachalis).
 
-  * [R] Removed extra gcc-specific options from `Makevars.win`  (#3627, h/t @kalibera).
+  * [R] Removed extra gcc-specific options from `Makevars.win`  (#3627, h/t
+    @kalibera).
 
-  * [R] Changed roxygen package-level documentation from using `@docType package` to `"_PACKAGE"`. (#3636)
+  * [R] Changed roxygen package-level documentation from using `@docType
+    package` to `"_PACKAGE"`. (#3636)
+
+  * Fix floating-point accuracy issue for decision trees that sometimes caused
+    crashes (#3595).
 
 ### mlpack 4.3.0
 ###### 2023-11-27

--- a/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp
@@ -158,6 +158,16 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       splitInfo[0] = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
 
+      // In some very extreme cases, floating-point inaccuracies can lead to the
+      // split result being the upper bound, which is problematic for later as
+      // all the child points will be sent to the left child.  If this happens,
+      // bump it down incrementally.
+      if (splitInfo[0] == data[sortedIndices[index]])
+      {
+        splitInfo[0] = std::nexttoward(splitInfo[0],
+            data[sortedIndices[index - 1]]);
+      }
+
       return gain;
     }
     else if (gain > bestFoundGain)
@@ -168,6 +178,16 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       splitInfo[0] = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
       improved = true;
+
+      // In some very extreme cases, floating-point inaccuracies can lead to the
+      // split result being the upper bound, which is problematic for later as
+      // all the child points will be sent to the left child.  If this happens,
+      // bump it down incrementally.
+      if (splitInfo[0] == data[sortedIndices[index]])
+      {
+        splitInfo[0] = std::nexttoward(splitInfo[0],
+            data[sortedIndices[index - 1]]);
+      }
     }
   }
 
@@ -297,6 +317,13 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       splitInfo = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
 
+      // In some very extreme cases, floating-point inaccuracies can lead to the
+      // split result being the upper bound, which is problematic for later as
+      // all the child points will be sent to the left child.  If this happens,
+      // bump it down incrementally.
+      if (splitInfo == data[sortedIndices[index]])
+        splitInfo = std::nexttoward(splitInfo, data[sortedIndices[index - 1]]);
+
       return gain;
     }
      if (gain > bestFoundGain)
@@ -306,6 +333,13 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       splitInfo = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
       improved = true;
+
+      // In some very extreme cases, floating-point inaccuracies can lead to the
+      // split result being the upper bound, which is problematic for later as
+      // all the child points will be sent to the left child.  If this happens,
+      // bump it down incrementally.
+      if (splitInfo == data[sortedIndices[index]])
+        splitInfo = std::nexttoward(splitInfo, data[sortedIndices[index - 1]]);
     }
   }
 
@@ -444,6 +478,13 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       splitInfo = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
 
+      // In some very extreme cases, floating-point inaccuracies can lead to the
+      // split result being the upper bound, which is problematic for later as
+      // all the child points will be sent to the left child.  If this happens,
+      // bump it down incrementally.
+      if (splitInfo == data[sortedIndices[index]])
+        splitInfo = std::nexttoward(splitInfo, data[sortedIndices[index - 1]]);
+
       return gain;
     }
     if (gain > bestFoundGain)
@@ -453,6 +494,13 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
       splitInfo = (data[sortedIndices[index - 1]] +
           data[sortedIndices[index]]) / 2.0;
       improved = true;
+
+      // In some very extreme cases, floating-point inaccuracies can lead to the
+      // split result being the upper bound, which is problematic for later as
+      // all the child points will be sent to the left child.  If this happens,
+      // bump it down incrementally.
+      if (splitInfo == data[sortedIndices[index]])
+        splitInfo = std::nexttoward(splitInfo, data[sortedIndices[index - 1]]);
     }
   }
   // If we didn't improve, return the original gain exactly as we got it


### PR DESCRIPTION
This is among the more esoteric issues that I have come across, although it's not particularly difficult to understand.  While I was reproducing #3595, on my system I would encounter a crash when building some of the trees in the random forest.  First I will write the problem, then I will show how it led to the crash:

Suppose I have two floating-point numbers `a` and `b`, and I want to compute the midpoint `(a + b) / 2`.

If `a` and `b` are adjacent (i.e. they differ by only one bit), then the midpoint actually cannot be represented as a floating-point number, and so the system will return either `a` *or* `b` as the result of `(a + b) / 2`, which is not correct but it's the best that floating-point can do.

Here's a very simple test case you can run to see:

```c++
#include <iostream>
#include <stdint.h>
#include <iomanip>

int main()
{
  uint64_t ua = 0x400357fe8b214d7b;
  double a = *reinterpret_cast<double*>(&u1);
  uint64_t ub = 0x400357fe8b214d79;
  double b = *reinterpret_cast<double*>(&u2);
  // a and b differ by one bit

  std::cout << "a: " << std::setprecision(20) << a << "\n";
  std::cout << "b: " << std::setprecision(20) << b << "\n";
  std::cout << "average: " << std::setprecision(20) << (a + b) / 2.0 << "\n";
  std::cout << "ua: " << std::hex << ua << "\n";
  std::cout << "ub: " << std::hex << ub << "\n";
}
```

In fact, you can get different results by changing the floating-point rounding mode with [fesetround()](https://en.cppreference.com/w/c/numeric/fenv/feround), but in any case the key is that I can get something back from this operation that is not a midpoint but instead either `a` or `b`.

This matters for decision trees because of how we do binary splits for numeric data.  When we find a split point where `a` is the last point that should go to the left child, and `b` is the first point that should go to the right child, we then assign `c = (a + b) / 2` as the split point, and use [the following rules](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/decision_tree/best_binary_numeric_split_impl.hpp#L478) to assign a point that has value `d`:

 * if `d <= c`, then the point goes to the left child
 * otherwise the point goes to the right child

This is used immediately during tree building.

So now putting the two pieces together... what happens if we are creating a decision tree, the only values we encounter are `a` and `b`, and also `a` and `b` are off by one bit?  You can get a situation where the returned midpoint `c` is equal to `max(a, b)`, and then this means that *all* points will go to the left child due to the rules above, and this causes problems during tree-building, because the tree-building code expects that any child it is building has more than zero points!

The solution I settled on here was to ensure that the split point value `c` that we choose is always less than `max(a, b)` (even if that is only by one bit).

Here is the (sub)vector of data that caused the problem:

```
index       point                 label

0           2.4179659719026718    1
1           2.4179659719026718    1
2           2.4179659719026718    1
3           0                     0
4           2.4179659719026714    1
5           2.4179659719026718    1
6           2.4179659719026718    1
7           2.4179659719026718    1
8           2.4179659719026718    1
9           2.4179659719026714    0
10          2.4179659719026718    1
11          2.4179659719026718    1
12          2.4179659719026714    1
13          0                     0
14          2.4179659719026718    1
15          2.4179659719026714    1
16          2.4179659719026714    1
17          0                     0
18          2.4179659719026714    0
19          2.4179659719026718    1
20          2.4179659719026714    1
21          2.4179659719026718    1
22          2.4179659719026718    1
23          2.4179659719026718    1
24          2.4179659719026718    1
25          2.4179659719026714    1
26          2.4179659719026718    1
27          0                     0
```

So there are two very very close values, and they are indeed off by one bit.  The old code would then select `2.4179659719026718` as the split point (due to the rounding reasons above), and this would then cause the error.