### PR TITLE
Post about stickers as a Github action

### DIFF
--- a/.github/workflows/stickers.yaml
+++ b/.github/workflows/stickers.yaml
@@ -1,0 +1,17 @@
+# Post a message to new contributors that they can get some stickers mailed to
+# them.
+name: 'Stickers for new contributors'
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  sticker_comment:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+        # Forked version of first-interaction that runs only on first merged PR.
+      - uses: rcurtin/first-interaction@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: "Hello there!  Thanks for your contribution.  Congratulations on your first contribution to mlpack!  If you'd like to add your name to the list of contributors in `COPYRIGHT.txt` and you haven't already, please feel free to push a change to this PR---or, if it gets merged before you can, feel free to open another PR.\n\nIn addition, if you'd like some stickers to put on your laptop, we can get them in the mail for you.  Just send an email with your physical mailing address to stickers@mlpack.org, and then one of the mlpack maintainers will put some stickers in an envelope for you.  It may take a few weeks to get them, depending on your location. :+1:"

--- a/.github/workflows/welcome-pr.yaml
+++ b/.github/workflows/welcome-pr.yaml
@@ -1,0 +1,16 @@
+# Post a message to new contributors that they can get some stickers mailed to
+# them.
+name: 'Welcome message for new contributors'
+on:
+  pull_request:
+    types: [open]
+
+jobs:
+  sticker_comment:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/first-interaction@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: "Thanks for opening your first pull request in this repository!  Someone will review it when they have a chance.  In the mean time, please be sure that you've handled the following things, to make the review process quicker and easier:\n\n - All code should follow the [style guide](https://github.com/mlpack/mlpack/wiki/DesignGuidelines#style-guidelines)\n - Documentation added for any new functionality\n - Tests added for any new functionality\n - Tests that are added follow the [testing guide](https://github.com/mlpack/mlpack/wiki/Testing-Guidelines)\n - Headers and license information added to the top of any new code files\n - HISTORY.md updated if the changes are big or user-facing\n - All CI checks should be passing\n\nThank you again for your contributions!  :+1:"


### PR DESCRIPTION
This replaces the now-non-working functionality of mlpack-bot to post to new contributors about stickers.
I think that maybe it has been a while since this worked correctly.

(So if you are seeing for the first time that we mail stickers out and you want some, well, go ahead and email stickers@mlpack.org, I will get some in the mail for you :))

I am less confident that these two actions (stickers on first contribution, and a welcome message for new contributors on their first PR) work correctly, so there may be some debugging after merge here.