### PR TITLE
Move to `MatType` in bias svd

### DIFF
--- a/src/mlpack/methods/bias_svd/bias_svd.hpp
+++ b/src/mlpack/methods/bias_svd/bias_svd.hpp
@@ -50,7 +50,9 @@ namespace mlpack {
  * @endcode
  *
  */
-template<typename OptimizerType = ens::StandardSGD>
+template<typename OptimizerType = ens::StandardSGD,
+         typename MatType = arma::mat,
+         typename VecType = arma::vec>
 class BiasSVD
 {
  public:
@@ -76,12 +78,12 @@ class BiasSVD
    * @param p Item bias.
    * @param q User bias.
    */
-  void Apply(const arma::mat& data,
+  void Apply(const MatType& data,
              const size_t rank,
-             arma::mat& u,
-             arma::mat& v,
-             arma::vec& p,
-             arma::vec& q);
+             MatType& u,
+             MatType& v,
+             VecType& p,
+             VecType& q);
 
  private:
   //! Number of optimization iterations.

--- a/src/mlpack/methods/bias_svd/bias_svd_function.hpp
+++ b/src/mlpack/methods/bias_svd/bias_svd_function.hpp
@@ -15,6 +15,7 @@
 #define MLPACK_METHODS_BIAS_SVD_BIAS_SVD_FUNCTION_HPP
 
 #include <mlpack/prereqs.hpp>
+#include <mlpack/core/math/make_alias.hpp>
 #include <ensmallen.hpp>
 
 namespace mlpack {
@@ -54,7 +55,7 @@ class BiasSVDFunction
    * @param parameters Parameters(user/item matrices/bias) of the
    *     decomposition.
    */
-  double Evaluate(const arma::mat& parameters) const;
+  double Evaluate(const MatType& parameters) const;
 
   /**
    * Evaluates the cost function for one training example. Useful for the SGD
@@ -65,7 +66,7 @@ class BiasSVDFunction
    * @param start First index of the training examples to be used.
    * @param batchSize Size of batch to evaluate.
    */
-  double Evaluate(const arma::mat& parameters,
+  double Evaluate(const MatType& parameters,
                   const size_t start,
                   const size_t batchSize = 1) const;
 
@@ -77,8 +78,8 @@ class BiasSVDFunction
    *     decomposition.
    * @param gradient Calculated gradient for the parameters.
    */
-  void Gradient(const arma::mat& parameters,
-                arma::mat& gradient) const;
+  void Gradient(const MatType& parameters,
+                MatType& gradient) const;
 
   /**
    * Evaluates the gradient of the cost function over one training example.
@@ -94,16 +95,16 @@ class BiasSVDFunction
    * @param batchSize Size of batch to calculate gradient for.
    */
   template <typename GradType>
-  void Gradient(const arma::mat& parameters,
+  void Gradient(const MatType& parameters,
                 const size_t start,
                 GradType& gradient,
                 const size_t batchSize = 1) const;
 
   //! Return the initial point for the optimization.
-  const arma::mat& GetInitialPoint() const { return initialPoint; }
+  const MatType& GetInitialPoint() const { return initialPoint; }
 
   //! Return the dataset passed into the constructor.
-  const arma::mat& Dataset() const { return data; }
+  const MatType& Dataset() const { return data; }
 
   //! Return the number of training examples. Useful for SGD optimizer.
   size_t NumFunctions() const { return data.n_cols; }
@@ -124,7 +125,7 @@ class BiasSVDFunction
   //! Rating data.  This will be an alias until Shuffle() is called.
   MatType data;
   //! Initial parameter point.
-  arma::mat initialPoint;
+  MatType initialPoint;
   //! Rank used for matrix factorization.
   size_t rank;
   //! Regularization parameter for the optimization.

--- a/src/mlpack/methods/bias_svd/bias_svd_function_impl.hpp
+++ b/src/mlpack/methods/bias_svd/bias_svd_function_impl.hpp
@@ -14,7 +14,6 @@
 #define MLPACK_METHODS_BIAS_SVD_BIAS_SVD_FUNCTION_IMPL_HPP
 
 #include "bias_svd_function.hpp"
-#include <mlpack/core/math/make_alias.hpp>
 
 namespace mlpack {
 
@@ -44,13 +43,13 @@ void BiasSVDFunction<MatType>::Shuffle()
 }
 
 template <typename MatType>
-double BiasSVDFunction<MatType>::Evaluate(const arma::mat& parameters) const
+double BiasSVDFunction<MatType>::Evaluate(const MatType& parameters) const
 {
   return Evaluate(parameters, 0, data.n_cols);
 }
 
 template <typename MatType>
-double BiasSVDFunction<MatType>::Evaluate(const arma::mat& parameters,
+double BiasSVDFunction<MatType>::Evaluate(const MatType& parameters,
                                           const size_t start,
                                           const size_t batchSize) const
 {
@@ -92,8 +91,8 @@ double BiasSVDFunction<MatType>::Evaluate(const arma::mat& parameters,
 }
 
 template <typename MatType>
-void BiasSVDFunction<MatType>::Gradient(const arma::mat& parameters,
-                                        arma::mat& gradient) const
+void BiasSVDFunction<MatType>::Gradient(const MatType& parameters,
+                                        MatType& gradient) const
 {
   // For an example with rating corresponding to user 'i' and item 'j', the
   // gradients for the parameters is as follows:
@@ -139,7 +138,7 @@ void BiasSVDFunction<MatType>::Gradient(const arma::mat& parameters,
 
 template <typename MatType>
 template <typename GradType>
-void BiasSVDFunction<MatType>::Gradient(const arma::mat& parameters,
+void BiasSVDFunction<MatType>::Gradient(const MatType& parameters,
                                         const size_t start,
                                         GradType& gradient,
                                         const size_t batchSize) const

--- a/src/mlpack/methods/bias_svd/bias_svd_impl.hpp
+++ b/src/mlpack/methods/bias_svd/bias_svd_impl.hpp
@@ -16,7 +16,7 @@
 
 namespace mlpack {
 
-template<typename OptimizerType>
+template<typename OptimizerType, typename MatType, typename VecType>
 BiasSVD<OptimizerType>::BiasSVD(const size_t iterations,
                                 const double alpha,
                                 const double lambda) :
@@ -27,13 +27,13 @@ BiasSVD<OptimizerType>::BiasSVD(const size_t iterations,
   // Nothing to do.
 }
 
-template<typename OptimizerType>
-void BiasSVD<OptimizerType>::Apply(const arma::mat& data,
+template<typename OptimizerType, typename MatType, typename VecType>
+void BiasSVD<OptimizerType>::Apply(const MatType& data,
                                    const size_t rank,
-                                   arma::mat& u,
-                                   arma::mat& v,
-                                   arma::vec& p,
-                                   arma::vec& q)
+                                   MatType& u,
+                                   MatType& v,
+                                   VecType& p,
+                                   VecType& q)
 {
   // batchSize is 1 in our implementation of Bias SVD.
   // batchSize other than 1 has not been supported yet.
@@ -47,7 +47,7 @@ void BiasSVD<OptimizerType>::Apply(const arma::mat& data,
       iterations * data.n_cols);
 
   // Get optimized parameters.
-  arma::mat parameters = biasSVDFunc.GetInitialPoint();
+  MatType parameters = biasSVDFunc.GetInitialPoint();
   optimizer.Optimize(biasSVDFunc, parameters);
 
   // Constants for extracting user and item matrices.

--- a/src/mlpack/methods/bias_svd/bias_svd_impl.hpp
+++ b/src/mlpack/methods/bias_svd/bias_svd_impl.hpp
@@ -17,9 +17,9 @@
 namespace mlpack {
 
 template<typename OptimizerType, typename MatType, typename VecType>
-BiasSVD<OptimizerType>::BiasSVD(const size_t iterations,
-                                const double alpha,
-                                const double lambda) :
+BiasSVD<OptimizerType, MatType, VecType>::BiasSVD(const size_t iterations,
+                                                  const double alpha,
+                                                  const double lambda) :
     iterations(iterations),
     alpha(alpha),
     lambda(lambda)
@@ -28,12 +28,12 @@ BiasSVD<OptimizerType>::BiasSVD(const size_t iterations,
 }
 
 template<typename OptimizerType, typename MatType, typename VecType>
-void BiasSVD<OptimizerType>::Apply(const MatType& data,
-                                   const size_t rank,
-                                   MatType& u,
-                                   MatType& v,
-                                   VecType& p,
-                                   VecType& q)
+void BiasSVD<OptimizerType, MatType, VecType>::Apply(const MatType& data,
+                                                     const size_t rank,
+                                                     MatType& u,
+                                                     MatType& v,
+                                                     VecType& p,
+                                                     VecType& q)
 {
   // batchSize is 1 in our implementation of Bias SVD.
   // batchSize other than 1 has not been supported yet.


### PR DESCRIPTION
I did not touch the code related to ensmallen in this file since I have no idea why it is here, and what it is supposed to do.
Maybe it should be moved to ensmallen at some point ? also why the template parameters are not filled in ?
I did not chance what is related to shuffle since we still do not have it in bandicoot.