### PR TITLE
Update the name of the fedora package

### DIFF
--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -24,7 +24,7 @@ sudo apt-get install libmlpack-dev
 and on Fedora or Red Hat:
 
 ```sh
-sudo dnf install mlpack
+sudo dnf install mlpack-devel
 ```
 
 You can also use a Docker image from Dockerhub, 

--- a/doc/user/core.md
+++ b/doc/user/core.md
@@ -1940,7 +1940,7 @@ std::cout << "Kernel values between two floating-point vectors: " << k5
 ### `HyperbolicTangentKernel`
 
 The `HyperbolicTangentKernel` implements the
-[hyperbolic tangent kernel](https://en.wikipedia.org/wiki/Support_vector_machine#Nonlinear_Kernels),
+[hyperbolic tangent kernel](https://en.wikipedia.org/wiki/Support_vector_machine#Nonlinear_kernels),
 which is defined by the following equation:
 `f(x1, x2) = tanh(s * (x1^T x2) + t)`
 where `s` is the scale parameter and `t` is the offset parameter.


### PR DESCRIPTION
Aligned the cpp quickstart fedora package with the instructions from https://www.mlpack.org/download.html