### PR TITLE
Remove deprecated functionality

### DIFF
--- a/src/mlpack/bindings/cli/print_help_impl.hpp
+++ b/src/mlpack/bindings/cli/print_help_impl.hpp
@@ -104,11 +104,6 @@ inline void PrintHelp(util::Params& params, const std::string& param)
       if ((pass == 2) && data.input) // Output options only (always optional).
         continue;
 
-      // For reverse compatibility: this can be removed when these options are
-      // gone in mlpack 3.0.0.  We don't want to print the deprecated options.
-      if (data.name == "inputFile")
-        continue;
-
       if (!printedHeader)
       {
         printedHeader = true;

--- a/src/mlpack/core/dists/regression_distribution.hpp
+++ b/src/mlpack/core/dists/regression_distribution.hpp
@@ -48,18 +48,6 @@ class RegressionDistribution
    * @param predictors Matrix of predictors (X).
    * @param responses Vector of responses (y).
    */
-  mlpack_deprecated RegressionDistribution(const arma::mat& predictors,
-                                           const arma::vec& responses) :
-    RegressionDistribution(predictors, arma::rowvec(responses.t()))
-  {}
-
-  /**
-   * Create a Conditional Gaussian distribution with conditional mean function
-   * obtained by running RegressionFunction on predictors, responses.
-   *
-   * @param predictors Matrix of predictors (X).
-   * @param responses Vector of responses (y).
-   */
   RegressionDistribution(const arma::mat& predictors,
                          const arma::rowvec& responses)
   {
@@ -103,15 +91,6 @@ class RegressionDistribution
    * @param observations List of observations.
    * @param weights Probability that given observation is from distribution.
    */
-  mlpack_deprecated void Train(const arma::mat& observations,
-                               const arma::vec& weights);
-
-  /**
-   * Estimate parameters using provided observation weights.
-   *
-   * @param observations List of observations.
-   * @param weights Probability that given observation is from distribution.
-   */
   void Train(const arma::mat& observations, const arma::rowvec& weights);
 
   /**
@@ -130,15 +109,6 @@ class RegressionDistribution
   {
     return std::log(Probability(observation));
   }
-
-  /**
-   * Calculate y_i for each data point in points.
-   *
-   * @param points The data points to calculate with.
-   * @param predictions Y, will contain calculated values on completion.
-   */
-  mlpack_deprecated void Predict(const arma::mat& points,
-                                 arma::vec& predictions) const;
 
   /**
    * Calculate y_i for each data point in points.

--- a/src/mlpack/core/dists/regression_distribution_impl.hpp
+++ b/src/mlpack/core/dists/regression_distribution_impl.hpp
@@ -32,17 +32,6 @@ inline void RegressionDistribution::Train(const arma::mat& observations)
   err.Train(observations.row(0) - fitted);
 }
 
-/**
- * Estimate parameters using provided observation weights.
- *
- * @param weights Probability that given observation is from distribution.
- */
-inline void RegressionDistribution::Train(const arma::mat& observations,
-                                          const arma::vec& weights)
-{
-  Train(observations, arma::rowvec(weights.t()));
-}
-
 inline void RegressionDistribution::Train(const arma::mat& observations,
                                           const arma::rowvec& weights)
 {
@@ -65,14 +54,6 @@ inline double RegressionDistribution::Probability(
   arma::rowvec fitted;
   rf.Predict(observation.rows(1, observation.n_rows - 1), fitted);
   return err.Probability(observation(0) - fitted.t());
-}
-
-inline void RegressionDistribution::Predict(const arma::mat& points,
-                                            arma::vec& predictions) const
-{
-  arma::rowvec rowPredictions;
-  Predict(points, rowPredictions);
-  predictions = rowPredictions.t();
 }
 
 inline void RegressionDistribution::Predict(const arma::mat& points,

--- a/src/mlpack/methods/adaboost/adaboost_classify_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_classify_main.cpp
@@ -61,7 +61,6 @@ BINDING_EXAMPLE(
 
 // Classification options.
 PARAM_MATRIX_IN_REQ("test", "Test dataset.", "T");
-// PARAM_UROW_OUT("output") is deprecated and will be removed in mlpack 4.0.0.
 PARAM_UROW_OUT("predictions", "Predicted labels for the test set.", "P");
 
 // Loading/saving of a model.

--- a/src/mlpack/methods/adaboost/adaboost_main.cpp
+++ b/src/mlpack/methods/adaboost/adaboost_main.cpp
@@ -84,14 +84,7 @@ BINDING_LONG_DESC(
     "classes for each point in the test dataset are output to the " +
     PRINT_PARAM_STRING("predictions") + " output parameter.  The AdaBoost "
     "model itself is output to the " + PRINT_PARAM_STRING("output_model") +
-    " output parameter."
-    "\n\n"
-    "Note: the following parameter is deprecated and "
-    "will be removed in mlpack 4.0.0: " + PRINT_PARAM_STRING("output") +
-    "."
-    "\n"
-    "Use " + PRINT_PARAM_STRING("predictions") + " instead of " +
-    PRINT_PARAM_STRING("output") + '.');
+    " output parameter.");
 
 // Example.
 BINDING_EXAMPLE(
@@ -127,8 +120,6 @@ PARAM_UROW_IN("labels", "Labels for the training set.", "l");
 
 // Classification options.
 PARAM_MATRIX_IN("test", "Test dataset.", "T");
-// PARAM_UROW_OUT("output") is deprecated and will be removed in mlpack 4.0.0.
-PARAM_UROW_OUT("output", "Predicted labels for the test set.", "o");
 PARAM_UROW_OUT("predictions", "Predicted labels for the test set.", "P");
 PARAM_MATRIX_OUT("probabilities", "Predicted class probabilities for each "
     "point in the test set.", "p");
@@ -178,10 +169,9 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
         "no task will be performed");
   }
 
-  RequireAtLeastOnePassed(params, { "output_model", "output", "predictions" },
-      false, "no results will be saved");
+  RequireAtLeastOnePassed(params, { "output_model", "predictions" }, false,
+      "no results will be saved");
 
-  // "output" will be removed in mlpack 4.0.0.
   ReportIgnoredParam(params, {{ "test", false }}, "predictions");
 
   AdaBoostModel* m;
@@ -266,8 +256,6 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     data::RevertLabels(predictedLabels, m->Mappings(), results);
 
     // Save the predicted labels.
-    if (params.Has("output"))
-      params.Get<arma::Row<size_t>>("output") = results;
     if (params.Has("predictions"))
       params.Get<arma::Row<size_t>>("predictions") = std::move(results);
     if (params.Has("probabilities"))

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -57,8 +57,8 @@ BINDING_LONG_DESC(
     "the minimum gain that is needed for the node to split.  The " +
     PRINT_PARAM_STRING("maximum_depth") + " parameter specifies "
     "the maximum depth of the tree.  If " +
-    PRINT_PARAM_STRING("print_training_error") + " is specified, the training "
-    "error will be printed."
+    PRINT_PARAM_STRING("print_training_accuracy") + " is specified, the "
+    "training accuracy will be printed."
     "\n\n"
     "Test data may be specified with the " + PRINT_PARAM_STRING("test") + " "
     "parameter, and if performance numbers are desired for that test set, "
@@ -115,9 +115,6 @@ PARAM_DOUBLE_IN("minimum_gain_split", "Minimum gain for node splitting.", "g",
     1e-7);
 PARAM_INT_IN("maximum_depth", "Maximum depth of the tree (0 means no limit).",
     "D", 0);
-// This is deprecated and should be removed in mlpack 4.0.0.
-PARAM_FLAG("print_training_error", "Print the training error (deprecated; will "
-      "be removed in mlpack 4.0.0).", "e");
 PARAM_FLAG("print_training_accuracy", "Print the training accuracy.", "a");
 
 // Output parameters.
@@ -180,12 +177,6 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
       [](double x) { return (x > 0.0 && x < 1.0); }, true,
       "gain split must be a fraction in range [0,1]");
 
-  if (params.Has("print_training_error"))
-  {
-    Log::Warn << "The option " << PRINT_PARAM_STRING("print_training_error")
-        << " is deprecated and will be removed in mlpack 4.0.0." << std::endl;
-  }
-
   // Load the model or build the tree.
   DecisionTreeModel* model;
   arma::mat trainingSet;
@@ -223,8 +214,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
     {
       arma::Row<double> weights =
           std::move(params.Get<arma::Mat<double>>("weights"));
-      if (params.Has("print_training_error") ||
-          params.Has("print_training_accuracy"))
+      if (params.Has("print_training_accuracy"))
       {
         model->tree = DecisionTree<>(trainingSet, model->info, labels,
             numClasses, std::move(weights), minLeafSize, minimumGainSplit,
@@ -239,7 +229,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
     }
     else
     {
-      if (params.Has("print_training_error"))
+      if (params.Has("print_training_accuracy"))
       {
         model->tree = DecisionTree<>(trainingSet, model->info, labels,
             numClasses, minLeafSize, minimumGainSplit, maxDepth);
@@ -253,8 +243,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
     }
 
     // Do we need to print training error?
-    if (params.Has("print_training_error") ||
-        params.Has("print_training_accuracy"))
+    if (params.Has("print_training_accuracy"))
     {
       arma::Row<size_t> predictions;
       arma::mat probabilities;

--- a/src/mlpack/methods/naive_bayes/nbc_main.cpp
+++ b/src/mlpack/methods/naive_bayes/nbc_main.cpp
@@ -61,12 +61,7 @@ BINDING_LONG_DESC(
     " may be saved with the " + PRINT_PARAM_STRING("predictions") +"predictions"
     "  parameter.  If saving the trained model is desired, this may be "
     "done with the " + PRINT_PARAM_STRING("output_model") + " output "
-    "parameter."
-    "\n\n"
-    "Note: the " + PRINT_PARAM_STRING("output") + " and " +
-    PRINT_PARAM_STRING("output_probs") + " parameters are deprecated and will "
-    "be removed in mlpack 4.0.0.  Use " + PRINT_PARAM_STRING("predictions") +
-    " and " + PRINT_PARAM_STRING("probabilities") + " instead.");
+    "parameter.");
 
 // Example.
 BINDING_EXAMPLE(
@@ -126,14 +121,8 @@ PARAM_FLAG("incremental_variance", "The variance of each class will be "
 
 // Test parameters.
 PARAM_MATRIX_IN("test", "A matrix containing the test set.", "T");
-// The parameter 'output' is deprecated and will be removed in mlpack 4.
-PARAM_UROW_OUT("output", "The matrix in which the predicted labels for the"
-    " test set will be written (deprecated).", "o");
 PARAM_UROW_OUT("predictions", "The matrix in which the predicted labels for the"
     " test set will be written.", "a");
-// The parameter 'output_probs' is deprecated and can be removed in mlpack 4.
-PARAM_MATRIX_OUT("output_probs", "The matrix in which the predicted probability"
-    " of labels for the test set will be written (deprecated).", "");
 PARAM_MATRIX_OUT("probabilities", "The matrix in which the predicted"
     " probability of labels for the test set will be written.", "p");
 
@@ -143,9 +132,8 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   RequireOnlyOnePassed(params, { "training", "input_model" }, true);
   ReportIgnoredParam(params, {{ "training", false }}, "labels");
   ReportIgnoredParam(params, {{ "training", false }}, "incremental_variance");
-  RequireAtLeastOnePassed(params, { "output", "predictions", "output_model",
-      "output_probs", "probabilities" }, false, "no output will be saved");
-  ReportIgnoredParam(params, {{ "test", false }}, "output");
+  RequireAtLeastOnePassed(params, { "predictions", "output_model",
+      "probabilities" }, false, "no output will be saved");
   ReportIgnoredParam(params, {{ "test", false }}, "predictions");
   if (params.Has("input_model") && !params.Has("test"))
     Log::Warn << "No test set given; no task will be performed!" << std::endl;
@@ -208,23 +196,20 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     model->nbc.Classify(testingData, predictions, probabilities);
     timers.Stop("nbc_testing");
 
-    if (params.Has("output") || params.Has("predictions"))
+    if (params.Has("predictions"))
     {
       // Un-normalize labels to prepare output.
       Row<size_t> rawResults;
       data::RevertLabels(predictions, model->mappings, rawResults);
 
       if (params.Has("predictions"))
-        params.Get<Row<size_t>>("predictions") = rawResults;
-      if (params.Has("output"))
-        params.Get<Row<size_t>>("output") = std::move(rawResults);
+        params.Get<Row<size_t>>("predictions") = std::move(rawResults);
     }
-    if (params.Has("output_probs") || params.Has("probabilities"))
+
+    if (params.Has("probabilities"))
     {
       if (params.Has("probabilities"))
-        params.Get<mat>("probabilities") = probabilities;
-      if (params.Has("output_probs"))
-        params.Get<mat>("output_probs") = std::move(probabilities);
+        params.Get<mat>("probabilities") = std::move(probabilities);
     }
   }
 

--- a/src/mlpack/methods/naive_bayes/nbc_main.cpp
+++ b/src/mlpack/methods/naive_bayes/nbc_main.cpp
@@ -78,8 +78,8 @@ BINDING_EXAMPLE(
     "classes to " + PRINT_DATASET("predictions") + ", the following command "
     "may be used:"
     "\n\n" +
-    PRINT_CALL("nbc", "input_model", "nbc_model", "test", "test_set", "output",
-        "predictions"));
+    PRINT_CALL("nbc", "input_model", "nbc_model", "test", "test_set",
+        "predictions", "predictions"));
 
 // See also...
 BINDING_SEE_ALSO("@softmax_regression", "#softmax_regression");

--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -56,14 +56,7 @@ BINDING_LONG_DESC(
     "on the test set may be saved with the " +
     PRINT_PARAM_STRING("predictions") +
     " output parameter.  The perceptron model may be saved with the " +
-    PRINT_PARAM_STRING("output_model") + " output parameter."
-    "\n\n"
-    "Note: the following parameter is deprecated and "
-    "will be removed in mlpack 4.0.0: " + PRINT_PARAM_STRING("output") +
-    "."
-    "\n"
-    "Use " + PRINT_PARAM_STRING("predictions") + " instead of " +
-    PRINT_PARAM_STRING("output") + '.');
+    PRINT_PARAM_STRING("output_model") + " output parameter.");
 
 // Example.
 BINDING_EXAMPLE(
@@ -144,9 +137,6 @@ PARAM_MODEL_OUT(PerceptronModel, "output_model", "Output for trained perceptron"
 
 // Testing/classification parameters.
 PARAM_MATRIX_IN("test", "A matrix containing the test set.", "T");
-// PARAM_UROW_OUT("output") is deprecated and will be removed in
-PARAM_UROW_OUT("output", "The matrix in which the predicted labels for the"
-    " test set will be written.", "o");
 PARAM_UROW_OUT("predictions", "The matrix in which the predicted labels for the"
     " test set will be written.", "P");
 
@@ -160,9 +150,8 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
 
   // If the user isn't going to save the output model or any predictions, we
   // should issue a warning.
-  RequireAtLeastOnePassed(params, { "output_model", "output", "predictions" },
-      false, "no output will be saved");
-  // "output" will be removed in mlpack 4.0.0.
+  RequireAtLeastOnePassed(params, { "output_model", "predictions" }, false,
+      "no output will be saved");
   ReportIgnoredParam(params, {{ "test", false }}, "predictions");
 
   // Check parameter validity.
@@ -320,8 +309,6 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     data::RevertLabels(predictedLabels, p->Map(), results);
 
     // Save the predicted labels.
-    if (params.Has("output"))
-      params.Get<arma::Row<size_t>>("output") = results;
     if (params.Has("predictions"))
       params.Get<arma::Row<size_t>>("predictions") = std::move(results);
   }

--- a/src/mlpack/tests/main_tests/adaboost_test.cpp
+++ b/src/mlpack/tests/main_tests/adaboost_test.cpp
@@ -52,8 +52,8 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostOutputDimensionTest",
   RUN_BINDING();
 
   // Check that number of predicted labels is equal to the input test points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
 }
 
 /**
@@ -120,7 +120,7 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostModelReuseTest",
   RUN_BINDING();
 
   arma::Row<size_t> output;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
 
   AdaBoostModel* model = params.Get<AdaBoostModel*>("output_model");
   ResetSettings();
@@ -131,7 +131,7 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostModelReuseTest",
   RUN_BINDING();
 
   // Check that initial output and output using saved model are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
 }
 
 /**
@@ -182,7 +182,7 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostWithoutLabelTest",
   RUN_BINDING();
 
   arma::Row<size_t> output;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
 
   CleanMemory();
   ResetSettings();
@@ -197,7 +197,7 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostWithoutLabelTest",
   RUN_BINDING();
 
   // Check that initial output and final output matrix are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
 }
 
 /**
@@ -218,30 +218,6 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostTrainingDataOrModelTest",
                 params.Get<AdaBoostModel*>("output_model"));
 
   REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);
-}
-
-/**
- * This test can be removed in mlpack 4.0.0.  This tests that the output and
- * predictions outputs are the same.
- */
-TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostOutputPredictionsTest",
-                 "[AdaBoostMainTest][BindingTests]")
-{
-  arma::mat trainData;
-  if (!data::Load("vc2.csv", trainData))
-    FAIL("Unable to load train dataset vc2.csv!");
-
-  arma::Row<size_t> labels;
-  if (!data::Load("vc2_labels.txt", labels))
-    FAIL("Unable to load label dataset vc2_labels.txt!");
-
-  SetInputParam("training", std::move(trainData));
-  SetInputParam("labels", std::move(labels));
-
-  RUN_BINDING();
-
-  CheckMatrices(params.Get<arma::Row<size_t>>("output"),
-                params.Get<arma::Row<size_t>>("predictions"));
 }
 
 /**
@@ -285,7 +261,7 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostDiffWeakLearnerOutputTest",
   RUN_BINDING();
 
   arma::Row<size_t> output;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
 
   CleanMemory();
   ResetSettings();
@@ -298,7 +274,7 @@ TEST_CASE_METHOD(AdaBoostTestFixture, "AdaBoostDiffWeakLearnerOutputTest",
   RUN_BINDING();
 
   arma::Row<size_t> outputPerceptron;
-  outputPerceptron = std::move(params.Get<arma::Row<size_t>>("output"));
+  outputPerceptron = std::move(params.Get<arma::Row<size_t>>("predictions"));
 
   REQUIRE(accu(output != outputPerceptron) > 1);
 }

--- a/src/mlpack/tests/main_tests/nbc_test.cpp
+++ b/src/mlpack/tests/main_tests/nbc_test.cpp
@@ -62,12 +62,12 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCOutputDimensionTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_rows == 2);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_rows == 2);
 }
 
 /**
@@ -106,18 +106,18 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCLabelsLessDimensionTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_rows == 2);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_rows == 2);
 
   // Store outputs.
   arma::Row<size_t> output;
   arma::mat output_probs;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
-  output_probs = std::move(params.Get<arma::mat>("output_probs"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
+  output_probs = std::move(params.Get<arma::mat>("probabilities"));
 
   // Reset data passed.
   CleanMemory();
@@ -136,17 +136,17 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCLabelsLessDimensionTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_rows == 2);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_rows == 2);
 
   // Check that initial output and final output matrix
   // from two models are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
-  CheckMatrices(output_probs, params.Get<arma::mat>("output_probs"));
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
+  CheckMatrices(output_probs, params.Get<arma::mat>("probabilities"));
 }
 
 /**
@@ -178,8 +178,8 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCModelReuseTest",
 
   arma::Row<size_t> output;
   arma::mat output_probs;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
-  output_probs = std::move(params.Get<arma::mat>("output_probs"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
+  output_probs = std::move(params.Get<arma::mat>("probabilities"));
 
   // Reset passed parameters.
   NBCModel* m = params.Get<NBCModel*>("output_model");
@@ -194,17 +194,17 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCModelReuseTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_rows == 2);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_rows == 2);
 
   // Check that initial output and final output
   // matrix using saved model are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
-  CheckMatrices(output_probs, params.Get<arma::mat>("output_probs"));
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
+  CheckMatrices(output_probs, params.Get<arma::mat>("probabilities"));
 }
 
 /**
@@ -260,18 +260,18 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCIncrementalVarianceTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_rows == 2);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_rows == 2);
 
   // Store outputs.
   arma::Row<size_t> output;
   arma::mat output_probs;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
-  output_probs = std::move(params.Get<arma::mat>("output_probs"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
+  output_probs = std::move(params.Get<arma::mat>("probabilities"));
 
   CleanMemory();
   ResetSettings();
@@ -286,112 +286,15 @@ TEST_CASE_METHOD(NBCTestFixture, "NBCIncrementalVarianceTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
-  REQUIRE(params.Get<arma::mat>("output_probs").n_rows == 2);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
+  REQUIRE(params.Get<arma::mat>("probabilities").n_rows == 2);
 
   // Check that initial output and final output matrix
   // from two models are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
-  CheckMatrices(output_probs, params.Get<arma::mat>("output_probs"));
-}
-
-/**
- * Ensure that the parameter 'output' and the parameter 'predictions' give the
- * same output.  This test case should be removed in mlpack 4 when the
- * deprecated parameter 'output' is removed.
- */
-TEST_CASE_METHOD(NBCTestFixture, "NBCOptionConsistencyTest",
-                "[NBCMainTest][BindingTests]")
-{
-  arma::mat inputData;
-  if (!data::Load("trainSet.csv", inputData))
-    FAIL("Cannot load train dataset trainSet.csv!");
-
-  // Get the labels out.
-  arma::Row<size_t> labels(inputData.n_cols);
-  for (size_t i = 0; i < inputData.n_cols; ++i)
-    labels[i] = inputData(inputData.n_rows - 1, i);
-
-  // Delete the last row containing labels from input dataset.
-  inputData.shed_row(inputData.n_rows - 1);
-
-  arma::mat testData;
-  if (!data::Load("testSet.csv", testData))
-    FAIL("Cannot load test dataset testSet.csv!");
-
-  // Delete the last row containing labels from test dataset.
-  testData.shed_row(testData.n_rows - 1);
-
-  // Input training data.
-  SetInputParam("training", std::move(inputData));
-  SetInputParam("labels", std::move(labels));
-
-  // Input test data.
-  SetInputParam("test", std::move(testData));
-
-  RUN_BINDING();
-
-  // Get the output from the 'output' parameter.
-  const arma::Row<size_t> testY1 =
-      std::move(params.Get<arma::Row<size_t>>("output"));
-
-  // Get output from 'predictions' parameter.
-  const arma::Row<size_t> testY2 =
-      params.Get<arma::Row<size_t>>("predictions");
-
-  // Both solutions must be equal.
-  CheckMatrices(testY1, testY2);
-}
-
-
-/**
- * This test ensures that the parameter 'output_probabilities' and the parameter
- * 'probabilities' give the same output.  This test case should be removed in
- * mlpack 4 when the deprecated parameter: 'output_probabilities' is removed.
- */
-TEST_CASE_METHOD(NBCTestFixture, "NBCOptionConsistencyTest2",
-                "[NBCMainTest][BindingTests]")
-{
-  arma::mat inputData;
-  if (!data::Load("trainSet.csv", inputData))
-    FAIL("Cannot load train dataset trainSet.csv!");
-
-  // Get the labels out.
-  arma::Row<size_t> labels(inputData.n_cols);
-  for (size_t i = 0; i < inputData.n_cols; ++i)
-    labels[i] = inputData(inputData.n_rows - 1, i);
-
-  // Delete the last row containing labels from input dataset.
-  inputData.shed_row(inputData.n_rows - 1);
-
-  arma::mat testData;
-  if (!data::Load("testSet.csv", testData))
-    FAIL("Cannot load test dataset testSet.csv!");
-
-  // Delete the last row containing labels from test dataset.
-  testData.shed_row(testData.n_rows - 1);
-
-  // Input training data.
-  SetInputParam("training", std::move(inputData));
-  SetInputParam("labels", std::move(labels));
-
-  // Input test data.
-  SetInputParam("test", std::move(testData));
-
-  RUN_BINDING();
-
-  // Get the output probabilites which is a deprecated parameter.
-  const arma::mat testY1 =
-      std::move(params.Get<arma::mat>("output_probs"));
-
-  // Get probabilities from 'predictions' parameter.
-  const arma::mat testY2 =
-      params.Get<arma::mat>("probabilities");
-
-  // Both solutions must be equal.
-  CheckMatrices(testY1, testY2);
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
+  CheckMatrices(output_probs, params.Get<arma::mat>("probabilities"));
 }

--- a/src/mlpack/tests/main_tests/perceptron_test.cpp
+++ b/src/mlpack/tests/main_tests/perceptron_test.cpp
@@ -62,10 +62,10 @@ TEST_CASE_METHOD(PerceptronTestFixture, "PerceptronOutputDimensionTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
 }
 
 /**
@@ -104,16 +104,16 @@ TEST_CASE_METHOD(PerceptronTestFixture, "PerceptronLabelsLessDimensionTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
 
   inputData.shed_row(inputData.n_rows - 1);
 
   // Store outputs.
   arma::Row<size_t> output;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
 
   // Reset data passed.
   CleanMemory();
@@ -130,48 +130,14 @@ TEST_CASE_METHOD(PerceptronTestFixture, "PerceptronLabelsLessDimensionTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
 
   // Check that initial output and final output matrix
   // from two models are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
-}
-
-/**
- * This test can be removed in mlpack 4.0.0. This tests that the output and
- * predictions outputs are the same.
- */
-TEST_CASE_METHOD(PerceptronTestFixture, "PerceptronOutputPredictionsCheck",
-                 "[PerceptronMainTest][BindingTests]")
-{
-  arma::mat trainX1;
-  arma::Row<size_t> labelsX1;
-
-  // Loading a train data set with 3 classes.
-  if (!data::Load("vc2.csv", trainX1))
-  {
-    FAIL("Could not load the train data (vc2.csv)");
-  }
-
-  // Loading the corresponding labels to the dataset.
-  if (!data::Load("vc2_labels.txt", labelsX1))
-  {
-    FAIL("Could not load the train data (vc2_labels.csv)");
-  }
-
-  SetInputParam("training", std::move(trainX1)); // Training data.
-  // Labels for the training data.
-  SetInputParam("labels", std::move(labelsX1));
-
-  // Training model using first training dataset.
-  RUN_BINDING();
-
-  // Check that the outputs are the same.
-  CheckMatrices(params.Get<arma::Row<size_t>>("output"),
-                params.Get<arma::Row<size_t>>("predictions"));
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
 }
 
 /**
@@ -202,7 +168,7 @@ TEST_CASE_METHOD(PerceptronTestFixture, "PerceptronModelReuseTest",
   RUN_BINDING();
 
   arma::Row<size_t> output;
-  output = std::move(params.Get<arma::Row<size_t>>("output"));
+  output = std::move(params.Get<arma::Row<size_t>>("predictions"));
 
   // Reset passed parameters.
   PerceptronModel* m = params.Get<PerceptronModel*>("output_model");
@@ -217,14 +183,14 @@ TEST_CASE_METHOD(PerceptronTestFixture, "PerceptronModelReuseTest",
   RUN_BINDING();
 
   // Check that number of output points are equal to number of input points.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_cols == testSize);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_cols == testSize);
 
   // Check output have only single row.
-  REQUIRE(params.Get<arma::Row<size_t>>("output").n_rows == 1);
+  REQUIRE(params.Get<arma::Row<size_t>>("predictions").n_rows == 1);
 
   // Check that initial output and final output matrix
   // using saved model are same.
-  CheckMatrices(output, params.Get<arma::Row<size_t>>("output"));
+  CheckMatrices(output, params.Get<arma::Row<size_t>>("predictions"));
 }
 
 /**


### PR DESCRIPTION
I found a number of options to bindings and other functions that had been marked deprecated with an intent to remove for mlpack 4.0.0.  So, since the current stable version is 4.3.0, I went ahead and removed them.  Better late than never 😄