### PR TITLE
Fix compilation errors with clang 19

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -151,12 +151,13 @@ Copyright:
   Copyright 2021, Roshan Nrusing Swain <swainroshan001@gmail.com>
   Copyright 2021, Suvarsha Chennareddy <suvarshachennareddy@gmail.com>
   Copyright 2021, Shubham Agrawal <shubham.agra1206@gmail.com>
-  Copyright 2020-2022, James Joseph Balamuta <balamut2@illinois.edu>  
+  Copyright 2020-2022, James Joseph Balamuta <balamut2@illinois.edu>
   Copyright 2022, Sri Madhan M <srimadhan11@gmail.com>
   Copyright 2022, Zhuojin Liu <zhuojinliu.cs@gmail.com>
   Copyright 2022, Richèl Bilderbeek <richel@richelbilderbeek.nl>
   Copyright 2022, Chetan Pandey <chetanpandey1266@gmail.com>
   Copyright 2024, Nikolay Apanasov <nikolay@apanasov.org>
+  Copyright 2024, Martin Lambertsen <github@lambertsen.one>
 
 License: BSD-3-clause
   All rights reserved.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 _????-??-??_
 
+ * Fix compilation with clang 19 (#3799)
+
 
 ## mlpack 4.5.0
 
@@ -12,7 +14,7 @@ _2024-09-17_
  * Distribute STB headers as part of R package (#3724, #3726).
 
  * Added OpenMP parallelization to Hamerly, Naive, and Elkan k-means (#3761, #3762, #3764).
- 
+
  * Added OpenMP support for fast approximation (#3685).
 
  * Implemented the Find and Fill algorithm into the Dropout Layer and added OpenMP support (#3684).
@@ -120,7 +122,7 @@ _2023-09-05_
   * Add `ClassProbabilities()` member to `DecisionTree` so that the internal
     details of trees can be more easily inspected (#3511).
 
-  * Bipolar sigmoid activation function added and invertible functions 
+  * Bipolar sigmoid activation function added and invertible functions
     fixed (#3506).
 
   * Add auto-configured `mlpack/config.hpp` to contain configuration details of

--- a/src/mlpack/core/tree/octree/octree_impl.hpp
+++ b/src/mlpack/core/tree/octree/octree_impl.hpp
@@ -378,8 +378,8 @@ operator=(const Octree& other)
     delete children[i];
   children.clear();
 
-  begin = other.Begin();
-  count = other.Count();
+  begin = other.begin;
+  count = other.count;
   bound = other.bound;
   dataset = ((other.parent == NULL) ? new MatType(*other.dataset) : NULL);
   parent = NULL;
@@ -442,8 +442,8 @@ operator=(Octree&& other)
   children.clear();
 
   children = std::move(other.children);
-  begin = other.Begin();
-  count = other.Count();
+  begin = other.begin;
+  count = other.count;
   bound = std::move(other.bound);
   dataset = other.dataset;
   parent = other.Parent();
@@ -460,7 +460,6 @@ operator=(Octree&& other)
   other.count = 0;
   other.dataset = new MatType();
   other.parentDistance = 0.0;
-  other.numDescendants = 0;
   other.furthestDescendantDistance = 0.0;
   other.parent = NULL;
 


### PR DESCRIPTION
The new compiler version seems to perform more exhaustive checks on templates, even if they are not initiated. As the code was malformed also before, it is likely that it is dead code. However, this commit is mainly to ensure users using clang 19 can include the header without compilation error.

Note that this commit does not guarantee that currently other code might not compile with clang 19, it just fixes some code which was used transitevily and caused problems.