### PR TITLE
fix decision tree dimensionality mismatch

### DIFF
--- a/src/mlpack/core/data/dataset_mapper.hpp
+++ b/src/mlpack/core/data/dataset_mapper.hpp
@@ -148,7 +148,9 @@ class DatasetMapper
   size_t Dimensionality() const;
 
   /**
-   * Remove a dimension and its corresponding mappings.
+   * Remove a dimension and its corresponding mappings. Note that all dimensions
+   * after the deleted dimension will have their indices shifted forward by 1,
+   * and dimensionality will be reduced by 1.
    *
    * @param dimension Dimension to remove.
    */

--- a/src/mlpack/core/data/dataset_mapper.hpp
+++ b/src/mlpack/core/data/dataset_mapper.hpp
@@ -148,6 +148,13 @@ class DatasetMapper
   size_t Dimensionality() const;
 
   /**
+   * Remove a dimension and its corresponding mappings.
+   *
+   * @param dimension Dimension to remove.
+   */
+  void RemoveDimension(const size_t dimension);
+
+  /**
    * Serialize the dataset information.
    */
   template<typename Archive>

--- a/src/mlpack/core/data/dataset_mapper_impl.hpp
+++ b/src/mlpack/core/data/dataset_mapper_impl.hpp
@@ -230,6 +230,23 @@ inline size_t DatasetMapper<PolicyType, InputType>::Dimensionality() const
   return types.size();
 }
 
+// Remove a dimension
+template<typename PolicyType, typename InputType>
+inline void DatasetMapper<PolicyType, InputType>::RemoveDimension(
+    const size_t dimension)
+{
+  if (dimension >= types.size())
+  {
+    std::ostringstream oss;
+    oss << "requested to remove dimension " << dimension << ", but dataset only "
+        << "has " << types.size() << " dimensions";
+    throw std::invalid_argument(oss.str());
+  }
+
+  types.erase(types.begin() + dimension);
+  maps.erase(dimension);
+}
+
 template<typename PolicyType, typename InputType>
 inline const PolicyType& DatasetMapper<PolicyType, InputType>::Policy() const
 {

--- a/src/mlpack/core/data/dataset_mapper_impl.hpp
+++ b/src/mlpack/core/data/dataset_mapper_impl.hpp
@@ -245,6 +245,14 @@ inline void DatasetMapper<PolicyType, InputType>::RemoveDimension(
 
   types.erase(types.begin() + dimension);
   maps.erase(dimension);
+
+  // Shift all dimensions after the deleted dimension forward by 1
+  size_t next = dimension + 1;
+  while (next <= types.size()) {
+    maps[next-1] = std::move(maps[next]);
+    maps.erase(next);
+    ++next;
+  }
 }
 
 template<typename PolicyType, typename InputType>

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -198,6 +198,21 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
       labels = ConvTo<arma::Row<size_t>>::From(
           trainingSet.row(trainingSet.n_rows - 1));
       trainingSet.shed_row(trainingSet.n_rows - 1);
+
+      // Create new DatasetInfo object without the last row
+      DatasetInfo newModelInfo(model -> info.Dimensionality() - 1);
+      for (size_t i = 0; i < model -> info.Dimensionality() - 1; ++i) {
+        // Check if dimension is categorical
+        if (model -> info.NumMappings(i) > 0) {
+          // If so, first set the dimention to categorical
+          newModelInfo.MapFirstPass<int>(model -> info.UnmapString(0, i), i);
+          // Then replicate the mappings from the original info object
+          for (size_t j = 0; j < model -> info.NumMappings(i); ++j) {
+            newModelInfo.MapString<int>(model -> info.UnmapString(j, i), i);
+          }
+        }
+      }
+      model -> info = std::move(newModelInfo);
     }
 
     const size_t numClasses = max(labels) + 1;

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -199,20 +199,8 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
           trainingSet.row(trainingSet.n_rows - 1));
       trainingSet.shed_row(trainingSet.n_rows - 1);
 
-      // Create new DatasetInfo object without the last row
-      DatasetInfo newModelInfo(model -> info.Dimensionality() - 1);
-      for (size_t i = 0; i < model -> info.Dimensionality() - 1; ++i) {
-        // Check if dimension is categorical
-        if (model -> info.NumMappings(i) > 0) {
-          // If so, first set the dimention to categorical
-          newModelInfo.MapFirstPass<int>(model -> info.UnmapString(0, i), i);
-          // Then replicate the mappings from the original info object
-          for (size_t j = 0; j < model -> info.NumMappings(i); ++j) {
-            newModelInfo.MapString<int>(model -> info.UnmapString(j, i), i);
-          }
-        }
-      }
-      model -> info = std::move(newModelInfo);
+      // Remove last row from dataset info
+      model -> info.RemoveDimension(trainingSet.n_rows - 1);
     }
 
     const size_t numClasses = max(labels) + 1;


### PR DESCRIPTION
Fixed the bug in issue #3719 by creating a new DatasetInfo object in the case where the last row of TrainingData needs to be removed.