### PR TITLE
Add stale configuration to replace mlpack-bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@9
+        with:
+          days-before-issues-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: "s: stale",
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had any recent activity.  It will be closed in 7 days if no further activity occurs.  Thank you for your contributions! :+1:"
+          days-before-pr-stale: 30,
+          days-before-pr-close: 14
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "s: keep open"
+          exempt-pr-labels: "s: keep open"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           days-before-issues-stale: 30
           days-before-issue-close: 7
-          stale-issue-label: "s: stale",
+          stale-issue-label: "s: stale"
           stale-issue-message: "This issue has been automatically marked as stale because it has not had any recent activity.  It will be closed in 7 days if no further activity occurs.  Thank you for your contributions! :+1:"
           days-before-pr-stale: 30,
           days-before-pr-close: 14


### PR DESCRIPTION
Since mlpack-bot is sadly built on code that is now completely deprecated, and I can't manage to get it to start anymore, it's probably time to move on (sorry mlpack-bot!).

This uses the https://github.com/actions/stale action to mark issues as stale after 30 days, and close them after another week.  I replicated the settings that were used by mlpack-bot.