### PR TITLE
Specify label for stale PRs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
           days-before-issues-stale: 30
           days-before-issue-close: 7
           stale-issue-label: "s: stale"
+          stale-pr-label: "s: stale"
           stale-issue-message: "This issue has been automatically marked as stale because it has not had any recent activity.  It will be closed in 7 days if no further activity occurs.  Thank you for your contributions! :+1:"
           days-before-pr-stale: 30,
           days-before-pr-close: 14


### PR DESCRIPTION
I noticed that the stale labeler was applying the incorrect label to PRs.  It turns out this is because the stale action needs different configuration for `stale-issue-label` and `stale-pr-label`; we were missing the latter, so I just added it.