### PR TITLE
Refactor `BoundType` to take `ElemType` as a second parameter

### DIFF
--- a/src/mlpack/core/tree/ballbound.hpp
+++ b/src/mlpack/core/tree/ballbound.hpp
@@ -27,12 +27,11 @@ namespace mlpack {
  * @tparam VecType Type of vector (arma::vec or arma::sp_vec or similar).
  */
 template<typename DistanceType = LMetric<2, true>,
-         typename VecType = arma::vec>
+         typename ElemType = double,
+         typename VecType = arma::Col<ElemType>>
 class BallBound
 {
  public:
-  //! The underlying data type.
-  typedef typename VecType::elem_type ElemType;
   //! A public version of the vector type.
   typedef VecType Vec;
 

--- a/src/mlpack/core/tree/ballbound_impl.hpp
+++ b/src/mlpack/core/tree/ballbound_impl.hpp
@@ -20,8 +20,8 @@
 namespace mlpack {
 
 //! Empty Constructor.
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>::BallBound() :
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>::BallBound() :
     radius(std::numeric_limits<ElemType>::lowest()),
     distance(new DistanceType()),
     ownsDistance(true)
@@ -32,8 +32,8 @@ BallBound<DistanceType, VecType>::BallBound() :
  *
  * @param dimension Dimensionality of ball bound.
  */
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>::BallBound(const size_t dimension) :
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>::BallBound(const size_t dimension) :
     radius(std::numeric_limits<ElemType>::lowest()),
     center(dimension),
     distance(new DistanceType()),
@@ -46,9 +46,9 @@ BallBound<DistanceType, VecType>::BallBound(const size_t dimension) :
  * @param radius Radius of ball bound.
  * @param center Center of ball bound.
  */
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>::BallBound(const ElemType radius,
-                                            const VecType& center) :
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>::BallBound(const ElemType radius,
+                                                      const VecType& center) :
     radius(radius),
     center(center),
     distance(new DistanceType()),
@@ -56,8 +56,8 @@ BallBound<DistanceType, VecType>::BallBound(const ElemType radius,
 { /* Nothing to do. */ }
 
 //! Copy Constructor. To prevent memory leaks.
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>::BallBound(const BallBound& other) :
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>::BallBound(const BallBound& other) :
     radius(other.radius),
     center(other.center),
     distance(other.distance),
@@ -65,8 +65,9 @@ BallBound<DistanceType, VecType>::BallBound(const BallBound& other) :
 { /* Nothing to do. */ }
 
 //! For the same reason as the copy constructor: to prevent memory leaks.
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>& BallBound<DistanceType, VecType>::operator=(
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>&
+BallBound<DistanceType, ElemType, VecType>::operator=(
     const BallBound& other)
 {
   if (this != &other)
@@ -80,8 +81,8 @@ BallBound<DistanceType, VecType>& BallBound<DistanceType, VecType>::operator=(
 }
 
 //! Move constructor.
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>::BallBound(BallBound&& other) :
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>::BallBound(BallBound&& other) :
     radius(other.radius),
     center(other.center),
     distance(other.distance),
@@ -95,8 +96,9 @@ BallBound<DistanceType, VecType>::BallBound(BallBound&& other) :
 }
 
 //! Move assignment operator.
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>& BallBound<DistanceType, VecType>::operator=(
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>&
+BallBound<DistanceType, ElemType, VecType>::operator=(
     BallBound&& other)
 {
   if (this != &other)
@@ -115,29 +117,30 @@ BallBound<DistanceType, VecType>& BallBound<DistanceType, VecType>::operator=(
 }
 
 //! Destructor to release allocated memory.
-template<typename DistanceType, typename VecType>
-BallBound<DistanceType, VecType>::~BallBound()
+template<typename DistanceType, typename ElemType, typename VecType>
+BallBound<DistanceType, ElemType, VecType>::~BallBound()
 {
   if (ownsDistance)
     delete distance;
 }
 
 //! Get the range in a certain dimension.
-template<typename DistanceType, typename VecType>
-RangeType<typename BallBound<DistanceType, VecType>::ElemType>
-BallBound<DistanceType, VecType>::operator[](const size_t i) const
+template<typename DistanceType, typename ElemType, typename VecType>
+RangeType<ElemType>
+BallBound<DistanceType, ElemType, VecType>::operator[](const size_t i) const
 {
   if (radius < 0)
-    return Range();
+    return RangeType<ElemType>();
   else
-    return Range(center[i] - radius, center[i] + radius);
+    return RangeType<ElemType>(center[i] - radius, center[i] + radius);
 }
 
 /**
  * Determines if a point is within the bound.
  */
-template<typename DistanceType, typename VecType>
-bool BallBound<DistanceType, VecType>::Contains(const VecType& point) const
+template<typename DistanceType, typename ElemType, typename VecType>
+bool BallBound<DistanceType, ElemType, VecType>::Contains(const VecType& point)
+    const
 {
   if (radius < 0)
     return false;
@@ -148,10 +151,9 @@ bool BallBound<DistanceType, VecType>::Contains(const VecType& point) const
 /**
  * Calculates minimum bound-to-point squared distance.
  */
-template<typename DistanceType, typename VecType>
+template<typename DistanceType, typename ElemType, typename VecType>
 template<typename OtherVecType>
-typename BallBound<DistanceType, VecType>::ElemType
-BallBound<DistanceType, VecType>::MinDistance(
+ElemType BallBound<DistanceType, ElemType, VecType>::MinDistance(
     const OtherVecType& point,
     typename std::enable_if_t<IsVector<OtherVecType>::value>* /* junk */) const
 {
@@ -164,10 +166,9 @@ BallBound<DistanceType, VecType>::MinDistance(
 /**
  * Calculates minimum bound-to-bound squared distance.
  */
-template<typename DistanceType, typename VecType>
-typename BallBound<DistanceType, VecType>::ElemType
-BallBound<DistanceType, VecType>::MinDistance(const BallBound& other)
-    const
+template<typename DistanceType, typename ElemType, typename VecType>
+ElemType BallBound<DistanceType, ElemType, VecType>::MinDistance(
+    const BallBound& other) const
 {
   if (radius < 0)
     return std::numeric_limits<ElemType>::max();
@@ -182,10 +183,9 @@ BallBound<DistanceType, VecType>::MinDistance(const BallBound& other)
 /**
  * Computes maximum distance.
  */
-template<typename DistanceType, typename VecType>
+template<typename DistanceType, typename ElemType, typename VecType>
 template<typename OtherVecType>
-typename BallBound<DistanceType, VecType>::ElemType
-BallBound<DistanceType, VecType>::MaxDistance(
+ElemType BallBound<DistanceType, ElemType, VecType>::MaxDistance(
     const OtherVecType& point,
     typename std::enable_if_t<IsVector<OtherVecType>::value>* /* junk */) const
 {
@@ -198,10 +198,9 @@ BallBound<DistanceType, VecType>::MaxDistance(
 /**
  * Computes maximum distance.
  */
-template<typename DistanceType, typename VecType>
-typename BallBound<DistanceType, VecType>::ElemType
-BallBound<DistanceType, VecType>::MaxDistance(const BallBound& other)
-    const
+template<typename DistanceType, typename ElemType, typename VecType>
+ElemType BallBound<DistanceType, ElemType, VecType>::MaxDistance(
+    const BallBound& other) const
 {
   if (radius < 0)
     return std::numeric_limits<ElemType>::max();
@@ -214,36 +213,36 @@ BallBound<DistanceType, VecType>::MaxDistance(const BallBound& other)
  *
  * Example: bound1.MinDistanceSq(other) for minimum squared distance.
  */
-template<typename DistanceType, typename VecType>
+template<typename DistanceType, typename ElemType, typename VecType>
 template<typename OtherVecType>
-RangeType<typename BallBound<DistanceType, VecType>::ElemType>
-BallBound<DistanceType, VecType>::RangeDistance(
+RangeType<ElemType> BallBound<DistanceType, ElemType, VecType>::RangeDistance(
     const OtherVecType& point,
     typename std::enable_if_t<IsVector<OtherVecType>::value>* /* junk */) const
 {
   if (radius < 0)
-    return Range(std::numeric_limits<ElemType>::max(),
-                       std::numeric_limits<ElemType>::max());
+    return RangeType<ElemType>(std::numeric_limits<ElemType>::max(),
+                               std::numeric_limits<ElemType>::max());
   else
   {
     const ElemType dist = distance->Evaluate(center, point);
-    return Range(std::max(dist - radius, (ElemType) 0.0), dist + radius);
+    return RangeType<ElemType>(std::max(dist - radius, (ElemType) 0.0),
+                               dist + radius);
   }
 }
 
-template<typename DistanceType, typename VecType>
-RangeType<typename BallBound<DistanceType, VecType>::ElemType>
-BallBound<DistanceType, VecType>::RangeDistance(
+template<typename DistanceType, typename ElemType, typename VecType>
+RangeType<ElemType> BallBound<DistanceType, ElemType, VecType>::RangeDistance(
     const BallBound& other) const
 {
   if (radius < 0)
-    return Range(std::numeric_limits<ElemType>::max(),
-                       std::numeric_limits<ElemType>::max());
+    return RangeType<ElemType>(std::numeric_limits<ElemType>::max(),
+                               std::numeric_limits<ElemType>::max());
   else
   {
     const ElemType dist = distance->Evaluate(center, other.center);
     const ElemType sumradius = radius + other.radius;
-    return Range(std::max(dist - sumradius, (ElemType) 0.0), dist + sumradius);
+    return RangeType<ElemType>(std::max(dist - sumradius, (ElemType) 0.0),
+                               dist + sumradius);
   }
 }
 
@@ -253,10 +252,10 @@ BallBound<DistanceType, VecType>::RangeDistance(
  * The difference lies in the way we initialize the ball bound. The way we
  * expand the bound is same.
  */
-template<typename DistanceType, typename VecType>
+template<typename DistanceType, typename ElemType, typename VecType>
 template<typename MatType>
-const BallBound<DistanceType, VecType>&
-BallBound<DistanceType, VecType>::operator|=(const MatType& data)
+const BallBound<DistanceType, ElemType, VecType>&
+BallBound<DistanceType, ElemType, VecType>::operator|=(const MatType& data)
 {
   if (radius < 0)
   {
@@ -284,9 +283,9 @@ BallBound<DistanceType, VecType>::operator|=(const MatType& data)
 }
 
 //! Serialize the BallBound.
-template<typename DistanceType, typename VecType>
+template<typename DistanceType, typename ElemType, typename VecType>
 template<typename Archive>
-void BallBound<DistanceType, VecType>::serialize(
+void BallBound<DistanceType, ElemType, VecType>::serialize(
     Archive& ar,
     const uint32_t /* version */)
 {

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
@@ -46,10 +46,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType = EmptyStatistic,
          typename MatType = arma::mat,
-         template<typename BoundDistanceType, typename...> class BoundType =
-            HRectBound,
-         template<typename SplitBoundType, typename SplitMatType>
-            class SplitType = MidpointSplit>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType = HRectBound,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType = MidpointSplit>
 class BinarySpaceTree
 {
  public:
@@ -58,7 +59,7 @@ class BinarySpaceTree
   //! The type of element held in MatType.
   typedef typename MatType::elem_type ElemType;
 
-  typedef SplitType<BoundType<DistanceType>, MatType> Split;
+  typedef SplitType<BoundType<DistanceType, ElemType>, MatType> Split;
 
  private:
   //! The left child node.
@@ -74,7 +75,7 @@ class BinarySpaceTree
   //! children).
   size_t count;
   //! The bound object for this node.
-  BoundType<DistanceType> bound;
+  BoundType<DistanceType, ElemType> bound;
   //! Any extra data contained in the node.
   StatisticType stat;
   //! The distance from the centroid of this node to the centroid of the parent.
@@ -210,7 +211,8 @@ class BinarySpaceTree
   BinarySpaceTree(BinarySpaceTree* parent,
                   const size_t begin,
                   const size_t count,
-                  SplitType<BoundType<DistanceType>, MatType>& splitter,
+                  SplitType<BoundType<DistanceType, ElemType>, MatType>&
+                      splitter,
                   const size_t maxLeafSize = 20);
 
   /**
@@ -236,7 +238,8 @@ class BinarySpaceTree
                   const size_t begin,
                   const size_t count,
                   std::vector<size_t>& oldFromNew,
-                  SplitType<BoundType<DistanceType>, MatType>& splitter,
+                  SplitType<BoundType<DistanceType, ElemType>, MatType>&
+                      splitter,
                   const size_t maxLeafSize = 20);
 
   /**
@@ -266,7 +269,8 @@ class BinarySpaceTree
                   const size_t count,
                   std::vector<size_t>& oldFromNew,
                   std::vector<size_t>& newFromOld,
-                  SplitType<BoundType<DistanceType>, MatType>& splitter,
+                  SplitType<BoundType<DistanceType, ElemType>, MatType>&
+                      splitter,
                   const size_t maxLeafSize = 20);
 
   /**
@@ -315,9 +319,9 @@ class BinarySpaceTree
   ~BinarySpaceTree();
 
   //! Return the bound object for this node.
-  const BoundType<DistanceType>& Bound() const { return bound; }
+  const BoundType<DistanceType, ElemType>& Bound() const { return bound; }
   //! Return the bound object for this node.
-  BoundType<DistanceType>& Bound() { return bound; }
+  BoundType<DistanceType, ElemType>& Bound() { return bound; }
 
   //! Return the statistic object for this node.
   const StatisticType& Stat() const { return stat; }
@@ -517,8 +521,9 @@ class BinarySpaceTree
    * @param maxLeafSize Maximum number of points held in a leaf.
    * @param splitter Instantiated SplitType object.
    */
-  void SplitNode(const size_t maxLeafSize,
-                 SplitType<BoundType<DistanceType>, MatType>& splitter);
+  void SplitNode(
+      const size_t maxLeafSize,
+      SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter);
 
   /**
    * Splits the current node, assigning its left and right children recursively.
@@ -528,9 +533,10 @@ class BinarySpaceTree
    * @param maxLeafSize Maximum number of points held in a leaf.
    * @param splitter Instantiated SplitType object.
    */
-  void SplitNode(std::vector<size_t>& oldFromNew,
-                 const size_t maxLeafSize,
-                 SplitType<BoundType<DistanceType>, MatType>& splitter);
+  void SplitNode(
+      std::vector<size_t>& oldFromNew,
+      const size_t maxLeafSize,
+      SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter);
 
   /**
    * Update the bound of the current node. This method does not take into
@@ -547,7 +553,7 @@ class BinarySpaceTree
    *
    * @param boundToUpdate The bound to update.
    */
-  void UpdateBound(HollowBallBound<DistanceType>& boundToUpdate);
+  void UpdateBound(HollowBallBound<DistanceType, ElemType>& boundToUpdate);
 
  protected:
   /**

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp
@@ -24,9 +24,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const MatType& data,
@@ -41,7 +43,7 @@ BinarySpaceTree(
     dataset(new MatType(data)) // Copies the dataset.
 {
   // Do the actual splitting of this node.
-  SplitType<BoundType<DistanceType>, MatType> splitter;
+  SplitType<BoundType<DistanceType, ElemType>, MatType> splitter;
   SplitNode(maxLeafSize, splitter);
 
   // Create the statistic depending on if we are a leaf or not.
@@ -51,9 +53,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const MatType& data,
@@ -74,7 +78,7 @@ BinarySpaceTree(
     oldFromNew[i] = i; // Fill with unharmed indices.
 
   // Now do the actual splitting.
-  SplitType<BoundType<DistanceType>, MatType> splitter;
+  SplitType<BoundType<DistanceType, ElemType>, MatType> splitter;
   SplitNode(oldFromNew, maxLeafSize, splitter);
 
   // Create the statistic depending on if we are a leaf or not.
@@ -84,9 +88,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const MatType& data,
@@ -108,7 +114,7 @@ BinarySpaceTree(
     oldFromNew[i] = i; // Fill with unharmed indices.
 
   // Now do the actual splitting.
-  SplitType<BoundType<DistanceType>, MatType> splitter;
+  SplitType<BoundType<DistanceType, ElemType>, MatType> splitter;
   SplitNode(oldFromNew, maxLeafSize, splitter);
 
   // Create the statistic depending on if we are a leaf or not.
@@ -123,9 +129,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(MatType&& data, const size_t maxLeafSize) :
     left(NULL),
@@ -138,7 +146,7 @@ BinarySpaceTree(MatType&& data, const size_t maxLeafSize) :
     dataset(new MatType(std::move(data)))
 {
   // Do the actual splitting of this node.
-  SplitType<BoundType<DistanceType>, MatType> splitter;
+  SplitType<BoundType<DistanceType, ElemType>, MatType> splitter;
   SplitNode(maxLeafSize, splitter);
 
   // Create the statistic depending on if we are a leaf or not.
@@ -148,9 +156,11 @@ BinarySpaceTree(MatType&& data, const size_t maxLeafSize) :
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     MatType&& data,
@@ -171,7 +181,7 @@ BinarySpaceTree(
     oldFromNew[i] = i; // Fill with unharmed indices.
 
   // Now do the actual splitting.
-  SplitType<BoundType<DistanceType>, MatType> splitter;
+  SplitType<BoundType<DistanceType, ElemType>, MatType> splitter;
   SplitNode(oldFromNew, maxLeafSize, splitter);
 
   // Create the statistic depending on if we are a leaf or not.
@@ -181,9 +191,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     MatType&& data,
@@ -205,7 +217,7 @@ BinarySpaceTree(
     oldFromNew[i] = i; // Fill with unharmed indices.
 
   // Now do the actual splitting.
-  SplitType<BoundType<DistanceType>, MatType> splitter;
+  SplitType<BoundType<DistanceType, ElemType>, MatType> splitter;
   SplitNode(oldFromNew, maxLeafSize, splitter);
 
   // Create the statistic depending on if we are a leaf or not.
@@ -220,15 +232,17 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     BinarySpaceTree* parent,
     const size_t begin,
     const size_t count,
-    SplitType<BoundType<DistanceType>, MatType>& splitter,
+    SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter,
     const size_t maxLeafSize) :
     left(NULL),
     right(NULL),
@@ -248,16 +262,18 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     BinarySpaceTree* parent,
     const size_t begin,
     const size_t count,
     std::vector<size_t>& oldFromNew,
-    SplitType<BoundType<DistanceType>, MatType>& splitter,
+    SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter,
     const size_t maxLeafSize) :
     left(NULL),
     right(NULL),
@@ -281,9 +297,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     BinarySpaceTree* parent,
@@ -291,7 +309,7 @@ BinarySpaceTree(
     const size_t count,
     std::vector<size_t>& oldFromNew,
     std::vector<size_t>& newFromOld,
-    SplitType<BoundType<DistanceType>, MatType>& splitter,
+    SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter,
     const size_t maxLeafSize) :
     left(NULL),
     right(NULL),
@@ -324,9 +342,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
     const BinarySpaceTree& other) :
@@ -384,9 +404,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>&
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 operator=(const BinarySpaceTree& other)
@@ -456,9 +478,11 @@ operator=(const BinarySpaceTree& other)
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>&
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 operator=(BinarySpaceTree&& other)
@@ -504,9 +528,11 @@ operator=(BinarySpaceTree&& other)
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(BinarySpaceTree&& other) :
     left(other.left),
@@ -546,9 +572,11 @@ BinarySpaceTree(BinarySpaceTree&& other) :
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename Archive>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BinarySpaceTree(
@@ -569,9 +597,11 @@ BinarySpaceTree(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
     ~BinarySpaceTree()
 {
@@ -586,9 +616,11 @@ BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline bool BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                             SplitType>::IsLeaf() const
 {
@@ -601,9 +633,11 @@ inline bool BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                               SplitType>::NumChildren() const
 {
@@ -622,9 +656,11 @@ inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename VecType>
 size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::GetNearestChild(
@@ -646,9 +682,11 @@ size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename VecType>
 size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::GetFurthestChild(
@@ -670,9 +708,11 @@ size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::GetNearestChild(const BinarySpaceTree& queryNode)
 {
@@ -695,9 +735,11 @@ size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::GetFurthestChild(const BinarySpaceTree& queryNode)
 {
@@ -720,9 +762,11 @@ size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline
 typename BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::ElemType
@@ -746,9 +790,11 @@ BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline
 typename BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::ElemType
@@ -762,9 +808,11 @@ BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline
 typename BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
     SplitType>::ElemType
@@ -780,9 +828,11 @@ BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                        SplitType>&
     BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
@@ -800,9 +850,11 @@ inline BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                               SplitType>::NumPoints() const
 {
@@ -818,9 +870,11 @@ inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                               SplitType>::NumDescendants() const
 {
@@ -833,9 +887,11 @@ inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                               SplitType>::Descendant(const size_t index) const
 {
@@ -848,9 +904,11 @@ inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                               SplitType>::Point(const size_t index) const
 {
@@ -860,13 +918,15 @@ inline size_t BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
     SplitNode(const size_t maxLeafSize,
-              SplitType<BoundType<DistanceType>, MatType>& splitter)
+              SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter)
 {
   // We need to expand the bounds of this node properly.
   UpdateBound(bound);
@@ -927,14 +987,16 @@ BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 SplitNode(std::vector<size_t>& oldFromNew,
           const size_t maxLeafSize,
-          SplitType<BoundType<DistanceType>, MatType>& splitter)
+          SplitType<BoundType<DistanceType, ElemType>, MatType>& splitter)
 {
   // We need to expand the bounds of this node properly.
   UpdateBound(bound);
@@ -996,9 +1058,11 @@ SplitNode(std::vector<size_t>& oldFromNew,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename BoundType2>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
@@ -1011,12 +1075,14 @@ UpdateBound(BoundType2& boundToUpdate)
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
-UpdateBound(HollowBallBound<DistanceType>& boundToUpdate)
+UpdateBound(HollowBallBound<DistanceType, ElemType>& boundToUpdate)
 {
   if (!parent)
   {
@@ -1039,9 +1105,11 @@ UpdateBound(HollowBallBound<DistanceType>& boundToUpdate)
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
     BinarySpaceTree() :
     left(NULL),
@@ -1063,9 +1131,11 @@ BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename Archive>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::

--- a/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
@@ -35,9 +35,11 @@ struct QueueFrame
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 class BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                       SplitType>::BreadthFirstDualTreeTraverser

--- a/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser_impl.hpp
@@ -22,9 +22,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BreadthFirstDualTreeTraverser<RuleType>::BreadthFirstDualTreeTraverser(
@@ -50,9 +52,11 @@ bool operator<(const QueueFrame<TreeType, TraversalInfoType>& a,
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
@@ -91,9 +95,11 @@ BreadthFirstDualTreeTraverser<RuleType>::Traverse(
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 void BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 BreadthFirstDualTreeTraverser<RuleType>::Traverse(

--- a/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser.hpp
@@ -24,9 +24,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 class BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                       SplitType>::DualTreeTraverser

--- a/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/dual_tree_traverser_impl.hpp
@@ -22,9 +22,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 DualTreeTraverser<RuleType>::DualTreeTraverser(RuleType& rule) :
@@ -38,9 +40,11 @@ DualTreeTraverser<RuleType>::DualTreeTraverser(RuleType& rule) :
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::

--- a/src/mlpack/core/tree/binary_space_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/single_tree_traverser.hpp
@@ -23,9 +23,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 class BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
                       SplitType>::SingleTreeTraverser

--- a/src/mlpack/core/tree/binary_space_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/single_tree_traverser_impl.hpp
@@ -24,9 +24,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::
 SingleTreeTraverser<RuleType>::SingleTreeTraverser(RuleType& rule) :
@@ -37,9 +39,11 @@ SingleTreeTraverser<RuleType>::SingleTreeTraverser(RuleType& rule) :
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 template<typename RuleType>
 void
 BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType, SplitType>::

--- a/src/mlpack/core/tree/binary_space_tree/traits.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/traits.hpp
@@ -26,9 +26,11 @@ namespace mlpack {
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType,
-         template<typename SplitBoundType, typename SplitMatType>
-             class SplitType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType,
+         template<typename SplitBoundType,
+                  typename SplitMatType> class SplitType>
 class TreeTraits<BinarySpaceTree<
     DistanceType, StatisticType, MatType, BoundType, SplitType>>
 {
@@ -80,7 +82,9 @@ class TreeTraits<BinarySpaceTree<
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType>
 class TreeTraits<BinarySpaceTree<
     DistanceType, StatisticType, MatType, BoundType, RPTreeMaxSplit>>
 {
@@ -130,9 +134,11 @@ class TreeTraits<BinarySpaceTree<
 template<typename DistanceType,
          typename StatisticType,
          typename MatType,
-         template<typename BoundDistanceType, typename...> class BoundType>
-class TreeTraits<BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
-                                 RPTreeMeanSplit>>
+         template<typename BoundDistanceType,
+                  typename BoundElemType,
+                  typename...> class BoundType>
+class TreeTraits<BinarySpaceTree<DistanceType, StatisticType, MatType,
+                                 BoundType, RPTreeMeanSplit>>
 {
  public:
   /**

--- a/src/mlpack/core/tree/space_split/projection_vector.hpp
+++ b/src/mlpack/core/tree/space_split/projection_vector.hpp
@@ -67,9 +67,9 @@ class AxisParallelProjVector
    * @param bound Bound to be projected.
    * @return Range of projected values.
    */
-  template<typename DistanceType, typename VecType>
-  RangeType<typename VecType::elem_type> Project(
-      const BallBound<DistanceType, VecType>& bound) const
+  template<typename DistanceType, typename ElemType, typename VecType>
+  RangeType<ElemType> Project(
+      const BallBound<DistanceType, ElemType, VecType>& bound) const
   {
     return bound[dim];
   }
@@ -128,11 +128,10 @@ class ProjVector
    * @param bound Bound to be projected.
    * @return Range of projected values.
    */
-  template<typename DistanceType, typename VecType>
-  RangeType<typename VecType::elem_type> Project(
-      const BallBound<DistanceType, VecType>& bound) const
+  template<typename DistanceType, typename ElemType, typename VecType>
+  RangeType<ElemType> Project(
+      const BallBound<DistanceType, ElemType, VecType>& bound) const
   {
-    typedef typename VecType::elem_type ElemType;
     const double center = Project(bound.Center());
     const ElemType radius = bound.Radius();
     return RangeType<ElemType>(center - radius, center + radius);

--- a/src/mlpack/tests/dbscan_test.cpp
+++ b/src/mlpack/tests/dbscan_test.cpp
@@ -17,18 +17,6 @@
 
 using namespace mlpack;
 
-/**
- * A couple of handful declarations for float32 testing.
- * These will be removed when we refactor the Bounds to accept MatType.
- * For now, we will keep the following declarations.
- */
-template<typename DistanceType>
-using FloatHRectBound = HRectBound<DistanceType, float>;
-
-template<typename DistanceType, typename StatisticType, typename MatType>
-using FloatKDTree = BinarySpaceTree<DistanceType, StatisticType, MatType,
-                                    FloatHRectBound, MidpointSplit>;
-
 TEST_CASE("OneClusterTest", "[DBSCANTest]")
 {
   // Make sure that if we have points in the unit box, and if we set epsilon
@@ -229,7 +217,7 @@ TEST_CASE("Float32OutlierSingleModeTest", "[DBSCANTest]")
   DBSCAN<RangeSearch<
          EuclideanDistance,
          arma::Mat<float>,
-         FloatKDTree>,
+         KDTree>,
          OrderedPointSelection> d(0.1, 3, false);
 
   arma::Row<size_t> assignments;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -17,18 +17,6 @@
 using namespace mlpack;
 
 /**
- * A couple of handful declarations for float32 testing.
- * These will be removed when we refactor the Bounds to accept MatType.
- * For now, we will keep the following declarations.
- */
-template<typename DistanceType>
-using FloatHRectBound = HRectBound<DistanceType, float>;
-
-template<typename DistanceType, typename StatisticType, typename MatType>
-using FloatKDTree = BinarySpaceTree<DistanceType, StatisticType, MatType,
-                                    FloatHRectBound, MidpointSplit>;
-
-/**
  * Test that Unmap() works in the dual-tree case (see unmap.hpp).
  */
 TEST_CASE("KNNDualTreeUnmapTest", "[KNNTest]")
@@ -777,14 +765,12 @@ TEST_CASE("KNNSingleTreeVsNaiveF32", "[KNNTest]")
 
   NeighborSearch<NearestNeighborSort,
                  EuclideanDistance,
-                 arma::fmat,
-                 FloatKDTree> knn(dataset, SINGLE_TREE_MODE);
+                 arma::fmat> knn(dataset, SINGLE_TREE_MODE);
 
   // Set up computation for naive mode.
   NeighborSearch<NearestNeighborSort,
                  EuclideanDistance,
-                 arma::fmat,
-                 FloatKDTree> naive(dataset, NAIVE_MODE);
+                 arma::fmat> naive(dataset, NAIVE_MODE);
 
   arma::Mat<size_t> neighborsTree;
   arma::fmat distancesTree;

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -152,12 +152,12 @@ TEST_CASE("BallBoundTest", "[SerializationTest]")
 
 TEST_CASE("MahalanobisBallBoundTest", "[SerializationTest]")
 {
-  BallBound<MahalanobisDistance<>, arma::vec> b(100);
+  BallBound<MahalanobisDistance<>, double, arma::vec> b(100);
   b.Center().randu();
   b.Radius() = 14.0;
   b.Distance().Q().randu(100, 100);
 
-  BallBound<MahalanobisDistance<>, arma::vec> xmlB, jsonB, binaryB;
+  BallBound<MahalanobisDistance<>, double, arma::vec> xmlB, jsonB, binaryB;
 
   SerializeObjectAll(b, xmlB, jsonB, binaryB);
 


### PR DESCRIPTION
Currently, using mlpack's `BinarySpaceTree` with non-`double` data is awkward because the bound type has no way of automatically knowing the type of data being used.  For instance, this is the type required for a `KDTree` built on `float`s:

```
BinarySpaceTree<EuclideanDistance,
                EmptyStatistic,
                arma::fmat,
                HRectBound<EuclideanDistance, float>>;
```

The ugly part here is that `HRectBound` that manually needs the `float` specified.

By modifying `BinarySpaceTree` to automatically apply its element type as the second template parameter of the bound type, we can resolve this and we get the much simpler:

```
BinarySpaceTree<EuclideanDistance,
                EmptyStatistic,
                arma::fmat>
``` 

In order to do this successfully, the `BallBound` type had to be modified to take an `ElemType` as its second template parameter.

Therefore, all `BoundType`s used by mlpack trees must have the following two template parameters:
 * `DistanceType`: the distance metric
 * `ElemType`: element type that the tree is being built on

Virtually all the changes here are just propagating the new template parameter throughout.  I also found some uses of `Range` that were not properly templatized and would not work correctly if `float` was used, and updated the code accordingly.

The actual improvement of the PR can be seen in `knn_test.cpp` and `dbscan_test.cpp`.