### PR TITLE
Update Jupyter notebook example links in documentation

### DIFF
--- a/doc/user/methods/adaboost.md
+++ b/doc/user/methods/adaboost.md
@@ -289,7 +289,7 @@ if (ab.WeakLearners() > 0)
 
 See also the following fully-working examples:
 
- - [Graduate admission classification with `AdaBoost`](https://github.com/mlpack/examples/blob/master/graduate_admission_classification_with_Adaboost/graduate-admission-classification-with-adaboost-cpp.ipynb)
+ - [Graduate admission classification with `AdaBoost`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/adaboost/graduate_admission_classification/graduate-admission-classification-cpp.ipynb)
 
 ### Advanced Functionality: Template Parameters
 

--- a/doc/user/methods/decision_tree.md
+++ b/doc/user/methods/decision_tree.md
@@ -270,7 +270,7 @@ else
 
 See also the following fully-working examples:
 
- - [Loan default prediction with `DecisionTree`](https://github.com/mlpack/examples/blob/master/loan_default_prediction_with_decision_tree/loan-default-prediction-with-decision-tree-cpp.ipynb)
+ - [Loan default prediction with `DecisionTree`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/decision_tree/loan_default_prediction/loan-default-prediction-cpp.ipynb)
 
 ### Advanced Functionality: Template Parameters
 

--- a/doc/user/methods/decision_tree_regressor.md
+++ b/doc/user/methods/decision_tree_regressor.md
@@ -194,7 +194,8 @@ See also the [simple usage example](#simple-usage-example) for a trivial use of
 
 ---
 
-Train a decision tree regressor on mixed categorical data.
+Train a decision tree regressor on mixed categorical data and save the model to
+disk.
 
 ```c++
 // Load a categorical dataset.
@@ -235,6 +236,9 @@ tree.Predict(testData, testPredictions);
 const double testAverageError = arma::mean(testResponses - testPredictions);
 std::cout << "Average error on test set: " << testAverageError << "."
     << std::endl;
+
+// Save the tree to "tree.bin" with the name "tree".
+mlpack::data::Save("tree.bin", "tree", tree);
 ```
 
 ---

--- a/doc/user/methods/linear_regression.md
+++ b/doc/user/methods/linear_regression.md
@@ -229,9 +229,9 @@ for (size_t t = 0; t < 3; ++t)
 
 See also the following fully-working examples:
 
- - [Salary prediction with `LinearRegression`](https://github.com/mlpack/examples/blob/master/salary_prediction_with_linear_regression/salary-prediction-linear-regression-cpp.ipynb)
- - [Avocado price prediction with `LinearRegression`](https://github.com/mlpack/examples/blob/master/avocado_price_prediction_with_linear_regression/avocado_price_prediction_with_lr_cpp.ipynb)
- - [California housing price prediction with `LinearRegression`](https://github.com/mlpack/examples/blob/master/california_housing_price_prediction_with_linear_regression/california_housing_price_prediction_with_lr_cpp.ipynb)
+ - [Salary prediction with `LinearRegression`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/linear_regression/salary_prediction/salary-prediction-cpp.ipynb)
+ - [Avocado price prediction with `LinearRegression`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/linear_regression/avocado_price_prediction/avocado_price_prediction_cpp.ipynb)
+ - [California housing price prediction with `LinearRegression`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/linear_regression/california_housing_price_prediction/california_housing_price_prediction_cpp.ipynb)
 
 ### Advanced Functionality: Different Element Types
 

--- a/doc/user/methods/naive_bayes_classifier.md
+++ b/doc/user/methods/naive_bayes_classifier.md
@@ -275,7 +275,7 @@ std::cout << "Random point class probabilities: " << probabilities.t();
 
 See also the following fully-working examples:
 
- - [Microchip QA Classification using `NaiveBayesClassifier`](https://github.com/mlpack/examples/blob/master/microchip_quality_control_naive_bayes/microchip-quality-control-naive-bayes-cpp.ipynb)
+ - [Microchip QA Classification using `NaiveBayesClassifier`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/naive_bayes/microchip_quality_control/microchip-quality-control-cpp.ipynb)
 
 ### Advanced Functionality: Different Element Types
 

--- a/doc/user/methods/random_forest.md
+++ b/doc/user/methods/random_forest.md
@@ -369,8 +369,8 @@ std::cout << "Probabilities of each class: " << probabilities.t();
 
 See also the following fully-working examples:
 
- - [Rainfall prediction with `RandomForest`](https://github.com/mlpack/examples/blob/master/rainfall_prediction_with_random_forest/rainfall-prediction-with-random-forest-cpp.ipynb)
- - [Forest cover type prediction with `RandomForest`](https://github.com/mlpack/examples/blob/master/rainfall_prediction_with_random_forest/rainfall-prediction-with-random-forest-cpp.ipynb)
+ - [Rainfall prediction with `RandomForest`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/random_forest/rainfall_prediction/rainfall-prediction-cpp.ipynb)
+ - [Forest cover type prediction with `RandomForest`](https://github.com/mlpack/examples/blob/master/jupyter_notebook/random_forest/forest_covertype_prediction/covertype-rf-cpp.ipynb)
 
 ### Advanced Functionality: Template Parameters
 

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -408,6 +408,7 @@ do
   checklink -qs \
       --follow-file-links \
       --suppress-broken 405 \
+      --suppress-broken 503 \
       --suppress-broken 301 \
       -X "https://eigen.tuxfamily.org/index.php\?title=Main_Page" \
       -X "https://mlpack.slack.com/" "$f" 2>&1 |

--- a/scripts/test-docs.sh
+++ b/scripts/test-docs.sh
@@ -300,6 +300,11 @@ run_code_blocks()
       if ! ./$f_exec 2>&1 >/dev/null;
       then
         echo "  Error running $f_exec!";
+        echo "  ---------------------------------------------------------------------  ";
+        echo "  Contents of $f:";
+        echo "";
+        cat $f;
+        echo "";
         exit 1;
       fi
     else

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor.hpp
@@ -450,7 +450,7 @@ class DecisionTreeRegressor :
     //! The dimension of the split, for internal nodes.
     size_t splitDimension;
   };
-  //! For internal nodes, the type of the split variable. 
+  //! For internal nodes, the type of the split variable.
   size_t dimensionType;
   //! For internal nodes, the split information for the splitter.
   arma::vec splitInfo;


### PR DESCRIPTION
Since https://github.com/mlpack/examples/pull/229 was merged, the notebooks inside the example repository now live in different directories, so the links inside the Markdown documentation need to be updated accordingly.