### PR TITLE
Fix batch handling for `Add::Gradient()`

### DIFF
--- a/src/mlpack/methods/ann/layer/add_impl.hpp
+++ b/src/mlpack/methods/ann/layer/add_impl.hpp
@@ -90,7 +90,8 @@ void AddType<MatType>::Gradient(
     const MatType& error,
     MatType& gradient)
 {
-  gradient = error;
+  // The gradient is the sum of the error across all input points.
+  gradient = sum(error, 1);
 }
 
 template<typename MatType>

--- a/src/mlpack/tests/ann/layer/add.cpp
+++ b/src/mlpack/tests/ann/layer/add.cpp
@@ -1,0 +1,98 @@
+/**
+ * @file tests/ann/layer/add.cpp
+ * @author Ryan Curtin
+ *
+ * Tests the Add layer (which is just a bias).
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/ann.hpp>
+
+#include "../../test_catch_tools.hpp"
+#include "../../catch.hpp"
+#include "../../serialization.hpp"
+#include "../ann_test_tools.hpp"
+
+using namespace mlpack;
+
+/**
+ * Simple test for Add layer.
+ */
+TEST_CASE("AddManualWeightTestCase", "[ANNLayerTest]")
+{
+  arma::mat input = arma::mat(1, 1);
+  input.zeros();
+
+  arma::mat weights(1, 1);
+
+  Add module;
+  module.InputDimensions() = std::vector<size_t>({ 1 });
+  module.ComputeOutputDimensions();
+  module.SetWeights(weights.memptr());
+  module.Parameters()[0] = 3.0;
+
+  arma::mat output(1, 1);
+  module.Forward(input, output);
+
+  REQUIRE(output[0] == Approx(input[0] + 3.0));
+
+  arma::mat delta(1, 1);
+
+  // The backwards pass does not modify anything.
+  module.Backward(input, output, output, delta);
+  REQUIRE(delta[0] == Approx(output[0]));
+
+  arma::mat error(1, 1);
+  error(0, 0) = 2.0;
+  arma::mat gradient(1, 1);
+  module.Gradient(input, error, gradient);
+  REQUIRE(gradient[0] == Approx(error[0]));
+}
+
+/**
+ * Test the Add layer with a batch size greater than 1.
+ */
+TEST_CASE("AddManualWeightBatchTestCase", "[ANNLayerTest]")
+{
+  arma::mat input = arma::mat(1, 5);
+  input.zeros();
+  input[1] = 2.0;
+
+  arma::mat weights(1, 1);
+
+  Add module;
+  module.InputDimensions() = std::vector<size_t>({ 1 });
+  module.ComputeOutputDimensions();
+  module.SetWeights(weights.memptr());
+  module.Parameters()[0] = 3.0;
+
+  arma::mat output(1, 5);
+  module.Forward(input, output);
+
+  REQUIRE(output[0] == Approx(input[0] + 3.0));
+  REQUIRE(output[1] == Approx(input[1] + 3.0));
+  REQUIRE(output[2] == Approx(input[2] + 3.0));
+  REQUIRE(output[3] == Approx(input[3] + 3.0));
+  REQUIRE(output[4] == Approx(input[4] + 3.0));
+
+  arma::mat delta(1, 5);
+
+  // The backwards pass does not modify anything.
+  module.Backward(input, output, output, delta);
+  REQUIRE(delta[0] == Approx(output[0]));
+  REQUIRE(delta[1] == Approx(output[1]));
+  REQUIRE(delta[2] == Approx(output[2]));
+  REQUIRE(delta[3] == Approx(output[3]));
+  REQUIRE(delta[4] == Approx(output[4]));
+
+  arma::mat error(1, 5);
+  error.fill(2.0);
+  error(0, 1) = 3.0;
+  arma::mat gradient(1, 1);
+  module.Gradient(input, error, gradient);
+  REQUIRE(gradient[0] == Approx(11.0));
+}

--- a/src/mlpack/tests/ann/layer_test.cpp
+++ b/src/mlpack/tests/ann/layer_test.cpp
@@ -18,6 +18,7 @@
 
 #include "layer/adaptive_max_pooling.cpp"
 #include "layer/adaptive_mean_pooling.cpp"
+#include "layer/add.cpp"
 #include "layer/add_merge.cpp"
 #include "layer/alpha_dropout.cpp"
 #include "layer/batch_norm.cpp"


### PR DESCRIPTION
The current implementation of the `Add` layer (which just adds a bias to each element) does not properly handle batch sizes greater than 1.  This can be seen in the example in #3666.

The `Gradient()` function expects the `error` matrix to be of size `outSize` x `batchSize`, and the gradient matrix itself is already sized to be `weightSize` x `1`.  (For the `Add` layer, it is conveniently true that `weightSize == outSize`.)

However, the existing implementation of `gradient = error` is only correct when `batchSize = 1`.  Much like [the Linear layer](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/ann/layer/linear_impl.hpp#L132), the bias term's gradient is computed as the *sum* across all input points in the batch.

I then noticed that the `Add` layer is not tested, so I added a simple test for it at a batch size of 1 and also at a larger batch size.  (Previous to this PR, the second test will fail.)