### PR TITLE
Fix sometimes-failing LARS tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,6 +41,8 @@
 
   * Fix non-working `verbose` option for R bindings (#3691).
 
+  * Fix divide-by-zero edge case for LARS (#3701).
+
 ### mlpack 4.3.0
 ###### 2023-11-27
   * Fix include ordering issue for `LinearRegression` (#3541).

--- a/src/mlpack/methods/lars/lars_impl.hpp
+++ b/src/mlpack/methods/lars/lars_impl.hpp
@@ -682,7 +682,7 @@ LARS<ModelMatType>::Train(const MatType& matX,
     // Compute signs of correlations.
     arma::Col<ElemType> s(activeSet.size());
     for (size_t i = 0; i < activeSet.size(); ++i)
-      s(i) = corr(activeSet[i]) / fabs(corr(activeSet[i]));
+      s(i) = corr(activeSet[i]) / (fabs(corr(activeSet[i])) + 1e-10);
 
     // Compute the "equiangular" direction in parameter space (betaDirection).
     // We use quotes because in the case of non-unit norm variables, this need
@@ -769,9 +769,11 @@ LARS<ModelMatType>::Train(const MatType& matX,
         // need to take a step with the previous beta direction towards the next
         // variable we will add.
         s = s.subvec(0, activeSet.size() - 1); // Drop last element.
+        matGramActive = matGramActive.submat(0, 0, activeSet.size() - 1,
+            activeSet.size() - 1);
         matS = s * ones<MatType>(1, activeSet.size());
         // This worked last iteration, so there can't be a singularity.
-        solve(unnormalizedBetaDirection,
+        const bool status2 = solve(unnormalizedBetaDirection,
             matGramActive % trans(matS) % matS,
             ones<MatType>(activeSet.size(), 1));
         normalization = 1.0 / std::sqrt(sum(unnormalizedBetaDirection));

--- a/src/mlpack/methods/lars/lars_impl.hpp
+++ b/src/mlpack/methods/lars/lars_impl.hpp
@@ -658,31 +658,6 @@ LARS<ModelMatType>::Train(const MatType& matX,
     if (maxCorr < tolerance)
       break;
 
-    // Floats require a really large tolerance for this condition.
-    const ElemType tol = (std::is_same<ElemType, double>::value) ? 1e-6 : 0.01;
-    if ((matGram != &matGramInternal) &&
-        ((maxActiveCorr - minActiveCorr) / maxActiveCorr) > tol)
-    {
-      // Construct the error message to match the user's settings.
-      std::cout << "maxActiveCorr: " << maxActiveCorr << " minActiveCorr: " << minActiveCorr << "; result " << ((maxActiveCorr - minActiveCorr) / maxActiveCorr) << "; tol " << tol << "\n";
-      std::ostringstream oss;
-      oss << "LARS::Train(): correlation conditions violated; check that your "
-          << "given Gram matrix is properly computed on ";
-      if (fitIntercept)
-        oss << "mean-centered ";
-      else
-        oss << "non-mean-centered ";
-      if (normalizeData)
-        oss << "unit-variance (normalized) ";
-      else
-        oss << "non-normalized ";
-      oss << "data";
-      if (lambda2 > 0.0)
-        oss << " with lambda2 = " << lambda2 << " added to the diagonal";
-      oss << "!";
-      throw std::runtime_error(oss.str());
-    }
-
     // Add the variable to the active set and update the Gram matrix as
     // necessary.
     if (!lassocond)

--- a/src/mlpack/methods/lars/lars_impl.hpp
+++ b/src/mlpack/methods/lars/lars_impl.hpp
@@ -682,7 +682,10 @@ LARS<ModelMatType>::Train(const MatType& matX,
     // Compute signs of correlations.
     arma::Col<ElemType> s(activeSet.size());
     for (size_t i = 0; i < activeSet.size(); ++i)
-      s(i) = corr(activeSet[i]) / (fabs(corr(activeSet[i])) + 1e-10);
+    {
+      const size_t j = activeSet[i];
+      s[i] = (ElemType) (corr(j) == 0.0 ? 0.0 : (corr(j) > 0) ? 1.0 : -1.0);
+    }
 
     // Compute the "equiangular" direction in parameter space (betaDirection).
     // We use quotes because in the case of non-unit norm variables, this need

--- a/src/mlpack/methods/lars/lars_impl.hpp
+++ b/src/mlpack/methods/lars/lars_impl.hpp
@@ -776,7 +776,7 @@ LARS<ModelMatType>::Train(const MatType& matX,
             activeSet.size() - 1);
         matS = s * ones<MatType>(1, activeSet.size());
         // This worked last iteration, so there can't be a singularity.
-        const bool status2 = solve(unnormalizedBetaDirection,
+        solve(unnormalizedBetaDirection,
             matGramActive % trans(matS) % matS,
             ones<MatType>(activeSet.size(), 1));
         normalization = 1.0 / std::sqrt(sum(unnormalizedBetaDirection));

--- a/src/mlpack/tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/sparse_coding_test.cpp
@@ -8,10 +8,6 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-
-// Note: We don't use BOOST_REQUIRE_CLOSE in the code below because we need
-// to use FPC_WEAK, and it's not at all intuitive how to do that.
-
 #include <mlpack/core.hpp>
 #include <mlpack/methods/sparse_coding.hpp>
 


### PR DESCRIPTION
I noticed that the tests for LARS were failing more than once every hundred trials with different random seeds, so I started digging in to see what was wrong.  I came out with a few conclusions:

 * With `float` as an element type, the `PredictTest` can be more flaky---this is expected due to less precision.  So now it allows multiple trials when the element type is `float`.
 
 * When a singularity is encountered, we try to remove the most-recently-added variable from the active set.  However, the `activeGramMatrix` was not removing its columns correctly.
 
 * When computing the signs of correlations, if the correlation was exactly 0, then there was a division by 0.  I fixed that just by adding a small value to the denominator.
 
 * The check to see if an externally-passed Gram matrix satisfied the expected conditions of mean-centeredness and unit-variance was more trouble than it was worth, and I think the note in the documentation is good enough.  So I removed the check, since it does not seem to be reliable.

Then, I ran `[LARSTest]` 1000 times with different random seeds and encountered no failures, so, hopefully this should help with test robustness.