### PR TITLE
Add more links to sidebar, including CV/HPT.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -124,9 +124,12 @@ Transform data from one space to another.
 
 ### Modeling utilities
 
-Cross-validation, hyperparameter tuning, etc.
+Tools for assembling a full data science pipeline.
 
-<!-- TODO: add some -->
+ * [Cross-validation](user/cv.md): k-fold cross-validation tools for any mlpack
+   algorithm
+ * [Hyperparameter tuning](user/hpt.md): generic hyperparameter tuner to find
+   good hyperparameters for any mlpack algorithm
 
 ## Bindings to other languages
 

--- a/doc/sidebar.html
+++ b/doc/sidebar.html
@@ -18,7 +18,44 @@ when the sidebar is built for each page.
 
   <ul>
     <li>
-    <a href="LINKROOTuser/core.html">Core</a>
+      <details>
+        <summary>
+          <a href="LINKROOTindex.html#mlpack-basics">
+            Basics
+          </a>
+        </summary>
+        <ul>
+          <li>
+            <a href="LINKROOTquickstart/cpp.html">
+              C++ quickstart
+            </a>
+          </li>
+          <li>
+            <a href="LINKROOTindex.html#bindings-to-other-languages">
+              Binding quickstarts
+            </a>
+          </li>
+          <li>
+            <a href="LINKROOTuser/matrices.html">
+              Matrices and data
+            </a>
+          </li>
+          <li>
+            <a href="LINKROOTuser/load_save.html">
+              Loading and saving
+            </a>
+          </li>
+          <li>
+            <a href="LINKROOTcitation.html">
+              Citation
+            </a>
+          </li>
+        </ul>
+      </details>
+    </li>
+
+    <li>
+    <a href="LINKROOTuser/core.html">Core library functions</a>
     </li>
 
     <!-- Classification algorithms -->
@@ -142,9 +179,25 @@ when the sidebar is built for each page.
 
     <!-- Modeling utilities -->
     <li>
-      <a href="LINKROOTindex.html#modeling-utilities">
-        Modeling
-      </a>
+      <details>
+        <summary>
+          <a href="LINKROOTindex.html#modeling-utilities">
+            Modeling
+          </a>
+        </summary>
+        <ul>
+          <li>
+            <a href="LINKROOTuser/cv.html">
+              Cross-validation
+            </a>
+          </li>
+          <li>
+            <a href="LINKROOTuser/hpt.html">
+              Hyperparameter tuning
+            </a>
+          </li>
+        </ul>
+      </details>
     </li>
 
     <!-- Bindings to other languages -->


### PR DESCRIPTION
These changes add a `Basics` section to the sidebar of the documentation, and also provide direct links to the existing CV/HPT documentation.

I think that with these changes, the documentation is ready to deploy, and we can have the `Documentation` link on the mlpack website link directly to the index.md page.

Compiled example:

[click](https://www.ratml.org/misc/mlpack-markdown-doc-2/)

![image](https://github.com/mlpack/mlpack/assets/1845039/aa361d17-efa0-410b-87fe-23aa92790822)

I thought about having the `Basics` section expanded by default in the sidebar, but I'd love to hear others' opinions on that too---and any other details.