### PR TITLE
Test "verbose" option for R.

### DIFF
--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -328,3 +328,10 @@ test_that("TestNotVerbose", {
   expect_silent(output1 <- test_r_binding(4.0, 12, "hello",
                                           build_model=TRUE))
 })
+
+# Test that we get no output when verbose output is explicitly disabled.
+test_that("TestReallyNotVerbose", {
+  expect_silent(output1 <- test_r_binding(4.0, 12, "hello",
+                                          build_model=TRUE,
+                                          verbose=FALSE))
+})

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -319,19 +319,19 @@ test_that("TestSerialization", {
 # Make sure that the verbose argument does anything at all.
 test_that("TestVerbose", {
   expect_output(test_r_binding(4.0, 12, "hello",
-                                          build_model=TRUE,
-                                          verbose=TRUE))
+                               build_model=TRUE,
+                               verbose=TRUE))
 })
 
 # Test that we get no output when verbose output is disabled.
 test_that("TestNotVerbose", {
   expect_silent(test_r_binding(4.0, 12, "hello",
-                                          build_model=TRUE))
+                               build_model=TRUE))
 })
 
 # Test that we get no output when verbose output is explicitly disabled.
 test_that("TestReallyNotVerbose", {
   expect_silent(test_r_binding(4.0, 12, "hello",
-                                          build_model=TRUE,
-                                          verbose=FALSE))
+                               build_model=TRUE,
+                               verbose=FALSE))
 })

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -325,7 +325,7 @@ test_that("TestVerbose", {
 
 # Test that we get no output when verbose output is disabled.
 test_that("TestNotVerbose", {
-  expect_silent(output1 <- test_r_binding(4.0, 12, "hello",
+  expect_silent(test_r_binding(4.0, 12, "hello",
                                           build_model=TRUE))
 })
 

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -315,3 +315,16 @@ test_that("TestSerialization", {
 
   expect_true(output2$model_bw_out == 20)
 })
+
+# Make sure that the verbose argument does anything at all.
+test_that("TestVerbose", {
+  expect_output(output1 <- test_r_binding(4.0, 12, "hello",
+                                          build_model=TRUE,
+                                          verbose=TRUE))
+})
+
+# Test that we get no output when verbose output is disabled.
+test_that("TestNotVerbose", {
+  expect_silent(output1 <- test_r_binding(4.0, 12, "hello",
+                                          build_model=TRUE))
+})

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -318,7 +318,7 @@ test_that("TestSerialization", {
 
 # Make sure that the verbose argument does anything at all.
 test_that("TestVerbose", {
-  expect_output(output1 <- test_r_binding(4.0, 12, "hello",
+  expect_output(test_r_binding(4.0, 12, "hello",
                                           build_model=TRUE,
                                           verbose=TRUE))
 })

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -331,7 +331,7 @@ test_that("TestNotVerbose", {
 
 # Test that we get no output when verbose output is explicitly disabled.
 test_that("TestReallyNotVerbose", {
-  expect_silent(output1 <- test_r_binding(4.0, 12, "hello",
+  expect_silent(test_r_binding(4.0, 12, "hello",
                                           build_model=TRUE,
                                           verbose=FALSE))
 })

--- a/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
+++ b/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
@@ -237,4 +237,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
     params.Get<double>("model_bw_out") =
         params.Get<GaussianKernel*>("model_in")->Bandwidth() * 2.0;
   }
+
+  // Provide some output if the user asked for it.
+  Log::Info << "Here is some verbose output!" << std::endl;
 }


### PR DESCRIPTION
As suggested by @eddelbuettel [here](https://github.com/mlpack/mlpack/pull/3691#issuecomment-2062312759), I wrote a simple test to ensure that when you pass `verbose = TRUE` to an R binding, you get some kind of output at all.

I'm not R-fluent, but this seems to be correct?  I could have misunderstood something :smile: 