### PR TITLE
Bump minimum Armadillo version to 10.8

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -24,13 +24,13 @@ steps:
 
     sudo apt-get install -y --allow-unauthenticated libopenblas-dev g++ xz-utils
 
-    if [ "${binding}" == "python" ]; then
+    if [ "$(binding)" == "python" ]; then
       export PYBIN=$(which python)
       $PYBIN -m pip install --upgrade pip
       $PYBIN -m pip install --upgrade --ignore-installed setuptools cython pandas wheel
     fi
 
-    if [ "a${julia.version}" != "a" ]; then
+    if [ "a$(julia.version)" != "a" ]; then
       wget https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.3-linux-x86_64.tar.gz
       sudo tar -C /opt/ -xvpf julia-1.6.3-linux-x86_64.tar.gz
     fi
@@ -70,7 +70,7 @@ steps:
 - script: |
     unset BOOST_ROOT
     mkdir build && cd build
-    if [ "${binding}" == "go" ]; then
+    if [ "$(binding)" == "go" ]; then
       export GOPATH=$PWD/src/mlpack/bindings/go
       export GO111MODULE=off
       go get -u -t gonum.org/v1/gonum/...

--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -24,19 +24,19 @@ steps:
 
     sudo apt-get install -y --allow-unauthenticated libopenblas-dev g++ xz-utils
 
-    if [ "$(binding)" == "python" ]; then
+    if [ "${binding}" == "python" ]; then
       export PYBIN=$(which python)
       $PYBIN -m pip install --upgrade pip
       $PYBIN -m pip install --upgrade --ignore-installed setuptools cython pandas wheel
     fi
 
-    if [ "a$(julia.version)" != "a" ]; then
+    if [ "a${julia.version}" != "a" ]; then
       wget https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.3-linux-x86_64.tar.gz
       sudo tar -C /opt/ -xvpf julia-1.6.3-linux-x86_64.tar.gz
     fi
 
     # Install armadillo.
-    curl -k -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz | tar -xvJ && \
+    curl -k -L https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz | tar -xvJ && \
         cd armadillo* && \
         cmake . && \
         make && \
@@ -70,7 +70,7 @@ steps:
 - script: |
     unset BOOST_ROOT
     mkdir build && cd build
-    if [ "$(binding)" == "go" ]; then
+    if [ "${binding}" == "go" ]; then
       export GOPATH=$PWD/src/mlpack/bindings/go
       export GO111MODULE=off
       go get -u -t gonum.org/v1/gonum/...

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -27,10 +27,10 @@ steps:
 - bash: |
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
 
-    curl -O -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz -o armadillo-9.800.6.tar.xz
-    tar -xvf armadillo-9.800.6.tar.xz
+    curl -O -L https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz -o armadillo-10.8.2.tar.xz
+    tar -xvf armadillo-10.8.2.tar.xz
 
-    cd armadillo-9.800.6/ && cmake $(CMakeGenerator) \
+    cd armadillo-10.8.2/ && cmake $(CMakeGenerator) \
     -DBLAS_LIBRARY:FILEPATH=$(Agent.ToolsDirectory)/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a \
     -DLAPACK_LIBRARY:FILEPATH=$(Agent.ToolsDirectory)/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a \
     -DCMAKE_PREFIX:FILEPATH=../../armadillo \
@@ -41,7 +41,7 @@ steps:
 # Build armadillo
 - task: MSBuild@1
   inputs:
-    solution: 'armadillo-9.800.6/*.sln'
+    solution: 'armadillo-10.8.2/*.sln'
     msbuildLocationMethod: 'location'
     msbuildVersion: $(MSBuildVersion)
     configuration: 'Release'
@@ -60,8 +60,8 @@ steps:
     $(CMakeArgs) `
     -DBLAS_LIBRARIES:FILEPATH=$(Agent.ToolsDirectory)\OpenBLAS.0.2.14.1\lib\native\lib\x64\libopenblas.dll.a `
     -DLAPACK_LIBRARIES:FILEPATH=$(Agent.ToolsDirectory)\OpenBLAS.0.2.14.1\lib\native\lib\x64\libopenblas.dll.a `
-    -DARMADILLO_INCLUDE_DIR="..\armadillo-9.800.6\tmp\include" `
-    -DARMADILLO_LIBRARY="..\armadillo-9.800.6\Release\armadillo.lib" `
+    -DARMADILLO_INCLUDE_DIR="..\armadillo-10.8.2\tmp\include" `
+    -DARMADILLO_LIBRARY="..\armadillo-10.8.2\Release\armadillo.lib" `
     -DCEREAL_INCLUDE_DIR="..\cereal-1.3.2\include" `
     -DENSMALLEN_INCLUDE_DIR=$(Agent.ToolsDirectory)\ensmallen.2.17.0\installed\x64-linux\include `
     -DBUILD_JULIA_BINDINGS=OFF `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(USE_PRECOMPILED_HEADERS "Use precompiled headers for mlpack_test build." 
 # For Armadillo, try to keep the minimum required version less than or equal to
 # what's available on the current Ubuntu LTS or most recent stable RHEL release.
 # See https://github.com/mlpack/mlpack/issues/3033 for some more discussion.
-set(ARMADILLO_VERSION "9.800")
+set(ARMADILLO_VERSION "10.8")
 set(ENSMALLEN_VERSION "2.10.0")
 set(CEREAL_VERSION "1.1.2")
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,8 @@ _????-??-??_
  * Implemented the Find and Fill algorithm into the Dropout Layer and added OpenMP support (#3684).
 
  * Update Python bindings to support NumPy 2.x (#3752).
+ 
+ * Bump minimum Armadillo version to 10.8 (#3760).
 
 ## mlpack 4.4.0
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Citations are beneficial for the growth and improvement of mlpack.
 
 **mlpack** requires the following additional dependencies:
  - C++17 compiler
- - [Armadillo](https://arma.sourceforge.net)      &nbsp;&emsp;>= 9.800
+ - [Armadillo](https://arma.sourceforge.net)      &nbsp;&emsp;>= 10.8
  - [ensmallen](https://ensmallen.org)      &emsp;>= 2.10.0
  - [cereal](http://uscilab.github.io/cereal/)         &ensp;&nbsp;&emsp;&emsp;>= 1.1.2
 
@@ -333,7 +333,7 @@ dependencies are installed:
 
  - R >= 4.0
  - Rcpp >= 0.12.12
- - RcppArmadillo >= 0.9.800.0
+ - RcppArmadillo >= 0.10.8.0
  - RcppEnsmallen >= 0.2.10.0
  - roxygen2
  - testthat

--- a/src/mlpack/bindings/go/mlpack/capi/arma_util.hpp
+++ b/src/mlpack/bindings/go/mlpack/capi/arma_util.hpp
@@ -39,9 +39,7 @@ inline typename T::elem_type* GetMemory(T& m)
     arma::access::rw(m.mem_state) = 1;
     // With Armadillo 10 and newer, we must set `n_alloc` to 0 so that
     // Armadillo does not deallocate the memory.
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(m.n_alloc) = 0;
-    #endif
+    arma::access::rw(m.n_alloc) = 0;
     return m.memptr();
   }
 }

--- a/src/mlpack/bindings/julia/julia_util.cpp
+++ b/src/mlpack/bindings/julia/julia_util.cpp
@@ -428,9 +428,7 @@ double* GetParamMat(void* params, const char* paramName)
   else
   {
     arma::access::rw(mat.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(mat.n_alloc) = 0;
-    #endif
+    arma::access::rw(mat.n_alloc) = 0;
     return mat.memptr();
   }
 }
@@ -475,9 +473,7 @@ size_t* GetParamUMat(void* params, const char* paramName)
   else
   {
     arma::access::rw(mat.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(mat.n_alloc) = 0;
-    #endif
+    arma::access::rw(mat.n_alloc) = 0;
     return mat.memptr();
   }
 }
@@ -513,9 +509,7 @@ double* GetParamCol(void* params, const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(vec.n_alloc) = 0;
-    #endif
+    arma::access::rw(vec.n_alloc) = 0;
     return vec.memptr();
   }
 }
@@ -552,9 +546,7 @@ size_t* GetParamUCol(void* params, const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(vec.n_alloc) = 0;
-    #endif
+    arma::access::rw(vec.n_alloc) = 0;
     return vec.memptr();
   }
 }
@@ -590,9 +582,7 @@ double* GetParamRow(void* params, const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(vec.n_alloc) = 0;
-    #endif
+    arma::access::rw(vec.n_alloc) = 0;
     return vec.memptr();
   }
 }
@@ -629,9 +619,7 @@ size_t* GetParamURow(void* params, const char* paramName)
   else
   {
     arma::access::rw(vec.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(vec.n_alloc) = 0;
-    #endif
+    arma::access::rw(vec.n_alloc) = 0;
     return vec.memptr();
   }
 }
@@ -707,9 +695,7 @@ double* GetParamMatWithInfoPtr(void* params, const char* paramName)
   else
   {
     arma::access::rw(m.mem_state) = 1;
-    #if ARMA_VERSION_MAJOR >= 10
-      arma::access::rw(m.n_alloc) = 0;
-    #endif
+    arma::access::rw(m.n_alloc) = 0;
     return m.memptr();
   }
 }

--- a/src/mlpack/bindings/python/mlpack/arma_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/arma_util.hpp
@@ -25,9 +25,8 @@ void SetMemState(T& t, int state)
   // If we just "released" the memory, so that the matrix does not own it, with
   // Armadillo 10 we must also ensure that the matrix does not deallocate the
   // memory by specifying `n_alloc = 0`.
-  #if ARMA_VERSION_MAJOR >= 10
-    const_cast<arma::uword&>(t.n_alloc) = 0;
-  #endif
+  
+  const_cast<arma::uword&>(t.n_alloc) = 0;
 }
 
 /**

--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -50,7 +50,7 @@ struct IsCube
 };
 
 // Commenting out the first template per case, because
-// Visual Studio doesn't like this instantiaion pattern (error C2910).
+// Visual Studio doesn't like this instantiation pattern (error C2910).
 // template<>
 template<typename eT>
 struct IsVector<arma::Col<eT> >
@@ -105,35 +105,17 @@ struct IsCube<arma::Cube<eT> >
   const static bool value = true;
 };
 
+template<typename eT>
+struct IsVector<arma::SpSubview_col<eT> >
+{
+  const static bool value = true;
+};
 
-#if ((ARMA_VERSION_MAJOR >= 10) || \
-    ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)))
-
-  // Armadillo 9.869+ has SpSubview_col and SpSubview_row
-
-  template<typename eT>
-  struct IsVector<arma::SpSubview_col<eT> >
-  {
-    const static bool value = true;
-  };
-
-  template<typename eT>
-  struct IsVector<arma::SpSubview_row<eT> >
-  {
-    const static bool value = true;
-  };
-
-#else
-
-  // fallback for older Armadillo versions
-
-  template<typename eT>
-  struct IsVector<arma::SpSubview<eT> >
-  {
-    const static bool value = true;
-  };
-
-#endif
+template<typename eT>
+struct IsVector<arma::SpSubview_row<eT> >
+{
+  const static bool value = true;
+};
 
 // Get the row vector type corresponding to a given MatType.
 


### PR DESCRIPTION
Bump minimum Armadillo version to 10.8.

This allows using the numerous Armadillo API additions and enhancements since 9.800.  It also allows assuming throughout the mlpack codebase that matrices are initialised to zero by default.

Current state of Armadillo versions in various distros:
- Ubuntu 22.04 LTS has Armadillo 10.8.2
- Ubuntu 24.04 LTS has Armadillo 12.6.7
- Debian 12 has Armadillo 11.4.2
- Debian 13 (testing) has Armadillo 12.8.2
- RHEL EPEL 8 & 9 has Armadillo 12.6.6 (subject to future upgrades)

Related: https://github.com/mlpack/ensmallen/pull/404
