### PR TITLE
Document `LocalCoordinateCoding`

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -120,6 +120,8 @@ Prepare data for machine learning algorithms.
 
 Transform data from one space to another.
 
+ * [`LocalCoordinateCoding`](user/methods/local_coordinate_coding.md): local
+   coordinate coding with dictionary learning
  * [`NMF`](user/methods/nmf.md): non-negative matrix factorization
  * [`PCA`](user/methods/pca.md): principal components analysis
  * [`SparseCoding`](user/methods/sparse_coding.md): sparse coding with

--- a/doc/sidebar.html
+++ b/doc/sidebar.html
@@ -180,6 +180,11 @@ when the sidebar is built for each page.
         </summary>
         <ul>
           <li>
+            <a href="LINKROOTuser/methods/local_coordinate_coding.html">
+              <code>LocalCoordinateCoding</code>
+            </a>
+          </li>
+          <li>
             <a href="LINKROOTuser/methods/nmf.html">
               <code>NMF</code>
             </a>

--- a/doc/user/core.md
+++ b/doc/user/core.md
@@ -81,7 +81,7 @@ avoid copies.
    - If `offset` is `0`, then the alias is identical: the first element of
      `a` is the first element of `mat`. Otherwise, the first element of `a`
      is the `offset`'th element of `mat`; elements in `mat` are ordered in
-     a [column-major way](../matrices.md#representing-data-in-mlpack).
+     a [column-major way](matrices.md#representing-data-in-mlpack).
    - If `strict` is `true`, the size of `a` cannot be changed.
    - `mat` and `a` should have the same matrix type (e.g. `arma::mat`,
      `arma::fmat`, `arma::sp_mat`).
@@ -93,7 +93,7 @@ avoid copies.
    - If `offset` is `0`, then the alias is identical: the first element of
      `a` is the first element of `cube`. Otherwise, the first element of `a`
      is the `offset`'th element of `cube`; elements in `cube` are ordered in
-     a [column-major way](../matrices.md#representing-data-in-mlpack).
+     a [column-major way](matrices.md#representing-data-in-mlpack).
    - If `strict` is `true`, the size of `a` cannot be changed.
    - `cube` and `a` should have the same cube type (e.g. `arma::cube`,
      `arma::fcube`).

--- a/doc/user/methods/local_coordinate_coding.md
+++ b/doc/user/methods/local_coordinate_coding.md
@@ -1,23 +1,24 @@
-## `SparseCoding`
+## `LocalCoordinateCoding`
 
-The `SparseCoding` class implements sparse coding with dictionary learning using
-L1 regularization or elastic net (L1+L2) regularization.  Sparse coding is a
-form of representation learning, and can be used to represent each point in a
-dataset as a sparse combination of *atoms* in the dictionary.
+The `LocalCoordinateCoding` class implements local coordinate coding, a
+variation of [sparse coding](sparse_coding.md) with dictionary learning.  Local
+coordinate coding is a form of representation learning, and can be used to
+represent each point in a dataset as a linear combination of a few nearby
+*atoms* in the learned dictionary.
 
 #### Simple usage example:
 
 ```c++
 // Create a random dataset with 100 points in 40 dimensions, and then a random
 // test dataset with 50 points.
-arma::mat data(40, 100, arma::fill::randu);
-arma::mat testData(40, 50, arma::fill::randu);
+arma::mat data(40, 100, arma::fill::randn);
+arma::mat testData(40, 50, arma::fill::randn);
 
-// Perform sparse coding with 20 atoms and an L1 penalty of 0.5.
-mlpack::SparseCoding sc(20, 0.5);  // Step 1: create object.
-double objective = sc.Train(data); // Step 2: learn dictionary.
+// Perform local coordinate coding with 20 atoms and an L1 penalty of 0.1.
+mlpack::LocalCoordinateCoding lcc(20, 0.1); // Step 1: create object.
+double objective = lcc.Train(data);         // Step 2: learn dictionary.
 arma::mat codes;
-sc.Encode(testData, codes);        // Step 3: encode new data.
+lcc.Encode(testData, codes);                // Step 3: encode new data.
 
 // Print some information about the test encoding.
 std::cout << "Average density of encoded test data: "
@@ -28,7 +29,7 @@ std::cout << "Average density of encoded test data: "
 
 #### Quick links:
 
- * [Constructors](#constructors): create `SparseCoding` objects.
+ * [Constructors](#constructors): create `LocalCoordinateCoding` objects.
  * [`Train()`](#training): train model (learn dictionary).
  * [`Encode()`](#encoding): encode points with a trained model.
  * [Other functionality](#other-functionality) for loading, saving, and
@@ -41,29 +42,30 @@ std::cout << "Average density of encoded test data: "
 
 #### See also:
 
- * [`LocalCoordinateCoding`](local_coordinate_coding.md)
- * [`LARS`](lars.md) (used internally by `SparseCoding`)
+ * [`SparseCoding`](sparse_coding.md)
+ * [`LARS`](lars.md) (used internally by `LocalCoordinateCoding`)
  * [mlpack transformations](../../index.md#transformations)
  * [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
- * [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+ * [Nonlinear learning using local coordinate coding (pdf)](https://www.ratml.org/misc/mlpack_new/doc/user/methods/logistic_regression.html#advanced-functionality-different-element-types)
 
 ### Constructors
 
- * `sc = SparseCoding()`
- * `sc = SparseCoding(atoms=0, lambda1=0.0, lambda2=0.0, maxIter=0, objTol=0.01, newtonTol=1e-6)`
-   - Create a `SparseCoding` object without learning a dictionary on data.
+ * `lcc = LocalCoordinateCoding()`
+ * `lcc = LocalCoordinateCoding(atoms=0, lambda=0.0, maxIter=0, tol=0.01)`
+   - Create a `LocalCoordinateCoding` object without learning a dictionary on
+     data.
    - If `atoms` is set to `0` (the default), it will need to be set to a value
-     greater than `0` before `Train()` is called (`sc.Atoms() = atoms` can be
+     greater than `0` before `Train()` is called (`lcc.Atoms() = atoms` can be
      used for this).
 
- * `sc = SparseCoding(data, atoms, lambda1=0.0, lambda2=0.0, maxIter=0, objTol=0.01, newtonTol=1e-6)`
-   - Create a `SparseCoding` object and train the dictionary on the given
-     `data`.
+ * `lcc = LocalCoordinateCoding(data, atoms, lambda=0.0, maxIter=0, tol=0.01)`
+   - Create a `LocalCoordinateCoding` object and train the dictionary on the
+     given `data`.
    - The dictionary will contain `atoms` elements.
 
- * `sc = SparseCoding(data, atoms, lambda1, lambda2, maxIter, objTol, newtonTol, initializer)`
-   - *Advanced constructor*: create a `SparseCoding` object that will use a
-     custom dictionary initializer and train on the given `data`.
+ * `lcc = LocalCoordinateCoding(data, atoms, lambda, maxIter, tol, initializer)`
+   - *Advanced constructor*: create a `LocalCoordinateCoding` object that will
+     use a custom dictionary initializer and train on the given `data`.
    - The dictionary will contain `atoms` elements.
    - `initializer` will be used to initialize the dictionary; see [Advanced
      Functionality: Different Dictionary Initialization
@@ -76,46 +78,37 @@ std::cout << "Average density of encoded test data: "
 |----------|----------|-----------------|-------------|
 | `data` | [`arma::mat`](../matrices.md) | [Column-major](../matrices.md#representing-data-in-mlpack) training matrix. | _(N/A)_ |
 | `atoms` | `size_t` | Number of atoms in dictionary. | _(N/A)_ |
-| `lambda1` | `double` | L1 regularization penalty.  Used in both `Train()` and `Encode()` steps. | `0.0` |
-| `lambda2` | `double` | L2 regularization penalty (for elastic net regularization).  Used in both `Train()` and `Encode()` steps. | `0.0` |
+| `lambda` | `double` | L1 regularization penalty.  Used in both `Train()` and `Encode()` steps. | `0.0` |
 | `maxIter` | `size_t` | Maximum number of iterations for dictionary learning.  `0` means no limit. | `0` |
-| `objTol` | `double` | Objective function tolerance for terminating dictionary learning. | `0.01` |
-| `newtonTol` | `double` | Tolerance for the Newton's method dictionary optimization step. | `1e-6` |
+| `tol` | `double` | Objective function tolerance for terminating dictionary learning. | `0.01` |
 
-As an alternative to passing `atoms`, `lambda1`, `lambda2`, `maxIter`, `objTol`,
-or `newtonTol`, these can be set with a standalone method.  The following
-functions can be used before calling `Train()`:
+As an alternative to passing `atoms`, `lambda`, `maxIter`, or `tol`, these can
+be set with a standalone method.  The following functions can be used before
+calling `Train()`:
 
- * `sc.Atoms() = a;` will set the number of atoms to use in the dictionary to
+ * `lcc.Atoms() = a;` will set the number of atoms to use in the dictionary to
    `a`.  Changing this after calling `Train()` will not make a difference to the
    dictionary size.
 
- * `sc.Lambda1() = l1;` will set the L1 regularization penalty to `l1`.  This
-   can be set after `Train()` to force sparser encodings when `Encode()` is
-   called.
+ * `lcc.Lambda() = l;` will set the L1 regularization penalty to `l1`.  This can
+   be set after `Train()` to force sparser encodings when `Encode()` is called.
 
- * `sc.Lambda2() = l2;` will set the L2 regularization penalty to `l2`.  This
-   can be set after `Train()` to increase the regularization when `Encode()` is
-   called.
-
- * `sc.MaxIterations() = m;` will set the maximum number of iterations for
+ * `lcc.MaxIterations() = m;` will set the maximum number of iterations for
    dictionary learning to `m`.  `0` means that the algorithm will run until
    convergence.
 
- * `sc.ObjTolerance() = ot;` will set the objective tolerance for convergence of
-   the dictionary learning algorithm to `ot`.
-
- * `sc.NewtonTolerance() = nt;` will set the tolerance for the Newton's method
-   dictionary optimization step to `nt`.
+ * `lcc.Tolerance() = t;` will set the objective tolerance for convergence of
+   the dictionary learning algorithm to `t`.
 
 ***Caveats***:
 
  * Larger settings of `atoms` (i.e. larger dictionary sizes) will be able to
    more accurately represent the data, but may take longer to learn.
 
- * Larger values of `lambda1` will cause the model to use sparser codings for
-   data when `Train()` and `Encode()` are called, but codings that are too
-   sparse may be inaccurate representations of the original points.
+ * Larger values of `lambda` will cause the model to use sparser encodings for
+   data (e.g. fewer nearby anchor points) when `Train()` and `Encode()` are
+   called, but when `lambda` is too large, the codings may be inaccurate
+   representations of the original points.
 
  * Training is not incremental; a second call to `Train()` will reinitialize the
    dictionary and restart the learning process.
@@ -125,71 +118,71 @@ functions can be used before calling `Train()`:
 If training the dictionary is not done as part of the constructor call, it can
 be done with one of the following versions of the `Train()` member function:
 
- * `sc.Train(data)`
- * `sc.Train(data, initializer)`
-   - Train the sparse coding dictionary on the given `data`.
+ * `lcc.Train(data)`
+ * `lcc.Train(data, initializer)`
+   - Train the local coordinate coding dictionary on the given `data`.
    - Optionally, use the given `initializer` to initialize the dictionary (see
      [`DictionaryInitializer`](#dictionaryinitializer-different-dictionary-initialization-strategies)
      for more details).
 
 ### Encoding
 
-Once a `SparseCoding` model has a trained dictionary, the `Encode()` member
-function can be used to encode new data points.
+Once a `LocalCoordinateCoding` model has a trained dictionary, the `Encode()`
+member function can be used to encode new data points.
 
- * `sc.Encode(data, codes)`
-   - Encode `data` (a
-     [column-major data matrix](../matrices.md#representing-data-in-mlpack))
-     as a set of sparse codes of the dictionary, storing the result in `codes`.
+ * `lcc.Encode(data, codes)`
+   - Encode `data` (a [column-major data
+     matrix](../matrices.md#representing-data-in-mlpack)) as a sparse set of
+     local atoms of the dictionary, storing hte result in `codes`.
    - Both `data` and `codes` should be the same matrix type (e.g. `arma::mat`);
      see [Different Element Types](#mattype-different-element-types) for more
      details.
    - `codes` will be set to have `atoms` rows and `data.n_cols` columns.
-   - Column `i` of `codes` corresponds to the sparse coding of the `i`'th column
-     of `data`.  Each row represents the weight associated with each atom in
-     the dictionary.
+   - Column `i` of `codes` corresponds to the coding of the `i`'th column of
+     `data`.  Each row represents the weight associated with each atom in the
+     dictionary.
 
-After encoding, the original data can be recovered as `sc.Dictionary() * data`.
+After encoding, the original data can be recovered as `lcc.Dictionary() * data`.
 
 ### Other Functionality
 
- * A `SparseCoding` model can be serialized with
+ * A `LocalCoordinateCoding` model can be serialized with
    [`data::Save()` and `data::Load()`](../load_save.md#mlpack-objects).
 
- * `sc.Dictionary()` will return an `arma::mat&` containing the dictionary
+ * `lcc.Dictionary()` will return an `arma::mat&` containing the dictionary
    matrix.  The matrix has `data.n_rows` rows and `atoms` columns; each column
-   corresponds to an atom in the dictionary.
+   corresponds to an atom in the dictionary.  Dictionary atoms are regularized
+   to be close to the manifold that data lie on.
 
- * `double obj = sc.Objective(data, codes)` computes the sparse coding objective
-   function on the given `data` and encodings `codes`.  This can be used after
-   `Encode()` to test the quality of the encodings (a smaller objective is
-   better).
+ * `double obj = lcc.Objective(data, codes)` computes the local coordinate
+   coding objective function on the given `data` and encodings `codes`.  This
+   can be used after `Encode()` to test the quality of the encodings (a smaller
+   objective is better).
 
 ### Simple Examples
 
 See also the [simple usage example](#simple-usage-example) for a trivial usage
-of the `SparseCoding` class.
+of the `LocalCoordinateCoding` class.
 
 ---
 
-Train a sparse coding model on the cloud dataset and print the reconstruction
-error.
+Train a local coordinate coding model on the cloud dataset and print the
+reconstruction error.
 
 ```c++
 // See https://datasets.mlpack.org/cloud.csv.
 arma::mat dataset;
 mlpack::data::Load("cloud.csv", dataset, true);
 
-mlpack::SparseCoding sc;
-sc.Atoms() = 50;
-sc.Lambda1() = 0.1;
-sc.Lambda2() = 0.001;
-sc.MaxIterations() = 25;
-sc.Train(dataset);
+mlpack::LocalCoordinateCoding lcc;
+lcc.Atoms() = 50;
+lcc.Lambda() = 0.1;
+lcc.MaxIterations() = 25;
+lcc.Train(dataset);
 
 // Encode the training dataset.
 arma::mat codes;
-sc.Encode(dataset, codes);
+lcc.Encode(dataset, codes);
 
 std::cout << "Input matrix size: " << dataset.n_rows << " x " << dataset.n_cols
     << "." << std::endl;
@@ -197,14 +190,15 @@ std::cout << "Codes matrix size: " << codes.n_rows << " x " << codes.n_cols
     << "." << std::endl;
 
 // Reconstruct the original matrix.
-arma::mat recon = sc.Dictionary() * codes;
+arma::mat recon = lcc.Dictionary() * codes;
 double error = std::sqrt(arma::norm(dataset - recon, "fro") / dataset.n_elem);
 std::cout << "RMSE of reconstructed matrix: " << error << "." << std::endl;
 ```
 
 ---
 
-Train a sparse coding model on the iris dataset and save the model to disk.
+Train a local coordinate coding model on the iris dataset and save the model to
+disk.
 
 ```c++
 // See https://datasets.mlpack.org/iris.train.csv.
@@ -212,39 +206,19 @@ arma::mat dataset;
 mlpack::data::Load("iris.train.csv", dataset, true);
 
 // Train the model in the constructor.
-mlpack::SparseCoding sc(dataset, 10 /* atoms */, 0.1 /* L1 penalty */);
+mlpack::LocalCoordinateCoding lcc(dataset,
+                                  10 /* atoms */,
+                                  0.1 /* L1 penalty */);
 
 // Save the model to disk.
-mlpack::data::Save("sc.bin", "sc", sc);
+mlpack::data::Save("lcc.bin", "lcc", lcc);
 ```
 
 ---
 
-Load a sparse coding model from disk and encode some new points from the
-iris dataset.
-
-```c++
-// Load model from disk.
-mlpack::SparseCoding sc;
-mlpack::data::Load("sc.bin", "sc", sc);
-
-// See https://datasets.mlpack.org/iris.test.csv.
-arma::mat dataset;
-mlpack::data::Load("iris.test.csv", dataset, true);
-
-// Encode the test points.
-arma::mat codes;
-sc.Encode(dataset, codes);
-
-// Compute the sparse coding objective on the test points.
-const double obj = sc.Objective(dataset, codes);
-std::cout << "Sparse coding objective on test set: " << obj << "." << std::endl;
-```
-
----
-
-Train a sparse coding model on the satellite dataset, trying several different
-dictionary sizes and checking the objective value on a held-out test dataset.
+Train a local coordinate coding model on the satellite dataset, trying several
+different regularization parameters and checking the objective value on a
+held-out test dataset.
 
 ```c++
 // See https://datasets.mlpack.org/satellite.train.csv.
@@ -254,20 +228,21 @@ mlpack::data::Load("satellite.train.csv", trainData, true);
 arma::mat testData;
 mlpack::data::Load("satellite.test.csv", testData, true);
 
-for (size_t atoms = 20; atoms < 100; atoms += 10)
+for (double lambda = 0.1; lambda <= 0.5; lambda += 0.1)
 {
-  mlpack::SparseCoding sc(atoms);
-  sc.Lambda1() = 0.1;
-  sc.MaxIterations() = 20; // Keep iterations low so this runs relatively fast.
+  mlpack::LocalCoordinateCoding lcc(25 /* atoms */);
+  lcc.Lambda() = lambda;
+  lcc.MaxIterations() = 20; // Keep iterations low so this runs relatively fast.
 
-  const double trainObj = sc.Train(trainData);
+  const double trainObj = lcc.Train(trainData);
 
   // Compute the objective on the test set.
   arma::mat codes;
-  sc.Encode(testData, codes);
-  const double testObj = sc.Objective(testData, codes);
+  lcc.Encode(testData, codes);
+  const double testObj = lcc.Objective(testData, codes);
 
-  std::cout << "Atoms: " << std::setfill(' ') << std::setw(3) << atoms << "; ";
+  std::cout << "Lambda: " << std::setfill(' ') << std::setw(3) << lambda
+      << "; ";
   std::cout << "training set objective: " << std::setw(6) << trainObj << "; ";
   std::cout << "test set objective: " << std::setw(6) << testObj << "."
       << std::endl;
@@ -276,16 +251,16 @@ for (size_t atoms = 20; atoms < 100; atoms += 10)
 
 ### Advanced Functionality: Template Parameters
 
-The `SparseCoding` class has one class template parameter that can be used for
-custom behavior.  The full signature of the class is:
+The `LocalCoordinateCoding` class has one class template parameter that can be
+used for custom behavior.  The full signature of the class is:
 
 ```
-SparseCoding<MatType>
+LocalCoordinateCoding<MatType>
 ```
 
-In addition, the [constructors](#constructors) and
-[`Train()` functions](#training) have a template parameter
-`DictionaryInitializer` that can be used for custom behavior.
+In addition, the [constructors](#constructors) and [`Train()`
+functions](#training) have a template parameter `DictionaryInitializer` that can
+be used for custom behavior.
 
  * `MatType`: the type of the matrix to use (e.g. `arma::mat`, `arma::fmat`,
    etc.).  The given `MatType` must support the Armadillo API and hold a
@@ -298,27 +273,23 @@ In addition, the [constructors](#constructors) and
 
 `MatType` specifies the type of matrix used for training data and internal
 representation of the dictionary.  Any matrix type that implements the Armadillo
-API can be used.  The example below trains a sparse coding model on 32-bit
-floating point data.
+API can be used.  The example below trains a local coordinate coding model on
+32-bit floating point data.
 
 ```c++
 // See https://datasets.mlpack.org/cloud.csv.
 arma::fmat dataset;
 mlpack::data::Load("cloud.csv", dataset, true);
 
-mlpack::SparseCoding<arma::fmat> sc;
-sc.Atoms() = 30;
-sc.Lambda1() = 0.15;
-sc.Lambda2() = 0.001;
-sc.MaxIterations() = 100;
-// Note: a looser tolerance is often required when using floats instead of
-// doubles.
-sc.ObjTolerance() = 0.01;
-sc.Train(dataset);
+mlpack::LocalCoordinateCoding<arma::fmat> lcc;
+lcc.Atoms() = 30;
+lcc.Lambda() = 0.15;
+lcc.MaxIterations() = 100;
+lcc.Train(dataset);
 
 // Encode the training dataset.
 arma::fmat codes;
-sc.Encode(dataset, codes);
+lcc.Encode(dataset, codes);
 
 std::cout << "Input matrix size: " << dataset.n_rows << " x " << dataset.n_cols
     << "." << std::endl;
@@ -326,7 +297,7 @@ std::cout << "Codes matrix size: " << codes.n_rows << " x " << codes.n_cols
     << "." << std::endl;
 
 // Reconstruct the original matrix.
-arma::fmat recon = sc.Dictionary() * codes;
+arma::fmat recon = lcc.Dictionary() * codes;
 double error = std::sqrt(arma::norm(dataset - recon, "fro") / dataset.n_elem);
 std::cout << "RMSE of reconstructed matrix: " << error << "." << std::endl;
 ```
@@ -363,17 +334,16 @@ arma::mat trainData;
 mlpack::data::Load("satellite.train.csv", trainData, true);
 
 const size_t atoms = 25;
-const double lambda1 = 0.1;
-const double lambda2 = 0.0;
+const double lambda = 0.1;
 const size_t maxIterations = 50;
 
 // Use a uniform random matrix as the initial dictionary.
 arma::mat initialDictionary(trainData.n_rows, atoms, arma::fill::randu);
 
-mlpack::SparseCoding sc(atoms, lambda1, lambda2, maxIterations);
-sc.Dictionary() = initialDictionary;
+mlpack::LocalCoordinateCoding lcc(atoms, lambda, maxIterations);
+lcc.Dictionary() = initialDictionary;
 
-const double obj = sc.Train<mlpack::NothingInitializer>(trainData);
+const double obj = lcc.Train<mlpack::NothingInitializer>(trainData);
 std::cout << "Training set objective: " << obj << "." << std::endl;
 ```
 

--- a/doc/user/methods/local_coordinate_coding.md
+++ b/doc/user/methods/local_coordinate_coding.md
@@ -110,6 +110,11 @@ calling `Train()`:
    called, but when `lambda` is too large, the codings may be inaccurate
    representations of the original points.
 
+<!-- TODO: indicate that you can get this info with MLPACK_PRINT_INFO and
+MLPACK_PRINT_WARN---once those are documented -->
+
+ * If `lambda` is set too large, encodings may be empty (e.g. all zeros).
+
  * Training is not incremental; a second call to `Train()` will reinitialize the
    dictionary and restart the learning process.
 
@@ -176,7 +181,7 @@ mlpack::data::Load("cloud.csv", dataset, true);
 
 mlpack::LocalCoordinateCoding lcc;
 lcc.Atoms() = 50;
-lcc.Lambda() = 0.1;
+lcc.Lambda() = 1e-5;
 lcc.MaxIterations() = 25;
 lcc.Train(dataset);
 
@@ -228,11 +233,12 @@ mlpack::data::Load("satellite.train.csv", trainData, true);
 arma::mat testData;
 mlpack::data::Load("satellite.test.csv", testData, true);
 
-for (double lambda = 0.1; lambda <= 0.5; lambda += 0.1)
+for (double lambdaPow = -6; lambdaPow <= -2; lambdaPow += 1)
 {
-  mlpack::LocalCoordinateCoding lcc(25 /* atoms */);
+  const double lambda = std::pow(10.0, lambdaPow);
+  mlpack::LocalCoordinateCoding lcc(50 /* atoms */);
   lcc.Lambda() = lambda;
-  lcc.MaxIterations() = 20; // Keep iterations low so this runs relatively fast.
+  lcc.MaxIterations() = 25; // Keep iterations low so this runs relatively fast.
 
   const double trainObj = lcc.Train(trainData);
 
@@ -283,7 +289,7 @@ mlpack::data::Load("cloud.csv", dataset, true);
 
 mlpack::LocalCoordinateCoding<arma::fmat> lcc;
 lcc.Atoms() = 30;
-lcc.Lambda() = 0.15;
+lcc.Lambda() = 1e-5;
 lcc.MaxIterations() = 100;
 lcc.Train(dataset);
 
@@ -334,7 +340,7 @@ arma::mat trainData;
 mlpack::data::Load("satellite.train.csv", trainData, true);
 
 const size_t atoms = 25;
-const double lambda = 0.1;
+const double lambda = 1e-5;
 const size_t maxIterations = 50;
 
 // Use a uniform random matrix as the initial dictionary.

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -75,9 +75,13 @@ namespace mlpack {
  * }
  * @endcode
  */
+template<typename MatType = arma::mat>
 class LocalCoordinateCoding
 {
  public:
+  typedef typename GetColType<MatType>::type ColType;
+  typedef typename GetRowType<MatType>::type RowType;
+
   /**
    * Set the parameters to LocalCoordinateCoding, and train the dictionary.
    * This constructor will also initialize the dictionary using the given
@@ -85,7 +89,7 @@ class LocalCoordinateCoding
    *
    * If you want to initialize the dictionary to a custom matrix, consider
    * either writing your own DictionaryInitializer class (with void
-   * Initialize(const arma::mat& data, arma::mat& dictionary) function), or call
+   * Initialize(const MatType& data, MatType& dictionary) function), or call
    * the constructor that does not take a data matrix, then call Dictionary() to
    * set the dictionary matrix to a matrix of your choosing, and then call
    * Train() with NothingInitializer (i.e.  Train<NothingInitializer>(data)).
@@ -99,7 +103,7 @@ class LocalCoordinateCoding
    * @param initializer Intializer to use.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
-  LocalCoordinateCoding(const arma::mat& data,
+  LocalCoordinateCoding(const MatType& data,
                         const size_t atoms,
                         const double lambda,
                         const size_t maxIterations = 0,
@@ -132,7 +136,7 @@ class LocalCoordinateCoding
    * @return The final objective value.
    */
   template<typename DictionaryInitializer = DataDependentRandomInitializer>
-  double Train(const arma::mat& data,
+  double Train(const MatType& data,
                const DictionaryInitializer& initializer =
                    DictionaryInitializer());
 
@@ -142,7 +146,7 @@ class LocalCoordinateCoding
    * @param data Matrix containing points to encode.
    * @param codes Output matrix to store codes in.
    */
-  void Encode(const arma::mat& data, arma::mat& codes);
+  void Encode(const MatType& data, MatType& codes);
 
   /**
    * Learn dictionary by solving linear system.
@@ -153,9 +157,18 @@ class LocalCoordinateCoding
    *    the coding matrix Z that are non-zero (the adjacency matrix for the
    *    bipartite graph of points and atoms)
    */
-  void OptimizeDictionary(const arma::mat& data,
-                          const arma::mat& codes,
+  void OptimizeDictionary(const MatType& data,
+                          const MatType& codes,
                           const arma::uvec& adjacencies);
+
+  /**
+   * Compute objective function given the list of adjacencies.
+   *
+   * @param data Matrix containing points to encode.
+   * @param codes Output matrix to store codes in.
+   */
+  double Objective(const MatType& data,
+                   const MatType& codes) const;
 
   /**
    * Compute objective function given the list of adjacencies.
@@ -166,8 +179,8 @@ class LocalCoordinateCoding
    *    the coding matrix Z that are non-zero (the adjacency matrix for the
    *    bipartite graph of points and atoms)
    */
-  double Objective(const arma::mat& data,
-                   const arma::mat& codes,
+  double Objective(const MatType& data,
+                   const MatType& codes,
                    const arma::uvec& adjacencies) const;
 
   //! Get the number of atoms.
@@ -176,9 +189,9 @@ class LocalCoordinateCoding
   size_t& Atoms() { return atoms; }
 
   //! Accessor for dictionary.
-  const arma::mat& Dictionary() const { return dictionary; }
+  const MatType& Dictionary() const { return dictionary; }
   //! Mutator for dictionary.
-  arma::mat& Dictionary() { return dictionary; }
+  MatType& Dictionary() { return dictionary; }
 
   //! Get the L1 regularization parameter.
   double Lambda() const { return lambda; }
@@ -204,7 +217,7 @@ class LocalCoordinateCoding
   size_t atoms;
 
   //! Dictionary (columns are atoms).
-  arma::mat dictionary;
+  MatType dictionary;
 
   //! l1 regularization term.
   double lambda;
@@ -216,6 +229,9 @@ class LocalCoordinateCoding
 };
 
 } // namespace mlpack
+
+CEREAL_TEMPLATE_CLASS_VERSION((typename MatType),
+    (mlpack::LocalCoordinateCoding<MatType>), (1));
 
 // Include implementation.
 #include "lcc_impl.hpp"

--- a/src/mlpack/methods/local_coordinate_coding/lcc_impl.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc_impl.hpp
@@ -232,7 +232,7 @@ inline void LocalCoordinateCoding<MatType>::OptimizeDictionary(
     arma::uvec atomReverseLookup(atoms);
     for (size_t i = 0; i < activeAtoms.size(); ++i)
     {
-      atomReverseLookup[i] = activeAtoms[i];
+      atomReverseLookup[activeAtoms[i]] = i;
     }
 
     codesPrime(arma::span::all, arma::span(0, data.n_cols - 1)) = activeCodes;
@@ -266,8 +266,11 @@ inline void LocalCoordinateCoding<MatType>::OptimizeDictionary(
     }
   }
 
-  wSquared.subvec(data.n_cols, wSquared.n_elem - 1) = lambda *
-      abs(wSquared.subvec(data.n_cols, wSquared.n_elem - 1));
+  if (adjacencies.n_elem > 0)
+  {
+    wSquared.subvec(data.n_cols, wSquared.n_elem - 1) = lambda *
+        abs(wSquared.subvec(data.n_cols, wSquared.n_elem - 1));
+  }
 
   // Solve system.
   if (nInactiveAtoms == 0)

--- a/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
+++ b/src/mlpack/methods/local_coordinate_coding/local_coordinate_coding_main.cpp
@@ -90,8 +90,7 @@ BINDING_SEE_ALSO("Nonlinear learning using local coordinate coding (pdf)",
         "https://papers.nips.cc/paper/3875-nonlinear-learning-using-local-"
         "coordinate-coding.pdf");
 BINDING_SEE_ALSO("LocalCoordinateCoding C++ class documentation",
-        "@src/mlpack/methods/local_coordinate_coding/local_coordinate_coding."
-        "hpp");
+        "@doc/user/methods/local_coordinate_coding.md");
 
 // Training parameters.
 PARAM_MATRIX_IN("training", "Matrix of training data (X).", "t");
@@ -106,9 +105,9 @@ PARAM_FLAG("normalize", "If set, the input data matrix will be normalized "
 PARAM_DOUBLE_IN("tolerance", "Tolerance for objective function.", "o", 0.01);
 
 // Load/save a model.
-PARAM_MODEL_IN(LocalCoordinateCoding, "input_model", "Input LCC model.", "m");
-PARAM_MODEL_OUT(LocalCoordinateCoding, "output_model", "Output for trained LCC "
-    "model.", "M");
+PARAM_MODEL_IN(LocalCoordinateCoding<>, "input_model", "Input LCC model.", "m");
+PARAM_MODEL_OUT(LocalCoordinateCoding<>, "output_model",
+    "Output for trained LCC model.", "M");
 
 // Test on another dataset.
 PARAM_MATRIX_IN("test", "Test points to encode.", "T");
@@ -143,9 +142,9 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   ReportIgnoredParam(params, {{ "training", false }}, "tolerance");
 
   // Do we have an existing model?
-  LocalCoordinateCoding* lcc = NULL;
+  LocalCoordinateCoding<>* lcc = NULL;
   if (params.Has("input_model"))
-    lcc = params.Get<LocalCoordinateCoding*>("input_model");
+    lcc = params.Get<LocalCoordinateCoding<>*>("input_model");
 
   if (params.Has("training"))
   {
@@ -171,7 +170,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
         [](double x) { return x > 0; }, 1,
         "Tolerance should be a positive real number");
 
-    lcc = new LocalCoordinateCoding(0, 0.0);
+    lcc = new LocalCoordinateCoding<>(0, 0.0);
 
     lcc->Lambda() = params.Get<double>("lambda");
     lcc->Atoms() = (size_t) params.Get<int>("atoms");
@@ -257,5 +256,5 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
 
   // Save the dictionary and the model.
   params.Get<mat>("dictionary") = lcc->Dictionary();
-  params.Get<LocalCoordinateCoding*>("output_model") = lcc;
+  params.Get<LocalCoordinateCoding<>*>("output_model") = lcc;
 }

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -108,7 +108,7 @@ namespace mlpack {
  * the Encode() function.
  *
  * @tparam DictionaryInitializationPolicy The class to use to initialize the
- *     dictionary; must have 'void Initialize(const arma::mat& data, arma::mat&
+ *     dictionary; must have 'void Initialize(const MatType& data, MatType&
  *     dictionary)' function.
  */
 template<typename MatType = arma::mat>
@@ -127,7 +127,7 @@ class SparseCoding
    *
    * If you want to initialize the dictionary to a custom matrix, consider
    * either writing your own DictionaryInitializer class (with void
-   * Initialize(const arma::mat& data, arma::mat& dictionary) function), or call
+   * Initialize(const MatType& data, MatType& dictionary) function), or call
    * the constructor that does not take a data matrix, then call Dictionary() to
    * set the dictionary matrix to a matrix of your choosing, and then call
    * Train() with NothingInitializer (i.e. Train<NothingInitializer>(data)).

--- a/src/mlpack/tests/local_coordinate_coding_test.cpp
+++ b/src/mlpack/tests/local_coordinate_coding_test.cpp
@@ -18,7 +18,10 @@
 using namespace arma;
 using namespace mlpack;
 
-void VerifyCorrectness(const vec& beta, const vec& errCorr, double lambda)
+template<typename MatType, typename VecType>
+void VerifyCorrectness(const MatType& beta,
+                       const VecType& errCorr,
+                       const double lambda)
 {
   const double tol = 0.1;
   size_t nDims = beta.n_elem;
@@ -43,15 +46,18 @@ void VerifyCorrectness(const vec& beta, const vec& errCorr, double lambda)
   }
 }
 
-
-TEST_CASE("LocalCoordinateCodingTestCodingStep",
-          "[LocalCoordinateCodingTest]")
+TEMPLATE_TEST_CASE("LocalCoordinateCodingTestCodingStep",
+    "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
+  typedef TestType MatType;
+  typedef arma::Col<typename MatType::elem_type> VecType;
+
   double lambda1 = 0.1;
   uword nAtoms = 10;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  mat inX; // The .arm file is saved as an arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // normalize each point since these are images
@@ -60,37 +66,40 @@ TEST_CASE("LocalCoordinateCodingTestCodingStep",
     X.col(i) /= norm(X.col(i), 2);
   }
 
-  mat Z;
-  LocalCoordinateCoding lcc(X, nAtoms, lambda1, 10);
+  MatType Z;
+  LocalCoordinateCoding<MatType> lcc(X, nAtoms, lambda1, 10);
   lcc.Encode(X, Z);
 
-  mat D = lcc.Dictionary();
+  MatType D = lcc.Dictionary();
 
   for (uword i = 0; i < nPoints; ++i)
   {
-    vec sqDists = vec(nAtoms);
+    VecType sqDists(nAtoms);
     for (uword j = 0; j < nAtoms; ++j)
     {
       sqDists[j] = arma::norm(D.col(j) - X.col(i));
     }
-    mat Dprime = D * diagmat(1.0 / sqDists);
-    mat zPrime = Z.unsafe_col(i) % sqDists;
+    MatType Dprime = D * diagmat(1.0 / sqDists);
+    MatType zPrime = Z.unsafe_col(i) % sqDists;
 
-    vec errCorr = trans(Dprime) * (Dprime * zPrime - X.unsafe_col(i));
+    VecType errCorr = trans(Dprime) * (Dprime * zPrime - X.unsafe_col(i));
     VerifyCorrectness(zPrime, errCorr, 0.5 * lambda1);
   }
 }
 
-TEST_CASE("LocalCoordinateCodingTestDictionaryStep",
-          "[LocalCoordinateCodingTest]")
+TEMPLATE_TEST_CASE("LocalCoordinateCodingTestDictionaryStep",
+    "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
+  typedef TestType MatType;
+
   const double tol = 0.1;
 
   double lambda = 0.1;
   uword nAtoms = 10;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  mat inX; // File is saved as an arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // normalize each point since these are images
@@ -99,15 +108,15 @@ TEST_CASE("LocalCoordinateCodingTestDictionaryStep",
     X.col(i) /= norm(X.col(i), 2);
   }
 
-  mat Z;
-  LocalCoordinateCoding lcc(X, nAtoms, lambda, 10);
+  MatType Z;
+  LocalCoordinateCoding<MatType> lcc(X, nAtoms, lambda, 10);
   lcc.Encode(X, Z);
   uvec adjacencies = find(Z);
   lcc.OptimizeDictionary(X, Z, adjacencies);
 
-  mat D = lcc.Dictionary();
+  MatType D = lcc.Dictionary();
 
-  mat grad = zeros(D.n_rows, D.n_cols);
+  MatType grad = zeros<MatType>(D.n_rows, D.n_cols);
   for (uword i = 0; i < nPoints; ++i)
   {
     grad += (D - repmat(X.unsafe_col(i), 1, nAtoms)) *
@@ -118,26 +127,30 @@ TEST_CASE("LocalCoordinateCodingTestDictionaryStep",
   REQUIRE(norm(grad, "fro") == Approx(0.0).margin(tol));
 }
 
-TEST_CASE("LocalCoordinateCodingSerializationTest",
-          "[LocalCoordinateCodingTest]")
+TEMPLATE_TEST_CASE("LocalCoordinateCodingSerializationTest",
+    "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
-  mat X = randu<mat>(100, 100);
+  typedef TestType MatType;
+
+  MatType X = randu<MatType>(100, 100);
   size_t nAtoms = 10;
 
-  LocalCoordinateCoding lcc(nAtoms, 0.05, 2 /* don't care about quality */);
+  LocalCoordinateCoding<MatType> lcc(nAtoms, 0.05,
+      2 /* don't care about quality */);
   lcc.Train(X);
 
-  mat Y = randu<mat>(100, 200);
-  mat codes;
+  MatType Y = randu<MatType>(100, 200);
+  MatType codes;
   lcc.Encode(Y, codes);
 
-  LocalCoordinateCoding lccXml(50, 0.1), lccJson(12, 0.0), lccBinary(0, 0.0);
+  LocalCoordinateCoding<MatType> lccXml(50, 0.1), lccJson(12, 0.0),
+      lccBinary(0, 0.0);
   SerializeObjectAll(lcc, lccXml, lccJson, lccBinary);
 
   CheckMatrices(lcc.Dictionary(), lccXml.Dictionary(), lccJson.Dictionary(),
       lccBinary.Dictionary());
 
-  mat xmlCodes, jsonCodes, binaryCodes;
+  MatType xmlCodes, jsonCodes, binaryCodes;
   lccXml.Encode(Y, xmlCodes);
   lccJson.Encode(Y, jsonCodes);
   lccBinary.Encode(Y, binaryCodes);
@@ -167,14 +180,17 @@ TEST_CASE("LocalCoordinateCodingSerializationTest",
  * Test that LocalCoordinateCoding::Train() returns finite final objective
  * value.
  */
-TEST_CASE("LocalCoordinateCodingTrainReturnObjective",
-          "[LocalCoordinateCodingTest]")
+TEMPLATE_TEST_CASE("LocalCoordinateCodingTrainReturnObjective",
+    "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
+  typedef TestType MatType;
+
   double lambda1 = 0.1;
   uword nAtoms = 10;
 
-  mat X;
-  X.load("mnist_first250_training_4s_and_9s.arm");
+  mat inX; // File is saved as arma::mat.
+  inX.load("mnist_first250_training_4s_and_9s.arm");
+  MatType X = arma::conv_to<MatType>::from(inX);
   uword nPoints = X.n_cols;
 
   // Normalize each point since these are images.
@@ -183,7 +199,7 @@ TEST_CASE("LocalCoordinateCodingTrainReturnObjective",
     X.col(i) /= norm(X.col(i), 2);
   }
 
-  LocalCoordinateCoding lcc(nAtoms, lambda1, 10);
+  LocalCoordinateCoding<MatType> lcc(nAtoms, lambda1, 10);
   double objVal = lcc.Train(X);
 
   REQUIRE(std::isfinite(objVal) == true);

--- a/src/mlpack/tests/main_tests/local_coordinate_coding_test.cpp
+++ b/src/mlpack/tests/main_tests/local_coordinate_coding_test.cpp
@@ -71,8 +71,8 @@ TEST_CASE_METHOD(LCCTestFixture, "LCCOutputModelTest",
   // Get the encoded output and dictionary after training.
   arma::mat initCodes = std::move(params.Get<arma::mat>("codes"));
   arma::mat initDict = std::move(params.Get<arma::mat>("dictionary"));
-  LocalCoordinateCoding* outputModel =
-      std::move(params.Get<LocalCoordinateCoding*>("output_model"));
+  LocalCoordinateCoding<>* outputModel =
+      std::move(params.Get<LocalCoordinateCoding<>*>("output_model"));
 
   ResetSettings();
 
@@ -158,8 +158,8 @@ TEST_CASE_METHOD(LCCTestFixture, "LCCTrainAndInputModelTest",
 
   RUN_BINDING();
 
-  LocalCoordinateCoding* outputModel =
-      std::move(params.Get<LocalCoordinateCoding*>("output_model"));
+  LocalCoordinateCoding<>* outputModel =
+      std::move(params.Get<LocalCoordinateCoding<>*>("output_model"));
 
   // No need to input training data again.
   SetInputParam("input_model", std::move(outputModel));
@@ -185,8 +185,8 @@ TEST_CASE_METHOD(LCCTestFixture, "LCCTrainedModelDimTest",
 
   RUN_BINDING();
 
-  LocalCoordinateCoding* outputModel =
-      std::move(params.Get<LocalCoordinateCoding*>("output_model"));
+  LocalCoordinateCoding<>* outputModel =
+      std::move(params.Get<LocalCoordinateCoding<>*>("output_model"));
 
   SetInputParam("input_model", std::move(outputModel));
   SetInputParam("test", std::move(t));


### PR DESCRIPTION
`LocalCoordinateCoding` is very similar to `SparseCoding`, so I went ahead and documented it using the sparse coding documentation as a starting point.  Essentially the documentation is the same, since the algorithms are just variations of each other and present identical APIs.

Here is a rendered version:
https://www.ratml.org/misc/mlpack-markdown-doc/user/methods/local_coordinate_coding.html

Some notes about code changes that had to happen and other changes too:

 * Added `MatType` template parameter to `LocalCoordinateCoding` and adapted tests.
 * Found some bugs for when too much regularization is applied (and some atoms are unused); these were relatively simple bugfixes.
 * Realized some things could be improved in the sparse coding documentation too, so I made those fixes.
 * Found some bad HTML links in `core.md` that came from a different PR, but that PR had passed the documentation build... so I am going to look carefully at the output of the CI job this time and see if it is just ignoring failures or something.