### PR TITLE
Fix `AdaBoost` constructor parameter table

### DIFF
--- a/doc/user/methods/adaboost.md
+++ b/doc/user/methods/adaboost.md
@@ -86,9 +86,7 @@ std::cout << arma::accu(predictions == 3) << " test points classified as class "
 | `data` | [`arma::mat`](../matrices.md) | [Column-major](../matrices.md#representing-data-in-mlpack) training matrix. | _(N/A)_ |
 | `labels` | [`arma::Row<size_t>`](../matrices.md) | Training labels, [between `0` and `numClasses - 1`](../load_save.md#normalizing-labels) (inclusive).  Should have length `data.n_cols`.  | _(N/A)_ |
 | `numClasses` | `size_t` | Number of classes in the dataset. | _(N/A)_ |
-| `weakLearner` | `Perceptron` | An initialized weak learner whose
-hyperparameters will be used as settings for weak learners during training. |
-_(N/A)_ |
+| `weakLearner` | `Perceptron` | An initialized weak learner whose hyperparameters will be used as settings for weak learners during training. | _(N/A)_ |
 | `maxIterations` | `size_t` | Maximum number of iterations of AdaBoost.MH to use.  This is the maximum number of weak learners to train.  (0 means no limit, and weak learners will be trained until the tolerance is met.) | `100` |
 | `tolerance` | `double` | When the weighted residual (`r_t`) of the model goes below `tolerance`, training will terminate and no more weak learners will be added. | `1e-6` |
 


### PR DESCRIPTION
I noticed while reading the AdaBoost documentation that the constructor parameters table did not render correctly; this is because of some line breaks in the table.  Oops.  This PR just makes the table line one line in the source Markdown, so that the table will render correctly again.