### PR TITLE
Round one of mlpack-bot action fixes.

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
      - name: Auto-approve pull requests
-       uses: rcurtin/auto-approve@v1.0.0
+       uses: rcurtin/auto-approve@v1.0.1
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          approval-message:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@9
+      - uses: actions/stale@v9
         with:
           days-before-issues-stale: 30
           days-before-issue-close: 7

--- a/.github/workflows/stickers.yaml
+++ b/.github/workflows/stickers.yaml
@@ -13,5 +13,5 @@ jobs:
         # Forked version of first-interaction that runs only on first merged PR.
       - uses: rcurtin/first-interaction@v1.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: "Hello there!  Thanks for your contribution.  Congratulations on your first contribution to mlpack!  If you'd like to add your name to the list of contributors in `COPYRIGHT.txt` and you haven't already, please feel free to push a change to this PR---or, if it gets merged before you can, feel free to open another PR.\n\nIn addition, if you'd like some stickers to put on your laptop, we can get them in the mail for you.  Just send an email with your physical mailing address to stickers@mlpack.org, and then one of the mlpack maintainers will put some stickers in an envelope for you.  It may take a few weeks to get them, depending on your location. :+1:"


### PR DESCRIPTION
This is a follow-up to #3755, #3756, and #3757.  Since I couldn't really completely test them before deploying them, there were a couple of issues that I fixed here:

 * The auto-approver was only waiting for 30ms after a review instead of 24 hours... fixed via an upstream version bump.
 * I specified the version of the stale action wrong.
 * Incorrect YAML key name for the stickers action.