### PR TITLE
Distribute patched STB with R package

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 _????-??-??_
 
+  * Distribute STB headers as part of R package (#3724, #3726).
+
 
 ## mlpack 4.4.0
 

--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -480,6 +480,24 @@ macro (post_r_setup)
       "" CEREAL_BASE64 "${CEREAL_BASE64}")
   file(WRITE ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/cereal/external/base64.hpp "${CEREAL_BASE64}")
 
+  # Copy STB headers for inclusion in the package, if STB is used.
+  # NOTE: for CRAN, `sprintf` cannot be used; but it is used in
+  # `stb_image_write.h`, so we replace it with `snprintf` below.
+  if (StbImage_FOUND)
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E
+        make_directory ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/stb
+    )
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${STB_IMAGE_INCLUDE_DIR}/stb_image.h
+            ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/stb/stb_image.h)
+    file(READ "${STB_IMAGE_INCLUDE_DIR}/stb_image_write.h" STB_IMAGE_WRITE_H)
+    string(REGEX REPLACE "sprintf\\(buffer," "snprintf(buffer, 128,"
+        STB_IMAGE_WRITE_H_MOD "${STB_IMAGE_WRITE_H}")
+    file(WRITE "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/stb/stb_image_write.h" "${STB_IMAGE_WRITE_H_MOD}")
+  endif ()
+
   # Then configure 'mlpack.h.in' using ${R_SRC}.
   configure_file(
       ${CMAKE_SOURCE_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in


### PR DESCRIPTION
I managed to knock this out during a meeting.  The changes are pretty simple:

 * Include `stb_image.h` and `stb_image_write.h` as part of the R package distribution.  This is important because we are not guaranteed that a user has these present on their system (which I think will cause a package installation failure if they don't).
 * Patch use of `sprintf()` inside `stb_image_write.h` to `snprintf()`.  This is actually already done in a slightly different way in an [open STB patch](https://github.com/nothings/stb/pull/1619), although that still leaves an `sprintf()` call in, so maybe  the patch I did is better, at least for CRAN.

I patched this locally in the version of mlpack I just submitted to CRAN.

This fixes #3724.