### PR TITLE
Getter and setter methods for epsilon, gamma, and beta values for the BatchNorm layer.

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -165,6 +165,21 @@ class BatchNormType : public Layer<MatType>
   //! Modify the parameters.
   MatType& Parameters() { return weights; }
 
+  //! Get the epsilon.
+  const double& Epsilon() const { return eps; }
+  //! Modify the epsilon.
+  double& Epsilon() { return eps; }
+
+  //! Get the gamma.
+  const MatType& Gamma() const { return gamma; }
+  //! Modify the gamma.
+  MatType& Gamma() { return gamma; }
+
+  //! Get the beta.
+  const MatType& Beta() const { return beta; }
+  //! Modify the beta.
+  MatType& Beta() { return beta; }
+  
   //! Get the mean over the training data.
   const MatType& TrainingMean() const { return runningMean; }
   //! Modify the mean over the training data.

--- a/src/mlpack/methods/ann/layer/linear.hpp
+++ b/src/mlpack/methods/ann/layer/linear.hpp
@@ -151,7 +151,7 @@ class LinearType : public Layer<MatType>
   size_t outSize;
 
   //! Locally-stored weight object.  This holds all the weights in a vectorized
-  //! form; i.e., the weights and the bias.
+  //! form; i.e., the weight and the bias.
   MatType weights;
 
   //! Locally-stored weight parameters.

--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -48,11 +48,7 @@ class MultiLayer : public Layer<MatType>
   MultiLayer& operator=(MultiLayer&& other);
 
   //! Virtual destructor: delete all held layers.
-  virtual ~MultiLayer()
-  {
-    for (size_t i = 0; i < network.size(); ++i)
-      delete network[i];
-  }
+  virtual ~MultiLayer(){}
 
   //! Create a copy of the MultiLayer (this is safe for polymorphic use).
   virtual MultiLayer* Clone() const { return new MultiLayer(*this); }


### PR DESCRIPTION
My ONNX project requires setting the values of the `epsilon`, `gamma`, and `beta` parameters of the BatchNorm layer. In the current implementation, these parameters are private, and there is no way to get a reference to them.