### PR TITLE
Getters and setters for the epsilon, gamma, and beta parameters of BatchNorm.

### DIFF
--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -165,11 +165,6 @@ class BatchNormType : public Layer<MatType>
   //! Modify the parameters.
   MatType& Parameters() { return weights; }
 
-  //! Get the epsilon.
-  const double& Epsilon() const { return eps; }
-  //! Modify the epsilon.
-  double& Epsilon() { return eps; }
-
   //! Get the gamma.
   const MatType& Gamma() const { return gamma; }
   //! Modify the gamma.
@@ -194,7 +189,9 @@ class BatchNormType : public Layer<MatType>
   size_t InputSize() const { return size; }
 
   //! Get the epsilon value.
-  double Epsilon() const { return eps; }
+  const double &Epsilon() const { return eps; }
+  //! Modify the epsilon.
+  double& Epsilon() { return eps; }
 
   //! Get the momentum value.
   double Momentum() const { return momentum; }

--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -165,6 +165,21 @@ class BatchNormType : public Layer<MatType>
   //! Modify the parameters.
   MatType& Parameters() { return weights; }
 
+  //! Get the epsilon.
+  const double& Epsilon() const { return eps; }
+  //! Modify the epsilon.
+  double& Epsilon() { return eps; }
+
+  //! Get the gamma.
+  const MatType& Gamma() const { return gamma; }
+  //! Modify the gamma.
+  MatType& Gamma() { return gamma; }
+
+  //! Get the beta.
+  const MatType& Beta() const { return beta; }
+  //! Modify the beta.
+  MatType& Beta() { return beta; }
+  
   //! Get the mean over the training data.
   const MatType& TrainingMean() const { return runningMean; }
   //! Modify the mean over the training data.

--- a/src/mlpack/methods/ann/layer/linear.hpp
+++ b/src/mlpack/methods/ann/layer/linear.hpp
@@ -151,7 +151,7 @@ class LinearType : public Layer<MatType>
   size_t outSize;
 
   //! Locally-stored weight object.  This holds all the weights in a vectorized
-  //! form; i.e., the weights and the bias.
+  //! form; i.e., the weight and the bias.
   MatType weights;
 
   //! Locally-stored weight parameters.

--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -48,7 +48,11 @@ class MultiLayer : public Layer<MatType>
   MultiLayer& operator=(MultiLayer&& other);
 
   //! Virtual destructor: delete all held layers.
-  virtual ~MultiLayer(){}
+  virtual ~MultiLayer()
+  {
+    for (size_t i = 0; i < network.size(); ++i)
+      delete network[i];
+  }
 
   //! Create a copy of the MultiLayer (this is safe for polymorphic use).
   virtual MultiLayer* Clone() const { return new MultiLayer(*this); }

--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -48,11 +48,7 @@ class MultiLayer : public Layer<MatType>
   MultiLayer& operator=(MultiLayer&& other);
 
   //! Virtual destructor: delete all held layers.
-  virtual ~MultiLayer()
-  {
-    for (size_t i = 0; i < network.size(); ++i)
-      delete network[i];
-  }
+  virtual ~MultiLayer(){}
 
   //! Create a copy of the MultiLayer (this is safe for polymorphic use).
   virtual MultiLayer* Clone() const { return new MultiLayer(*this); }


### PR DESCRIPTION
For my ONNX converter project, I need access to the `epsilon,` `gamma,` and `beta` parameters of the BatchNorm layer. However, in the current implementation of `BatchNorm,` these parameters are private. Therefore, I am making this PR to address this issue.





