### PR TITLE
Document `SparseCoding`

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -122,6 +122,8 @@ Transform data from one space to another.
 
  * [`NMF`](user/methods/nmf.md): non-negative matrix factorization
  * [`PCA`](user/methods/pca.md): principal components analysis
+ * [`SparseCoding`](user/methods/sparse_coding.md): sparse coding with
+   dictionary learning
 
 ### Modeling utilities
 

--- a/doc/sidebar.html
+++ b/doc/sidebar.html
@@ -189,6 +189,11 @@ when the sidebar is built for each page.
               <code>PCA</code>
             </a>
           </li>
+          <li>
+            <a href="LINKROOTuser/methods/sparse_coding.html">
+              <code>SparseCoding</code>
+            </a>
+          </li>
         </ul>
       </details>
     </li>

--- a/doc/user/methods/sparse_coding.md
+++ b/doc/user/methods/sparse_coding.md
@@ -42,7 +42,7 @@ std::cout << "Average sparsity of encoded test data: "
 
 <!-- TODO: add LCC link -->
 
- * [`LARS`](lars.md)
+ * [`LARS`](lars.md) (used internally by `SparseCoding`)
  * [mlpack transformations](../../index.md#transformations)
  * [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
  * [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
@@ -53,8 +53,8 @@ std::cout << "Average sparsity of encoded test data: "
  * `sc = SparseCoding(atoms=0, lambda1=0.0, lambda2=0.0, maxIter=0, objTol=0.01, newtonTol=1e-6)`
    - Create a `SparseCoding` object without learning a dictionary on data.
    - If `atoms` is set to `0` (the default), it will need to be set to a value
-     greater than 0 before `Train()` is called (`sc.Atoms() = atoms` can be used
-     for this).
+     greater than `0` before `Train()` is called (`sc.Atoms() = atoms` can be
+     used for this).
 
  * `sc = SparseCoding(data, atoms, lambda1=0.0, lambda2=0.0, maxIter=0, objTol=0.01, newtonTol=1e-6)`
    - Create a `SparseCoding` object and train the dictionary on the given
@@ -62,8 +62,8 @@ std::cout << "Average sparsity of encoded test data: "
    - The dictionary will contain `atoms` elements.
 
  * `sc = SparseCoding(data, atoms, lambda1, lambda2, maxIter, objTol, newtonTol, initializer)`
-   - Advanced constructor: create a `SparseCoding` object that will use a custom
-     dictionary initializer and train on the given `data`.
+   - *Advanced constructor*: create a `SparseCoding` object that will use a
+     custom dictionary initializer and train on the given `data`.
    - The dictionary will contain `atoms` elements.
    - `initializer` will be used to initialize the dictionary; see [Advanced
      Functionality: Different Dictionary Initialization
@@ -76,8 +76,7 @@ std::cout << "Average sparsity of encoded test data: "
 |----------|----------|-----------------|-------------|
 | `data` | [`arma::mat`](../matrices.md) | [Column-major](../matrices.md#representing-data-in-mlpack) training matrix. | _(N/A)_ |
 | `atoms` | `size_t` | Number of atoms in dictionary. | _(N/A)_ |
-| `lambda1` | `double` | L1 regularization penalty.  Used in both `Train()` and
-`Encode()` steps. | `0.0` |
+| `lambda1` | `double` | L1 regularization penalty.  Used in both `Train()` and `Encode()` steps. | `0.0` |
 | `lambda2` | `double` | L2 regularization penalty (for elastic net regularization).  Used in both `Train()` and `Encode()` steps. | `0.0` |
 | `maxIter` | `size_t` | Maximum number of iterations for dictionary learning.  `0` means no limit. | `0` |
 | `objTol` | `double` | Objective function tolerance for terminating dictionary learning. | `0.01` |

--- a/doc/user/methods/sparse_coding.md
+++ b/doc/user/methods/sparse_coding.md
@@ -21,7 +21,8 @@ sc.Encode(testData, codes);        // Step 3: encode new data.
 
 // Print some information about the test encoding.
 std::cout << "Average sparsity of encoded test data: "
-    << 100.0 * arma::mean(arma::sum(codes != 0)) << "\%." << std::endl;
+    << 100.0 * arma::mean(arma::sum(codes != 0)) / codes.n_elem << "\%."
+    << std::endl;
 ```
 <p style="text-align: center; font-size: 85%"><a href="#simple-examples">More examples...</a></p>
 
@@ -172,18 +173,19 @@ of the `SparseCoding` class.
 
 ---
 
-Train a sparse coding model on the MNIST dataset and print the reconstruction
+Train a sparse coding model on the cloud dataset and print the reconstruction
 error.
 
 ```c++
-// See https://datasets.mlpack.org/mnist.train.csv.
+// See https://datasets.mlpack.org/cloud.csv.
 arma::mat dataset;
-mlpack::data::Load("mnist.train.csv", dataset, true);
+mlpack::data::Load("cloud.csv", dataset, true);
 
 mlpack::SparseCoding sc;
 sc.Atoms() = 50;
 sc.Lambda1() = 0.1;
 sc.Lambda2() = 0.001;
+sc.MaxIterations() = 25;
 sc.Train(dataset);
 
 // Encode the training dataset.
@@ -203,15 +205,15 @@ std::cout << "RMSE of reconstructed matrix: " << error << "." << std::endl;
 
 ---
 
-Train a sparse coding model on the covertype dataset and save the model to disk.
+Train a sparse coding model on the iris dataset and save the model to disk.
 
 ```c++
-// See https://datasets.mlpack.org/covertype.train.csv.
+// See https://datasets.mlpack.org/iris.train.csv.
 arma::mat dataset;
-mlpack::data::Load("covertype.train.csv", dataset, true);
+mlpack::data::Load("iris.train.csv", dataset, true);
 
 // Train the model in the constructor.
-mlpack::SparseCoding sc(dataset, 100 /* atoms */, 0.1 /* L1 penalty */);
+mlpack::SparseCoding sc(dataset, 10 /* atoms */, 0.1 /* L1 penalty */);
 
 // Save the model to disk.
 mlpack::data::Save("sc.bin", "sc", sc);
@@ -220,16 +222,16 @@ mlpack::data::Save("sc.bin", "sc", sc);
 ---
 
 Load a sparse coding model from disk and encode some new points from the
-covertype dataset.
+iris dataset.
 
 ```c++
 // Load model from disk.
 mlpack::SparseCoding sc;
 mlpack::data::Load("sc.bin", "sc", sc);
 
-// See https://datasets.mlpack.org/covertype.test.csv.
+// See https://datasets.mlpack.org/iris.test.csv.
 arma::mat dataset;
-mlpack::data::Load("covertype.test.csv", dataset, true);
+mlpack::data::Load("iris.test.csv", dataset, true);
 
 // Encode the test points.
 arma::mat codes;
@@ -253,11 +255,11 @@ mlpack::data::Load("satellite.train.csv", trainData, true);
 arma::mat testData;
 mlpack::data::Load("satellite.test.csv", testData, true);
 
-for (size_t atoms = 20; atoms < 200; atoms += 10)
+for (size_t atoms = 20; atoms < 100; atoms += 10)
 {
   mlpack::SparseCoding sc(atoms);
   sc.Lambda1() = 0.1;
-  sc.MaxIterations() = 100;
+  sc.MaxIterations() = 20; // Keep iterations low so this runs relatively fast.
 
   const double trainObj = sc.Train(trainData);
 
@@ -303,9 +305,9 @@ API can be used.  The example below trains a sparse coding model on 32-bit
 floating point data.
 
 ```c++
-// See https://datasets.mlpack.org/mnist.train.csv.
+// See https://datasets.mlpack.org/cloud.csv.
 arma::fmat dataset;
-mlpack::data::Load("mnist.train.csv", dataset, true);
+mlpack::data::Load("cloud.csv", dataset, true);
 
 mlpack::SparseCoding<arma::fmat> sc;
 sc.Atoms() = 30;
@@ -365,14 +367,17 @@ arma::mat trainData;
 mlpack::data::Load("satellite.train.csv", trainData, true);
 
 const size_t atoms = 25;
+const double lambda1 = 0.1;
+const double lambda2 = 0.0;
+const size_t maxIterations = 50;
 
 // Use a uniform random matrix as the initial dictionary.
-arma::mat initialDictionary(data.n_rows, atoms, arma::fill::randu);
+arma::mat initialDictionary(trainData.n_rows, atoms, arma::fill::randu);
 
-SparseCoding(atoms);
+mlpack::SparseCoding sc(atoms, lambda1, lambda2, maxIterations);
 sc.Dictionary() = initialDictionary;
 
-const double obj = sc.Train<NothingInitializer>(trainData);
+const double obj = sc.Train<mlpack::NothingInitializer>(trainData);
 std::cout << "Training set objective: " << obj << "." << std::endl;
 ```
 

--- a/doc/user/methods/sparse_coding.md
+++ b/doc/user/methods/sparse_coding.md
@@ -13,15 +13,15 @@ dataset as a sparse combination of *atoms* in the dictionary.
 arma::mat data(40, 100, arma::fill::randu);
 arma::mat testData(40, 50, arma::fill::randu);
 
-// Perform sparse coding with 20 atoms and an L1 penalty of 0.1.
-mlpack::SparseCoding sc(20, 0.1);  // Step 1: create object.
+// Perform sparse coding with 20 atoms and an L1 penalty of 0.5.
+mlpack::SparseCoding sc(20, 0.5);  // Step 1: create object.
 double objective = sc.Train(data); // Step 2: learn dictionary.
 arma::mat codes;
 sc.Encode(testData, codes);        // Step 3: encode new data.
 
 // Print some information about the test encoding.
-std::cout << "Average sparsity of encoded test data: "
-    << 100.0 * arma::mean(arma::sum(codes != 0)) / codes.n_elem << "\%."
+std::cout << "Average density of encoded test data: "
+    << 100.0 * arma::mean(arma::sum(codes != 0)) / codes.n_rows << "\%."
     << std::endl;
 ```
 <p style="text-align: center; font-size: 85%"><a href="#simple-examples">More examples...</a></p>

--- a/doc/user/methods/sparse_coding.md
+++ b/doc/user/methods/sparse_coding.md
@@ -276,12 +276,16 @@ for (size_t atoms = 20; atoms < 200; atoms += 10)
 
 ### Advanced Functionality: Template Parameters
 
-The `SparseCoding` class has two template parameters that can be used for custom
-behavior.  The full signature of the class is:
+The `SparseCoding` class has one class template parameter that can be used for
+custom behavior.  The full signature of the class is:
 
 ```
-SparseCoding<MatType, DictionaryInitializer>
+SparseCoding<MatType>
 ```
+
+In addition, the [constructors](#constructors) and
+[`Train()` functions](#training) have a template parameter
+`DictionaryInitializer` that can be used for custom behavior.
 
 <!-- TODO: check whether it works on sparse data -->
 
@@ -309,6 +313,9 @@ sc.Atoms() = 30;
 sc.Lambda1() = 0.15;
 sc.Lambda2() = 0.001;
 sc.MaxIterations() = 100;
+// Note: a looser tolerance is often required when using floats instead of
+// doubles.
+sc.ObjTolerance() = 0.01;
 sc.Train(dataset);
 
 // Encode the training dataset.
@@ -363,10 +370,10 @@ const size_t atoms = 25;
 // Use a uniform random matrix as the initial dictionary.
 arma::mat initialDictionary(data.n_rows, atoms, arma::fill::randu);
 
-SparseCoding<arma::mat, NothingInitializer>(atoms);
+SparseCoding(atoms);
 sc.Dictionary() = initialDictionary;
 
-const double obj = sc.Train(trainData);
+const double obj = sc.Train<NothingInitializer>(trainData);
 std::cout << "Training set objective: " << obj << "." << std::endl;
 ```
 

--- a/doc/user/methods/sparse_coding.md
+++ b/doc/user/methods/sparse_coding.md
@@ -1,0 +1,391 @@
+## `SparseCoding`
+
+The `SparseCoding` class implements sparse coding with dictionary learning using
+L1 regularization or elastic net (L1+L2) regularization.  Sparse coding is a
+form of representation learning, and can be used to represent each point in a
+dataset as a sparse combination of *atoms* in the dictionary.
+
+#### Simple usage example:
+
+```c++
+// Create a random dataset with 100 points in 40 dimensions, and then a random
+// test dataset with 50 points.
+arma::mat data(40, 100, arma::fill::randu);
+arma::mat testData(40, 50, arma::fill::randu);
+
+// Perform sparse coding with 20 atoms and an L1 penalty of 0.1.
+mlpack::SparseCoding sc(20, 0.1);  // Step 1: create object.
+double objective = sc.Train(data); // Step 2: learn dictionary.
+arma::mat codes;
+sc.Encode(testData, codes);        // Step 3: encode new data.
+
+// Print some information about the test encoding.
+std::cout << "Average sparsity of encoded test data: "
+    << 100.0 * arma::mean(arma::sum(codes != 0)) << "\%." << std::endl;
+```
+<p style="text-align: center; font-size: 85%"><a href="#simple-examples">More examples...</a></p>
+
+#### Quick links:
+
+ * [Constructors](#constructors): create `SparseCoding` objects.
+ * [`Train()`](#training): train model (learn dictionary).
+ * [`Encode()`](#encoding): encode points with a trained model.
+ * [Other functionality](#other-functionality) for loading, saving, and
+   inspecting.
+ * [Examples](#simple-examples) of simple usage and links to detailed example
+   projects.
+ * [Template parameters](#advanced-functionality-template-parameters) for
+   advanced functionality: different element types and dictionary initialization
+   strategies.
+
+#### See also:
+
+<!-- TODO: add LCC link -->
+
+ * [`LARS`](lars.md)
+ * [mlpack transformations](../../index.md#transformations)
+ * [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
+ * [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+
+### Constructors
+
+ * `sc = SparseCoding()`
+ * `sc = SparseCoding(atoms=0, lambda1=0.0, lambda2=0.0, maxIter=0, objTol=0.01, newtonTol=1e-6)`
+   - Create a `SparseCoding` object without learning a dictionary on data.
+   - If `atoms` is set to `0` (the default), it will need to be set to a value
+     greater than 0 before `Train()` is called (`sc.Atoms() = atoms` can be used
+     for this).
+
+ * `sc = SparseCoding(data, atoms, lambda1=0.0, lambda2=0.0, maxIter=0, objTol=0.01, newtonTol=1e-6)`
+   - Create a `SparseCoding` object and train the dictionary on the given
+     `data`.
+   - The dictionary will contain `atoms` elements.
+
+ * `sc = SparseCoding(data, atoms, lambda1, lambda2, maxIter, objTol, newtonTol, initializer)`
+   - Advanced constructor: create a `SparseCoding` object that will use a custom
+     dictionary initializer and train on the given `data`.
+   - The dictionary will contain `atoms` elements.
+   - `initializer` will be used to initialize the dictionary; see [Advanced
+     Functionality: Different Dictionary Initialization
+     Strategies](#dictionaryinitializer-different-dictionary-initialization-strategies)
+     for details.
+
+#### Constructor Parameters:
+
+| **name** | **type** | **description** | **default** |
+|----------|----------|-----------------|-------------|
+| `data` | [`arma::mat`](../matrices.md) | [Column-major](../matrices.md#representing-data-in-mlpack) training matrix. | _(N/A)_ |
+| `atoms` | `size_t` | Number of atoms in dictionary. | _(N/A)_ |
+| `lambda1` | `double` | L1 regularization penalty.  Used in both `Train()` and
+`Encode()` steps. | `0.0` |
+| `lambda2` | `double` | L2 regularization penalty (for elastic net regularization).  Used in both `Train()` and `Encode()` steps. | `0.0` |
+| `maxIter` | `size_t` | Maximum number of iterations for dictionary learning.  `0` means no limit. | `0` |
+| `objTol` | `double` | Objective function tolerance for terminating dictionary learning. | `0.01` |
+| `newtonTol` | `double` | Tolerance for the Newton's method dictionary optimization step. | `1e-6` |
+
+As an alternative to passing `atoms`, `lambda1`, `lambda2`, `maxIter`, `objTol`,
+or `newtonTol`, these can be set with a standalone method.  The following
+functions can be used before calling `Train()`:
+
+ * `sc.Atoms() = a;` will set the number of atoms to use in the dictionary to
+   `a`.  Changing this after calling `Train()` will not make a difference to the
+   dictionary size.
+
+ * `sc.Lambda1() = l1;` will set the L1 regularization penalty to `l1`.  This
+   can be set after `Train()` to force sparser encodings when `Encode()` is
+   called.
+
+ * `sc.Lambda2() = l2;` will set the L2 regularization penalty to `l2`.  This
+   can be set after `Train()` to increase the regularization when `Encode()` is
+   called.
+
+ * `sc.MaxIterations() = m;` will set the maximum number of iterations for
+   dictionary learning to `m`.  `0` means that the algorithm will run until
+   convergence.
+
+ * `sc.ObjTolerance() = ot;` will set the objective tolerance for convergence of
+   the dictionary learning algorithm to `ot`.
+
+ * `sc.NewtonTolerance() = nt;` will set the tolerance for the Newton's method
+   dictionary optimization step to `nt`.
+
+***Caveats***:
+
+ * Larger settings of `atoms` (i.e. larger dictionary sizes) will be able to
+   more accurately represent the data, but may take longer to learn.
+
+ * Larger values of `lambda1` will cause the model to use sparser codings for
+   data when `Train()` and `Encode()` are called, but codings that are too
+   sparse may be inaccurate representations of the original points.
+
+ * Training is not incremental; a second call to `Train()` will reinitialize the
+   dictionary and restart the learning process.
+
+### Training
+
+If training the dictionary is not done as part of the constructor call, it can
+be done with one of the following versions of the `Train()` member function:
+
+ * `sc.Train(data)`
+ * `sc.Train(data, initializer)`
+   - Train the sparse coding dictionary on the given `data`.
+   - Optionally, use the given `initializer` to initialize the dictionary (see
+     [`DictionaryInitializer`](#dictionaryinitializer-different-dictionary-initialization-strategies)
+     for more details).
+
+### Encoding
+
+Once a `SparseCoding` model has a trained dictionary, the `Encode()` member
+function can be used to encode new data points.
+
+ * `sc.Encode(data, codes)`
+   - Encode `data` (a
+     [column-major data matrix](../matrices.md#representing-data-in-mlpack))
+     as a set of sparse codes of the dictionary, storing the result in `codes`.
+   - Both `data` and `codes` should be the same matrix type (e.g. `arma::mat`);
+     see [Different Element Types](#mattype-different-element-types) for more
+     details.
+   - `codes` will be set to have `atoms` rows and `data.n_cols` columns.
+   - Column `i` of `codes` corresponds to the sparse coding of the `i`'th column
+     of `data`.  Each row represents the weight associated with each atom in
+     the dictionary.
+
+After encoding, the original data can be recovered as `sc.Dictionary() * data`.
+
+### Other Functionality
+
+ * A `SparseCoding` model can be serialized with
+   [`data::Save()` and `data::Load()`](../load_save.md#mlpack-objects).
+
+ * `sc.Dictionary()` will return an `arma::mat&` containing the dictionary
+   matrix.  The matrix has `data.n_rows` rows and `atoms` columns; each column
+   corresponds to an atom in the dictionary.
+
+ * `double obj = sc.Objective(data, codes)` computes the sparse coding objective
+   function on the given `data` and encodings `codes`.  This can be used after
+   `Encode()` to test the quality of the encodings (a smaller objective is
+   better).
+
+### Simple Examples
+
+See also the [simple usage example](#simple-usage-example) for a trivial usage
+of the `SparseCoding` class.
+
+---
+
+Train a sparse coding model on the MNIST dataset and print the reconstruction
+error.
+
+```c++
+// See https://datasets.mlpack.org/mnist.train.csv.
+arma::mat dataset;
+mlpack::data::Load("mnist.train.csv", dataset, true);
+
+mlpack::SparseCoding sc;
+sc.Atoms() = 50;
+sc.Lambda1() = 0.1;
+sc.Lambda2() = 0.001;
+sc.Train(dataset);
+
+// Encode the training dataset.
+arma::mat codes;
+sc.Encode(dataset, codes);
+
+std::cout << "Input matrix size: " << dataset.n_rows << " x " << dataset.n_cols
+    << "." << std::endl;
+std::cout << "Codes matrix size: " << codes.n_rows << " x " << codes.n_cols
+    << "." << std::endl;
+
+// Reconstruct the original matrix.
+arma::mat recon = sc.Dictionary() * codes;
+double error = std::sqrt(arma::norm(dataset - recon, "fro") / dataset.n_elem);
+std::cout << "RMSE of reconstructed matrix: " << error << "." << std::endl;
+```
+
+---
+
+Train a sparse coding model on the covertype dataset and save the model to disk.
+
+```c++
+// See https://datasets.mlpack.org/covertype.train.csv.
+arma::mat dataset;
+mlpack::data::Load("covertype.train.csv", dataset, true);
+
+// Train the model in the constructor.
+mlpack::SparseCoding sc(dataset, 100 /* atoms */, 0.1 /* L1 penalty */);
+
+// Save the model to disk.
+mlpack::data::Save("sc.bin", "sc", sc);
+```
+
+---
+
+Load a sparse coding model from disk and encode some new points from the
+covertype dataset.
+
+```c++
+// Load model from disk.
+mlpack::SparseCoding sc;
+mlpack::data::Load("sc.bin", "sc", sc);
+
+// See https://datasets.mlpack.org/covertype.test.csv.
+arma::mat dataset;
+mlpack::data::Load("covertype.test.csv", dataset, true);
+
+// Encode the test points.
+arma::mat codes;
+sc.Encode(dataset, codes);
+
+// Compute the sparse coding objective on the test points.
+const double obj = sc.Objective(dataset, codes);
+std::cout << "Sparse coding objective on test set: " << obj << "." << std::endl;
+```
+
+---
+
+Train a sparse coding model on the satellite dataset, trying several different
+dictionary sizes and checking the objective value on a held-out test dataset.
+
+```c++
+// See https://datasets.mlpack.org/satellite.train.csv.
+arma::mat trainData;
+mlpack::data::Load("satellite.train.csv", trainData, true);
+// See https://datasets.mlpack.org/satellite.test.csv.
+arma::mat testData;
+mlpack::data::Load("satellite.test.csv", testData, true);
+
+for (size_t atoms = 20; atoms < 200; atoms += 10)
+{
+  mlpack::SparseCoding sc(atoms);
+  sc.Lambda1() = 0.1;
+  sc.MaxIterations() = 100;
+
+  const double trainObj = sc.Train(trainData);
+
+  // Compute the objective on the test set.
+  arma::mat codes;
+  sc.Encode(testData, codes);
+  const double testObj = sc.Objective(testData, codes);
+
+  std::cout << "Atoms: " << std::setfill(' ') << std::setw(3) << atoms << "; ";
+  std::cout << "training set objective: " << std::setw(6) << trainObj << "; ";
+  std::cout << "test set objective: " << std::setw(6) << testObj << "."
+      << std::endl;
+}
+```
+
+### Advanced Functionality: Template Parameters
+
+The `SparseCoding` class has two template parameters that can be used for custom
+behavior.  The full signature of the class is:
+
+```
+SparseCoding<MatType, DictionaryInitializer>
+```
+
+<!-- TODO: check whether it works on sparse data -->
+
+ * `MatType`: the type of the matrix to use (e.g. `arma::mat`, `arma::fmat`,
+   etc.).  The given `MatType` must support the Armadillo API and hold a
+   floating-point element type (e.g. `float`, `double`, etc.).
+
+ * `DictionaryInitializer`: the strategy used to initialize the dictionary.  By
+   default, `DataDependentRandomInitializer` is used.
+
+#### ```MatType```: Different Element Types
+
+`MatType` specifies the type of matrix used for training data and internal
+representation of the dictionary.  Any matrix type that implements the Armadillo
+API can be used.  The example below trains a sparse coding model on 32-bit
+floating point data.
+
+```c++
+// See https://datasets.mlpack.org/mnist.train.csv.
+arma::fmat dataset;
+mlpack::data::Load("mnist.train.csv", dataset, true);
+
+mlpack::SparseCoding<arma::fmat> sc;
+sc.Atoms() = 30;
+sc.Lambda1() = 0.15;
+sc.Lambda2() = 0.001;
+sc.MaxIterations() = 100;
+sc.Train(dataset);
+
+// Encode the training dataset.
+arma::fmat codes;
+sc.Encode(dataset, codes);
+
+std::cout << "Input matrix size: " << dataset.n_rows << " x " << dataset.n_cols
+    << "." << std::endl;
+std::cout << "Codes matrix size: " << codes.n_rows << " x " << codes.n_cols
+    << "." << std::endl;
+
+// Reconstruct the original matrix.
+arma::fmat recon = sc.Dictionary() * codes;
+double error = std::sqrt(arma::norm(dataset - recon, "fro") / dataset.n_elem);
+std::cout << "RMSE of reconstructed matrix: " << error << "." << std::endl;
+
+```
+
+#### ```DictionaryInitializer```: Different Dictionary Initialization Strategies
+
+The `DictionaryInitializer` template class specifies the strategy to be used to
+initialize the dictionary when `Train()` is called.
+
+ * The `DataDependentRandomInitalizer` class (the default) uses the average of
+   three random points in the dataset to initialize each atom in the dictionary.
+
+ * The `NothingInitializer` class does not modify the dictionary matrix in any
+   way, and could be used either to set a specific dictionary before training
+   with `sc.Dictionary()`, or to allow incremental training that does not modify
+   the existing dictionary when `Train()` is called a second time.
+
+ * The `RandomInitializer` class initializes the dictionary by sampling norm-1
+   atoms from a normal distribution.
+
+***Note:*** none of the classes above have any members, and as such it is not
+necessary to use the constructor or `Train()` variants that take an initialized
+`initializer` object.  That would only be necessary for a custom
+`DictionaryInitializer` class that stored internal members.
+
+---
+
+The example below uses `NothingInitializer` to set a specific initial
+dictionary.
+
+```c++
+// See https://datasets.mlpack.org/satellite.train.csv.
+arma::mat trainData;
+mlpack::data::Load("satellite.train.csv", trainData, true);
+
+const size_t atoms = 25;
+
+// Use a uniform random matrix as the initial dictionary.
+arma::mat initialDictionary(data.n_rows, atoms, arma::fill::randu);
+
+SparseCoding<arma::mat, NothingInitializer>(atoms);
+sc.Dictionary() = initialDictionary;
+
+const double obj = sc.Train(trainData);
+std::cout << "Training set objective: " << obj << "." << std::endl;
+```
+
+---
+
+ * An entirely custom class can also be implemented.  The class must implement
+   one method, `Initialize()`:
+
+```c++
+// You can use this as a starting point for implementation.
+class CustomDictionaryInitializer
+{
+ public:
+  // Initialize the dictionary to have the given number of atoms, given the
+  // dataset.  MatType will be the matrix type used by the sparse coding model
+  // (e.g. `arma::mat`, `arma::fmat`, etc.).
+  template<typename MatType>
+  void Initialize(const MatType& data,
+                  const size_t atoms,
+                  MatType& dictionary);
+};
+```

--- a/src/mlpack/methods/sparse_coding/data_dependent_random_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/data_dependent_random_initializer.hpp
@@ -34,9 +34,10 @@ class DataDependentRandomInitializer
    * @param atoms Number of atoms in dictionary.
    * @param dictionary Dictionary to initialize.
    */
-  static void Initialize(const arma::mat& data,
+  template<typename MatType>
+  static void Initialize(const MatType& data,
                          const size_t atoms,
-                         arma::mat& dictionary)
+                         MatType& dictionary)
   {
     // Set the size of the dictionary.
     dictionary.set_size(data.n_rows, atoms);

--- a/src/mlpack/methods/sparse_coding/nothing_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/nothing_initializer.hpp
@@ -31,9 +31,10 @@ class NothingInitializer
    * for SparseCoding if the dictionary is not set manually before running the
    * method.
    */
-  static void Initialize(const arma::mat& /* data */,
+  template<typename MatType>
+  static void Initialize(const MatType& /* data */,
                          const size_t /* atoms */,
-                         arma::mat& /* dictionary */)
+                         MatType& /* dictionary */)
   {
     // Do nothing!
   }

--- a/src/mlpack/methods/sparse_coding/random_initializer.hpp
+++ b/src/mlpack/methods/sparse_coding/random_initializer.hpp
@@ -33,9 +33,10 @@ class RandomInitializer
    * @param atoms Number of atoms (columns) in the dictionary.
    * @param dictionary Dictionary to initialize.
    */
-  static void Initialize(const arma::mat& data,
+  template<typename MatType>
+  static void Initialize(const MatType& data,
                          const size_t atoms,
-                         arma::mat& dictionary)
+                         MatType& dictionary)
   {
     // Create random dictionary.
     dictionary.randn(data.n_rows, atoms);

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -111,9 +111,13 @@ namespace mlpack {
  *     dictionary; must have 'void Initialize(const arma::mat& data, arma::mat&
  *     dictionary)' function.
  */
+template<typename MatType = arma::mat>
 class SparseCoding
 {
  public:
+  typedef typename GetColType<MatType>::type ColType;
+  typedef typename GetRowType<MatType>::type RowType;
+
   /**
    * Set the parameters to SparseCoding.  lambda2 defaults to 0.  This
    * constructor will train the model.  If that is not desired, call the other
@@ -142,7 +146,7 @@ class SparseCoding
    * @param initializer The initializer to use.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
-  SparseCoding(const arma::mat& data,
+  SparseCoding(const MatType& data,
                const size_t atoms,
                const double lambda1,
                const double lambda2 = 0,
@@ -180,7 +184,7 @@ class SparseCoding
    * @return The final objective value.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
-  double Train(const arma::mat& data,
+  double Train(const MatType& data,
                const DictionaryInitializer& initializer =
                    DictionaryInitializer());
 
@@ -191,7 +195,7 @@ class SparseCoding
    * @param data Input data matrix to be encoded.
    * @param codes Output codes matrix.
    */
-  void Encode(const arma::mat& data, arma::mat& codes);
+  void Encode(const MatType& data, MatType& codes);
 
   /**
    * Learn dictionary via Newton method based on Lagrange dual.
@@ -204,8 +208,8 @@ class SparseCoding
    * @return the norm of the gradient of the Lagrange dual with respect to
    *    the dual variables
    */
-  double OptimizeDictionary(const arma::mat& data,
-                            const arma::mat& codes,
+  double OptimizeDictionary(const MatType& data,
+                            const MatType& codes,
                             const arma::uvec& adjacencies);
 
   /**
@@ -216,12 +220,12 @@ class SparseCoding
   /**
    * Compute the objective function.
    */
-  double Objective(const arma::mat& data, const arma::mat& codes) const;
+  double Objective(const MatType& data, const MatType& codes) const;
 
   //! Access the dictionary.
-  const arma::mat& Dictionary() const { return dictionary; }
+  const MatType& Dictionary() const { return dictionary; }
   //! Modify the dictionary.
-  arma::mat& Dictionary() { return dictionary; }
+  MatType& Dictionary() { return dictionary; }
 
   //! Access the number of atoms.
   size_t Atoms() const { return atoms; }
@@ -262,7 +266,7 @@ class SparseCoding
   size_t atoms;
 
   //! Dictionary (columns are atoms).
-  arma::mat dictionary;
+  MatType dictionary;
 
   //! l1 regularization term.
   double lambda1;
@@ -278,6 +282,9 @@ class SparseCoding
 };
 
 } // namespace mlpack
+
+CEREAL_TEMPLATE_CLASS_VERSION((typename MatType),
+    (mlpack::SparseCoding<MatType>), (1));
 
 // Include implementation.
 #include "sparse_coding_impl.hpp"

--- a/src/mlpack/methods/sparse_coding/sparse_coding_impl.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding_impl.hpp
@@ -18,9 +18,10 @@
 
 namespace mlpack {
 
+template<typename MatType>
 template<typename DictionaryInitializer>
-SparseCoding::SparseCoding(
-    const arma::mat& data,
+SparseCoding<MatType>::SparseCoding(
+    const MatType& data,
     const size_t atoms,
     const double lambda1,
     const double lambda2,
@@ -38,7 +39,8 @@ SparseCoding::SparseCoding(
   Train(data, initializer);
 }
 
-inline SparseCoding::SparseCoding(
+template<typename MatType>
+inline SparseCoding<MatType>::SparseCoding(
     const size_t atoms,
     const double lambda1,
     const double lambda2,
@@ -55,12 +57,13 @@ inline SparseCoding::SparseCoding(
   // Nothing to do.
 }
 
-inline void SparseCoding::Encode(const arma::mat& data,
-                                 arma::mat& codes)
+template<typename MatType>
+inline void SparseCoding<MatType>::Encode(const MatType& data,
+                                          MatType& codes)
 {
   // When using the Cholesky version of LARS, this is correct even if
   // lambda2 > 0.
-  arma::mat matGram = trans(dictionary) * dictionary;
+  MatType matGram = trans(dictionary) * dictionary;
 
   codes.set_size(atoms, data.n_cols);
   for (size_t i = 0; i < data.n_cols; ++i)
@@ -71,23 +74,25 @@ inline void SparseCoding::Encode(const arma::mat& data,
 
     bool useCholesky = true;
     // Intercept fitting and data normalization is disabled.
-    LARS<> lars(useCholesky, lambda1, lambda2, 1e-16 /* default tolerance */,
-        false, false);
+    LARS<MatType> lars(useCholesky, lambda1, lambda2,
+        1e-16 /* default tolerance */, false, false);
 
     // Create an alias of the code (using the same memory), and then LARS will
     // place the result directly into that; then we will not need to have an
     // extra copy.
-    arma::vec code = codes.unsafe_col(i);
-    arma::rowvec responses = data.unsafe_col(i).t();
+    ColType code = codes.unsafe_col(i);
+    RowType responses = data.unsafe_col(i).t();
     lars.Train(dictionary, responses, false, useCholesky, matGram);
     code = lars.Beta();
   }
 }
 
 // Dictionary step for optimization.
-inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
-                                               const arma::mat& codes,
-                                               const arma::uvec& adjacencies)
+template<typename MatType>
+inline double SparseCoding<MatType>::OptimizeDictionary(
+    const MatType& data,
+    const MatType& codes,
+    const arma::uvec& adjacencies)
 {
   // Count the number of atomic neighbors for each point x^i.
   arma::uvec neighborCounts = zeros<arma::uvec>(data.n_cols, 1);
@@ -124,7 +129,7 @@ inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
   const size_t nInactiveAtoms = atoms - nActiveAtoms;
 
   // Efficient construction of Z restricted to active atoms.
-  arma::mat matActiveZ;
+  MatType matActiveZ;
   if (nInactiveAtoms > 0)
   {
     matActiveZ = codes.rows(arma::uvec(activeAtoms));
@@ -142,7 +147,7 @@ inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
   // multiplication with inv(A) seems to be unavoidable. Although more
   // expensive, the code written this way (we use solve()) should be more
   // numerically stable than just using inv(A) for everything.
-  arma::vec dualVars = zeros<arma::vec>(nActiveAtoms);
+  ColType dualVars = zeros<ColType>(nActiveAtoms);
 
   // vec dualVars = 1e-14 * ones<vec>(nActiveAtoms);
 
@@ -159,8 +164,8 @@ inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
   bool converged = false;
 
   // If we have any inactive atoms, we must construct these differently.
-  arma::mat codesXT;
-  arma::mat codesZT;
+  MatType codesXT;
+  MatType codesZT;
 
   if (nInactiveAtoms == 0)
   {
@@ -177,16 +182,15 @@ inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
   double improvement = 0;
   for (size_t t = 1; (t != maxIterations) && !converged; ++t)
   {
-    arma::mat A = codesZT + diagmat(dualVars);
+    MatType A = codesZT + diagmat(dualVars);
 
-    arma::mat matAInvZXT = solve(A, codesXT);
+    MatType matAInvZXT = solve(A, codesXT);
 
-    arma::vec gradient = -sum(square(matAInvZXT), 1);
-    gradient += 1;
+    ColType gradient = -sum(square(matAInvZXT), 1) + 1;
 
-    arma::mat hessian = -(-2 * (matAInvZXT * trans(matAInvZXT)) % inv(A));
+    MatType hessian = -(-2 * (matAInvZXT * trans(matAInvZXT)) % inv(A));
 
-    arma::vec searchDirection = -solve(hessian, gradient);
+    ColType searchDirection = -solve(hessian, gradient);
 
     // Armijo line search.
     const double c = 1e-4;
@@ -234,7 +238,7 @@ inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
   }
   else
   {
-    arma::mat activeDictionary = trans(solve(codesZT +
+    MatType activeDictionary = trans(solve(codesZT +
         diagmat(dualVars), codesXT));
 
     // Update all atoms.
@@ -266,7 +270,8 @@ inline double SparseCoding::OptimizeDictionary(const arma::mat& data,
 }
 
 // Project each atom of the dictionary back into the unit ball (if necessary).
-inline void SparseCoding::ProjectDictionary()
+template<typename MatType>
+inline void SparseCoding<MatType>::ProjectDictionary()
 {
   for (size_t j = 0; j < atoms; ++j)
   {
@@ -281,8 +286,9 @@ inline void SparseCoding::ProjectDictionary()
 }
 
 // Compute the objective function.
-inline double SparseCoding::Objective(const arma::mat& data, 
-                                      const arma::mat& codes)
+template<typename MatType>
+inline double SparseCoding<MatType>::Objective(const MatType& data,
+                                               const MatType& codes)
     const
 {
   double l11NormZ = sum(sum(arma::abs(codes)));
@@ -300,9 +306,10 @@ inline double SparseCoding::Objective(const arma::mat& data,
   }
 }
 
+template<typename MatType>
 template<typename DictionaryInitializer>
-double SparseCoding::Train(
-    const arma::mat& data,
+double SparseCoding<MatType>::Train(
+    const MatType& data,
     const DictionaryInitializer& initializer)
 {
   // Now, train.
@@ -316,7 +323,7 @@ double SparseCoding::Train(
   // optimization loop.
   Log::Info << "Initial coding step." << std::endl;
 
-  arma::mat codes(atoms, data.n_cols);
+  MatType codes(atoms, data.n_cols);
   Encode(data, codes);
   arma::uvec adjacencies = find(codes);
 
@@ -368,11 +375,24 @@ double SparseCoding::Train(
   return lastObjVal;
 }
 
+template<typename MatType>
 template<typename Archive>
-void SparseCoding::serialize(Archive& ar, const uint32_t /* version */)
+void SparseCoding<MatType>::serialize(Archive& ar, const uint32_t version)
 {
   ar(CEREAL_NVP(atoms));
-  ar(CEREAL_NVP(dictionary));
+
+  if (cereal::is_loading<Archive>() && version == 0)
+  {
+    // Older versions of SparseCoding always stored dictionary as an arma::mat.
+    arma::mat dictionaryTmp;
+    ar(cereal::make_nvp("dictionary", dictionaryTmp));
+    dictionary = ConvTo<MatType>::From(dictionaryTmp);
+  }
+  else
+  {
+    ar(CEREAL_NVP(dictionary));
+  }
+
   ar(CEREAL_NVP(lambda1));
   ar(CEREAL_NVP(lambda2));
   ar(CEREAL_NVP(maxIterations));

--- a/src/mlpack/methods/sparse_coding/sparse_coding_main.cpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding_main.cpp
@@ -113,9 +113,9 @@ PARAM_DOUBLE_IN("newton_tolerance", "Tolerance for convergence of Newton "
     "method.", "w", 1e-6);
 
 // Load/save a model.
-PARAM_MODEL_IN(SparseCoding, "input_model", "File containing input sparse "
+PARAM_MODEL_IN(SparseCoding<>, "input_model", "File containing input sparse "
     "coding model.", "m");
-PARAM_MODEL_OUT(SparseCoding, "output_model", "File to save trained sparse "
+PARAM_MODEL_OUT(SparseCoding<>, "output_model", "File to save trained sparse "
     "coding model to.", "M");
 
 PARAM_MATRIX_OUT("dictionary", "Matrix to save the output dictionary to.", "d");
@@ -177,11 +177,11 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       "Newton method tolerance must be nonnegative");
 
   // Do we have an existing model?
-  SparseCoding* sc;
+  SparseCoding<>* sc;
   if (params.Has("input_model"))
-    sc = params.Get<SparseCoding*>("input_model");
+    sc = params.Get<SparseCoding<>*>("input_model");
   else
-    sc = new SparseCoding(0, 0.0);
+    sc = new SparseCoding<>(0, 0.0);
 
   if (params.Has("training"))
   {
@@ -207,7 +207,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     if (params.Has("input_model"))
     {
       Log::Info << "Using dictionary from existing model in '"
-          << params.GetPrintable<SparseCoding>("input_model")
+          << params.GetPrintable<SparseCoding<>>("input_model")
           << "' as initial dictionary for training." << endl;
       sc->Train<NothingInitializer>(matX);
     }
@@ -286,5 +286,5 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
       sc->Dictionary().n_rows, sc->Dictionary().n_cols, false, false);
 
   // Save the model.
-  params.Get<SparseCoding*>("output_model") = sc;
+  params.Get<SparseCoding<>*>("output_model") = sc;
 }

--- a/src/mlpack/tests/main_tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/main_tests/sparse_coding_test.cpp
@@ -234,7 +234,7 @@ TEST_CASE_METHOD(SparseCodingTestFixture, "SparseCodingModelVerTest",
   LoadData(inputData, testData);
 
   mat initialDictionary = inputData.cols(0, 1);
-  SparseCoding* c = new SparseCoding();
+  SparseCoding<>* c = new SparseCoding<>();
 
   // Input trained model and initial_dictionary.
   SetInputParam("input_model", c);
@@ -340,8 +340,8 @@ TEST_CASE_METHOD(SparseCodingTestFixture, "SparseCodingModelReuseTest",
   arma::mat codes = std::move(params.Get<arma::mat>("codes"));
 
   // Reset passed parameters.
-  SparseCoding* m = params.Get<SparseCoding*>("output_model");
-  params.Get<SparseCoding*>("output_model") = NULL;
+  SparseCoding<>* m = params.Get<SparseCoding<>*>("output_model");
+  params.Get<SparseCoding<>*>("output_model") = NULL;
   CleanMemory();
   ResetSettings();
 

--- a/src/mlpack/tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/sparse_coding_test.cpp
@@ -22,9 +22,13 @@
 using namespace arma;
 using namespace mlpack;
 
-void SCVerifyCorrectness(vec beta, vec errCorr, double lambda)
+template<typename VecType>
+void SCVerifyCorrectness(const VecType& beta,
+                         const VecType& errCorr,
+                         double lambda)
 {
-  const double tol = 1e-12;
+  const double tol = std::is_same<typename VecType::elem_type, float>::value ?
+      1e-6 : 1e-12;
   size_t nDims = beta.n_elem;
   for (size_t j = 0; j < nDims; ++j)
   {
@@ -47,13 +51,18 @@ void SCVerifyCorrectness(vec beta, vec errCorr, double lambda)
   }
 }
 
-TEST_CASE("SparseCodingTestCodingStepLasso", "[SparseCodingTest]")
+TEMPLATE_TEST_CASE("SparseCodingTestCodingStepLasso", "[SparseCodingTest]",
+    arma::mat, arma::fmat)
 {
+  typedef TestType MatType;
+  typedef arma::Col<typename MatType::elem_type> VecType;
+
   double lambda1 = 0.1;
   uword nAtoms = 25;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  arma::mat inX; // The .arm file contains an arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // Normalize each point since these are images.
@@ -62,72 +71,82 @@ TEST_CASE("SparseCodingTestCodingStepLasso", "[SparseCodingTest]")
     X.col(i) /= norm(X.col(i), 2);
   }
 
-  SparseCoding sc(nAtoms, lambda1);
-  mat Z;
+  SparseCoding<MatType> sc(nAtoms, lambda1);
+  MatType Z;
   DataDependentRandomInitializer::Initialize(X, 25, sc.Dictionary());
   sc.Encode(X, Z);
 
-  mat D = sc.Dictionary();
+  MatType D = sc.Dictionary();
 
   for (uword i = 0; i < nPoints; ++i)
   {
-    vec errCorr = trans(D) * (D * Z.unsafe_col(i) - X.unsafe_col(i));
+    VecType errCorr = trans(D) * (D * Z.unsafe_col(i) - X.unsafe_col(i));
     SCVerifyCorrectness(Z.unsafe_col(i), errCorr, lambda1);
   }
 }
 
-TEST_CASE("SparseCodingTestCodingStepElasticNet", "[SparseCodingTest]")
+TEMPLATE_TEST_CASE("SparseCodingTestCodingStepElasticNet", "[SparseCodingTest]",
+    arma::mat, arma::fmat)
 {
+  typedef TestType MatType;
+  typedef arma::Col<typename MatType::elem_type> VecType;
+
   double lambda1 = 0.1;
   double lambda2 = 0.2;
   uword nAtoms = 25;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  arma::mat inX; // The .arm file contains an arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // Normalize each point since these are images.
   for (uword i = 0; i < nPoints; ++i)
     X.col(i) /= norm(X.col(i), 2);
 
-  SparseCoding sc(nAtoms, lambda1, lambda2);
-  mat Z;
+  SparseCoding<MatType> sc(nAtoms, lambda1, lambda2);
+  MatType Z;
   DataDependentRandomInitializer::Initialize(X, 25, sc.Dictionary());
   sc.Encode(X, Z);
 
-  mat D = sc.Dictionary();
+  MatType D = sc.Dictionary();
 
   for (uword i = 0; i < nPoints; ++i)
   {
-    vec errCorr =
-      (trans(D) * D + lambda2 * eye(nAtoms, nAtoms)) * Z.unsafe_col(i)
-      - trans(D) * X.unsafe_col(i);
+    VecType errCorr =
+        (trans(D) * D + lambda2 * eye<MatType>(nAtoms, nAtoms)) *
+        Z.unsafe_col(i) - trans(D) * X.unsafe_col(i);
 
     SCVerifyCorrectness(Z.unsafe_col(i), errCorr, lambda1);
   }
 }
 
-TEST_CASE("SparseCodingTestDictionaryStep", "[SparseCodingTest]")
+TEMPLATE_TEST_CASE("SparseCodingTestDictionaryStep", "[SparseCodingTest]",
+    arma::mat, arma::fmat)
 {
-  const double tol = 1e-6;
+  typedef TestType MatType;
+
+  const double tol = std::is_same<typename MatType::elem_type, float>::value ?
+      0.01 : 1e-6;
 
   double lambda1 = 0.1;
   uword nAtoms = 25;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  arma::mat inX; // The .arm file contains an arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // Normalize each point since these are images.
   for (uword i = 0; i < nPoints; ++i)
     X.col(i) /= norm(X.col(i), 2);
 
-  SparseCoding sc(nAtoms, lambda1, 0.0, 0, 0.01, tol);
-  mat Z;
+  SparseCoding<MatType> sc(nAtoms, lambda1, 0.0, 0, 0.01, tol);
+  MatType Z;
   DataDependentRandomInitializer::Initialize(X, 25, sc.Dictionary());
   sc.Encode(X, Z);
 
-  mat D = sc.Dictionary();
+  MatType D = sc.Dictionary();
 
   uvec adjacencies = find(Z);
   double normGradient = sc.OptimizeDictionary(X, Z, adjacencies);
@@ -135,25 +154,28 @@ TEST_CASE("SparseCodingTestDictionaryStep", "[SparseCodingTest]")
   REQUIRE(normGradient == Approx(0.0).margin(tol));
 }
 
-TEST_CASE("SerializationTest", "[SparseCodingTest]")
+TEMPLATE_TEST_CASE("SerializationTest", "[SparseCodingTest]", arma::mat,
+    arma::fmat)
 {
-  mat X = randu<mat>(100, 100);
+  typedef TestType MatType;
+
+  MatType X = randu<MatType>(100, 100);
   size_t nAtoms = 25;
 
-  SparseCoding sc(nAtoms, 0.05, 0.1);
+  SparseCoding<MatType> sc(nAtoms, 0.05, 0.1, 10);
   sc.Train(X);
 
-  mat Y = randu<mat>(100, 200);
-  mat codes;
+  MatType Y = randu<MatType>(100, 200);
+  MatType codes;
   sc.Encode(Y, codes);
 
-  SparseCoding scXml(50, 0.01), scJson(nAtoms, 0.05), scBinary(0, 0.0);
+  SparseCoding<MatType> scXml(50, 0.01), scJson(nAtoms, 0.05), scBinary(0, 0.0);
   SerializeObjectAll(sc, scXml, scJson, scBinary);
 
   CheckMatrices(sc.Dictionary(), scXml.Dictionary(), scJson.Dictionary(),
       scBinary.Dictionary());
 
-  mat xmlCodes, jsonCodes, binaryCodes;
+  MatType xmlCodes, jsonCodes, binaryCodes;
   scXml.Encode(Y, xmlCodes);
   scJson.Encode(Y, jsonCodes);
   scBinary.Encode(Y, binaryCodes);
@@ -192,22 +214,27 @@ TEST_CASE("SerializationTest", "[SparseCodingTest]")
 /**
  * Test that SparseCoding::Train() returns finite final objective value.
  */
-TEST_CASE("SparseCodingTrainReturnObjective", "[SparseCodingTest]")
+TEMPLATE_TEST_CASE("SparseCodingTrainReturnObjective", "[SparseCodingTest]",
+    arma::mat, arma::fmat)
 {
-  const double tol = 1e-6;
+  typedef TestType MatType;
+
+  const double tol = std::is_same<typename MatType::elem_type, float>::value ?
+      0.01 : 1e-6;
 
   double lambda1 = 0.1;
   uword nAtoms = 25;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  arma::mat inX; // The .arm file contains an arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // Normalize each point since these are images.
   for (uword i = 0; i < nPoints; ++i)
     X.col(i) /= norm(X.col(i), 2);
 
-  SparseCoding sc(nAtoms, lambda1, 0.0, 0, 0.01, tol);
+  SparseCoding<MatType> sc(nAtoms, lambda1, 0.0, 0, 0.01, tol);
   double objVal = sc.Train(X);
 
   REQUIRE(std::isfinite(objVal) == true);


### PR DESCRIPTION
I wrote up documentation for the `SparseCoding` class.  You can see it here:

https://www.ratml.org/misc/mlpack-markdown-doc/user/methods/sparse_coding.html

I also changed `SparseCoding` so that it supports different `MatType`s.  Otherwise, not much was needed here, which made the documentation process pretty straightforward (hooray!).