### PR TITLE
Removed deletion of layer object inside multilayer destructor

### DIFF
--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -48,11 +48,7 @@ class MultiLayer : public Layer<MatType>
   MultiLayer& operator=(MultiLayer&& other);
 
   //! Virtual destructor: delete all held layers.
-  virtual ~MultiLayer()
-  {
-    for (size_t i = 0; i < network.size(); ++i)
-      delete network[i];
-  }
+  virtual ~MultiLayer(){}
 
   //! Create a copy of the MultiLayer (this is safe for polymorphic use).
   virtual MultiLayer* Clone() const { return new MultiLayer(*this); }


### PR DESCRIPTION
The `MultiLayer` destructor explicitly destroys the `Layer` object inside its destructor. Since the Layer class itself has a destructor, the program tries to use a deleted pointer, which causes a segmentation fault.
This can be seen in the example below:


```cpp
#include "mlpack.hpp"
using namespace std;
using namespace mlpack;


int main()
{
        arma::mat matrix(10000, 3);
        for (int i = 0; i < 100; i++) {
                for (int j = 0; j < 100; j++) {
                                matrix(100*i + j, 0) = i;
                                matrix(100*i + j, 1) = j;
                                matrix(100*i + j, 2) = 2*i + 3*j + 4;
                        }
        }
        matrix = matrix.t();

        // spliting the data into training and validation dataset
        arma::mat train, valid;
        float RATIO = 0.3;
        mlpack::data::Split(matrix, train, valid, RATIO);

        cout<<train.n_rows<<" "<<train.n_cols<<endl;
        arma::mat Xtrain, Xvalid, ytrain, yvalid;
        Xtrain = train.submat(0, 0, train.n_rows-2, train.n_cols-1);
        ytrain = train.submat(2, 0, 2, train.n_cols-1);

        // Xvalid and yvalid assignment corrected
        Xvalid = valid.submat(0, 0, valid.n_rows-2, valid.n_cols-1);
        yvalid = valid.submat(2, 0, 2, valid.n_cols-1);

        mlpack::FFN<mlpack::MeanSquaredError, mlpack::RandomInitialization> model;

        mlpack::MultiLayer<arma::mat> multiLayer;
        multiLayer.Add(new LinearNoBias(1));
        multiLayer.Add(new Add());
        model.Add(&multiLayer);

        vector<size_t> v= {2};
        model.InputDimensions() = v;

        int EPOCHS = 20;
        ens::AdaDelta optimizer(0.05, 10, 0.99, 1e-8, Xtrain.n_cols * EPOCHS, 1e-9, true);
        model.Train(
                Xtrain,
                ytrain,
                optimizer,
                ens::PrintLoss(),
                ens::ProgressBar(),
                ens::EarlyStopAtMinLoss(20)
        );
        return 0;
}
```