### PR TITLE
catch2 workaround for recent issue under macOS

### DIFF
--- a/src/mlpack/tests/catch.hpp
+++ b/src/mlpack/tests/catch.hpp
@@ -69,6 +69,9 @@
 // See e.g.:
 // https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
+#  ifndef __has_extension
+#    define __has_extension(x) 0
+#  endif
 #  include <TargetConditionals.h>
 #  if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || \
       (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)


### PR DESCRIPTION
adapted from upstream catch2 repo: https://github.com/catchorg/Catch2/pull/2840

same content as the PR for ensmallen: https://github.com/mlpack/ensmallen/pull/398
