### PR TITLE
Round two of mlpack-bot Github actions fixes

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
      - name: Auto-approve pull requests
-       uses: rcurtin/auto-approve@v1.0.1
+       uses: rcurtin/auto-approve@v1.0.2
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          approval-message:

--- a/.github/workflows/stickers.yaml
+++ b/.github/workflows/stickers.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
         # Forked version of first-interaction that runs only on first merged PR.
-      - uses: rcurtin/first-interaction@v1.0.0
+      - uses: rcurtin/first-interaction@v1.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: "Hello there!  Thanks for your contribution.  Congratulations on your first contribution to mlpack!  If you'd like to add your name to the list of contributors in `COPYRIGHT.txt` and you haven't already, please feel free to push a change to this PR---or, if it gets merged before you can, feel free to open another PR.\n\nIn addition, if you'd like some stickers to put on your laptop, we can get them in the mail for you.  Just send an email with your physical mailing address to stickers@mlpack.org, and then one of the mlpack maintainers will put some stickers in an envelope for you.  It may take a few weeks to get them, depending on your location. :+1:"


### PR DESCRIPTION
This time I am hoping to fix these things:

 * The auto-approve action filtered out all PR reviews less than a day old, so it missed its own review on #3758 and posted a second auto-approval message.  https://github.com/rcurtin/auto-approve/commit/157e87f2904c3accd724af6d085fbc68a100b652 is the actual underlying fix.

 * I don't know why the stickers job (which currently doesn't have permissions to post the comments) thought that I was a first-time contributor in #3758, but I modified the [first-interaction](https://github.com/rcurtin/first-interaction) action to print a bit more debugging output.  So there will definitely be a third round there.