### PR TITLE
Network initialization method that allows to set the weights outside of the network.

### DIFF
--- a/src/mlpack/methods/ann/init_rules/init_rules.hpp
+++ b/src/mlpack/methods/ann/init_rules/init_rules.hpp
@@ -25,5 +25,6 @@
 #include "oivs_init.hpp"
 #include "orthogonal_init.hpp"
 #include "random_init.hpp"
+#include "layer_init.hpp"
 
 #endif

--- a/src/mlpack/methods/ann/init_rules/init_rules_traits.hpp
+++ b/src/mlpack/methods/ann/init_rules/init_rules_traits.hpp
@@ -31,6 +31,12 @@ class InitTraits
    * This is true if the initialization method is used for a single layer.
    */
   static const bool UseLayer = true;
+
+  /**
+   * This is true if the initialization method should use the parameters
+   * of the network.
+   */
+  static const bool UseNetwork = false;
 };
 
 } // namespace mlpack

--- a/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
@@ -172,6 +172,9 @@ class InitTraits<KathirvalavakumarSubavathiInitialization>
   //! The kathirvalavakumar subavath initialization rule is applied over the
   //! entire network.
   static const bool UseLayer = false;
+  //! The kathirvalavakumar initialization rule does not use the network to set
+  //! the weights.
+  static const bool UseNetwork = false;
 };
 
 

--- a/src/mlpack/methods/ann/init_rules/layer_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/layer_init.hpp
@@ -1,0 +1,116 @@
+/**
+ * @file methods/ann/init_rules/layer_init.hpp
+ * @author Marcus Edel
+ *
+ * Definition and implementation of the LayerInitialization method.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_INIT_RULES_LAYER_INIT_HPP
+#define MLPACK_METHODS_ANN_INIT_RULES_LAYER_INIT_HPP
+
+#include <mlpack/prereqs.hpp>
+
+#include "init_rules_traits.hpp"
+
+namespace mlpack {
+
+/**
+ * This class does nothing and is used to initialize the weight matrix with the
+ * weights form the network layer.
+ */
+class LayerInitialization
+{
+ public:
+  /**
+   * Placeholder constructor, which does nothing. The actual initialization is
+   * network_init.hpp/Initialize routine.
+   */
+  LayerInitialization()
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements of the specified weight matrix with the
+   * Layer initialization method.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   */
+  template<typename MatType>
+  void Initialize(MatType& /* W */, const size_t /* rows */, const size_t /* cols */)
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements of the specified weight matrix with the
+   * Layer initialization method.
+   *
+   * @param W Weight matrix to initialize.
+   */
+  template<typename MatType>
+  void Initialize(MatType& /* W */,
+      const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
+  {
+    // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements of the specified weight 3rd order tensor with the
+   * Layer initialization method.
+   *
+   * @param W Weight matrix to initialize.
+   * @param rows Number of rows.
+   * @param cols Number of columns.
+   * @param slices Number of slices.
+   */
+  template<typename CubeType>
+  void Initialize(CubeType& /* W */,
+                  const size_t /* rows */,
+                  const size_t /* cols */,
+                  const size_t /* slices */)
+  {
+     // Nothing to do here.
+  }
+
+  /**
+   * Initialize the elements of the specified weight 3rd order tensor with the
+   * Layer initialization method.
+   *
+   * @param W Weight matrix to initialize.
+   */
+  template<typename CubeType>
+  void Initialize(CubeType& /* W */,
+      const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
+  {
+    // Nothing to do here.
+  }
+ 
+  /**
+   * Serialize the initialization.  (Nothing to serialize for this one.)
+   */
+  template<typename Archive>
+  void serialize(Archive& /* ar */, const uint32_t /* version */) { }
+}; // class LayerInitialization
+
+//! Initialization traits of the Layer initialization rule.
+template<>
+class InitTraits<LayerInitialization>
+{
+ public:
+  //! The Layer initialization rule is applied over the entire network.
+  static const bool UseLayer = false;
+  //! The layer initialization rule uses the network to set
+  //! the weights.
+  static const bool UseNetwork = true;
+};
+
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/init_rules/network_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/network_init.hpp
@@ -79,6 +79,23 @@ class NetworkInitialization
         offset += weight;
       }
     }
+    // Intialize the network with the parameter/weight from the network itself.
+    else if (InitTraits<InitializationRuleType>::UseNetwork)
+    {
+      for (size_t i = 0, offset = parameterOffset; i < network.size(); ++i)
+      {
+        const size_t weight = network[i]->WeightSize();
+        arma::Mat<eT> tmp = arma::Mat<eT>(parameters.memptr() + offset,
+            weight, 1, false, false);
+
+        // Overwirte the parameter/weight with the network parameter/weight.
+        if (!tmp.is_empty())
+          tmp = network[i]->Parameters();
+
+        // Increase the parameter/weight offset for the next layer.
+        offset += weight;
+      }
+    }
     else
     {
       initializeRule.Initialize(parameters, parameters.n_elem, 1);

--- a/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/nguyen_widrow_init.hpp
@@ -162,6 +162,9 @@ class InitTraits<NguyenWidrowInitialization>
  public:
   //! The Nguyen-Widrow initialization rule is applied over the entire network.
   static const bool UseLayer = false;
+  //! The Nguyen-Widrow initialization rule uses the network to set
+  //! the weights.
+  static const bool UseNetwork = true;
 };
 
 } // namespace mlpack

--- a/src/mlpack/tests/ann/init_rules_test.cpp
+++ b/src/mlpack/tests/ann/init_rules_test.cpp
@@ -363,3 +363,35 @@ TEST_CASE("LecunNormalInitTest", "[InitRulesTest]")
   REQUIRE(weights3d.n_cols == cols);
   REQUIRE(weights3d.n_slices == slices);
 }
+
+/**
+ * Simple test of the LayerInitialization class.
+ */
+TEST_CASE("LayerInitTest", "[InitRulesTest]")
+{
+  Linear* linearModule_0 = new Linear(5);
+  Linear* linearModule_1 = new Linear(2);
+
+  arma::mat linearModule_0_params = arma::randu(30, 1);
+  arma::mat linearModule_1_params = arma::randu(12, 1);
+
+  // Set the parameters of the layers outside of the network.
+  linearModule_0->Parameters() = linearModule_0_params;
+  linearModule_1->Parameters() = linearModule_1_params;
+
+  arma::mat input = arma::ones(5, 1);
+  arma::mat response;
+  NegativeLogLikelihood outputLayer;
+
+  FFN<NegativeLogLikelihood, LayerInitialization> model(
+      std::move(outputLayer));
+  model.Add(linearModule_0);
+  model.Add(linearModule_1);
+  model.Add<LogSoftMax>();
+  model.Predict(input, response);
+
+  // The model parameters should be the same as the parameters of
+  // the layers, that we set outside of the network.
+  REQUIRE(arma::accu(model.Parameters() - arma::join_vert(
+      linearModule_0_params, linearModule_1_params)) == 0);
+}


### PR DESCRIPTION
Network initialization method that allows to set the weights outside of the network. This initialization rule is used in combination with the ONNX model loader, which set's the layer parameter manually. 