### PR TITLE
Documentation for `NMF` plus some bugfixes

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -120,6 +120,7 @@ Prepare data for machine learning algorithms.
 
 Transform data from one space to another.
 
+ * [`NMF`](user/methods/nmf.md): non-negative matrix factorization
  * [`PCA`](user/methods/pca.md): principal components analysis
 
 ### Modeling utilities

--- a/doc/sidebar.html
+++ b/doc/sidebar.html
@@ -180,6 +180,11 @@ when the sidebar is built for each page.
         </summary>
         <ul>
           <li>
+            <a href="LINKROOTuser/methods/nmf.html">
+              <code>NMF</code>
+            </a>
+          </li>
+          <li>
             <a href="LINKROOTuser/methods/pca.html">
               <code>PCA</code>
             </a>

--- a/doc/user/load_save.md
+++ b/doc/user/load_save.md
@@ -677,7 +677,9 @@ specified with the `format` parameter using one of the options below:
    contents.
 
  - `FileType::CSVASCII` (autodetect extensions `.csv`, `.tsv`): CSV format
-   with no header.
+   with no header.  If loading a sparse matrix and the CSV has three columns,
+   the data is interpreted as a
+   [coordinate list](https://arma.sourceforge.net/docs.html#save_load_mat).
 
  - `FileType::RawASCII` (autodetect extensions `.csv`, `.txt`):
    space-separated values or tab-separated values (TSV) with no header.
@@ -687,8 +689,8 @@ specified with the `format` parameter using one of the options below:
    [`arma_ascii`](https://arma.sourceforge.net/docs.html#save_load_mat)
    format.
 
- - `FileType::CoordASCII` (not autodetected, must be manually specified):
-   coordinate list format for sparse data (see
+ - `FileType::CoordASCII` (autodetect extensions `.txt`, `.tsv`; must be
+   loading a sparse matrix type): coordinate list format for sparse data (see
    [`coord_ascii`](https://arma.sourceforge.net/docs.html#save_load_mat)).
 
  - `FileType::ArmaBinary` (autodetect extension `.bin`): Armadillo's

--- a/doc/user/load_save.md
+++ b/doc/user/load_save.md
@@ -30,9 +30,9 @@ following functions.
    * By default the format is auto-detected based on the file extension, but can
      be explicitly specified with `format`; see [Formats](#formats).
 
-   * `matrix` is an `arma::mat&`, `arma::Mat<size_t>&`, or similar (e.g., a
-     reference to an Armadillo object that data will be loaded into or saved
-     from).
+   * `matrix` is an `arma::mat&`, `arma::Mat<size_t>&`, `arma::sp_mat&`, or
+     similar (e.g., a reference to an Armadillo object that data will be loaded
+     into or saved from).
 
    * If `fatal` is `true`, a `std::runtime_error` will be thrown on failure.
 

--- a/doc/user/methods/nmf.md
+++ b/doc/user/methods/nmf.md
@@ -97,8 +97,9 @@ std::cout << "RMSE of reconstructed matrix: "
 ***Notes***:
 
  - Low values of `rank` will give smaller matrices `W` and `H`, but the
-   decomposition will be less accurate.  Every problem is different, so `rank`
-   must be specified manually.
+   decomposition will be less accurate.  Larger values of `rank` will give more
+   accurate decompositions, but will take longer to compute.  Every problem is
+   different, so `rank` must be specified manually.
 
  - The expression `W * H` can be used to reconstruct the matrix `V`.
 

--- a/doc/user/methods/nmf.md
+++ b/doc/user/methods/nmf.md
@@ -270,21 +270,20 @@ NMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>
  - The nonzero residual is defined as the root of the sum of squared elements in
    the reconstruction error matrix `(V - WH)`, limited to locations where `V` is
    nonzero.
- - Constructor: `SimpleToleranceTermination<MatType, WHMatType>(tolerance=1e-5, maxIterations=10000,
-   reverseStepTolerance=3)`
+ - Constructor: `SimpleToleranceTermination<MatType, WHMatType>(tol=1e-5, maxIter=10000, extraSteps=3)`
    * `MatType` should be set to the type of `V` (see
-     [`Apply()` Parameters](#apply-parameters).
+     [`Apply()` Parameters](#apply-parameters)).
    * `WHMatType` (default `arma::mat`) should be set to the type of `W` and `H`
      (see [`Apply()` Parameters](#apply-parameters)).
-   * `tolerance` (a `double`) specifies the relative nonzero residual tolerance
-     for convergence.
-   * `maxIterations` (a `size_t`) specifies the maximum number of iterations
+   * `tol` (a `double`) specifies the relative nonzero residual tolerance for
+     convergence.
+   * `maxIter` (a `size_t`) specifies the maximum number of iterations
      before termination.
-   * `reverseStepTolerance` (a `size_t`) specifies the number of iterations
+   * `extraSteps` (a `size_t`) specifies the number of iterations
      where the relative nonzero residual must be below the tolerance for
      convergence.
  - The best `W` and `H` matrices (according to the nonzero residual) from the
-   final `reverseStepTolerance` iterations are returned by `nmf.Apply()`.
+   final `extraSteps` iterations are returned by `nmf.Apply()`.
  - `nmf.Apply()` will return the nonzero residue of the iteration corresponding
    to the best `W` and `H` matrices.
 
@@ -299,19 +298,19 @@ NMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>
    iterations.
  - `MatType` should be set to the type of `V` (see
    [`Apply()` Parameters](#apply-parameters)).
- - Constructor: `ValidationRMSETermination<MatType>(V, numValPoints, tolerance=1e-5, maxIterations=10000, reverseStepTolerance=3)`
+ - Constructor: `ValidationRMSETermination<MatType>(V, numValPoints, tol=1e-5, maxIter=10000, extraSteps=3)`
    * `V` is the matrix to be decomposed by `Apply()`.  This will be modified
      (validation elements will be removed).
    * `numValPoints` (a `size_t`) specifies number of test points from `V` to be
      held out.
-   * `tolerance` (a `double`) specifies the relative tolerance for the
-     validation RMSE for termination.
-   * `maxIterations` (a `size_t`) specifies the maximum number of iterations
-     before termination.
-   * `reverseStepTolerance` (a `size_t`) specifies the number of iterations
-     where the validation RMSE must be below the tolerance for convergence.
+   * `tol` (a `double`) specifies the relative tolerance for the validation RMSE
+     for termination.
+   * `maxIter` (a `size_t`) specifies the maximum number of iterations before
+     termination.
+   * `extraSteps` (a `size_t`) specifies the number of iterations where the
+     validation RMSE must be below the tolerance for convergence.
  - The best `W` and `H` matrices (according to the validation RMSE) from the
-   final `reverseStepTolerance` iterations are returned by `nmf.Apply()`.
+   final `extraSteps` iterations are returned by `nmf.Apply()`.
  - `nmf.Apply()` will return the best validation RMSE.
 
 ---

--- a/doc/user/methods/nmf.md
+++ b/doc/user/methods/nmf.md
@@ -1,0 +1,519 @@
+## `NMF`
+
+The `NMF` class implements non-negative matrix factorization, a technique to
+decompose a large (potentially sparse) matrix `V` into two smaller matrices `W`
+and `H`, such that `V ~= W * H`, and `W` and `H` only contain nonnegative
+elements.  This technique may be used for dimensionality reduction, or as part
+of a recommender system.
+
+The `NMF` class allows fully configurable behavior via [template
+parameters](#advanced-functionality-template-parameters).  For more general
+matrix factorization strategies, see the [`AMF`](user/methods/amf.md)
+(alternating matrix factorization) class documentation.
+
+#### Simple usage example:
+
+```c++
+// Create a random sparse matrix (V) of size 10x100, with 5% nonzeros.
+arma::sp_mat V;
+V.sprandu(100, 100, 0.05);
+
+// W and H will be low-rank matrices of size 100x10 and 10x100.
+arma::mat W, H;
+
+NMF nmf;                              // Step 1: create object.
+double rmse = nmf.Apply(V, 10, W, H); // Step 2: apply NMF to decompose V.
+
+// Now print some information about the factorized matrices.
+std::cout << "W has size: " << W.n_rows << " x " << W.n_cols << "."
+    << std::endl;
+std::cout << "H has size: " << H.n_rows << " x " << H.n_cols << "."
+    << std::endl;
+std::cout << "Reconstruction error (RMSE): " << rmse << "." << std::endl;
+```
+<p style="text-align: center; font-size: 85%"><a href="#simple-examples">More examples...</a></p>
+
+#### Quick links:
+
+ * [Constructors](#constructors): create `NMF` objects.
+ * [`Apply()`](#applying-decompositions): apply `NMF` decomposition to data.
+ * [Examples](#simple-examples) of simple usage and links to detailed example
+   projects.
+ * [Template parameters](#advanced-functionality-template-parameters) for
+   using different update rules, initialization strategies, and termination
+   criteria.
+ * [Advanced template examples](#advanced-functionality-examples) of use with
+   custom template parameters.
+
+#### See also:
+
+ * [`AMF`](amf.md): alternating matrix factorization
+ * [`CF`](cf.md): collaborative filtering (recommender system)
+ * [`SparseCoding`](sparse_coding.md)
+ * [mlpack transformations](../../index.md#transformations)
+ * [Non-negative matrix factorization on Wikipedia](https://en.wikipedia.org/wiki/Non-negative_Matrix_Factorization)
+ * [original paper](...) <!-- TODO -->
+
+### Constructors
+
+ * `nmf = NMF()`
+   - Create an `NMF` object.
+   - The rank of the decomposition is specified in the call to
+     [`Apply()`](#applying-decompositions).
+
+---
+
+ * `nmf = NMF(SimpleResidueTermination(minResidue=1e-5, maxIterations=10000))`
+   - Create an NMF object with custom termination parameters.
+   - `minResidue` (a `double`) specifies the minimum difference of the norm of
+     `W * H` between iterations for termination.
+   - `maxIterations` specifies the maximum number of iterations before
+     decomposition terminates.
+
+---
+
+### Applying Decompositions
+
+ * `double rmse = nmf.Apply(V, rank, W, H)`
+   - Decompose the matrix `V` into two non-negative matrices `W` and `H` with
+     rank `rank`.
+   - `W` will be set to size `V.n_rows` x `rank`.
+   - `H` will be set to size `rank` x `V.n_cols`.
+   - `W` and `H` are initialized randomly using the
+     [Acol](#initialization-rules) initialization strategy; i.e., each column of
+     `W` is an average of 5 random columns of `V`, and `H` is initialized
+     uniformly randomly.
+   - The RMSE (root mean squared error) of the decomposition is returned.
+
+---
+
+***Notes***:
+
+ - Low values of `rank` will give smaller matrices `W` and `H`, but the
+   decomposition will be less accurate.  Every problem is different, so `rank`
+   must be specified manually.
+
+ - The expression `W * H` can be used to reconstruct the matrix `V`.
+
+ - Custom behavior, such as custom initialization of `W` and `H`, different or
+   custom termination rules, and different update rules are discussed in the
+   [advanced functionality](#advanced-functionality-template-parameters)
+   section.
+
+#### `Apply()` Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `V` | [`arma::sp_mat` or `arma::mat`](../matrices.md) | Input matrix to be factorized. |
+| `rank` | `size_t` | Rank of decomposition; lower is smaller, higher is more
+accurate. |
+| `W` | [`arma::mat`](../matrices.md) | Output matrix in which `W` will be stored. |
+| `H` | [`arma::mat`](../matrices.md) | Output matrix in which `H` will be stored. |
+
+***Note:*** Matrices with different element types can be used for `V`, `W`, and
+`H`; e.g., `arma::fmat`.  While `V` can be sparse or dense, `W` and `H` must be
+dense matrices.
+
+### Simple Examples
+
+See also the [simple usage example](#simple-usage-example) for a trivial use of
+`NMF`.
+
+---
+
+Decompose a dense matrix with custom termination parameters.
+
+```c++
+// The matrix will have size 500x5000 with normally distributed elements.
+arma::mat V(500, 5000, arma::fill::randn);
+
+// Create the NMF object with a looser tolerance of 1e-3 and a maximum of 100
+// iterations only.
+mlpack::NMF nmf(mlpack::SimpleResidueTermination(1e-3, 100));
+
+arma::mat W, H;
+
+// Decompose with a rank of 25.
+// W will have size 500 x 25, and H will have size 25 x 5000.
+const double rmse = nmf.Apply(V, 25, W, H);
+
+std::cout << "RMSE of decomposition: " << rmse << "." << std::endl;
+
+// Compute norm of error matrix.
+const double errorNorm = arma::norm(V - W * H);
+std::cout << "Norm of error matrix: " << errorNorm << "." << std::endl;
+```
+
+---
+
+Decompose the sparse MovieLens dataset using a rank-12 decomposition and `float`
+element type.
+
+```c++
+// See https://datasets.mlpack.org/movielens-100k.csv.
+arma::sp_fmat V;
+mlpack::data::Load("movielens-100k.csv", V, true);
+
+// Create the NMF object.
+mlpack::NMF nmf;
+
+arma::fmat W, H;
+
+// Decompose the Movielens dataset with rank 12.
+const double rmse = nmf.Apply(V, 12, W, H);
+
+std::cout << "RMSE of MovieLens decomposition: " << rmse << "." << std::endl;
+```
+
+---
+
+Compare quality of decompositions of MovieLens with different ranks.
+
+```c++
+// See https://datasets.mlpack.org/movielens-100k.csv
+arma::sp_mat V;
+mlpack::data::Load("movielens-100k.csv", V, true);
+
+// Create the NMF object.
+mlpack::NMF nmf;
+arma::mat W, H;
+
+for (size_t rank = 10; rank < 100; rank += 5)
+{
+  // Decompose with the given rank.
+  const double rmse = nmf.Apply(V, rank, W, H);
+
+  std::cout << "RMSE for rank-" << rank << " decomposition: " << rmse << "."
+      << std::endl;
+}
+```
+
+---
+
+### Advanced Functionality: Template Parameters
+
+The `NMF` class has three template parameters that can be used for custom
+behavior.  The full signature of the class is:
+
+```
+NMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>
+```
+
+ * `TerminationPolicyType`: the strategy used to choose when to terminate NMF.
+ * `InitializationRuleType`: the strategy used to choose the initial `W` and `H`
+   matrices.
+ * `UpdateRuleType`: the update rules used for NMF:
+   - `NMFMultiplicativeDistanceUpdate`: update rule that ensure the Frobenius
+     norm of the reconstruction error is decreasing at each iteration.
+   - `NMFMultiplicativeDivergenceUpdate`: update rules that ensure
+     Kullback-Leibler divergence is decreasing at each iteration.
+   - `NMFALSUpdate`: alternating least-squares projections for `W` and `H`.
+   - For custom update rules, use the more general
+     [`AMF`](/src/mlpack/methods/amf/amf.hpp) class.
+
+<!-- TODO: update link above to Markdown documentation -->
+
+---
+
+#### `TerminationPolicyType`
+
+ * Specifies the strategy to use to choose when to stop the NMF algorithm.
+ * An instantiated `TerminationPolicyType` can be passed to the NMF constructor.
+ * The following choices are available for drop-in usage:
+
+***`SimpleResidueTermination`*** (default):
+
+ - Terminates when a maximum number of iterations is reached, or when the
+   residue (change in norm of `W * H` between iterations) is sufficiently small.
+ - Constructor: `SimpleResidueTermination(minResidue=1e-5, maxIterations=10000)`
+   * `minResidue` (a `double`) specifies the sufficiently small residue for
+     termination.
+   * `maxIterations` (a `size_t`) specifies the maximum number of iterations.
+
+***`MaxIterationTermination`***:
+
+ - Terminates when the maximum number of iterations is reached.
+ - No other condition is checked.
+ - Constructor: `MaxIterationTermination(maxIterations=1000)`
+
+***`SimpleToleranceTermination<MatType, WHMatType>`***:
+
+ - Terminates when the nonzero residual decreases a sufficiently small relative
+   amount between iterations (e.g. `(lastNonzeroResidual - nonzeroResidual) /
+   lastNonzeroResidual` is below a threshold), or when the maximum number of
+   iterations is reached.
+ - The residual must remain below the threshold for a specified number of
+   iterations.
+ - The nonzero residual is defined as the root of the sum of squared elements in
+   the reconstruction error matrix `(V - WH)`, limited to locations where `V` is
+   nonzero.
+ - Constructor: `SimpleToleranceTermination<MatType, WHMatType>(tolerance=1e-5, maxIterations=10000,
+   reverseStepTolerance=3)`
+   * `MatType` should be set to the type of `V` (see
+     [`Apply()` Parameters](#apply-parameters).
+   * `WHMatType` (default `arma::mat`) should be set to the type of `W` and `H`
+     (see [`Apply()` Parameters](#apply-parameters)).
+   * `tolerance` (a `double`) specifies the relative nonzero residual tolerance
+     for convergence.
+   * `maxIterations` (a `size_t`) specifies the maximum number of iterations
+     before termination.
+   * `reverseStepTolerance` (a `size_t`) specifies the number of iterations
+     where the relative nonzero residual must be below the tolerance for
+     convergence.
+ - The best `W` and `H` matrices (according to the nonzero residual) from the
+   final `reverseStepTolerance` iterations are returned by `Apply()`.
+
+***`ValidationRMSETermination<MatType>`***:
+
+ - Holds out a validation set of nonzero elements from `V`, and terminates when
+   the RMSE (root mean squared error) on this validation set is sufficiently
+   small between iterations.
+ - The validation RMSE must remain below the threshold for a specified number of
+   iterations.
+ - `MatType` should be set to the type of `V` (see
+   [`Apply()` Parameters](#apply-parameters)).
+ - Constructor: `ValidationRMSETermination<MatType>(V, numValPoints, tolerance=1e-5, maxIterations=10000, reverseStepTolerance=3)`
+   * `V` is the matrix to be decomposed by `Apply()`.  This will be modified
+     (validation elements will be removed).
+   * `numValPoints` (a `size_t`) specifies number of test points from `V` to be
+     held out.
+   * `tolerance` (a `double`) specifies the relative tolerance for the
+     validation RMSE for termination.
+   * `maxIterations` (a `size_t`) specifies the maximum number of iterations
+     before termination.
+   * `reverseStepTolerance` (a `size_t`) specifies the number of iterations
+     where the validation RMSE must be below the tolerance for convergence.
+ - The best `W` and `H` matrices (according to the validation RMSE) from the
+   final `reverseStepTolerance` iterations are returned by `Apply()`.
+
+***Custom policies***:
+
+ - A custom class for termination behavior must implement the following
+   functions.
+
+```c++
+// You can use this as a starting point for implementation.
+class CustomTerminationPolicy
+{
+ public:
+  // Initialize the termination policy for the given matrix V.  (It is okay to
+  // do nothing.)  This function is called at the beginning of Apply().
+  //
+  // If the termination policy requires V to compute convergence, store a
+  // reference or pointer to it in this function.
+  template<typename MatType>
+  void Initialize(const MatType& V);
+
+  // Check if convergence has occurred for the given W and H matrices.  Return
+  // `true` if so.
+  //
+  // Note that W and H may have different types than V (i.e. V may be sparse,
+  // and W and H must be dense.)
+  template<typename WHMatType>
+  bool IsConverged(const MatType& H, const MatType& W);
+};
+```
+
+---
+
+#### `InitializationRuleType`
+
+ * Specifies the strategy to use to initialize `W` and `H` at the beginning of
+   the NMF algorithm.
+ * An initialization `InitializationRuleType` can be passed to the following
+   constructor:
+   - `nmf = NMF(terminationPolicy, initializationRule)`
+ * The following choices are available for drop-in usage:
+
+***`RandomAcolInitialization<N>`*** (default):
+
+ - Initialize `W` by averaging `N` randomly chosen columns of `V`.
+ - Initialize `H` as uniform random in the range `[0, 1]`.
+ - The default value for `N` is 5.
+ - See also [the paper](https://arxiv.org/abs/1407.7299) describing the
+   strategy.
+
+***`NoInitialization`***:
+
+ - When `nmf.Apply(V, rank, W, H)`, the existing values of `W` and `H` will be
+   used.
+ - If `W` is not of size `V.n_rows` x `rank`, or if `H` is not of size `rank` x
+   `V.n_cols`, a `std::invalid_argument` exception will be thrown.
+
+***`GivenInitialization<MatType>`***:
+
+ - Set `W` and/or `H` to the given matrices when `Apply()` is called.
+ - `MatType` should be set to the type of `W` or `H` (default `arma::mat`); see
+   [`Apply()` Parameters](#apply-parameters).
+ - Constructors:
+   * `GivenInitialization<MatType>(W, H)`
+     - Specify both initial `W` and `H` matrices.
+   * `GivenInitialization<MatType>(M, isW=true)`
+     - If `isW` is `true`, then set initial `W` to `M`.
+     - If `isW` is `false`, then set initial `H` to `M`.
+     - This constructor is meant to only be used with `MergeInitialization`
+       (below).
+
+***`RandomInit`***:
+
+ - Initialize `W` and `H` as uniform random in the range `[0, 1]`.
+
+***`AverageInitialization`***:
+
+ - Initialize each element of `W` and `H` to the square root of the average
+   value of `V`, adding uniform random noise in the range `[0, 1]`.
+
+***`MergeInitialization<WRule, HRule>`***:
+
+ - Use two different initialization rules, one for `W` (`WRule`) and one for `H`
+   (`HRule`).
+ - Constructors:
+   * `MergeInitialization<WRule, HRule>()`
+     - Create the merge initialization with default-constructed rules for `W`
+       and `H`.
+   * `MergeInitialization<WRule, HRule>(wRule, hRule)`
+     - Create the merge initialization with instantiated rules for `W` and `H`.
+     - `wRule` and `hRule` will be copied.
+ - Any `WRule` and `HRule` classes must implement the `InitializeOne()`
+   function.
+
+***Custom rules***:
+
+ - A custom class for initializing `W` and `H` must implement the following
+   functions.
+
+```c++
+// You can use this as a starting point for implementation.
+class CustomInitialization
+{
+ public:
+  // Initialize the W and H matrices, given V and the rank of the decomposition.
+  // This is called at the start of `Apply()`.
+  //
+  // Note that `MatType` may be different from `WHMatType`; e.g., `V` could be
+  // sparse, but `W` and `H` must be dense.
+  template<typename MatType, typename WHMatType>
+  void Initialize(const MatType& V,
+                  const size_t rank,
+                  WHMatType& W,
+                  WHMatType& H);
+
+  // Initialize one of the W or H matrices, given V and the rank of the
+  // decomposition.
+  //
+  // If `isW` is `true`, then `M` should be treated as though it is `W`;
+  // if `isW` is `false`, then `M` should be treated as thought it is `H`.
+  //
+  // This function only needs to be implemented if it is intended to use the
+  // custom initialization strategy with `MergeInitialization`.
+  template<typename MatType, typename WHMatType>
+  void InitializeOne(const MatType& V,
+                     const size_t rank,
+                     WHMatType& M,
+                     const bool isW);
+};
+```
+
+---
+
+### Advanced Functionality Examples
+
+Use a pre-specified initialization for `W` and `H`.
+
+```c++
+// See https://datasets.mlpack.org/movielens-100k.csv.
+arma::sp_mat V;
+mlpack::data::Load("movielens-100k.csv", V, true);
+
+arma::mat W, H;
+
+// Pre-initialize W and H.
+// W will be filled with random values from a normal distribution.
+// H will be filled with 1s.
+W.randn(V.n_rows, 15);
+H.set_size(15, V.n_cols);
+H.fill(1.0);
+
+mlpack::NMF<NoInitialization> nmf;
+const double rmse = nmf.Apply(V, 15, W, H);
+
+std::cout << "RMSE of NMF decomposition with pre-specified W and H: " << rmse
+    << "." << std::endl;
+```
+
+---
+
+Use `ValidationRMSETermination` to decompose the MovieLens dataset until the
+RMSE of the held-out validation set is sufficiently low.
+
+```c++
+// See https://datasets.mlpack.org/movielens-100k.csv.
+arma::sp_mat V;
+mlpack::data::Load("movielens-100k.csv", V, true);
+
+arma::mat W, H;
+
+// Create a ValidationRMSETermination class that will hold out 3k points from V.
+// This will remove 3000 nonzero entries from V.
+mlpack::ValidationRMSETermination<arma::sp_mat> t(V, 3000);
+
+// Create the NMF object with the instantiated termination policy.
+mlpack::NMF<mlpack::ValidationRMSETermination<arma::sp_mat>> nmf(t);
+
+// Perform NMF with a rank of 20.
+// Note the RMSE returned here is the RMSE on V itself, but *not* the validation
+// set.
+const double rmse = nmf.Apply(V, 20, W, H);
+
+std::cout << "Validation RMSE: " << t.RMSE() << "." << std::endl;
+```
+
+---
+
+Use a custom termination policy that sets a limit on how long NMF is allowed to
+take.  First, we define the termination policy:
+
+```c++
+class CustomTimeTermination
+{
+ public:
+  CustomTimeTermination(const double totalAllowedTime) :
+      totalAllowedTime(totalAllowedTime) { }
+
+  template<typename MatType>
+  void Initialize(const MatType& /* V */)
+  {
+    totalTime = 0.0;
+    c.tic();
+  }
+
+  template<typename WHMatType>
+  bool IsConverged(const WHMatType& /* W */, const WHMatType& /* H */)
+  {
+    totalTime += c.toc();
+    c.tic();
+    return (totalTime > totalAllowedTime);
+  }
+
+ private:
+  double totalAllowedTime;
+  double totalTime;
+  arma::wall_clock c; // used for convenient timing
+};
+```
+
+Then we can use it in the test program:
+
+```c++
+// See https://datasets.mlpack.org/movielens-100k.csv.
+arma::sp_fmat V;
+mlpack::data::Load("movielens-100k.csv", V, true);
+
+CustomTimeTermination t(5 /* seconds */);
+mlpack::NMF<CustomTimeTermination> nmf(t);
+
+arma::fmat W, H;
+const double rmse = nmf.Apply(V, 10, W, H);
+
+std::cout << "RMSE after 5 seconds: " << rmse << "." << std::endl;
+```

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -320,7 +320,7 @@ do
   echo "Checking links in $f...";
 
   # To run checklink we have to strip out some perl stderr warnings...
-  checklink -qs --follow-file-links --suppress-broken 405 --suppress-broken 301 "$f" 2>&1 |
+  checklink -qs --follow-file-links --suppress-broken 405 --suppress-broken 301  -X "https://eigen.tuxfamily.org/index.php\?title=Main_Page" "$f" 2>&1 |
       grep -v 'Use of uninitialized value' > checklink_out;
   if [ -s checklink_out ];
   then

--- a/src/mlpack/core/data/detect_file_type.hpp
+++ b/src/mlpack/core/data/detect_file_type.hpp
@@ -64,6 +64,12 @@ inline FileType AutoDetect(std::fstream& stream,
  */
 inline FileType DetectFromExtension(const std::string& filename);
 
+/**
+ * Count the number of columns in the file.  The file must be a CSV/TSV/TXT file
+ * with no header.
+ */
+inline size_t CountCols(std::fstream& stream);
+
 } // namespace data
 } // namespace mlpack
 

--- a/src/mlpack/core/data/load.hpp
+++ b/src/mlpack/core/data/load.hpp
@@ -83,6 +83,7 @@ bool Load(const std::string& filename,
  *
  * The supported types of files are the same as found in Armadillo:
  *
+ *  - CSV (coord_ascii), denoted by .csv or .txt
  *  - TSV (coord_ascii), denoted by .tsv or .txt
  *  - TXT (coord_ascii), denoted by .txt
  *  - Raw binary (raw_binary), denoted by .bin
@@ -109,7 +110,8 @@ template<typename eT>
 bool Load(const std::string& filename,
           arma::SpMat<eT>& matrix,
           const bool fatal = false,
-          const bool transpose = true);
+          const bool transpose = true,
+          const FileType inputLoadType = FileType::AutoDetect);
 
 /**
  * Load a column vector from a file, guessing the filetype from the extension.

--- a/src/mlpack/core/data/types_impl.hpp
+++ b/src/mlpack/core/data/types_impl.hpp
@@ -35,43 +35,43 @@ inline arma::file_type ToArmaFileType(const FileType& type)
     case FileType::AutoDetect:
       return arma::auto_detect;
       break;
-    
+
     case FileType::RawASCII:
       return arma::raw_ascii;
       break;
-    
+
     case FileType::ArmaASCII:
       return arma::arma_ascii;
       break;
-    
+
     case FileType::CSVASCII:
       return arma::csv_ascii;
       break;
-    
+
     case FileType::RawBinary:
       return arma::raw_binary;
       break;
-    
+
     case FileType::ArmaBinary:
       return arma::arma_binary;
       break;
-    
+
     case FileType::PGMBinary:
       return arma::pgm_binary;
       break;
-    
+
     case FileType::PPMBinary:
       return arma::ppm_binary;
       break;
-    
+
     case FileType::HDF5Binary:
       return arma::hdf5_binary;
       break;
-    
+
     case FileType::CoordASCII:
       return arma::coord_ascii;
       break;
-    
+
     default:
       return arma::file_type_unknown;
       break;

--- a/src/mlpack/methods/amf/amf.hpp
+++ b/src/mlpack/methods/amf/amf.hpp
@@ -161,6 +161,7 @@ using SVDIncompleteIncrementalFactorizer = AMF<
     SimpleResidueTermination,
     RandomAcolInitialization<>,
     SVDIncompleteIncrementalLearning>;
+
 /**
  * SVDCompleteIncrementalFactorizer factorizes given matrix V into two matrices
  * W and H by complete incremental gradient descent. SVD complete incremental
@@ -174,6 +175,16 @@ using SVDCompleteIncrementalFactorizer = AMF<
     SimpleResidueTermination,
     RandomAcolInitialization<>,
     SVDCompleteIncrementalLearning<MatType>>;
+
+/**
+ * Convenience typedef: NMF can be represented by the AMF class, so for
+ * usability and discoverability we make the AMF class available under both
+ * names.
+ */
+template<typename TerminationPolicyType,
+         typename InitializationRuleType,
+         typename UpdateRuleType>
+using NMF = AMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/amf/amf.hpp
+++ b/src/mlpack/methods/amf/amf.hpp
@@ -97,11 +97,11 @@ class AMF
    * @param H Encoding matrix to output.
    * @param r Rank r of the factorization.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   double Apply(const MatType& V,
                const size_t r,
-               arma::mat& W,
-               arma::mat& H);
+               WHMatType& W,
+               WHMatType& H);
 
   //! Access the termination policy.
   const TerminationPolicyType& TerminationPolicy() const
@@ -181,10 +181,21 @@ using SVDCompleteIncrementalFactorizer = AMF<
  * usability and discoverability we make the AMF class available under both
  * names.
  */
-template<typename TerminationPolicyType,
-         typename InitializationRuleType,
-         typename UpdateRuleType>
-using NMF = AMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>;
+template<typename TerminationPolicyType = SimpleResidueTermination,
+         typename InitializationRuleType = RandomAcolInitialization<>,
+         typename UpdateRuleType = NMFMultiplicativeDistanceUpdate>
+class NMF : public AMF<TerminationPolicyType,
+                       InitializationRuleType,
+                       UpdateRuleType>
+{
+ public:
+  // Mirror constructor from AMF.
+  NMF(const TerminationPolicyType& terminationPolicy = TerminationPolicyType(),
+      const InitializationRuleType& initializeRule = InitializationRuleType(),
+      const UpdateRuleType& update = UpdateRuleType()) :
+      AMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>(
+          terminationPolicy, initializeRule, update) { }
+};
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/amf/amf_impl.hpp
+++ b/src/mlpack/methods/amf/amf_impl.hpp
@@ -39,12 +39,12 @@ AMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>::AMF(
 template<typename TerminationPolicyType,
          typename InitializationRuleType,
          typename UpdateRuleType>
-template<typename MatType>
+template<typename MatType, typename WHMatType>
 double AMF<TerminationPolicyType, InitializationRuleType, UpdateRuleType>::
 Apply(const MatType& V,
       const size_t r,
-      arma::mat& W,
-      arma::mat& H)
+      WHMatType& W,
+      WHMatType& H)
 {
   // Initialize W and H.
   initializationRule.Initialize(V, r, W, H);
@@ -57,11 +57,15 @@ Apply(const MatType& V,
   terminationPolicy.Initialize(V);
 
   // check if termination conditions are met
+  size_t iter = 0;
   while (!terminationPolicy.IsConverged(W, H))
   {
     // Update the values of W and H based on the update rules provided.
     update.WUpdate(V, W, H);
     update.HUpdate(V, W, H);
+    ++iter;
+    Log::Info << "AMF::Apply(): iteration " << iter << "; residue "
+        << terminationPolicy.Index() << ".\n";
   }
 
   // get final residue and iteration count from termination policy

--- a/src/mlpack/methods/amf/amf_impl.hpp
+++ b/src/mlpack/methods/amf/amf_impl.hpp
@@ -64,8 +64,8 @@ Apply(const MatType& V,
     update.WUpdate(V, W, H);
     update.HUpdate(V, W, H);
     ++iter;
-    Log::Info << "AMF::Apply(): iteration " << iter << "; residue "
-        << terminationPolicy.Index() << ".\n";
+    Log::Debug << "AMF::Apply(): iteration " << iter
+        << "; termination condition " << terminationPolicy.Index() << ".\n";
   }
 
   // get final residue and iteration count from termination policy

--- a/src/mlpack/methods/amf/init_rules/average_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/average_init.hpp
@@ -38,11 +38,11 @@ class AverageInitialization
    * @param W W matrix, to be initialized.
    * @param H H matrix, to be initialized.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void Initialize(const MatType& V,
                                 const size_t r,
-                                arma::mat& W,
-                                arma::mat& H)
+                                WHMatType& W,
+                                WHMatType& H)
   {
     const size_t n = V.n_rows;
     const size_t m = V.n_cols;
@@ -81,10 +81,10 @@ class AverageInitialization
    * with uniform random noise added.
    * @param whichMatrix If true, initialize W. Otherwise, initialize H.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void InitializeOne(const MatType& V,
                                    const size_t r,
-                                   arma::mat& M,
+                                   WHMatType& M,
                                    const bool whichMatrix = true)
   {
     const size_t n = V.n_rows;

--- a/src/mlpack/methods/amf/init_rules/given_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/given_init.hpp
@@ -23,6 +23,7 @@ namespace mlpack {
  * not use std::move() during the Initialize() method, so it can be reused for
  * multiple AMF objects, but will incur copies of the W and H matrices.
  */
+template<typename MatType = arma::mat>
 class GivenInitialization
 {
  public:
@@ -30,12 +31,12 @@ class GivenInitialization
   GivenInitialization() : wIsGiven(false), hIsGiven(false) { }
 
   // Initialize the GivenInitialization object with the given matrices.
-  GivenInitialization(const arma::mat& w, const arma::mat& h) :
+  GivenInitialization(const MatType& w, const MatType& h) :
     w(w), h(h), wIsGiven(true), hIsGiven(true) { }
 
   // Initialize the GivenInitialization object, taking control of the given
   // matrices.
-  GivenInitialization(const arma::mat&& w, const arma::mat&& h) :
+  GivenInitialization(const MatType&& w, const MatType&& h) :
     w(std::move(w)),
     h(std::move(h)),
     wIsGiven(true),
@@ -43,7 +44,7 @@ class GivenInitialization
   { }
 
   // Initialize either H or W with the given matrix.
-  GivenInitialization(const arma::mat& m, const bool whichMatrix = true)
+  GivenInitialization(const MatType& m, const bool whichMatrix = true)
   {
     if (whichMatrix)
     {
@@ -60,7 +61,7 @@ class GivenInitialization
   }
 
   // Initialize either H or W, taking control of the given matrix.
-  GivenInitialization(const arma::mat&& m, const bool whichMatrix = true)
+  GivenInitialization(const MatType&& m, const bool whichMatrix = true)
   {
     if (whichMatrix)
     {
@@ -84,11 +85,11 @@ class GivenInitialization
    * @param W W matrix, to be initialized to given matrix.
    * @param H H matrix, to be initialized to given matrix.
    */
-  template<typename MatType>
-  inline void Initialize(const MatType& V,
+  template<typename VMatType>
+  inline void Initialize(const VMatType& V,
                          const size_t r,
-                         arma::mat& W,
-                         arma::mat& H)
+                         MatType& W,
+                         MatType& H)
   {
     // Make sure the initial W, H matrices are given
     if (!wIsGiven)
@@ -139,10 +140,10 @@ class GivenInitialization
    * @param M W or H matrix, to be initialized to given matrix.
    * @param whichMatrix If true, initialize W. Otherwise, initialize H.
    */
-  template<typename MatType>
-  inline void InitializeOne(const MatType& V,
+  template<typename VMatType>
+  inline void InitializeOne(const VMatType& V,
                             const size_t r,
-                            arma::mat& M,
+                            MatType& M,
                             const bool whichMatrix = true)
   {
     if (whichMatrix)
@@ -207,9 +208,9 @@ class GivenInitialization
 
  private:
   //! The W matrix for initialization.
-  arma::mat w;
+  MatType w;
   //! The H matrix for initialization.
-  arma::mat h;
+  MatType h;
   //! Whether initial W is given.
   bool wIsGiven;
   //! Whether initial H is given.

--- a/src/mlpack/methods/amf/init_rules/init_rules.hpp
+++ b/src/mlpack/methods/amf/init_rules/init_rules.hpp
@@ -15,6 +15,7 @@
 #include "average_init.hpp"
 #include "given_init.hpp"
 #include "merge_init.hpp"
+#include "no_init.hpp"
 #include "random_acol_init.hpp"
 #include "random_init.hpp"
 

--- a/src/mlpack/methods/amf/init_rules/merge_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/merge_init.hpp
@@ -45,11 +45,11 @@ class MergeInitialization
    * @param W W matrix, to be initialized to given matrix.
    * @param H H matrix, to be initialized to given matrix.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline void Initialize(const MatType& V,
                          const size_t r,
-                         arma::mat& W,
-                         arma::mat& H)
+                         WHMatType& W,
+                         WHMatType& H)
   {
     wInitializationRule.InitializeOne(V, r, W);
     hInitializationRule.InitializeOne(V, r, H, false);

--- a/src/mlpack/methods/amf/init_rules/no_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/no_init.hpp
@@ -1,0 +1,103 @@
+/**
+ * @file methods/amf/init_rules/no_init.hpp
+ * @author Ryan Curtin
+ *
+ * Initialization rule for alternating matrix factorization (AMF). This simple
+ * initialization leaves matrices the way they are, only checking the size.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_AMF_INIT_RULES_NO_INIT_HPP
+#define MLPACK_METHODS_AMF_INIT_RULES_NO_INIT_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+
+/**
+ * This initialization rule for AMF does not initialize W and H, but instead
+ * simply sets them to the right size.  An exception is thrown if W or H is not
+ * the correct size.
+ */
+class NoInitialization
+{
+ public:
+  // Nothing to do in the constructor.
+  NoInitialization() { }
+
+  /**
+   * Check that W and H are the right sizes.
+   *
+   * @param V Input matrix.
+   * @param r Rank of decomposition.
+   * @param W W matrix, to be initialized to given matrix.
+   * @param H H matrix, to be initialized to given matrix.
+   */
+  template<typename MatType, typename WHMatType>
+  static inline void Initialize(const MatType& V,
+                                const size_t r,
+                                WHMatType& W,
+                                WHMatType& H)
+  {
+    // Make sure the initial W, H matrices have correct size.
+    if (W.n_rows != V.n_rows || W.n_cols != r)
+    {
+      std::ostringstream oss;
+      oss << "NoInitialization::Initialize(): W has incorrect size; expected "
+          << V.n_rows << " x " << r << ", got " << W.n_rows << " x " << W.n_cols
+          << "!";
+      throw std::invalid_argument(oss.str());
+    }
+
+    if (H.n_rows != r || H.n_cols != V.n_cols)
+    {
+      std::ostringstream oss;
+      oss << "NoInitialization::Initialize(): H has incorrect size; expected "
+          << r << " x " << V.n_cols << ", got " << H.n_rows << " x " << H.n_cols
+          << "!";
+      throw std::invalid_argument(oss.str());
+    }
+  }
+
+  // Initialize either W or H.
+  template<typename MatType, typename WHMatType>
+  static inline void InitializeOne(const MatType& V,
+                                   const size_t r,
+                                   WHMatType& M,
+                                   const bool whichMatrix = true)
+  {
+    if (whichMatrix)
+    {
+      if (M.n_rows != V.n_rows || M.n_cols != r)
+      {
+        std::ostringstream oss;
+        oss << "NoInitialization::Initialize(): W has incorrect size; expected "
+            << V.n_rows << " x " << r << ", got " << M.n_rows << " x "
+            << M.n_cols << "!";
+        throw std::invalid_argument(oss.str());
+      }
+    }
+    else
+    {
+      if (M.n_rows != r || M.n_cols != V.n_cols)
+      {
+        std::ostringstream oss;
+        oss << "NoInitialization::Initialize(): H has incorrect size; expected "
+            << r << " x " << V.n_cols << ", got " << M.n_rows << " x "
+            << M.n_cols << "!";
+        throw std::invalid_argument(oss.str());
+      }
+    }
+  }
+
+  //! Serialize the object (in this case, there is nothing to serialize).
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */) { }
+};
+
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/amf/init_rules/random_acol_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/random_acol_init.hpp
@@ -47,11 +47,11 @@ class RandomAcolInitialization
   RandomAcolInitialization()
   { }
 
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void Initialize(const MatType& V,
                                 const size_t r,
-                                arma::mat& W,
-                                arma::mat& H)
+                                WHMatType& W,
+                                WHMatType& H)
   {
     const size_t n = V.n_rows;
     const size_t m = V.n_cols;
@@ -70,8 +70,7 @@ class RandomAcolInitialization
     {
       for (size_t randCol = 0; randCol < columnsToAverage; randCol++)
       {
-        // .col() does not work in this case, as of Armadillo 3.920.
-        W.unsafe_col(col) += V.col(RandInt(0, m));
+        W.col(col) += V.col(RandInt(0, m));
       }
     }
 

--- a/src/mlpack/methods/amf/init_rules/random_init.hpp
+++ b/src/mlpack/methods/amf/init_rules/random_init.hpp
@@ -35,11 +35,11 @@ class RandomAMFInitialization
    * @param W W matrix, to be filled with random noise.
    * @param H H matrix, to be filled with random noise.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void Initialize(const MatType& V,
                                 const size_t r,
-                                arma::mat& W,
-                                arma::mat& H)
+                                WHMatType& W,
+                                WHMatType& H)
   {
     // Simple implementation (left in the header file due to its simplicity).
     const size_t n = V.n_rows;
@@ -58,10 +58,10 @@ class RandomAMFInitialization
    * @param M W or H matrix, to be filled with random noise.
    * @param whichMatrix If true, initialize W. Otherwise, initialize H.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline void InitializeOne(const MatType& V,
                             const size_t r,
-                            arma::mat& M,
+                            WHMatType& M,
                             const bool whichMatrix = true)
   {
     // Simple implementation (left in the header file due to its simplicity).

--- a/src/mlpack/methods/amf/termination_policies/max_iteration_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/max_iteration_termination.hpp
@@ -29,7 +29,7 @@ class MaxIterationTermination
    *
    * @param maxIterations Maximum number of allowed iterations.
    */
-  MaxIterationTermination(const size_t maxIterations) :
+  MaxIterationTermination(const size_t maxIterations = 1000) :
       maxIterations(maxIterations),
       iteration(0)
   {
@@ -48,7 +48,8 @@ class MaxIterationTermination
   /**
    * Check if convergence has occurred.
    */
-  bool IsConverged(const arma::mat& /* H */, const arma::mat& /* W */)
+  template<typename MatType>
+  bool IsConverged(const MatType& /* H */, const MatType& /* W */)
   {
     // Return true if we have performed the correct number of iterations.
     return (++iteration >= maxIterations);

--- a/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_residue_termination.hpp
@@ -72,7 +72,8 @@ class SimpleResidueTermination
    * @param W Basis matrix of output.
    * @param H Encoding matrix of output.
    */
-  bool IsConverged(arma::mat& W, arma::mat& H)
+  template<typename MatType>
+  bool IsConverged(MatType& W, MatType& H)
   {
     // Calculate the norm and compute the residue, but do it by hand, so as to
     // avoid calculating (W*H), which may be very large.

--- a/src/mlpack/methods/amf/termination_policies/simple_tolerance_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/simple_tolerance_termination.hpp
@@ -18,15 +18,15 @@ namespace mlpack {
 
 /**
  * This class implements residue tolerance termination policy. Termination
- * criterion is met when increase in residue value drops below the given tolerance.
- * To accommodate spikes certain number of successive residue drops are accepted.
- * This upper imit on successive drops can be adjusted with reverseStepCount.
- * Secondary termination criterion terminates algorithm when iteration count
- * goes above the threshold.
+ * criterion is met when increase in residue value drops below the given
+ * tolerance.  To accommodate spikes certain number of successive residue drops
+ * are accepted.  This upper limit on successive drops can be adjusted with
+ * reverseStepCount.  Secondary termination criterion terminates algorithm when
+ * iteration count goes above the threshold.
  *
  * @see AMF
  */
-template <class MatType>
+template<typename MatType, typename WHMatType = arma::mat>
 class SimpleToleranceTermination
 {
  public:
@@ -43,8 +43,8 @@ class SimpleToleranceTermination
       reverseStepTolerance(reverseStepTolerance),
       reverseStepCount(0),
       isCopy(false),
-      c_indexOld(0),
-      c_index(0)
+      cIndexOld(0),
+      cIndex(0)
   { }
 
   /**
@@ -62,21 +62,19 @@ class SimpleToleranceTermination
 
     this->V = &V;
 
-    c_index = 0;
-    c_indexOld = 0;
+    cIndex = 0;
+    cIndexOld = 0;
   }
 
   /**
-   * Check if termination criterio is met.
+   * Check if termination criterion is met.
    *
    * @param W Basis matrix of output.
    * @param H Encoding matrix of output.
    */
-  bool IsConverged(arma::mat& W, arma::mat& H)
+  bool IsConverged(WHMatType& W, WHMatType& H)
   {
-    arma::mat WH;
-
-    WH = W * H;
+    WHMatType WH = W * H;
 
     // Compute residue.
     residueOld = residue;
@@ -86,17 +84,17 @@ class SimpleToleranceTermination
     size_t count = 0;
     for (size_t i = 0; i < n; ++i)
     {
-        for (size_t j = 0; j < m; ++j)
+      for (size_t j = 0; j < m; ++j)
+      {
+        double temp = 0;
+        if ((temp = (*V)(i, j)) != 0)
         {
-            double temp = 0;
-            if ((temp = (*V)(i, j)) != 0)
-            {
-                temp = (temp - WH(i, j));
-                temp = temp * temp;
-                sum += temp;
-                count++;
-            }
+          temp = (temp - WH(i, j));
+          temp = temp * temp;
+          sum += temp;
+          count++;
         }
+      }
     }
 
     residue = sum;
@@ -120,8 +118,8 @@ class SimpleToleranceTermination
         this->W = W;
         this->H = H;
         // Store residue values.
-        c_index = residue;
-        c_indexOld = residueOld;
+        cIndex = residue;
+        cIndexOld = residueOld;
       }
       // Increase successive drop count.
       reverseStepCount++;
@@ -132,7 +130,7 @@ class SimpleToleranceTermination
       // Initialize successive drop count.
       reverseStepCount = 0;
       // If residue is droped below minimum scrap stored values.
-      if (residue <= c_indexOld && isCopy == true)
+      if (residue <= cIndexOld && isCopy == true)
       {
         isCopy = false;
       }
@@ -147,7 +145,7 @@ class SimpleToleranceTermination
       {
         W = this->W;
         H = this->H;
-        residue = c_index;
+        residue = cIndex;
       }
       return true;
     }
@@ -195,10 +193,10 @@ class SimpleToleranceTermination
   bool isCopy;
 
   //! Variables to store information of minimum residue poi.
-  arma::mat W;
-  arma::mat H;
-  double c_indexOld;
-  double c_index;
+  WHMatType W;
+  WHMatType H;
+  double cIndexOld;
+  double cIndex;
 }; // class SimpleToleranceTermination
 
 } // namespace mlpack

--- a/src/mlpack/methods/amf/termination_policies/validation_rmse_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/validation_rmse_termination.hpp
@@ -183,6 +183,7 @@ class ValidationRMSETermination
 
   //! Get current value of residue
   const double& Index() const { return rmse; }
+  const double& RMSE() const { return rmse; }
 
   //! Get current iteration count
   const size_t& Iteration() const { return iteration; }

--- a/src/mlpack/methods/amf/termination_policies/validation_rmse_termination.hpp
+++ b/src/mlpack/methods/amf/termination_policies/validation_rmse_termination.hpp
@@ -18,19 +18,21 @@ namespace mlpack {
 
 /**
  * This class implements validation termination policy based on RMSE index.
- * The input data matrix is divided into 2 sets, training set and validation set.
+ * The input data matrix is divided into 2 sets, training set and validation
+ * set.
+ *
  * Entries of validation set are nullifed in the input matrix. Termination
  * criterion is met when increase in validation set RMSe value drops below the
- * given tolerance. To accommodate spikes certain number of successive validation
- * RMSE drops are accepted. This upper imit on successive drops can be adjusted
- * with reverseStepCount. Secondary termination criterion terminates algorithm
- * when iteration count goes above the threshold.
+ * given tolerance. To accommodate spikes certain number of successive
+ * validation RMSE drops are accepted. This upper imit on successive drops can
+ * be adjusted with reverseStepCount. Secondary termination criterion terminates
+ * algorithm when iteration count goes above the threshold.
  *
  * @note The input matrix is modified by this termination policy.
  *
  * @see AMF
  */
-template <class MatType>
+template<typename MatType, typename WHMatType = arma::mat>
 class ValidationRMSETermination
 {
  public:
@@ -39,29 +41,29 @@ class ValidationRMSETermination
    * set in data matrix(training set).
    *
    * @param V Input matrix to be factorized.
-   * @param num_test_points number of validation test points
+   * @param numTestPoints number of validation test points
    * @param tolerance the tolerance value to compare RMSe against
    * @param maxIterations max iteration count before termination
    * @param reverseStepTolerance max successive RMSE drops allowed
    */
   ValidationRMSETermination(MatType& V,
-                            size_t num_test_points,
+                            size_t numTestPoints,
                             double tolerance = 1e-5,
                             size_t maxIterations = 10000,
                             size_t reverseStepTolerance = 3)
         : tolerance(tolerance),
           maxIterations(maxIterations),
-          num_test_points(num_test_points),
+          numTestPoints(numTestPoints),
           reverseStepTolerance(reverseStepTolerance)
   {
     size_t n = V.n_rows;
     size_t m = V.n_cols;
 
     // initialize validation set matrix
-    test_points.zeros(num_test_points, 3);
+    testPoints.zeros(numTestPoints, 3);
 
     // fill validation set matrix with random chosen entries
-    for (size_t i = 0; i < num_test_points; ++i)
+    for (size_t i = 0; i < numTestPoints; ++i)
     {
       double t_val;
       size_t t_row;
@@ -75,9 +77,9 @@ class ValidationRMSETermination
       } while ((t_val = V(t_row, t_col)) == 0);
 
       // add the entry to the validation set
-      test_points(i, 0) = t_row;
-      test_points(i, 1) = t_col;
-      test_points(i, 2) = t_val;
+      testPoints(i, 0) = t_row;
+      testPoints(i, 1) = t_col;
+      testPoints(i, 2) = t_val;
 
       // nullify the added entry from data matrix (training set)
       V(t_row, t_col) = 0;
@@ -96,8 +98,8 @@ class ValidationRMSETermination
     rmse = DBL_MAX;
     rmseOld = DBL_MAX;
 
-    c_index = 0;
-    c_indexOld = 0;
+    cIndex = 0;
+    cIndexOld = 0;
 
     reverseStepCount = 0;
     isCopy = false;
@@ -109,27 +111,25 @@ class ValidationRMSETermination
    * @param W Basis matrix of output.
    * @param H Encoding matrix of output.
    */
-  bool IsConverged(arma::mat& W, arma::mat& H)
+  bool IsConverged(WHMatType& W, WHMatType& H)
   {
-    arma::mat WH;
-
-    WH = W * H;
+    WHMatType WH = W * H;
 
     // compute validation RMSE
     if (iteration != 0)
     {
       rmseOld = rmse;
       rmse = 0;
-      for (size_t i = 0; i < num_test_points; ++i)
+      for (size_t i = 0; i < numTestPoints; ++i)
       {
-        size_t t_row = test_points(i, 0);
-        size_t t_col = test_points(i, 1);
-        double t_val = test_points(i, 2);
+        size_t t_row = testPoints(i, 0);
+        size_t t_col = testPoints(i, 1);
+        double t_val = testPoints(i, 2);
         double temp = (t_val - WH(t_row, t_col));
         temp *= temp;
         rmse += temp;
       }
-      rmse /= num_test_points;
+      rmse /= numTestPoints;
       rmse = std::sqrt(rmse);
     }
 
@@ -147,8 +147,8 @@ class ValidationRMSETermination
         this->W = W;
         this->H = H;
         // store residue values
-        c_indexOld = rmseOld;
-        c_index = rmse;
+        cIndexOld = rmseOld;
+        cIndex = rmse;
       }
       // increase successive drop count
       reverseStepCount++;
@@ -159,7 +159,7 @@ class ValidationRMSETermination
       // initialize successive drop count
       reverseStepCount = 0;
       // if residue is droped below minimum scrap stored values
-      if (rmse <= c_indexOld && isCopy == true)
+      if (rmse <= cIndexOld && isCopy == true)
       {
         isCopy = false;
       }
@@ -174,7 +174,7 @@ class ValidationRMSETermination
       {
         W = this->W;
         H = this->H;
-        rmse = c_index;
+        rmse = cIndex;
       }
       return true;
     }
@@ -188,7 +188,7 @@ class ValidationRMSETermination
   const size_t& Iteration() const { return iteration; }
 
   //! Get number of validation points
-  const size_t& NumTestPoints() const { return num_test_points; }
+  const size_t& NumTestPoints() const { return numTestPoints; }
 
   //! Access upper limit of iteration count
   const size_t& MaxIterations() const { return maxIterations; }
@@ -204,13 +204,13 @@ class ValidationRMSETermination
   //! max iteration limit
   size_t maxIterations;
   //! number of validation test points
-  size_t num_test_points;
+  size_t numTestPoints;
 
   //! current iteration count
   size_t iteration;
 
   //! validation point matrix
-  arma::mat test_points;
+  WHMatType testPoints;
 
   //! rmse values
   double rmseOld;
@@ -226,10 +226,10 @@ class ValidationRMSETermination
   bool isCopy;
 
   //! variables to store information of minimum residue point
-  arma::mat W;
-  arma::mat H;
-  double c_indexOld;
-  double c_index;
+  WHMatType W;
+  WHMatType H;
+  double cIndexOld;
+  double cIndex;
 }; // class ValidationRMSETermination
 
 } // namespace mlpack

--- a/src/mlpack/methods/amf/update_rules/nmf_als.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_als.hpp
@@ -67,10 +67,10 @@ class NMFALSUpdate
    * @param W Basis matrix to be updated.
    * @param H Encoding matrix.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void WUpdate(const MatType& V,
-                             arma::mat& W,
-                             const arma::mat& H)
+                             WHMatType& W,
+                             const WHMatType& H)
   {
     // The call to inv() sometimes fails; so we are using the psuedoinverse.
     // W = (inv(H * H.t()) * H * V.t()).t();
@@ -100,10 +100,10 @@ class NMFALSUpdate
    * @param W Basis matrix.
    * @param H Encoding matrix to be updated.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void HUpdate(const MatType& V,
-                             const arma::mat& W,
-                             arma::mat& H)
+                             const WHMatType& W,
+                             WHMatType& H)
   {
     H = pinv(W.t() * W) * W.t() * V;
 

--- a/src/mlpack/methods/amf/update_rules/nmf_mult_dist.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_mult_dist.hpp
@@ -65,12 +65,13 @@ class NMFMultiplicativeDistanceUpdate
    * @param W Basis matrix to be updated.
    * @param H Encoding matrix.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void WUpdate(const MatType& V,
-                             arma::mat& W,
-                             const arma::mat& H)
+                             WHMatType& W,
+                             const WHMatType& H)
   {
-    W = (W % (V * H.t())) / (W * H * H.t());
+    WHMatType zz = W * H * H.t();
+    W = (W % (V * H.t())) / (W * H * H.t() + 1e-15);
   }
 
   /**
@@ -87,12 +88,13 @@ class NMFMultiplicativeDistanceUpdate
    * @param W Basis matrix.
    * @param H Encoding matrix to be updated.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void HUpdate(const MatType& V,
-                             const arma::mat& W,
-                             arma::mat& H)
+                             const WHMatType& W,
+                             WHMatType& H)
   {
-    H = (H % (W.t() * V)) / (W.t() * W * H);
+    WHMatType zz = W.t() * W * H;
+    H = (H % (W.t() * V)) / (W.t() * W * H + 1e-15);
   }
 
   //! Serialize the object (in this case, there is nothing to serialize).

--- a/src/mlpack/methods/amf/update_rules/nmf_mult_div.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_mult_div.hpp
@@ -81,27 +81,8 @@ class NMFMultiplicativeDivergenceUpdate
                              const WHMatType& H)
   {
     // Simple implementation left in the header file.
-    WHMatType t1;
-    arma::Row<typename WHMatType::elem_type> t2;
-
-    t1 = W * H;
-    for (size_t i = 0; i < W.n_rows; ++i)
-    {
-      for (size_t j = 0; j < W.n_cols; ++j)
-      {
-        // Writing this as a single expression does not work as of Armadillo
-        // 3.920.  This should be fixed in a future release, and then the code
-        // below can be fixed.
-        // t2 = H.row(j) % V.row(i) / t1.row(i);
-        t2.set_size(H.n_cols);
-        for (size_t k = 0; k < t2.n_elem; ++k)
-        {
-          t2(k) = H(j, k) * V(i, k) / (t1(i, k) + 1e-15);
-        }
-
-        W(i, j) = W(i, j) * sum(t2) / (sum(H.row(j)) + 1e-15);
-      }
-    }
+    W %= ((V / (W * H + 1e-15)) * H.t()) /
+        (repmat(sum(H, 1).t(), W.n_rows, 1) + 1e-15);
   }
 
   /**
@@ -125,27 +106,8 @@ class NMFMultiplicativeDivergenceUpdate
                              WHMatType& H)
   {
     // Simple implementation left in the header file.
-    WHMatType t1;
-    arma::Col<typename WHMatType::elem_type> t2;
-
-    t1 = W * H;
-    for (size_t i = 0; i < H.n_rows; ++i)
-    {
-      for (size_t j = 0; j < H.n_cols; ++j)
-      {
-        // Writing this as a single expression does not work as of Armadillo
-        // 3.920.  This should be fixed in a future release, and then the code
-        // below can be fixed.
-        // t2 = W.col(i) % V.col(j) / t1.col(j);
-        t2.set_size(W.n_rows);
-        for (size_t k = 0; k < t2.n_elem; ++k)
-        {
-          t2(k) = W(k, i) * V(k, j) / (t1(k, j) + 1e-15);
-        }
-
-        H(i, j) = H(i, j) * sum(t2) / (sum(W.col(i)) + 1e-15);
-      }
-    }
+    H %= (W.t() * (V / (W * H + 1e-15))) /
+        (repmat(sum(W, 0).t(), 1, H.n_cols) + 1e-15);
   }
 
   //! Serialize the object (in this case, there is nothing to serialize).

--- a/src/mlpack/methods/amf/update_rules/nmf_mult_div.hpp
+++ b/src/mlpack/methods/amf/update_rules/nmf_mult_div.hpp
@@ -75,14 +75,14 @@ class NMFMultiplicativeDivergenceUpdate
    * @param W Basis matrix to be updated.
    * @param H Encoding matrix.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void WUpdate(const MatType& V,
-                             arma::mat& W,
-                             const arma::mat& H)
+                             WHMatType& W,
+                             const WHMatType& H)
   {
     // Simple implementation left in the header file.
-    arma::mat t1;
-    arma::rowvec t2;
+    WHMatType t1;
+    arma::Row<typename WHMatType::elem_type> t2;
 
     t1 = W * H;
     for (size_t i = 0; i < W.n_rows; ++i)
@@ -96,10 +96,10 @@ class NMFMultiplicativeDivergenceUpdate
         t2.set_size(H.n_cols);
         for (size_t k = 0; k < t2.n_elem; ++k)
         {
-          t2(k) = H(j, k) * V(i, k) / t1(i, k);
+          t2(k) = H(j, k) * V(i, k) / (t1(i, k) + 1e-15);
         }
 
-        W(i, j) = W(i, j) * sum(t2) / sum(H.row(j));
+        W(i, j) = W(i, j) * sum(t2) / (sum(H.row(j)) + 1e-15);
       }
     }
   }
@@ -119,14 +119,14 @@ class NMFMultiplicativeDivergenceUpdate
    * @param W Basis matrix.
    * @param H Encoding matrix to updated.
    */
-  template<typename MatType>
+  template<typename MatType, typename WHMatType>
   inline static void HUpdate(const MatType& V,
-                            const arma::mat& W,
-                            arma::mat& H)
+                             const WHMatType& W,
+                             WHMatType& H)
   {
     // Simple implementation left in the header file.
-    arma::mat t1;
-    arma::colvec t2;
+    WHMatType t1;
+    arma::Col<typename WHMatType::elem_type> t2;
 
     t1 = W * H;
     for (size_t i = 0; i < H.n_rows; ++i)
@@ -140,10 +140,10 @@ class NMFMultiplicativeDivergenceUpdate
         t2.set_size(W.n_rows);
         for (size_t k = 0; k < t2.n_elem; ++k)
         {
-          t2(k) = W(k, i) * V(k, j) / t1(k, j);
+          t2(k) = W(k, i) * V(k, j) / (t1(k, j) + 1e-15);
         }
 
-        H(i, j) = H(i, j) * sum(t2) / sum(W.col(i));
+        H(i, j) = H(i, j) * sum(t2) / (sum(W.col(i)) + 1e-15);
       }
     }
   }

--- a/src/mlpack/methods/nmf/nmf_main.cpp
+++ b/src/mlpack/methods/nmf/nmf_main.cpp
@@ -158,9 +158,9 @@ void ApplyFactorization(util::Params& params,
   if (params.Has("initial_w") && params.Has("initial_h"))
   {
     // Initialize W and H with given matrices
-    GivenInitialization ginit = GivenInitialization(initialW, initialH);
+    GivenInitialization<> ginit = GivenInitialization<>(initialW, initialH);
     AMF<SimpleResidueTermination,
-        GivenInitialization,
+        GivenInitialization<>,
         UpdateRuleType> amf(srt, ginit);
     amf.Apply(V, r, W, H);
   }
@@ -168,13 +168,13 @@ void ApplyFactorization(util::Params& params,
   {
     // Merge GivenInitialization and RandomAMFInitialization rules
     // to initialize W with the given matrix, and H with random noise
-    GivenInitialization ginit = GivenInitialization(initialW);
+    GivenInitialization<> ginit = GivenInitialization<>(initialW);
     RandomAMFInitialization rinit = RandomAMFInitialization();
-    MergeInitialization<GivenInitialization, RandomAMFInitialization> minit =
-        MergeInitialization<GivenInitialization, RandomAMFInitialization>
+    MergeInitialization<GivenInitialization<>, RandomAMFInitialization> minit =
+        MergeInitialization<GivenInitialization<>, RandomAMFInitialization>
         (ginit, rinit);
     AMF<SimpleResidueTermination,
-        MergeInitialization<GivenInitialization, RandomAMFInitialization>,
+        MergeInitialization<GivenInitialization<>, RandomAMFInitialization>,
         UpdateRuleType> amf(srt, minit);
     amf.Apply(V, r, W, H);
   }
@@ -182,13 +182,13 @@ void ApplyFactorization(util::Params& params,
   {
     // Merge GivenInitialization and RandomAMFInitialization rules
     // to initialize H with the given matrix, and W with random noise
-    GivenInitialization ginit = GivenInitialization(initialH, false);
+    GivenInitialization<> ginit = GivenInitialization<>(initialH, false);
     RandomAMFInitialization rinit = RandomAMFInitialization();
-    MergeInitialization<RandomAMFInitialization, GivenInitialization> minit =
-        MergeInitialization<RandomAMFInitialization, GivenInitialization>
+    MergeInitialization<RandomAMFInitialization, GivenInitialization<>> minit =
+        MergeInitialization<RandomAMFInitialization, GivenInitialization<>>
         (rinit, ginit);
     AMF<SimpleResidueTermination,
-        MergeInitialization<RandomAMFInitialization, GivenInitialization>,
+        MergeInitialization<RandomAMFInitialization, GivenInitialization<>>,
         UpdateRuleType> amf(srt, minit);
     amf.Apply(V, r, W, H);
   }

--- a/src/mlpack/tests/nmf_test.cpp
+++ b/src/mlpack/tests/nmf_test.cpp
@@ -301,3 +301,32 @@ TEST_CASE("NonNegNMFALSTest", "[NMFTest]")
   REQUIRE((arma::all(vectorise(w) >= 0)
       && arma::all(vectorise(h) >= 0)));
 }
+
+/**
+ * Check that NoInitialization doesn't do anything to the elements of a matrix.
+ */
+TEMPLATE_TEST_CASE("NoInitializationTest", "[NMFTest]", float, double)
+{
+  typedef TestType eT;
+
+  arma::Mat<eT> W, H;
+  W.randu(100, 5);
+  H.randu(5, 50);
+  arma::Mat<eT> oldW = W;
+  arma::Mat<eT> oldH = H;
+
+  arma::Mat<eT> V(100, 50, fill::zeros);
+
+  REQUIRE_NOTHROW(NoInitialization::Initialize(V, 5, W, H));
+  REQUIRE_NOTHROW(NoInitialization::InitializeOne(V, 5, W, true));
+  REQUIRE_NOTHROW(NoInitialization::InitializeOne(V, 5, H, false));
+
+  REQUIRE(arma::approx_equal(oldW, W, "both", 1e-5, 1e-5));
+  REQUIRE(arma::approx_equal(oldH, H, "both", 1e-5, 1e-5));
+
+  // And if something is the wrong size, it should throw an exception.
+  W.set_size(10, 10);
+
+  REQUIRE_THROWS(NoInitialization::Initialize(V, 5, W, H));
+  REQUIRE_THROWS(NoInitialization::InitializeOne(V, 5, W, true));
+}

--- a/src/mlpack/tests/nmf_test.cpp
+++ b/src/mlpack/tests/nmf_test.cpp
@@ -153,11 +153,11 @@ TEST_CASE("SparseNMFAcolDistTest", "[NMFTest]")
     // Get an initialization.
     arma::mat iw, ih;
     RandomAcolInitialization<>::Initialize(v, r, iw, ih);
-    GivenInitialization g(std::move(iw), std::move(ih));
+    GivenInitialization<> g(std::move(iw), std::move(ih));
 
     // The GivenInitialization will force the same initialization for both
     // Apply() calls.
-    AMF<SimpleResidueTermination, GivenInitialization> nmf(srt, g);
+    AMF<SimpleResidueTermination, GivenInitialization<>> nmf(srt, g);
     nmf.Apply(v, r, w, h);
     nmf.Apply(dv, r, dw, dh);
 
@@ -212,11 +212,11 @@ TEST_CASE("SparseNMFALSTest", "[NMFTest]")
       // Get an initialization.
       arma::mat iw, ih;
       RandomAcolInitialization<>::Initialize(v, r, iw, ih);
-      GivenInitialization g(std::move(iw), std::move(ih));
+      GivenInitialization<> g(std::move(iw), std::move(ih));
 
       SimpleResidueTermination srt(1e-10, 10000);
-      AMF<SimpleResidueTermination, GivenInitialization, NMFALSUpdate> nmf(srt,
-          g);
+      AMF<SimpleResidueTermination, GivenInitialization<>, NMFALSUpdate>
+          nmf(srt, g);
       nmf.Apply(v, r, w, h);
       nmf.Apply(dv, r, dw, dh);
 


### PR DESCRIPTION
I documented the `NMF` class---which actually did not exist before this PR.  Previously, you would use `AMF` with certain template types.  But, this felt strange to write in the documentation for something like `NMF`, which is a well-known technique name (whereas `AMF` is not necessarily a well-known name because it is just a general shell of an algorithm).  So, I created the `NMF` class, which is just a different name for the `AMF` class, and then wrote documentation for it.

The documentation can be seen here: https://www.ratml.org/misc/mlpack-markdown-doc/user/methods/nmf.html

In writing and testing the documentation, I changed or fixed a handful of other things:

 * I noticed that `data::Load()` for sparse matrices did not autodetect types correctly; so I rewrote it internally, wrote some tests for it, and then updated the documentation in `core.md` accordingly.
 
 * The termination policies, update rules, initialization rules, and `AMF` itself are now templatized so that the `W` and `H` matrices can hold any element type.  One of the documentation tests uses this.
 
 * I added a `NoInitialization` initialization policy, which allows you to call `nmf.Apply(V, rank, W, H)` with a pre-initialized `W` and `H` matrix, and it just checks their sizes and does nothing else.  That's useful for custom initializations.  It felt a little more awkward to use the `GivenInitialization` class for this purpose, so I thought `NoInitialization` would be a slightly easier way to do this.  There is still a use case for `GivenInitialization`, for instance, if you want to call `nmf.Apply()` multiple times with different ranks.

 * I fixed some small style issues that I found.
 
 * I came across some ancient code written to work around an issue in Armadillo 3 for the NMF mult-div update rules... that was a very very long time ago, so I updated that.  Then I found that it was terribly slow, so I did some linear algebra, figured out how to make the whole thing an expression, and now those rules are about 10x faster than they were when I started. (Hooray!  I don't know if anyone uses those vs. the mult-dist rules though.  mult-dist was still a good bit faster for my little simulation on movielens-100k.)
 
 * The NMF rules may divide elements by 0, causing all kinds of NaNs and other badness.  I added a small value (`1e-15`) to the denominators to prevent this, and this caused my simulations to actually converge instead of exploding.