### PR TITLE
Fix copy/move constructor and operator for LSTM layer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,8 +4,9 @@
 
 _????-??-??_
 
- * Fix compilation with clang 19 (#3799)
+ * Fix compilation with clang 19 (#3799).
 
+ * Fix LSTM layer copy/move constructors (#3809).
 
 ## mlpack 4.5.0
 

--- a/src/mlpack/methods/ann/layer/lstm_impl.hpp
+++ b/src/mlpack/methods/ann/layer/lstm_impl.hpp
@@ -20,6 +20,7 @@ namespace mlpack {
 template<typename MatType>
 LSTMType<MatType>::LSTMType() :
     RecurrentLayer<MatType>(),
+    inSize(0),
     outSize(0)
 {
   // Nothing to do here.
@@ -28,6 +29,7 @@ LSTMType<MatType>::LSTMType() :
 template<typename MatType>
 LSTMType<MatType>::LSTMType(const size_t outSize) :
     RecurrentLayer<MatType>(),
+    inSize(0),
     outSize(outSize)
 {
   // Nothing to do here.
@@ -35,16 +37,21 @@ LSTMType<MatType>::LSTMType(const size_t outSize) :
 
 template<typename MatType>
 LSTMType<MatType>::LSTMType(const LSTMType& layer) :
-    RecurrentLayer<MatType>(layer)
+    RecurrentLayer<MatType>(layer),
+    inSize(layer.inSize),
+    outSize(layer.outSize)
 {
   // Nothing to do here.
 }
 
 template<typename MatType>
 LSTMType<MatType>::LSTMType(LSTMType&& layer) :
-    RecurrentLayer<MatType>(std::move(layer))
+    RecurrentLayer<MatType>(std::move(layer)),
+    inSize(layer.inSize),
+    outSize(layer.outSize)
 {
-  // Nothing to do here.
+  layer.inSize = 0;
+  layer.outSize = 0;
 }
 
 template<typename MatType>
@@ -53,6 +60,8 @@ LSTMType<MatType>& LSTMType<MatType>::operator=(const LSTMType& layer)
   if (this != &layer)
   {
     RecurrentLayer<MatType>::operator=(layer);
+    inSize = layer.inSize;
+    outSize = layer.outSize;
   }
 
   return *this;
@@ -64,6 +73,11 @@ LSTMType<MatType>& LSTMType<MatType>::operator=(LSTMType&& layer)
   if (this != &layer)
   {
     RecurrentLayer<MatType>::operator=(std::move(layer));
+    inSize = layer.inSize;
+    outSize = layer.outSize;
+
+    layer.inSize = 0;
+    layer.outSize = 0;
   }
 
   return *this;


### PR DESCRIPTION
I debugged mlpack/examples#239 and found that the `LSTM` layer did not properly copy all of its internal members, leading to an attempted way-too-large memory allocations in some cases.

The fix is pretty simple: `inSize` and `outSize` just need to be set correctly.

Thanks @CyberShadow for the report!