### PR TITLE
Fix name of package in Debian/Ubuntu

### DIFF
--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -17,7 +17,7 @@ your distribution; for instance, for Ubuntu and Debian you can simply run the
 command
 
 ```sh
-sudo apt-get install mlpack-dev
+sudo apt-get install libmlpack-dev
 ```
 
 and on Fedora or Red Hat:


### PR DESCRIPTION
I noticed while looking at the quickstart that the Debian/Ubuntu package is named wrong.  Oops, easy fix...