### PR TITLE
Added Simplified Constructor for RL algorithms with unit tests.

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/reinforcement_learning.hpp
+++ b/src/mlpack/methods/reinforcement_learning/reinforcement_learning.hpp
@@ -18,6 +18,7 @@
 #include "replay/replay.hpp"
 #include "worker/worker.hpp"
 #include "noise/noise.hpp"
+#include "rl_default_settings.hpp"
 
 #include "training_config.hpp"
 #include "async_learning.hpp"

--- a/src/mlpack/methods/reinforcement_learning/rl_default_settings.hpp
+++ b/src/mlpack/methods/reinforcement_learning/rl_default_settings.hpp
@@ -1,0 +1,67 @@
+/**
+ * @file methods/reinforcement_learning/td3.hpp
+ * @author Ali Hossam
+ *
+ * This file contains a class called RLDefaultParams. This class holds 
+ * default settings for different reinforcement learning algorithms. 
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MLPACK_METHODS_RL_DEFAULT_PARAMS
+#define MLPACK_METHODS_RL_DEFAULT_PARAMS
+
+#include <mlpack/core.hpp>
+#include <ensmallen.hpp>
+#include <mlpack/methods/ann/ann.hpp>
+
+#include "training_config.hpp"
+using namespace mlpack;
+using namespace ens;
+
+namespace mlpack
+{
+
+class RLdefaultParams
+{
+public:
+  RLdefaultParams() {
+    // Set up Training configuration.
+    config.StepSize() = 0.01;
+    config.TargetNetworkSyncInterval() = 1;
+    config.UpdateInterval() = 3;
+    config.Rho() = 0.001;
+
+    // Set up Actor network.
+    policyNetwork = FFN<EmptyLoss, GaussianInitialization>(
+        EmptyLoss(), GaussianInitialization(0, 0.1));
+    policyNetwork.Add(new Linear(128));
+    policyNetwork.Add(new ReLU());
+    policyNetwork.Add(new Linear(1));
+    policyNetwork.Add(new TanH());
+
+    // Set up Critic network.
+    qNetwork = FFN<EmptyLoss, GaussianInitialization>(
+        EmptyLoss(), GaussianInitialization(0, 0.1));
+    qNetwork.Add(new Linear(128));
+    qNetwork.Add(new ReLU());
+    qNetwork.Add(new Linear(1));
+  }
+
+  // Training configuration.
+  TrainingConfig config;
+
+  // Actor and Critic networks.
+  FFN<EmptyLoss, GaussianInitialization> policyNetwork;
+  FFN<EmptyLoss, GaussianInitialization> qNetwork;
+  
+  // Updater
+  AdamUpdate updater;
+};
+
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/reinforcement_learning/td3.hpp
+++ b/src/mlpack/methods/reinforcement_learning/td3.hpp
@@ -19,6 +19,7 @@
 
 #include "replay/replay.hpp"
 #include "training_config.hpp"
+#include "rl_default_settings.hpp"
 
 namespace mlpack {
 
@@ -47,9 +48,9 @@ namespace mlpack {
  */
 template <
   typename EnvironmentType,
-  typename QNetworkType,
-  typename PolicyNetworkType,
-  typename UpdaterType,
+  typename QNetworkType = decltype(RLdefaultParams().qNetwork),
+  typename PolicyNetworkType = decltype(RLdefaultParams().policyNetwork),
+  typename UpdaterType = decltype(RLdefaultParams().updater),
   typename ReplayType = RandomReplay<EnvironmentType>
 >
 class TD3
@@ -62,6 +63,13 @@ class TD3
   using ActionType = typename EnvironmentType::Action;
 
   /**
+   * Create the TD3 object with default settings.
+   * @param replayMethod Experience replay method.
+   * @param defaultParams Default parameters to call the other constructor.
+   */
+  TD3(ReplayType& replayMethod, RLdefaultParams& defaultParams);
+
+/**
    * Create the TD3 object with given settings.
    *
    * If you want to pass in a parameter and discard the original parameter

--- a/src/mlpack/methods/reinforcement_learning/td3_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/td3_impl.hpp
@@ -19,6 +19,26 @@
 
 namespace mlpack {
 
+// Empty constructor.
+template <
+  typename EnvironmentType,
+  typename QNetworkType,
+  typename PolicyNetworkType,
+  typename UpdaterType,
+  typename ReplayType
+>
+TD3<
+  EnvironmentType,
+  QNetworkType,
+  PolicyNetworkType,
+  UpdaterType,
+  ReplayType
+>::TD3(ReplayType& replayMethod, RLdefaultParams& defaultParams):
+  TD3(defaultParams.config,
+      defaultParams.qNetwork,
+      defaultParams.policyNetwork,
+      replayMethod) { }
+
 template <
   typename EnvironmentType,
   typename QNetworkType,

--- a/src/mlpack/tests/policy_gradient_test.cpp
+++ b/src/mlpack/tests/policy_gradient_test.cpp
@@ -227,6 +227,31 @@ TEST_CASE("GaussianNoiseTest", "[PolicyGradientTest]")
 }
 
 //! Test TD3 on Pendulum task.
+TEST_CASE("PendulumWithTD3-SimplifiedConstructor", "[PolicyGradientTest]")
+{
+  // It isn't guaranteed that the network will converge in the specified number
+  // of iterations using random weights.
+  bool converged = false;
+  for (size_t trial = 0; trial < 8; ++trial)
+  {
+    Log::Debug << "Trial number: " << trial << std::endl;
+    // Set up the replay method.
+    RandomReplay<Pendulum> replayMethod(32, 10000);
+
+    // Set up default params
+    RLdefaultParams defaultParams;
+
+    // Set up Twin Delayed Deep Deterministic policy gradient agent.
+    TD3<Pendulum>agent(replayMethod, defaultParams);
+
+    converged = testAgent<decltype(agent)>(agent, -900, 500, 10);
+    if (converged)
+      break;
+  }
+  REQUIRE(converged);
+}
+
+//! Test TD3 on Pendulum task.
 TEST_CASE("PendulumWithTD3", "[PolicyGradientTest]")
 {
   // It isn't guaranteed that the network will converge in the specified number


### PR DESCRIPTION
## Description

This pull request introduces a new constructor version with default settings for RL algorithms (currently TD3 algorithm only) to simplify agent creation procedure.
The implementation introduces a new class called RLdefaultParams which would store default parameters for different algorithms.

#### Proposed approach
```c++
// Set up default parameters
RLdefaultParams defaultParams;
// Set up Twin Delayed Deep Deterministic policy gradient agent.
TD3<Pendulum>agent(replayMethod, defaultParams);
```
If the current approach is approved i shall extend it to include other RL algorithms.

## Related Issue
#3648

