### PR TITLE
Add Warning for Ubuntu LTS installation instructions

### DIFF
--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -24,7 +24,7 @@ sudo apt-get install libmlpack-dev
 repositories may not always be the latest. This can lead to issues, such as
 missing header files (e.g., mlpack.hpp missing in versions prior to 4.0). To 
 ensure compatibility with the latest mlpack features and examples, we recommend
- either building mlpack from source or using Docker, as explained in 
+ building mlpack from source, as explained in 
  [our installation guide](../../README.md#3-installing-and-using-mlpack-in-c).
 
 and on Fedora or Red Hat:

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -12,20 +12,14 @@ looking for, see the quickstarts for [Python](python.md),
 
 To use mlpack in C++, you only need the header files associated with the
 libraries, and the dependencies Armadillo and ensmallen (detailed in the
-[main README](../../README.md)).  The headers may already be pre-packaged for
-your distribution; for instance, for Ubuntu and Debian you can simply run the
-command
+[main README](../../README.md)).
+
+The headers may already be pre-packaged for your distribution;
+for instance, for Ubuntu and Debian you can simply run the command
 
 ```sh
 sudo apt-get install libmlpack-dev
 ```
-
-**Note for Ubuntu LTS Users**: The libmlpack-dev version in the Ubuntu LTS 
-repositories may not always be the latest. This can lead to issues, such as
-missing header files (e.g., mlpack.hpp missing in versions prior to 4.0). To 
-ensure compatibility with the latest mlpack features and examples, we recommend
- building mlpack from source, as explained in 
- [our installation guide](../../README.md#3-installing-and-using-mlpack-in-c).
 
 and on Fedora or Red Hat:
 
@@ -33,16 +27,21 @@ and on Fedora or Red Hat:
 sudo dnf install mlpack
 ```
 
-If you run a different distribution, mlpack may be packaged under a different
-name.  And if it is not packaged, you can use a Docker image from Dockerhub:
+You can also use a Docker image from Dockerhub, 
+whihch has mlpack headers already installed:
 
 ```sh
 docker run -it mlpack/mlpack /bin/bash
 ```
 
-This Docker image has mlpack headers already installed.
-
 If you prefer to build mlpack from scratch, see the
+[main README](../../README.md).
+
+**Note for Ubuntu LTS Users**: The libmlpack-dev version in the Ubuntu LTS 
+repositories may not always be the latest. This can lead to issues, such as
+missing header files (e.g., `mlpack.hpp` missing in versions prior to 4.0).
+To ensure compatibility with the latest mlpack features and examples,
+we recommend building mlpack from source, as explained in the
 [main README](../../README.md).
 
 ## Installing mlpack from vcpkg

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -20,6 +20,13 @@ command
 sudo apt-get install libmlpack-dev
 ```
 
+**Note for Ubuntu LTS Users**: The libmlpack-dev version in the Ubuntu LTS 
+repositories may not always be the latest. This can lead to issues, such as
+missing header files (e.g., mlpack.hpp missing in versions prior to 4.0). To 
+ensure compatibility with the latest mlpack features and examples, we recommend
+ either building mlpack from source or using Docker, as explained in 
+ [our installation guide](../../README.md#3-installing-and-using-mlpack-in-c).
+
 and on Fedora or Red Hat:
 
 ```sh

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -28,7 +28,7 @@ sudo dnf install mlpack
 ```
 
 You can also use a Docker image from Dockerhub, 
-whihch has mlpack headers already installed:
+which has mlpack headers already installed:
 
 ```sh
 docker run -it mlpack/mlpack /bin/bash


### PR DESCRIPTION
**Description**:

This PR refines the installation section of the mlpack Quickstart guide to better serve Ubuntu LTS users, who may face issues due to outdated libmlpack-dev versions in their repositories (currently version 3.4.2). The lack of the mlpack.hpp header in these versions can hinder new users' ability to run mlpack successfully.

**Changes**:

- Included a note for Ubuntu LTS users about the older `libmlpack-dev` version. 
- Recommended building mlpack from source or using Docker for accessing the latest version.

Appreciate your review and feedback on this documentation update.