### PR TITLE
Optimized the backward convolution function

### DIFF
--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -432,8 +432,8 @@ void ConvolutionType<
                   dilatedMappedError.slice(outMap + offset * maps),
                   rotatedFilters.slice((outMap * inMaps) + inMap),
                   curG,
-                  1, 
-                  1, 
+                  strideWidth, 
+                  strideHeight, 
                   1, 
                   1, 
                   true); 
@@ -519,8 +519,8 @@ void ConvolutionType<
             tempCube.slice(inMap + fullInputOffset),
             curError,
             gradientTemp.slice((outMap * inMaps) + inMap),
-            1,
-            1,
+            strideWidth,
+            strideHeight,
             strideWidth,
             strideHeight,
             true);

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -382,41 +382,34 @@ void ConvolutionType<
       inMaps * higherInDimensions * batchSize);
   gTemp.zeros();
 
-  const bool usingPadding =
-      (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0);
+  const bool usingPadding = (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0);
 
-  // To perform the backward pass, we need to rotate all the filters.
-  CubeType rotatedFilters(weight.n_rows,
-      weight.n_cols, weight.n_slices);
-
-  // To perform the backward pass, we need to dilate all the mappedError.
-  CubeType dilatedMappedError;
-  if (strideHeight == 1 && strideWidth == 1)
+  CubeType dilatedMappedError(mappedError.n_rows * (strideWidth == 1 ? 1 : strideWidth - 1),
+                              mappedError.n_cols * (strideHeight == 1 ? 1 : strideHeight - 1),
+                              mappedError.n_slices);
+  #pragma omp parallel for collapse(3)
+  for (size_t i = 0; i < mappedError.n_slices; ++i)
   {
-    MakeAlias(dilatedMappedError, mappedError, mappedError.n_rows,
-        mappedError.n_cols, mappedError.n_slices);
-  }
-  else
-  {
-    dilatedMappedError.zeros(mappedError.n_rows * strideWidth -
-        (strideWidth - 1), mappedError.n_cols * strideHeight -
-        (strideHeight - 1), mappedError.n_slices);
-    #pragma omp parallel for collapse(3)
-    for (size_t i = 0; i < mappedError.n_slices; ++i)
+    for (size_t j = 0; j < mappedError.n_cols; ++j)
     {
-      for (size_t j = 0; j < mappedError.n_cols; ++j)
+      for (size_t k = 0; k < mappedError.n_rows; ++k)
       {
-        for (size_t k = 0; k < mappedError.n_rows; ++k)
+        if (strideHeight > 1 || strideWidth > 1)
         {
           dilatedMappedError(k * strideWidth, j * strideHeight, i)
               = mappedError(k, j, i);
+        }
+        else
+        {
+          dilatedMappedError(k, j, i) = mappedError(k, j, i);
         }
       }
     }
   }
 
+  CubeType rotatedFilters(weight.n_rows, weight.n_cols, weight.n_slices);
   #pragma omp parallel for
-  for (size_t map = 0; map < (size_t) (maps * inMaps); ++map)
+  for (size_t map = 0; map < weight.n_slices; ++map)
   {
     Rotate180(weight.slice(map), rotatedFilters.slice(map));
   }
@@ -427,31 +420,25 @@ void ConvolutionType<
   MakeAlias(outputCube, output, apparentWidth, apparentHeight,
       inMaps * higherInDimensions * batchSize);
 
-  // See Forward() for the overall iteration strategy.
+  #pragma omp parallel for collapse(2)
   for (size_t offset = 0; offset < (higherInDimensions * batchSize); ++offset)
   {
-    const size_t fullInputOffset = offset * inMaps;
-    const size_t fullOutputOffset = offset * maps;
-
-    // Iterate over input maps.
-    #pragma omp parallel for
-    for (size_t inMap = 0; inMap < (size_t) inMaps; ++inMap)
-    {
-      // Iterate over output maps.
-      MatType& curG = outputCube.slice(inMap + fullInputOffset);
-      for (size_t outMap = 0; outMap < maps; ++outMap)
+      for (size_t inMap = 0; inMap < (size_t) inMaps; ++inMap)
       {
-        BackwardConvolutionRule::Convolution(
-            dilatedMappedError.slice(outMap + fullOutputOffset),
-            rotatedFilters.slice((outMap * inMaps) + inMap),
-            curG,
-            1,
-            1,
-            1,
-            1,
-            true);
+          MatType& curG = outputCube.slice(inMap + offset * inMaps);
+          for (size_t outMap = 0; outMap < maps; ++outMap)
+          {
+              BackwardConvolutionRule::Convolution(
+                  dilatedMappedError.slice(outMap + offset * maps),
+                  rotatedFilters.slice((outMap * inMaps) + inMap),
+                  curG,
+                  1, 
+                  1, 
+                  1, 
+                  1, 
+                  true); 
+          }
       }
-    }
   }
   MatType temp(padding.OutputDimensions()[0] * padding.OutputDimensions()[1] *
       inMaps * higherInDimensions, batchSize);
@@ -472,7 +459,6 @@ void ConvolutionType<
     gTemp = tempCube;
   }
 }
-
 template<
     typename ForwardConvolutionRule,
     typename BackwardConvolutionRule,

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -382,11 +382,15 @@ void ConvolutionType<
       inMaps * higherInDimensions * batchSize);
   gTemp.zeros();
 
-  const bool usingPadding = (padWLeft != 0 || padWRight != 0 || padHTop != 0 || padHBottom != 0);
+  const bool usingPadding = 
+    (padWLeft != 0 || padWRight != 0 || 
+     padHTop != 0 || padHBottom != 0);
 
-  CubeType dilatedMappedError(mappedError.n_rows * (strideWidth == 1 ? 1 : strideWidth - 1),
-                              mappedError.n_cols * (strideHeight == 1 ? 1 : strideHeight - 1),
-                              mappedError.n_slices);
+  CubeType dilatedMappedError(
+    mappedError.n_rows * (strideWidth == 1 ? 1 : strideWidth - 1),
+    mappedError.n_cols * (strideHeight == 1 ? 1 : strideHeight - 1),
+    mappedError.n_slices
+  );
   #pragma omp parallel for collapse(3)
   for (size_t i = 0; i < mappedError.n_slices; ++i)
   {

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -357,7 +357,6 @@ void ConvolutionType<
   }
 }
 
-
 template<
     typename ForwardConvolutionRule,
     typename BackwardConvolutionRule,
@@ -454,14 +453,12 @@ void ConvolutionType<
       }
     }
   }
-
   MatType temp(padding.OutputDimensions()[0] * padding.OutputDimensions()[1] *
       inMaps * higherInDimensions, batchSize);
   CubeType tempCube;
   MakeAlias(tempCube, temp, padding.OutputDimensions()[0],
       padding.OutputDimensions()[1], inMaps * higherInDimensions * batchSize);
   paddingBackward.Forward(output, temp);
-
   if (usingPadding)
   {
     gTemp = tempCube.tube(
@@ -475,7 +472,6 @@ void ConvolutionType<
     gTemp = tempCube;
   }
 }
-
 
 template<
     typename ForwardConvolutionRule,


### PR DESCRIPTION
I've made several optimizations to the backward function in the convolution code; the main areas of improvement include padding, rotation, and dilation operations. These changes aim to reduce computational overhead and a speed up.

**Changes**

_Padding Optimization_
Instead of adding padding to the input data separately, I've integrated the fixed padding values directly into the convolution operation. This reduces the number of steps required.

_Rotation Optimization_
The previous method involved rotating filters by 180 degrees. To optimize this, I replaced the rotation with a combination of matrix flipping or transposing followed by reversing. Additionally I embedded the rotation directly into the convolution step, which simplifies the overall computation.

_Dilation Optimization_
For consistent and predetermined dilation factors, I've embedded these directly into the convolution. This minimizes the total computational workload and enhances performance.

I'm happy to show you these benchmarks run based on the mnist-code from the [mlpack-benchmarks repo](https://github.com/MarkFischinger/mlpack-benchmarks/blob/master/src/convolutional/backward/mnist/mnist_benchmark.cpp):
```
Time Elapsed: 73222ms (original)
Time Elapsed: 50517ms (optimized)
```
