### PR TITLE
Enable more parallelization on the R action worker via:  -j $(nproc)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
     outputs:
       r_bindings: ${{ steps.mlpack_version.outputs.mlpack_r_package }}
 
+    env:
+      MAKEFLAGS: "-j $(nproc)"
+      
     steps:
       - uses: actions/checkout@v3
 
@@ -116,7 +119,7 @@ jobs:
             }
 
     env:
-      MAKEFLAGS: "-j 2"
+      MAKEFLAGS: "-j $(nproc)"
       R_BUILD_ARGS: "--no-build-vignettes"
       R_CHECK_ARGS: "--no-build-vignettes"
       _R_CHECK_FORCE_SUGGESTS: 0


### PR DESCRIPTION
Improves the `env` variable `MAKEFLAGS` to use all available cores instead of 2 due to variability in the GH runner.

Close #3707 