### PR TITLE
DecisionTree documentation - NoRecursion flag

### DIFF
--- a/doc/user/methods/decision_tree.md
+++ b/doc/user/methods/decision_tree.md
@@ -325,7 +325,7 @@ DecisionTree<FitnessFunction,
    data dimensions
  * `DimensionSelectionType`: the strategy used for proposing dimensions to
    attempt to split on
- * `NoRecursion`: a boolean indicating whether or not to build a tree or a stump
+ * `NoRecursion`: a boolean indicating whether to build a tree or a stump
    (one level tree)
 
 Below, details are given for the requirements of each of these template types.
@@ -581,6 +581,6 @@ class CustomDimensionSelect
 
  * A `bool` value that indicates whether a decision tree should be
    constructed recursively.
- * If `true` _(default)_, a full decision tree will be built.
- * If `false`, only the root node will be split (producing a decision
+ * If `true`, only the root node will be split (producing a decision
    stump).
+ * If `false` _(default)_, a full decision tree will be built.

--- a/doc/user/methods/decision_tree_regressor.md
+++ b/doc/user/methods/decision_tree_regressor.md
@@ -314,7 +314,7 @@ DecisionTreeRegressor<FitnessFunction,
    data dimensions
  * `DimensionSelectionType`: the strategy used for proposing dimensions to
    attempt to split on
- * `NoRecursion`: a boolean indicating whether or not to build a tree or a stump
+ * `NoRecursion`: a boolean indicating whether to build a tree or a stump
    (one level tree)
 
 Below, details are given for the requirements of each of these template types.
@@ -583,6 +583,6 @@ class CustomDimensionSelect
 
  * A `bool` value that indicates whether a decision tree should be
    constructed recursively.
- * If `true` _(default)_, a full decision tree will be built.
- * If `false`, only the root node will be split (producing a decision
+ * If `true`, only the root node will be split (producing a decision
    stump).
+ * If `false` _(default)_, a full decision tree will be built.


### PR DESCRIPTION
Noticed a few faults in the DecisionTree and DecisionTreeRegressor documentation related to the `NoRecursion` flag:

- In the code it has been defaulted to false
![Screenshot 2024-03-30 222928](https://github.com/mlpack/mlpack/assets/92638241/2787cecd-b073-489d-b39e-795fa75a41c0)
![Screenshot 2024-03-30 222955](https://github.com/mlpack/mlpack/assets/92638241/8562c432-d983-4f52-b8b4-b27e34754ad1)

but in the documentation it said defaulted to true

- `NoRecursion=false` implies that it will be a full Decision Tree, and `NoRecursion=true` implies that it will be a stump, but it's the opposite in the documentation.