### PR TITLE
Auto-approve action

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,22 @@
+# Once a PR has been approved by one member of the mlpack organization, a second
+# approving review will automatically be added 24 hours later.  This allows time
+# for other maintainers to take a look.
+name: Auto-approve pull requests
+on:
+  schedule:
+   # Run roughly every four hours.
+   - cron: "15 0,4,8,12,16,20 * * *"
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+     - name: Auto-approve pull requests
+       uses: rcurtin/auto-approve
+       with:
+         repo-token: ${{ secrets.GITHUB_TOKEN }}
+         approval-message:
+           'Second approval provided automatically after 24 hours. :+1:'

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
      - name: Auto-approve pull requests
-       uses: rcurtin/auto-approve
+       uses: rcurtin/auto-approve@v1.0.0
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          approval-message:


### PR DESCRIPTION
Since I can't get mlpack-bot to run anymore (and admittedly the entire stack it is built on is deprecated and mostly archived), I built a Github action to do the same thing:

https://github.com/rcurtin/auto-approve

Hopefully, if that all works correctly, adding it to the repository here should re-enable the 24-hour-delayed auto-approvals that have been missing for the past couple weeks.