### PR TITLE
Fix `verbose` for R bindings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,8 @@
 
   * Allow PCA to take different matrix types (#3677).
 
+  * Fix non-working `verbose` option for R bindings (#3691).
+
 ### mlpack 4.3.0
 ###### 2023-11-27
   * Fix include ordering issue for `LinearRegression` (#3541).

--- a/src/mlpack/bindings/R/mlpack/src/rcpp_mlpack.h
+++ b/src/mlpack/bindings/R/mlpack/src/rcpp_mlpack.h
@@ -15,9 +15,6 @@
 
 #include <Rcpp.h>
 
-// To suppress Found '__assert_fail', possibly from 'assert' (C).
-#define BOOST_DISABLE_ASSERTS
-
 // Rcpp has its own stream object which cooperates more nicely with R's i/o
 // And as of armadillo and mlpack, we can use this stream object as well.
 #if !defined(ARMA_COUT_STREAM)

--- a/src/mlpack/bindings/R/print_R.cpp
+++ b/src/mlpack/bindings/R/print_R.cpp
@@ -184,20 +184,9 @@ void PrintR(util::Params& params,
        << endl;
   for (const string& opt : inputOptions)
   {
-    if (opt != "verbose")
-    {
-      util::ParamData& d = parameters.at(opt);
-      params.functionMap[d.tname]["PrintInputProcessing"](d, NULL, NULL);
-    }
+    util::ParamData& d = parameters.at(opt);
+    params.functionMap[d.tname]["PrintInputProcessing"](d, NULL, NULL);
   }
-
-  // Special handling for verbose output.
-  cout << "  if (verbose) {" << endl;
-  cout << "    EnableVerbose()" << endl;
-  cout << "  } else {" << endl;
-  cout << "    DisableVerbose()" << endl;
-  cout << "  }" << endl;
-  cout << endl;
 
   // Mark output parameters as passed.
   cout << "  # Mark all output options as passed." << endl;

--- a/src/mlpack/bindings/R/r_method.cpp.in
+++ b/src/mlpack/bindings/R/r_method.cpp.in
@@ -17,6 +17,11 @@ void ${PROGRAM_NAME}_call(SEXP params, SEXP timers)
   util::Params& p = *Rcpp::as<Rcpp::XPtr<util::Params>>(params);
   util::Timers& t = *Rcpp::as<Rcpp::XPtr<util::Timers>>(timers);
 
+  if (p.Has("verbose"))
+    Log::Info.ignoreInput = false;
+  else
+    Log::Info.ignoreInput = true;
+
   BINDING_FUNCTION(p, t);
 }
 


### PR DESCRIPTION
This fixes #3675.

I reproduced the issue and found that the `verbose` argument to mlpack's R bindings had no effect, even though the `EnableVerbose()` function was successfully being called.

This is because `Log::Info` (which is what the `EnableVerbose()` function modified) is a singleton object, and exists once *in each translation unit*.  Since `EnableVerbose()` is compiled into the translation unit for the file `r_util.cpp`, the `Log::Info` modified by `EnableVerbose()` ends up being *different* than the `Log::Info` that is being used by each individual binding---so, in essence, we are enabling verbose mode... with the wrong `Log::Info` object.

I fixed this by removing the standalone `EnableVerbose()` and `DisableVerbose()` functions, and instead modifying the `Log::Info` object's verbose state directly inside each printed binding.  So, e.g., this block is now gone from the R code:

```r
  if (verbose) {
    EnableVerbose()
  } else {
    DisableVerbose()
  }
```

and the actual binding code, which before looked like this:

```
// [[Rcpp::export]]
void knn_call(SEXP params, SEXP timers)
{
  util::Params& p = *Rcpp::as<Rcpp::XPtr<util::Params>>(params);
  util::Timers& t = *Rcpp::as<Rcpp::XPtr<util::Timers>>(timers);

  if (p.Has("verbose"))
    Log::Info.ignoreInput = false;
  else
    Log::Info.ignoreInput = true;

  BINDING_FUNCTION(p, t);
}
```

now looks like this:

```
// [[Rcpp::export]]
void knn_call(SEXP params, SEXP timers)
{
  util::Params& p = *Rcpp::as<Rcpp::XPtr<util::Params>>(params);
  util::Timers& t = *Rcpp::as<Rcpp::XPtr<util::Timers>>(timers);

  if (p.Has("verbose"))
    Log::Info.ignoreInput = false;
  else
    Log::Info.ignoreInput = true;

  BINDING_FUNCTION(p, t);
}
```

and so when I run the example code provided by @cgiachalis:

```r
set.seed(1234)
x <- matrix(rnorm(10*5), ncol = 5)

# KNN EXAMPLE
res <- mlpack::knn(query = x, reference = x, k = 3, verbose = TRUE)
```

I get this output instead of nothing:

```
> res <- mlpack::knn(query = x, reference = x, k = 3, verbose = TRUE)
[INFO ] Using reference data from 5x10 matrix.
[INFO ] Building reference tree...
[INFO ] Tree built.
[INFO ] Using query data from 5x10 matrix.
[INFO ] Searching for 3 neighbors with dual-tree kd-tree search...
[INFO ] 11 node combinations were scored.
[INFO ] 100 base cases were calculated.
[INFO ] 11 node combinations were scored.
[INFO ] 100 base cases were calculated.
[INFO ] Search complete.
```

Hooray!