### PR TITLE
Don't fully specify version number for Github actions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
      - name: Auto-approve pull requests
-       uses: rcurtin/auto-approve@v1.0.2
+       uses: rcurtin/auto-approve@v1
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          approval-message:

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
      - name: Auto-approve pull requests
-       uses: rcurtin/auto-approve@v1
+       uses: rcurtin/actions/auto-approve@v1
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          approval-message:

--- a/.github/workflows/stickers.yaml
+++ b/.github/workflows/stickers.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
         # Forked version of first-interaction that runs only on first merged PR.
-      - uses: rcurtin/first-interaction@v1
+      - uses: rcurtin/actions/stickers@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: "Hello there!  Thanks for your contribution.  Congratulations on your first contribution to mlpack!  If you'd like to add your name to the list of contributors in `COPYRIGHT.txt` and you haven't already, please feel free to push a change to this PR---or, if it gets merged before you can, feel free to open another PR.\n\nIn addition, if you'd like some stickers to put on your laptop, we can get them in the mail for you.  Just send an email with your physical mailing address to stickers@mlpack.org, and then one of the mlpack maintainers will put some stickers in an envelope for you.  It may take a few weeks to get them, depending on your location. :+1:"

--- a/.github/workflows/stickers.yaml
+++ b/.github/workflows/stickers.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
         # Forked version of first-interaction that runs only on first merged PR.
-      - uses: rcurtin/first-interaction@v1.0.1
+      - uses: rcurtin/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: "Hello there!  Thanks for your contribution.  Congratulations on your first contribution to mlpack!  If you'd like to add your name to the list of contributors in `COPYRIGHT.txt` and you haven't already, please feel free to push a change to this PR---or, if it gets merged before you can, feel free to open another PR.\n\nIn addition, if you'd like some stickers to put on your laptop, we can get them in the mail for you.  Just send an email with your physical mailing address to stickers@mlpack.org, and then one of the mlpack maintainers will put some stickers in an envelope for you.  It may take a few weeks to get them, depending on your location. :+1:"


### PR DESCRIPTION
I think that I can make my Github actions life a little bit easier if I don't fully specify the version number down to the patch version in the Github actions configurations.

This means I can push patch releases to [rcurtin/auto-approve](https://github.com/rcurtin/auto-approve) and [rcurtin/first-contribution](https://github.com/rcurtin/first-contribution) and those changes should be automatically applied to the mlpack repository.  (So, I can fix things like the auto-approver not approving and the sticker message being sent too liberally behind-the-scenes.)