### PR TITLE
Handle different behavior of .array() in NumPy 2.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,9 @@
 
 _????-??-??_
 
-  * Distribute STB headers as part of R package (#3724, #3726).
+ * Distribute STB headers as part of R package (#3724, #3726).
+
+ * Update Python bindings to support NumPy 2.x (#3752).
 
 
 ## mlpack 4.4.0

--- a/src/mlpack/bindings/python/mlpack/matrix_utils.py
+++ b/src/mlpack/bindings/python/mlpack/matrix_utils.py
@@ -160,10 +160,10 @@ def to_matrix_with_info(x, dtype, copy=False):
       dims = len(x)
 
     d = np.zeros([dims])
-    if copy:
-      out = np.array(x, dtype=dtype, copy=True)
+    if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
+      out = np.array(x, dtype=dtype, copy=(True if copy else None))
     else:
-      out = np.array(x, dtype=dtype, copy=None)
+      out = np.array(x, dtype=dtype, copy=copy)
 
     # Since we don't have a great way to check if these are using the same
     # memory location, we will probe manually (ugh).

--- a/src/mlpack/bindings/python/mlpack/matrix_utils.py
+++ b/src/mlpack/bindings/python/mlpack/matrix_utils.py
@@ -161,9 +161,9 @@ def to_matrix_with_info(x, dtype, copy=False):
 
     d = np.zeros([dims])
     if copy:
-      out = np.asarray(x, dtype=dtype, copy=True)
+      out = np.array(x, dtype=dtype, copy=True)
     else:
-      out = np.asarray(x, dtype=dtype, copy=None)
+      out = np.array(x, dtype=dtype, copy=None)
 
     # Since we don't have a great way to check if these are using the same
     # memory location, we will probe manually (ugh).

--- a/src/mlpack/bindings/python/mlpack/matrix_utils.py
+++ b/src/mlpack/bindings/python/mlpack/matrix_utils.py
@@ -160,7 +160,10 @@ def to_matrix_with_info(x, dtype, copy=False):
       dims = len(x)
 
     d = np.zeros([dims])
-    out = np.array(x, dtype=dtype, copy=copy) # Try to avoid copy...
+    if copy:
+      out = np.asarray(x, dtype=dtype, copy=True)
+    else:
+      out = np.asarray(x, dtype=dtype, copy=None)
 
     # Since we don't have a great way to check if these are using the same
     # memory location, we will probe manually (ugh).


### PR DESCRIPTION
This should fix #3723; the behavior of `np.array()` changed in NumPy 2.0.0 and now throws a `ValueError` if the `copy=False` argument is given and a copy cannot be avoided.  But we were using `copy=False` with the intention of "don't copy unless you need to"---where the more correct option is just to pass `None` instead.  According to the documentation that should be backwards-compatible with NumPy 1.x too; CI will tell us if that's true in just a few minutes. :)

@jakirkham if you happen to have a moment to review, it would be appreciated, but no worries if too much is going on. :+1: