### PR TITLE
Use global option for R package verbosity

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,7 +39,8 @@
 
   * Fix usage of precompiled headers; remove cotire (#3635).
 
-  * Fix non-working `verbose` option for R bindings (#3691).
+  * Fix non-working `verbose` option for R bindings (#3691), and add global
+    `mlpack.verbose` option (#3706).
 
 ### mlpack 4.3.0
 ###### 2023-11-27

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -34,9 +34,22 @@ std::string DefaultParamImpl(
 {
   std::ostringstream oss;
   if (std::is_same<T, bool>::value)
-    oss << "FALSE";
+  {
+    // If this is the verbose option, print the default that uses the global
+    // package option.
+    if (data.name == "verbose")
+    {
+      oss << "getOption(\"mlpack.verbose\", FALSE)";
+    }
+    else
+    {
+      oss << "FALSE";
+    }
+  }
   else
+  {
     oss << MLPACK_ANY_CAST<T>(data.value);
+  }
 
   return oss.str();
 }

--- a/src/mlpack/bindings/R/mlpack/src/r_util.cpp
+++ b/src/mlpack/bindings/R/mlpack/src/r_util.cpp
@@ -363,20 +363,6 @@ List IO_GetParamMatWithInfo(SEXP params, const std::string& paramName)
                       Rcpp::Named("Data") = std::move(m));
 }
 
-// Enable verbose output.
-// [[Rcpp::export]]
-void EnableVerbose()
-{
-  Log::Info.ignoreInput = false;
-}
-
-// Disable verbose output.
-// [[Rcpp::export]]
-void DisableVerbose()
-{
-  Log::Info.ignoreInput = true;
-}
-
 // Reset the state of all timers.
 // [[Rcpp::export]]
 void ResetTimers()

--- a/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
+++ b/src/mlpack/bindings/R/mlpack/tests/testthat/test-R_binding.R
@@ -335,3 +335,25 @@ test_that("TestReallyNotVerbose", {
                                build_model=TRUE,
                                verbose=FALSE))
 })
+
+# Make sure that the mlpack verbose global option does anything at all.
+test_that("TestGlobalVerbose", {
+  options(mlpack.verbose = TRUE)
+  expect_output(test_r_binding(4.0, 12, "hello",
+                               build_model=TRUE))
+})
+
+# Test that we get no output when the global verbose option is set to false.
+test_that("TestGlobalNotVerbose", {
+  options(mlpack.verbose = FALSE)
+  expect_silent(test_r_binding(4.0, 12, "hello",
+                               build_model=TRUE))
+})
+
+# Test that we can override the global verbose option.
+test_that("TestGlobalVerboseOverride", {
+  options(mlpack.verbose = TRUE)
+  expect_silent(test_r_binding(4.0, 12, "hello",
+                               build_model=TRUE,
+                               verbose=FALSE))
+})

--- a/src/mlpack/bindings/R/print_doc.hpp
+++ b/src/mlpack/bindings/R/print_doc.hpp
@@ -67,7 +67,16 @@ void PrintDoc(util::ParamData& d,
       }
       else if (d.cppType == "bool")
       {
-        oss << (MLPACK_ANY_CAST<bool>(d.value) ? "TRUE" : "FALSE");
+        // If the option is `verbose`, be sure to print the use of the global
+        // mlpack package option as a default.
+        if (d.name == "verbose")
+        {
+          oss << "getOption(\"mlpack.verbose\", FALSE)";
+        }
+        else
+        {
+          oss << (MLPACK_ANY_CAST<bool>(d.value) ? "TRUE" : "FALSE");
+        }
       }
       oss << "\"";
     }

--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -30,9 +30,22 @@ void PrintInputParam(util::ParamData& d,
 {
   MLPACK_COUT_STREAM << d.name;
   if (std::is_same<T, bool>::value)
-    MLPACK_COUT_STREAM << "=FALSE";
+  {
+    if (d.name == "verbose")
+    {
+      // Make sure that we use the global verbose option for the mlpack package
+      // as the default.
+      MLPACK_COUT_STREAM << "=getOption(\"mlpack.verbose\", FALSE)";
+    }
+    else
+    {
+      MLPACK_COUT_STREAM << "=FALSE";
+    }
+  }
   else if (!d.required)
+  {
     MLPACK_COUT_STREAM << "=NA";
+  }
 }
 
 } // namespace r


### PR DESCRIPTION
This fixes #3692 in just the way that @cgiachalis suggested.

Instead of the `verbose` option being printed with a default of `FALSE` (e.g. `verbose = FALSE`), it is now printed as `verbose = getOption("mlpack.verbose", FALSE)`.  That is, it defaults to false unless `mlpack.verbose` has been set (at least to the best of my limited R understanding).

I also added tests to make sure that it operates correctly.

@eddelbuettel @coatless let me know what you think here, a double-check would be much appreciated. :+1: