### PR TITLE
Use Go modules for Go bindings

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -69,11 +69,6 @@ steps:
 # Configure mlpack (CMake)
 - script: |
     mkdir build && cd build
-    if [ "$BINDING" = "go" ]; then
-      export GOPATH=$PWD/src/mlpack/bindings/go
-      export GO111MODULE=off
-      go get -u -t gonum.org/v1/gonum/...
-    fi
     cmake $CMAKEARGS -DPYTHON_EXECUTABLE=`which python` -DCEREAL_INCLUDE_DIR=/usr/include/ ..
   displayName: 'CMake'
 

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -24,6 +24,10 @@ steps:
       brew install --cask julia
     fi
 
+    if [ "$BINDING" = "go" ]; then
+      brew install go
+    fi
+
   displayName: 'Install Build Dependencies'
 
 # Configure mlpack (CMake)

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -33,11 +33,6 @@ steps:
 # Configure mlpack (CMake)
 - script: |
     mkdir build && cd build
-    if [ "$BINDING" = "go" ]; then
-      export GOPATH=$PWD/src/mlpack/bindings/go
-      export GO111MODULE=off
-      go get -u gonum.org/v1/gonum/...
-    fi
     if [ "$BINDING" = "python" ]; then
       cmake $CMAKEARGS -DPYTHON_EXECUTABLE=$(which python) ..
     else

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -36,7 +36,7 @@ steps:
     if [ "$BINDING" = "go" ]; then
       export GOPATH=$PWD/src/mlpack/bindings/go
       export GO111MODULE=off
-      go get -u -t gonum.org/v1/gonum/...
+      go get -u gonum.org/v1/gonum/...
     fi
     if [ "$BINDING" = "python" ]; then
       cmake $CMAKEARGS -DPYTHON_EXECUTABLE=$(which python) ..

--- a/README.md
+++ b/README.md
@@ -400,10 +400,19 @@ the Gonum package is available.  You can use `go get` to install mlpack as a
 module in a Go project:
 
 ```sh
-go get -u -d mlpack.org/v1/mlpack
-cd ${GOPATH}/src/mlpack.org/v1/mlpack
-make install
+go get -u mlpack.org/v1/mlpack
 ```
+
+The Go bindings themselves will then need to be compiled.  Find the mlpack
+directory under `$GOMODCACHE/mlpack.org/v1/mlpack` and run these commands:
+
+```sh
+make
+sudo make install
+```
+
+Then, `go run my_code.go` will be able to correctly link against mlpack's Go
+bindings and run.
 
 The process of building the Go bindings by hand is a little tedious, so
 following the steps above is recommended.  However, if you wish to build the Go

--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ and then `using mlpack` should work.
 *See also the [Go quickstart](doc/quickstart/go.md).*
 
 To build mlpack's Go bindings, ensure that Go >= 1.11.0 is installed, and that
-the Gonum package is available.  You can use `go get` to install mlpack for Go:
+the Gonum package is available.  You can use `go get` to install mlpack as a
+module in a Go project:
 
 ```sh
 go get -u -d mlpack.org/v1/mlpack

--- a/doc/quickstart/go.md
+++ b/doc/quickstart/go.md
@@ -9,13 +9,21 @@ This quickstart guide is also available for [C++](cpp.md), [Python](python.md),
 ## Installing mlpack
 
 Installing the mlpack bindings for Go is somewhat time-consuming as the library
-must be built; you can run the following code:
+must be built; you can run the following to add mlpack as a dependency inside of
+a Go module:
 
 ```sh
 go get -u -d mlpack.org/v1/mlpack
-cd ${GOPATH}/src/mlpack.org/v1/mlpack
-make install
 ```
+
+The Go bindings themselves will then need to be compiled.  Find the mlpack
+directory under `$GOMODCACHE/mlpack.org/v1/mlpack` and run these commands:
+
+```sh
+make
+sudo make install
+```
+
 Building the Go bindings from scratch is a little more in-depth, though.  For
 information on that, follow the instructions in the
 [main README](../../README.md).

--- a/src/mlpack/bindings/go/CMakeLists.txt
+++ b/src/mlpack/bindings/go/CMakeLists.txt
@@ -40,20 +40,17 @@ endif ()
 
 if (BUILD_GO_BINDINGS)
 
+  # Gonum will automatically be installed by Go's module support during build.
   find_package(Go 1.11.0)
   if (NOT GO_FOUND)
     set(GO_NOT_FOUND_MSG "${GO_NOT_FOUND_MSG}\n    - Go")
-  endif ()
-  find_package(Gonum)
-  if (NOT GONUM_FOUND)
-    set(GO_NOT_FOUND_MSG "${GO_NOT_FOUND_MSG}\n    - Gonum")
   endif ()
 
   ## We need to check here if Golang is even available.  Although actually
   ## technically, I'm not sure if we even need to know!  For the tests though we
   ## do.  So it's probably a good idea to check.
   if (FORCE_BUILD_GO_BINDINGS)
-    if (NOT GO_FOUND OR NOT GONUM_FOUND)
+    if (NOT GO_FOUND)
       unset(BUILD_GO_BINDINGS CACHE)
       set(BUILD_GO_SHLIB OFF)
       message(FATAL_ERROR "\nCould not Build Go Bindings; the following modules are not available: ${GO_NOT_FOUND_MSG}")

--- a/src/mlpack/bindings/go/tests/CMakeLists.txt
+++ b/src/mlpack/bindings/go/tests/CMakeLists.txt
@@ -5,7 +5,4 @@ if (BUILD_GO_BINDINGS)
 add_test(NAME go_binding_test
     COMMAND ${GO_EXECUTABLE} test -v  ${CMAKE_CURRENT_SOURCE_DIR}/go_binding_test.go
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/mlpack/bindings/go/src/mlpack.org/v1/mlpack/)
-set_tests_properties(go_binding_test
-      PROPERTIES ENVIRONMENT "GOPATH=$ENV{GOPATH}:${CMAKE_BINARY_DIR}/src/mlpack/bindings/go/;
-      LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/src/mlpack/bindings/go/src/mlpack.org/v1/mlpack/")
 endif()


### PR DESCRIPTION
Just noticed that the MacOS CI builds for Go are failing, looks like because Go is not installed.  Let's see if this fixes it...

*Edit*: in the process of debugging the MacOS Go build, I figured out what was necessary to use Go modules. (This is the "new" way for Go packages as of... 2018? It's been a while.)

Basically Go in modules mode will go and get the dependencies we need during the build process (just Gonum). So, instead of checking for it in the CMake configuration step, we can just depend on the go build system to install gonum as needed.

Then, I updated the quickstart and installation directions to work with Go modules.