### PR TITLE
Added dimension importance support to Decision Trees

### DIFF
--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -299,6 +299,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    * @param maximumDepth Maximum depth for the tree.
    * @param dimensionSelector Instantiated dimension selection policy.
+   * @param featImp Pointer to FeatureImportance object to store feature info
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
@@ -328,6 +329,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    * @param maximumDepth Maximum depth for the tree.
    * @param dimensionSelector Instantiated dimension selection policy.
+   * @param featImp Pointer to FeatureImportance object to store feature info
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType>
@@ -360,6 +362,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    * @param maximumDepth Maximum depth for the tree.
    * @param dimensionSelector Instantiated dimension selection policy.
+   * @param featImp Pointer to FeatureImportance object to store feature info
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
@@ -394,6 +397,7 @@ class DecisionTree :
    * @param minimumGainSplit Minimum gain for the node to split.
    * @param maximumDepth Maximum depth for the tree.
    * @param dimensionSelector Instantiated dimension selection policy.
+   * @param featImp Pointer to FeatureImportance object to store feature info
    * @return The final entropy of decision tree.
    */
   template<typename MatType, typename LabelsType, typename WeightsType>
@@ -551,6 +555,7 @@ class DecisionTree :
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
    * @param maximumDepth Maximum depth for the tree.
+   * @param featImp Pointer to FeatureImportance object to store feature info
    * @return The final entropy of decision tree.
    */
   template<bool UseWeights, typename MatType, typename WeightsType>
@@ -581,6 +586,7 @@ class DecisionTree :
    * @param minimumLeafSize Minimum number of points in each leaf node.
    * @param minimumGainSplit Minimum gain for the node to split.
    * @param maximumDepth Maximum depth for the tree.
+   * @param featImp Pointer to FeatureImportance object to store feature info
    * @return The final entropy of decision tree.
    */
   template<bool UseWeights, typename MatType, typename WeightsType>

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -462,6 +462,12 @@ class DecisionTree :
   //! Get the number of children.
   size_t NumChildren() const { return children.size(); }
 
+  //! Get the Feature frequency information
+  map<size_t, size_t> FeatureFrequency() { return featureFrequency; }
+
+  //! Get the Feature gain information
+  map<size_t, double> FeatureCover() { return featureCover; }
+
   //! Get the child of the given index.
   const DecisionTree& Child(const size_t i) const { return *children[i]; }
   //! Modify the child of the given index (be careful!).
@@ -496,6 +502,10 @@ class DecisionTree :
   std::vector<DecisionTree*> children;
   //! The dimension this node splits on.
   size_t splitDimension;
+  //! Stores the number of times a particular feature was used to split
+  map<size_t, size_t> featureFrequency;
+  //! Stores the net gain provided by a particular feature for splitting
+  map<size_t, double> featureCover;
 
   union
   {

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -29,6 +29,8 @@
 #include "random_dimension_select.hpp"
 #include "multiple_random_dimension_select.hpp"
 
+#include "mlpack/methods/xgboost/feature_importance.hpp"
+
 namespace mlpack {
 
 /**
@@ -308,7 +310,8 @@ class DecisionTree :
                const double minimumGainSplit = 1e-7,
                const size_t maximumDepth = 0,
                DimensionSelectionType dimensionSelector =
-                   DimensionSelectionType());
+                   DimensionSelectionType(),
+               FeatureImportance* featImp = nullptr);
 
   /**
    * Train the decision tree on the given data, assuming that all dimensions are
@@ -335,7 +338,8 @@ class DecisionTree :
                const double minimumGainSplit = 1e-7,
                const size_t maximumDepth = 0,
                DimensionSelectionType dimensionSelector =
-                   DimensionSelectionType());
+                   DimensionSelectionType(),
+               FeatureImportance* featImp = nullptr);
 
   /**
    * Train the decision tree on the given weighted data.  This will overwrite
@@ -370,7 +374,8 @@ class DecisionTree :
                DimensionSelectionType dimensionSelector =
                    DimensionSelectionType(),
                const std::enable_if_t<arma::is_arma_type<typename
-                   std::remove_reference<WeightsType>::type>::value>* = 0);
+                   std::remove_reference<WeightsType>::type>::value>* = 0,
+               FeatureImportance* featImp = nullptr);
 
   /**
    * Train the decision tree on the given weighted data, assuming that all
@@ -402,7 +407,8 @@ class DecisionTree :
                DimensionSelectionType dimensionSelector =
                    DimensionSelectionType(),
                const std::enable_if_t<arma::is_arma_type<typename
-                   std::remove_reference<WeightsType>::type>::value>* = 0);
+                   std::remove_reference<WeightsType>::type>::value>* = 0,
+               FeatureImportance* featImp = nullptr);
 
   /**
    * Classify the given point, using the entire tree.  The predicted label is
@@ -558,7 +564,8 @@ class DecisionTree :
                const size_t minimumLeafSize,
                const double minimumGainSplit,
                const size_t maximumDepth,
-               DimensionSelectionType& dimensionSelector);
+               DimensionSelectionType& dimensionSelector,
+               FeatureImportance* featImp = nullptr);
 
   /**
    * Corresponding to the public Train() method, this method is designed for
@@ -586,7 +593,8 @@ class DecisionTree :
                const size_t minimumLeafSize,
                const double minimumGainSplit,
                const size_t maximumDepth,
-               DimensionSelectionType& dimensionSelector);
+               DimensionSelectionType& dimensionSelector,
+               FeatureImportance* featImp = nullptr);
 };
 
 /**

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -462,12 +462,6 @@ class DecisionTree :
   //! Get the number of children.
   size_t NumChildren() const { return children.size(); }
 
-  //! Get the Feature frequency information
-  map<size_t, size_t> FeatureFrequency() { return featureFrequency; }
-
-  //! Get the Feature gain information
-  map<size_t, double> FeatureCover() { return featureCover; }
-
   //! Get the child of the given index.
   const DecisionTree& Child(const size_t i) const { return *children[i]; }
   //! Modify the child of the given index (be careful!).
@@ -502,10 +496,6 @@ class DecisionTree :
   std::vector<DecisionTree*> children;
   //! The dimension this node splits on.
   size_t splitDimension;
-  //! Stores the number of times a particular feature was used to split
-  map<size_t, size_t> featureFrequency;
-  //! Stores the net gain provided by a particular feature for splitting
-  map<size_t, double> featureCover;
 
   union
   {

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -878,8 +878,8 @@ double DecisionTree<FitnessFunction,
   if (bestDim != data.n_rows)
   {
     // Store the information about the feature contributions
-    featImp.featureFrequency[bestDim]++;
-    featImp.featureCover[bestDim] += featureFrequency;
+    featImp.increaseFeatureFrequency(bestDim, 1);
+    featImp.increaseFeatureCover(bestDim, bestGain);
     
     // We know that the split is numeric.
     size_t numChildren =

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -699,6 +699,10 @@ double DecisionTree<FitnessFunction,
   // Did we split or not?  If so, then split the data and create the children.
   if (bestDim != datasetInfo.Dimensionality())
   {
+    // Store the information about the feature contributions
+    featureFrequency[bestDim]++;
+    featureCover[bestDim] += featureFrequency;
+
     dimensionType = (size_t) datasetInfo.Type(bestDim);
     splitDimension = bestDim;
 
@@ -869,6 +873,10 @@ double DecisionTree<FitnessFunction,
   // Did we split or not?  If so, then split the data and create the children.
   if (bestDim != data.n_rows)
   {
+    // Store the information about the feature contributions
+    featureFrequency[bestDim]++;
+    featureCover[bestDim] += featureFrequency;
+    
     // We know that the split is numeric.
     size_t numChildren =
         NumericSplit::NumChildren(classProbabilities[0], *this);

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -13,8 +13,12 @@
 #define MLPACK_METHODS_DECISION_TREE_DECISION_TREE_IMPL_HPP
 
 #include "decision_tree.hpp"
+#include "mlpack/methods/xgboost/feature_importance.hpp"
 
 namespace mlpack {
+
+// Initiating a FeatureImportance object.
+FeatureImportance featImp;
 
 //! Construct and train without weight.
 template<typename FitnessFunction,
@@ -700,8 +704,8 @@ double DecisionTree<FitnessFunction,
   if (bestDim != datasetInfo.Dimensionality())
   {
     // Store the information about the feature contributions
-    featureFrequency[bestDim]++;
-    featureCover[bestDim] += featureFrequency;
+    featImp.featureFrequency[bestDim]++;
+    featImp.featureCover[bestDim] += featureFrequency;
 
     dimensionType = (size_t) datasetInfo.Type(bestDim);
     splitDimension = bestDim;
@@ -874,8 +878,8 @@ double DecisionTree<FitnessFunction,
   if (bestDim != data.n_rows)
   {
     // Store the information about the feature contributions
-    featureFrequency[bestDim]++;
-    featureCover[bestDim] += featureFrequency;
+    featImp.featureFrequency[bestDim]++;
+    featImp.featureCover[bestDim] += featureFrequency;
     
     // We know that the split is numeric.
     size_t numChildren =

--- a/src/mlpack/methods/decision_tree/mse_gain.hpp
+++ b/src/mlpack/methods/decision_tree/mse_gain.hpp
@@ -34,7 +34,7 @@ class MSEGain
    * sure to use 'gain >= 0.0' and not 'gain == 0.0'. The values vector
    * should always be of type arma::Row<double> or arma::rowvec.
    *
-   * @param values Set of values to evaluate MAD gain on.
+   * @param values Set of values to evaluate MSE gain on.
    * @param weights Weights associated to each value.
    * @param begin Start index.
    * @param end End index.

--- a/src/mlpack/methods/xgboost/feature_importance.hpp
+++ b/src/mlpack/methods/xgboost/feature_importance.hpp
@@ -1,0 +1,37 @@
+/*
+ * @file methods/xgboost/feature_importance.hpp
+ * @author Abhimanyu Dayal
+ *
+ * Implementation of the featureImportance class in xgboost.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+// Include guard - Used to prevent including double copies of the same code
+#ifndef MLPACK_METHODS_XGBOOST_FEATURE_IMPORTANCE_HPP
+#define MLPACK_METHODS_XGBOOST_FEATURE_IMPORTANCE_HPP
+
+#include "xgboost.hpp"
+
+namespace mlpack {
+
+/**
+ * After training, xgboost can calculate feature importance to understand 
+ * the contribution of each feature in the classification decision.
+ * XGBoost provides two main types of feature importance scores:
+ * 
+ * - Weight (Frequency): This is the number of times a feature is used to 
+ *   split a node across all trees in the model. It counts how often each 
+ *   feature appears in all trees of the model.
+ * 
+ * - Gain (Cover): This measures the improvement in accuracy brought by a 
+ *   feature to the model. For each feature, it sums the improvement in accuracy 
+ *   (reduction in loss) brought by the feature when it is used in tree splits.
+ */
+
+}
+
+#endif

--- a/src/mlpack/methods/xgboost/feature_importance.hpp
+++ b/src/mlpack/methods/xgboost/feature_importance.hpp
@@ -86,7 +86,7 @@ class FeatureImportance {
 
     for(; it != featureCover.end(); ++it)
     {
-      pq.push({-it->second, it->first});
+      pq.push({-(it->second), it->first});
     }
 
     while(!pq.empty())

--- a/src/mlpack/methods/xgboost/feature_importance.hpp
+++ b/src/mlpack/methods/xgboost/feature_importance.hpp
@@ -34,10 +34,13 @@ namespace mlpack {
  */
 
 class FeatureImportance {
-  public: 
 
+  private:
   map<size_t, size_t> featureFrequency;
   map<size_t, double> featureCover;
+
+
+  public: 
 
   FeatureImportance() { /*Nothing to do*/ }
 

--- a/src/mlpack/methods/xgboost/feature_importance.hpp
+++ b/src/mlpack/methods/xgboost/feature_importance.hpp
@@ -2,7 +2,7 @@
  * @file methods/xgboost/feature_importance.hpp
  * @author Abhimanyu Dayal
  *
- * Implementation of the featureImportance class in xgboost.
+ * Implementation of the Feature Importance class in xgboost.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -16,11 +16,12 @@
 
 // #include "xgboost.hpp"
 #include <map>
+#include <queue>
 
 namespace mlpack {
 
 /**
- * After training, xgboost can calculate feature importance to understand 
+ * After training, XGBoost can calculate feature importance to understand 
  * the contribution of each feature in the classification decision.
  * XGBoost provides two main types of feature importance scores:
  * 
@@ -36,22 +37,64 @@ namespace mlpack {
 class FeatureImportance {
 
   private:
+
   map<size_t, size_t> featureFrequency;
   map<size_t, double> featureCover;
-
+  vector<size_t> rankByFrequency;
+  vector<size_t> rankByCover;
 
   public: 
 
+  // Empty class constructor.
   FeatureImportance() { /*Nothing to do*/ }
 
-  void increaseFeatureFrequency(size_t index, size_t increment)
+  //! Edit the featureFrequency value.
+  void increaseFeatureFrequency(size_t index, size_t incrementValue)
   {
-    featureFrequency[index] += increment;
+    featureFrequency[index] += incrementValue;
   }
 
-  void increaseFeatureCover(size_t index, double increment)
+  //! Edit the featureCover value.
+  void increaseFeatureCover(size_t index, double incrementValue)
   {
-    featureCover[index] += increment;
+    featureCover[index] += incrementValue;
+  }
+
+  void RankByFrequency()
+  {
+    priority_queue<pair<size_t, size_t>> pq; 
+
+    map<size_t, size_t>::iterator it = featureFrequency.begin(); 
+
+    for(; it != featureFrequency.end(); ++it)
+    {
+      pq.push({-it->second, it->first});
+    }
+
+    while(!pq.empty())
+    {
+      size_t elem = pq.top().second; pq.pop();
+      rankByFrequency.push_back(elem);
+    }
+  }
+
+  void RankByCover()
+  {
+    priority_queue<pair<double, size_t>> pq; 
+
+    map<size_t, double>::iterator it = featureCover.begin(); 
+
+    for(; it != featureCover.end(); ++it)
+    {
+      pq.push({-it->second, it->first});
+    }
+
+    while(!pq.empty())
+    {
+      size_t elem = pq.top().second; pq.pop();
+      rankByCover.push_back(elem);
+    }
+
   }
 
 };

--- a/src/mlpack/methods/xgboost/feature_importance.hpp
+++ b/src/mlpack/methods/xgboost/feature_importance.hpp
@@ -14,7 +14,8 @@
 #ifndef MLPACK_METHODS_XGBOOST_FEATURE_IMPORTANCE_HPP
 #define MLPACK_METHODS_XGBOOST_FEATURE_IMPORTANCE_HPP
 
-#include "xgboost.hpp"
+// #include "xgboost.hpp"
+#include <map>
 
 namespace mlpack {
 
@@ -31,6 +32,26 @@ namespace mlpack {
  *   feature to the model. For each feature, it sums the improvement in accuracy 
  *   (reduction in loss) brought by the feature when it is used in tree splits.
  */
+
+class FeatureImportance {
+  public: 
+
+  map<size_t, size_t> featureFrequency;
+  map<size_t, double> featureCover;
+
+  FeatureImportance() { /*Nothing to do*/ }
+
+  void increaseFeatureFrequency(size_t index, size_t increment)
+  {
+    featureFrequency[index] += increment;
+  }
+
+  void increaseFeatureCover(size_t index, double increment)
+  {
+    featureCover[index] += increment;
+  }
+
+};
 
 }
 

--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -11,6 +11,7 @@
  */
 #include <mlpack/core.hpp>
 #include <mlpack/methods/decision_tree.hpp>
+#include <mlpack/methods/xgboost/feature_importance.hpp>
 
 #include "catch.hpp"
 #include "serialization.hpp"
@@ -1392,4 +1393,29 @@ TEST_CASE("DifferentMaximumDepthTest", "[DecisionTreeTest]")
   REQUIRE(d2.NumChildren() == 2);
   REQUIRE(d2.Child(0).NumChildren() == 2);
   REQUIRE(d2.Child(1).NumChildren() == 2);
+}
+
+/**
+ * Test if the feature importance function works.
+ */
+TEST_CASE("FeatureImportanceTest", "[DecisionTreeTest]")
+{
+  arma::mat dataset;
+  arma::Row<size_t> labels;
+  data::DatasetInfo di;
+  MockCategoricalData(dataset, labels, di);
+
+  arma::Row<double> weights = arma::ones<arma::Row<double>>(labels.n_elem);
+
+  size_t numFeatures = dataset.n_cols;
+
+  FeatureImportance* fi = new FeatureImportance();
+
+  DecisionTree<> d(5);
+  d.Train(dataset, di, labels, 5, 10, fi);
+  
+  fi->RankByFrequency();
+
+  REQUIRE((fi->rankByFrequency).size() == numFeatures);
+
 }


### PR DESCRIPTION
Cherry-picked from PR #3736 

After training, xgboost can calculate feature importance to understand 
the contribution of each feature in the classification decision.
XGBoost provides two main types of feature importance scores:

- Weight (Frequency): This is the number of times a feature is used to 
  split a node across all trees in the model. It counts how often each 
  feature appears in all trees of the model.

- Gain (Cover): This measures the improvement in accuracy brought by a 
  feature to the model. For each feature, it sums the improvement in accuracy 
  (reduction in loss) brought by the feature when it is used in tree splits.