### PR TITLE
Modernize STL type traits

### DIFF
--- a/doc/developer/trees.md
+++ b/doc/developer/trees.md
@@ -222,7 +222,7 @@ class ExampleTree
   template<typename Archive>
   ExampleTree(
       Archive& ar,
-      const typename std::enable_if_c<typename Archive::is_loading>::type* = 0);
+      const std::enable_if_t<typename Archive::is_loading>* = 0);
 
   // Release any resources held by the tree.
   ~ExampleTree();
@@ -476,7 +476,7 @@ archive:
 template<typename Archive>
 ExampleTree(
     Archive& ar,
-    const typename std::enable_if_c<typename Archive::is_loading>::type* = 0);
+    const std::enable_if_t<typename Archive::is_loading>* = 0);
 ```
 
 This has implications on how the tree must be stored.  In this case, the dataset

--- a/doc/user/cv.md
+++ b/doc/user/cv.md
@@ -111,7 +111,7 @@ DecisionTree(MatType&& data,
              WeightsType&& weights,
              const size_t minimumLeafSize = 10,
              const std::enable_if_t<arma::is_arma_type<
-                 typename std::remove_reference<WeightsType>::type>::value>*
+                 std::remove_reference_t<WeightsType>>::value>*
                   = 0);
 ```
 

--- a/src/mlpack/bindings/R/default_param.hpp
+++ b/src/mlpack/bindings/R/default_param.hpp
@@ -48,8 +48,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const std::enable_if_t<std::is_same_v<T, std::string>
-        >* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>>* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -62,7 +61,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */ = 0);
+                                     arma::mat>>>* /* junk */ = 0);
 
 /**
  * Return the default value of a model option (this returns the default

--- a/src/mlpack/bindings/R/default_param.hpp
+++ b/src/mlpack/bindings/R/default_param.hpp
@@ -26,13 +26,13 @@ namespace r {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -40,7 +40,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return the default value of a string option.
@@ -48,8 +48,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value
-        >::type* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>
+        >* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -59,10 +59,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */ = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -71,8 +71,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be
@@ -84,7 +84,7 @@ void DefaultParam(util::ParamData& data,
                   void* output)
 {
   std::string* outstr = (std::string*) output;
-  *outstr = DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+  *outstr = DefaultParamImpl<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -24,15 +24,15 @@ namespace r {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T, std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     // If this is the verbose option, print the default that uses the global
     // package option.
@@ -58,13 +58,13 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
   const T& vector = std::any_cast<T>(data.value);
   oss << "c(";
-  if (std::is_same<T, std::vector<std::string>>::value)
+  if (std::is_same_v<T, std::vector<std::string>>)
   {
     if (vector.size() > 0)
     {
@@ -101,7 +101,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, std::string>>*)
 {
   const std::string& s = *std::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -114,21 +114,21 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same<T, arma::rowvec>::value ||
-      std::is_same<T, arma::vec>::value ||
-      std::is_same<T, arma::mat>::value)
+  if (std::is_same_v<T, arma::rowvec> ||
+      std::is_same_v<T, arma::vec> ||
+      std::is_same_v<T, arma::mat>)
   {
     return "matrix(numeric(), 0, 0)";
   }
-  else if (std::is_same<T, arma::Row<size_t>>::value ||
-      std::is_same<T, arma::Col<size_t>>::value ||
-      std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Row<size_t>> ||
+      std::is_same_v<T, arma::Col<size_t>> ||
+      std::is_same_v<T, arma::Mat<size_t>>)
   {
     return "matrix(integer(), 0, 0)";
   }
@@ -144,8 +144,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "NA";
 }

--- a/src/mlpack/bindings/R/default_param_impl.hpp
+++ b/src/mlpack/bindings/R/default_param_impl.hpp
@@ -117,7 +117,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */)
+                                     arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
   if (std::is_same_v<T, arma::rowvec> ||

--- a/src/mlpack/bindings/R/get_printable_param.hpp
+++ b/src/mlpack/bindings/R/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace r {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Get the matrix.
   const T& matrix = std::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << std::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // Get the matrix.
   const T& tuple = std::any_cast<T>(data.value);
@@ -116,7 +116,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/get_printable_type.hpp
+++ b/src/mlpack/bindings/R/get_printable_type.hpp
@@ -23,88 +23,88 @@ namespace r {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<
-        !std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<
+        !std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
-    const typename std::enable_if<!std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*,
+    const std::enable_if_t<!std::is_same_v<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,
@@ -112,7 +112,7 @@ void GetPrintableType(util::ParamData& d,
                       void* output)
 {
   *((std::string*) output) =
-      GetPrintableType<typename std::remove_pointer<T>::type>(d);
+      GetPrintableType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/get_printable_type.hpp
+++ b/src/mlpack/bindings/R/get_printable_type.hpp
@@ -50,12 +50,9 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<
         !std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*);

--- a/src/mlpack/bindings/R/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/R/get_printable_type_impl.hpp
@@ -22,11 +22,11 @@ namespace r {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "unknown";
 }
@@ -34,11 +34,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "integer";
 }
@@ -46,11 +46,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "numeric";
 }
@@ -58,15 +58,15 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<
-        !std::is_same<std::string,
-         std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<
+        !std::is_same_v<std::string,
+         std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "character";
 }
@@ -74,11 +74,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
-    const typename std::enable_if<!std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*,
+    const std::enable_if_t<!std::is_same_v<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "integer";
 }
@@ -86,11 +86,11 @@ inline std::string GetPrintableType<size_t>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "logical";
 }
@@ -98,9 +98,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "vector of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -108,17 +108,17 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string type = "numeric matrix";
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_row || T::is_col)
       type = "numeric vector";
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     type = "integer matrix";
     if (T::is_row || T::is_col)
@@ -131,8 +131,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "categorical matrix/data.frame";
 }
@@ -140,10 +140,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string type = util::StripType(d.cppType);
   if (type == "mlpackModel")

--- a/src/mlpack/bindings/R/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/R/get_printable_type_impl.hpp
@@ -58,12 +58,9 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<
         !std::is_same_v<std::string,
          std::tuple<data::DatasetInfo, arma::mat>>>*)

--- a/src/mlpack/bindings/R/get_r_type.hpp
+++ b/src/mlpack/bindings/R/get_r_type.hpp
@@ -83,12 +83,9 @@ inline std::string GetRType<double>(
 template<>
 inline std::string GetRType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<
         !std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*)

--- a/src/mlpack/bindings/R/get_r_type.hpp
+++ b/src/mlpack/bindings/R/get_r_type.hpp
@@ -23,11 +23,11 @@ namespace r {
 template<typename T>
 inline std::string GetRType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "unknown";
 }
@@ -35,11 +35,11 @@ inline std::string GetRType(
 template<>
 inline std::string GetRType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "logical";
 }
@@ -47,11 +47,11 @@ inline std::string GetRType<bool>(
 template<>
 inline std::string GetRType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "integer";
 }
@@ -59,11 +59,11 @@ inline std::string GetRType<int>(
 template<>
 inline std::string GetRType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
-    const typename std::enable_if<!std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*,
+    const std::enable_if_t<!std::is_same_v<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "integer";
 }
@@ -71,11 +71,11 @@ inline std::string GetRType<size_t>(
 template<>
 inline std::string GetRType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "numeric";
 }
@@ -83,15 +83,15 @@ inline std::string GetRType<double>(
 template<>
 inline std::string GetRType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<
-        !std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<
+        !std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "character";
 }
@@ -99,7 +99,7 @@ inline std::string GetRType<std::string>(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   return GetRType<typename T::value_type>(d) + " vector";
 }
@@ -107,9 +107,9 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   std::string elemType = GetRType<typename T::elem_type>(d);
   std::string type = "matrix";
@@ -124,8 +124,8 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "numeric matrix/data.frame with info";
 }
@@ -133,8 +133,8 @@ inline std::string GetRType(
 template<typename T>
 inline std::string GetRType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   return util::StripType(d.cppType);
 }

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -24,11 +24,11 @@ namespace r {
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "unknown";
 }
@@ -36,11 +36,11 @@ inline std::string GetType(
 template<>
 inline std::string GetType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "Int";
 }
@@ -48,11 +48,11 @@ inline std::string GetType<int>(
 template<>
 inline std::string GetType<float>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*,
-    const typename std::enable_if<!std::is_same<float,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<float>::value>*,
+    const std::enable_if_t<!data::HasSerialize<float>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<float>::value>*,
+    const std::enable_if_t<!std::is_same_v<float,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "Float";
 }
@@ -60,11 +60,11 @@ inline std::string GetType<float>(
 template<>
 inline std::string GetType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "Double";
 }
@@ -72,14 +72,14 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "String";
 }
@@ -87,11 +87,11 @@ inline std::string GetType<std::string>(
 template<>
 inline std::string GetType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "Bool";
 }
@@ -99,9 +99,9 @@ inline std::string GetType<bool>(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "Vec" + GetType<typename T::value_type>(d);
 }
@@ -109,12 +109,12 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::string type = "";
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_row)
       type = "Row";
@@ -123,7 +123,7 @@ inline std::string GetType(
     else
       type = "Mat";
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     if (T::is_row)
       type = "URow";
@@ -139,8 +139,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "MatWithInfo";
 }
@@ -148,8 +148,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   return d.cppType;
 }
@@ -170,7 +170,7 @@ void GetType(util::ParamData& d,
              void* output)
 {
   *((std::string*) output) =
-      GetType<typename std::remove_pointer<T>::type>(d);
+      GetType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/get_type.hpp
+++ b/src/mlpack/bindings/R/get_type.hpp
@@ -72,12 +72,9 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*)
 {

--- a/src/mlpack/bindings/R/print_doc.hpp
+++ b/src/mlpack/bindings/R/print_doc.hpp
@@ -82,7 +82,7 @@ void PrintDoc(util::ParamData& d,
     }
   }
 
-  oss << " (" << GetRType<typename std::remove_pointer<T>::type>(d) << ").";
+  oss << " (" << GetRType<std::remove_pointer_t<T>>(d) << ").";
 
   if (out)
     oss << "}";

--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -29,7 +29,7 @@ void PrintInputParam(util::ParamData& d,
                      void* /* output */)
 {
   MLPACK_COUT_STREAM << d.name;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     if (d.name == "verbose")
     {

--- a/src/mlpack/bindings/R/print_input_processing.hpp
+++ b/src/mlpack/bindings/R/print_input_processing.hpp
@@ -26,10 +26,10 @@ namespace r {
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   if (!d.required)
   {
@@ -72,7 +72,7 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   std::string extraTransStr = "";
   if (d.cppType == "arma::mat")
@@ -135,8 +135,8 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   if (!d.required)
   {
@@ -182,8 +182,8 @@ void PrintInputProcessing(
 template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   if (!d.required)
   {
@@ -229,7 +229,7 @@ void PrintInputProcessing(util::ParamData& d,
                           const void* /* input */,
                           void* /* output */)
 {
-  PrintInputProcessing<typename std::remove_pointer<T>::type>(d);
+  PrintInputProcessing<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/print_output_processing.hpp
+++ b/src/mlpack/bindings/R/print_output_processing.hpp
@@ -26,10 +26,10 @@ namespace r {
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   /**
    * This gives us code like:
@@ -48,9 +48,9 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   /**
    * This gives us code like:
@@ -69,8 +69,8 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   /**
    * This gives us code like:
@@ -89,8 +89,8 @@ void PrintOutputProcessing(
 template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   /**
    * This gives us code like:
@@ -112,7 +112,7 @@ void PrintOutputProcessing(util::ParamData& d,
                            const void* /*input*/,
                            void* /* output */)
 {
-  PrintOutputProcessing<typename std::remove_pointer<T>::type>(d);
+  PrintOutputProcessing<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/print_serialize_util.hpp
+++ b/src/mlpack/bindings/R/print_serialize_util.hpp
@@ -25,8 +25,8 @@ namespace r {
 template<typename T>
 void PrintSerializeUtil(
     util::ParamData& /* d */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   // Do Nothing.
 }
@@ -37,7 +37,7 @@ void PrintSerializeUtil(
 template<typename T>
 void PrintSerializeUtil(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Do Nothing.
 }
@@ -48,8 +48,8 @@ void PrintSerializeUtil(
 template<typename T>
 void PrintSerializeUtil(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   /**
    * This gives us code like:
@@ -76,7 +76,7 @@ void PrintSerializeUtil(util::ParamData& d,
                         const void* /*input*/,
                         void* /* output */)
 {
-  PrintSerializeUtil<typename std::remove_pointer<T>::type>(d);
+  PrintSerializeUtil<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/print_type_doc.hpp
+++ b/src/mlpack/bindings/R/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace r {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -53,8 +53,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -74,7 +74,7 @@ void PrintTypeDoc(util::ParamData& data,
                   void* output)
 {
   *((std::string*) output) =
-      PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+      PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace r

--- a/src/mlpack/bindings/R/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/R/print_type_doc_impl.hpp
@@ -24,29 +24,29 @@ namespace r {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // A flag type.
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     return "A boolean flag option (i.e. `TRUE` or `FALSE`).";
   }
   // An integer.
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
   {
     return "An integer (i.e., `1`).";
   }
   // A floating point value.
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
   {
     return "A floating-point number (i.e., `0.5`).";
   }
   // A string.
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
   {
     return "A character string (i.e., `\"hello\"`).";
   }
@@ -64,13 +64,13 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
   {
     return "A vector of integers; i.e., `c(0, 1, 2)`.";
   }
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
   {
     return "A vector of strings; i.e., `c(\"hello\", \"goodbye\")`.";
   }
@@ -86,9 +86,9 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_col || T::is_row)
     {
@@ -102,7 +102,7 @@ std::string PrintTypeDoc(
           "2-d `matrix`).";
     }
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     if (T::is_col || T::is_row)
     {
@@ -128,8 +128,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "A 2-d array containing `numeric` data.  Like the regular 2-d matrices"
       ", this can be a `matrix`, or a `data.frame`. However, this type can also"
@@ -146,8 +146,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "An mlpack model pointer.  `<Model>` refers to the type of model that "
       "is being stored, so, e.g., for `cf()`, the type will be `CFModel`. "

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -33,15 +33,12 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const std::enable_if_t<!std::is_same_v<T,
-                    bool>>* = 0,
-                const std::enable_if_t<!
-                    arma::is_arma_type<T>::value>* = 0,
-                const std::enable_if_t<!
-                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
                 const std::enable_if_t<std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>* = 0)
+                               arma::mat>>>* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -65,15 +62,12 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const std::enable_if_t<!std::is_same_v<T,
-                    bool>>* = 0,
-                const std::enable_if_t<!
-                    arma::is_arma_type<T>::value>* = 0,
-                const std::enable_if_t<
-                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
                 const std::enable_if_t<!std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>* = 0)
+                               arma::mat>>>* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -97,13 +91,11 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const std::enable_if_t<!
-                    std::is_same_v<T, bool>>* = 0,
-                const std::enable_if_t<
-                    arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
                 const std::enable_if_t<!std::is_same_v<T,
                   std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>* = 0)
+                             arma::mat>>>* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -127,15 +119,12 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const std::enable_if_t<!
-                    std::is_same_v<T, bool>>* = 0,
-                const std::enable_if_t<!
-                    arma::is_arma_type<T>::value>* = 0,
-                const std::enable_if_t<!
-                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
                 const std::enable_if_t<!std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>* = 0)
+                               arma::mat>>>* = 0)
 {
   app.add_option_function<T>(cliName.c_str(),
       [&param](const T& value)
@@ -157,15 +146,12 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const std::enable_if_t<
-                    std::is_same_v<T, bool>>* = 0,
-                const std::enable_if_t<!
-                    arma::is_arma_type<T>::value>* = 0,
-                const std::enable_if_t<!
-                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
                 const std::enable_if_t<!std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>>* = 0)
+                               arma::mat>>>* = 0)
 {
   app.add_flag_function(cliName.c_str(),
       [&param](const T& value)

--- a/src/mlpack/bindings/cli/add_to_cli11.hpp
+++ b/src/mlpack/bindings/cli/add_to_cli11.hpp
@@ -33,15 +33,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename std::enable_if<!std::is_same<T,
-                    bool>::value>::type* = 0,
-                const typename std::enable_if<!
-                    arma::is_arma_type<T>::value>::type* = 0,
-                const typename std::enable_if<!
-                    data::HasSerialize<T>::value>::type* = 0,
-                const typename std::enable_if<std::is_same<T,
+                const std::enable_if_t<!std::is_same_v<T,
+                    bool>>* = 0,
+                const std::enable_if_t<!
+                    arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!
+                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>::value>::type* = 0)
+                    arma::mat>>>* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -65,15 +65,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename std::enable_if<!std::is_same<T,
-                    bool>::value>::type* = 0,
-                const typename std::enable_if<!
-                    arma::is_arma_type<T>::value>::type* = 0,
-                const typename std::enable_if<
-                    data::HasSerialize<T>::value>::type* = 0,
-                const typename std::enable_if<!std::is_same<T,
+                const std::enable_if_t<!std::is_same_v<T,
+                    bool>>* = 0,
+                const std::enable_if_t<!
+                    arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<
+                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>::value>::type* = 0)
+                    arma::mat>>>* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -97,13 +97,13 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename std::enable_if<!
-                    std::is_same<T, bool>::value>::type* = 0,
-                const typename std::enable_if<
-                    arma::is_arma_type<T>::value>::type* = 0,
-                const typename std::enable_if<!std::is_same<T,
+                const std::enable_if_t<!
+                    std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<
+                    arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T,
                   std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>::value>::type* = 0)
+                    arma::mat>>>* = 0)
 {
   app.add_option_function<std::string>(cliName.c_str(),
       [&param](const std::string& value)
@@ -127,15 +127,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename std::enable_if<!
-                    std::is_same<T, bool>::value>::type* = 0,
-                const typename std::enable_if<!
-                    arma::is_arma_type<T>::value>::type* = 0,
-                const typename std::enable_if<!
-                    data::HasSerialize<T>::value>::type* = 0,
-                const typename std::enable_if<!std::is_same<T,
+                const std::enable_if_t<!
+                    std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<!
+                    arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!
+                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>::value>::type* = 0)
+                    arma::mat>>>* = 0)
 {
   app.add_option_function<T>(cliName.c_str(),
       [&param](const T& value)
@@ -157,15 +157,15 @@ template<typename T>
 void AddToCLI11(const std::string& cliName,
                 util::ParamData& param,
                 CLI::App& app,
-                const typename std::enable_if<
-                    std::is_same<T, bool>::value>::type* = 0,
-                const typename std::enable_if<!
-                    arma::is_arma_type<T>::value>::type* = 0,
-                const typename std::enable_if<!
-                    data::HasSerialize<T>::value>::type* = 0,
-                const typename std::enable_if<!std::is_same<T,
+                const std::enable_if_t<
+                    std::is_same_v<T, bool>>* = 0,
+                const std::enable_if_t<!
+                    arma::is_arma_type<T>::value>* = 0,
+                const std::enable_if_t<!
+                    data::HasSerialize<T>::value>* = 0,
+                const std::enable_if_t<!std::is_same_v<T,
                     std::tuple<mlpack::data::DatasetInfo,
-                    arma::mat>>::value>::type* = 0)
+                    arma::mat>>>* = 0)
 {
   app.add_flag_function(cliName.c_str(),
       [&param](const T& value)
@@ -194,14 +194,14 @@ void AddToCLI11(util::ParamData& param,
 
   // Generate the name to be given to CLI11.
   const std::string mappedName =
-      MapParameterName<typename std::remove_pointer<T>::type>(param.name);
+      MapParameterName<std::remove_pointer_t<T>>(param.name);
   std::string cliName = (param.alias != '\0') ?
       "-" + std::string(1, param.alias) + ",--" + mappedName :
       "--" + mappedName;
 
   // Note that we have to add the option as type equal to the mapped type, not
   // the true type of the option.
-  AddToCLI11<typename std::remove_pointer<T>::type>(
+  AddToCLI11<std::remove_pointer_t<T>>(
       cliName, param, *app);
 }
 

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -91,21 +91,21 @@ class CLIOption
     data.cppType = cppName;
 
     // Apply default value.
-    if (std::is_same<typename std::remove_pointer<N>::type,
-                     typename ParameterType<typename
-                         std::remove_pointer<N>::type>::type>::value)
+    if (std::is_same_v<std::remove_pointer_t<N>,
+                     typename ParameterType<
+                         std::remove_pointer_t<N>>::type>)
     {
       data.value = defaultValue;
     }
     else
     {
-      typename ParameterType<typename std::remove_pointer<N>::type>::type tmp;
+      typename ParameterType<std::remove_pointer_t<N>>::type tmp;
       data.value = std::tuple<N, decltype(tmp)>(defaultValue, tmp);
     }
 
     const std::string tname = data.tname;
     const std::string cliName = MapParameterName<
-        typename std::remove_pointer<N>::type>(identifier);
+        std::remove_pointer_t<N>>(identifier);
     std::string progOptId = (alias[0] != '\0') ?
         "-" + std::string(1, alias[0]) + ",--" + cliName : "--" + cliName;
 

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -92,8 +92,7 @@ class CLIOption
 
     // Apply default value.
     if (std::is_same_v<std::remove_pointer_t<N>,
-                     typename ParameterType<
-                         std::remove_pointer_t<N>>::type>)
+                       typename ParameterType<std::remove_pointer_t<N>>::type>)
     {
       data.value = defaultValue;
     }

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -29,8 +29,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
     const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
     const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>* = 0,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
@@ -48,8 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const std::enable_if_t<std::is_same_v<T, std::string>
-        >* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>>* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -62,7 +60,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */ = 0);
+                                     arma::mat>>>* /* junk */ = 0);
 
 /**
  * Return the default value of a model option (this returns the default

--- a/src/mlpack/bindings/cli/default_param.hpp
+++ b/src/mlpack/bindings/cli/default_param.hpp
@@ -26,13 +26,13 @@ namespace cli {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -40,7 +40,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return the default value of a string option.
@@ -48,8 +48,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value
-        >::type* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>
+        >* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -59,10 +59,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */ = 0);
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */ = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -71,8 +71,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be
@@ -84,7 +84,7 @@ void DefaultParam(util::ParamData& data,
                   void* output)
 {
   std::string* outstr = (std::string*) output;
-  *outstr = DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+  *outstr = DefaultParamImpl<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -27,8 +27,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>*,
     const std::enable_if_t<!util::IsStdVector<T>::value>*,
     const std::enable_if_t<!data::HasSerialize<T>::value>*,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>*,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
@@ -104,7 +103,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */)
+                                     arma::mat>>>* /* junk */)
 {
   // The filename will always be empty.
   return "''";

--- a/src/mlpack/bindings/cli/default_param_impl.hpp
+++ b/src/mlpack/bindings/cli/default_param_impl.hpp
@@ -24,16 +24,16 @@ namespace cli {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
-  if (!std::is_same<T, bool>::value)
+  if (!std::is_same_v<T, bool>)
     oss << std::any_cast<T>(data.value);
 
   return oss.str();
@@ -45,13 +45,13 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
   const T& vector = std::any_cast<T>(data.value);
   oss << "[";
-  if (std::is_same<T, std::vector<std::string>>::value)
+  if (std::is_same_v<T, std::vector<std::string>>)
   {
     if (vector.size() > 0)
     {
@@ -89,7 +89,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, std::string>>*)
 {
   const std::string& s = *std::any_cast<std::string>(&data.value);
   return "'" + s + "'";
@@ -101,10 +101,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */)
 {
   // The filename will always be empty.
   return "''";
@@ -116,8 +116,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "''";
 }

--- a/src/mlpack/bindings/cli/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/delete_allocated_memory.hpp
@@ -21,8 +21,8 @@ namespace cli {
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -30,7 +30,7 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -38,8 +38,8 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
   typedef std::tuple<T*, std::string> TupleType;
@@ -52,7 +52,7 @@ void DeleteAllocatedMemory(
     const void* /* input */,
     void* /* output */)
 {
-  DeleteAllocatedMemoryImpl<typename std::remove_pointer<T>::type>(d);
+  DeleteAllocatedMemoryImpl<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -53,8 +53,7 @@ void GetAllocatedMemory(util::ParamData& d,
                         const void* /* input */,
                         void* output)
 {
-  *((void**) output) =
-      GetAllocatedMemory<std::remove_pointer_t<T>>(d);
+  *((void**) output) = GetAllocatedMemory<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -22,8 +22,8 @@ namespace cli {
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   return NULL;
 }
@@ -31,7 +31,7 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   return NULL;
 }
@@ -39,8 +39,8 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Here we have a model, which is a tuple, and we need the address of the
   // memory.
@@ -54,7 +54,7 @@ void GetAllocatedMemory(util::ParamData& d,
                         void* output)
 {
   *((void**) output) =
-      GetAllocatedMemory<typename std::remove_pointer<T>::type>(d);
+      GetAllocatedMemory<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -28,10 +28,10 @@ namespace cli {
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0)
 {
   // No mapping is needed, so just cast it directly.
   return *std::any_cast<T>(&d.value);
@@ -45,7 +45,7 @@ T& GetParam(
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // If the matrix is an input matrix, we have to load the matrix.  'value'
   // contains the filename.  It's possible we could load empty matrices many
@@ -80,8 +80,8 @@ T& GetParam(
 template<typename T>
 T& GetParam(
     util::ParamData& d,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0)
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
@@ -110,8 +110,8 @@ T& GetParam(
 template<typename T>
 T*& GetParam(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // If the model is an input model, we have to load it from file.  'value'
   // contains the filename.
@@ -140,7 +140,7 @@ template<typename T>
 void GetParam(util::ParamData& d, const void* /* input */, void* output)
 {
   // Cast to the correct type.
-  *((T**) output) = &GetParam<typename std::remove_pointer<T>::type>(d);
+  *((T**) output) = &GetParam<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_printable_param.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param.hpp
@@ -47,8 +47,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const std::enable_if_t<arma::is_arma_type<T>::value ||
-                                  std::is_same_v<T,
+    const std::enable_if_t<arma::is_arma_type<T>::value || std::is_same_v<T,
         std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**

--- a/src/mlpack/bindings/cli/get_printable_param.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param.hpp
@@ -27,11 +27,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print a vector option, with spaces between it.
@@ -39,7 +39,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Print a matrix/tuple option (this just prints the filename).
@@ -47,9 +47,9 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value ||
-                                  std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value ||
+                                  std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print a model option (this just prints the filename).
@@ -57,8 +57,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print an option into a std::string.  This should print a short, one-line
@@ -71,7 +71,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -38,8 +38,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const std::enable_if_t<util::IsStdVector<T>::value>*
-        /* junk */)
+    const std::enable_if_t<util::IsStdVector<T>::value>* /* junk */)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -74,8 +73,7 @@ std::string GetMatrixSize(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const std::enable_if_t<arma::is_arma_type<T>::value ||
-                                  std::is_same_v<T,
+    const std::enable_if_t<arma::is_arma_type<T>::value || std::is_same_v<T,
         std::tuple<data::DatasetInfo, arma::mat>>>* /* junk */)
 {
   // Extract the string from the tuple that's being held.

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -23,11 +23,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -38,7 +38,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*
+    const std::enable_if_t<util::IsStdVector<T>::value>*
         /* junk */)
 {
   const T& t = std::any_cast<T>(data.value);
@@ -53,7 +53,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetMatrixSize(
     T& matrix,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   std::ostringstream oss;
   oss << matrix.n_rows << "x" << matrix.n_cols << " matrix";
@@ -64,8 +64,8 @@ std::string GetMatrixSize(
 template<typename T>
 std::string GetMatrixSize(
     T& matrixAndInfo,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return GetMatrixSize(std::get<1>(matrixAndInfo));
 }
@@ -74,9 +74,9 @@ std::string GetMatrixSize(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value ||
-                                  std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
+    const std::enable_if_t<arma::is_arma_type<T>::value ||
+                                  std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* /* junk */)
 {
   // Extract the string from the tuple that's being held.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
@@ -103,8 +103,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   // Extract the string from the tuple that's being held.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/get_printable_param_name.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_name.hpp
@@ -26,10 +26,10 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -38,7 +38,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -47,8 +47,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -57,8 +57,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter's name as seen by the user.
@@ -70,7 +70,7 @@ void GetPrintableParamName(
     void* output)
 {
   *((std::string*) output) =
-      GetPrintableParamName<typename std::remove_pointer<T>::type>(d);
+      GetPrintableParamName<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_printable_param_name_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_name_impl.hpp
@@ -26,10 +26,10 @@ namespace cli {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "--" + data.name;
 }
@@ -41,7 +41,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   return "--" + data.name + "_file";
 }
@@ -53,8 +53,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "--" + data.name + "_file";
 }
@@ -66,8 +66,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "--" + data.name + "_file";
 }

--- a/src/mlpack/bindings/cli/get_printable_param_value.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_value.hpp
@@ -27,10 +27,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -40,7 +40,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -50,8 +50,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -61,8 +61,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter's name as seen by the user.
@@ -74,7 +74,7 @@ void GetPrintableParamValue(
     void* output)
 {
   *((std::string*) output) =
-      GetPrintableParamValue<typename std::remove_pointer<T>::type>(d,
+      GetPrintableParamValue<std::remove_pointer_t<T>>(d,
       *((std::string*) input));
 }
 

--- a/src/mlpack/bindings/cli/get_printable_param_value_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_value_impl.hpp
@@ -28,10 +28,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return input;
 }
@@ -44,7 +44,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   return input + ".csv";
 }
@@ -57,8 +57,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return input + ".bin";
 }
@@ -71,8 +71,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return input + ".arff";
 }

--- a/src/mlpack/bindings/cli/get_printable_type.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type.hpp
@@ -71,8 +71,7 @@ void GetPrintableType(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableType<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableType<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_printable_type.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type.hpp
@@ -23,11 +23,11 @@ namespace cli {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -35,7 +35,7 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -43,7 +43,7 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -51,8 +51,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -60,8 +60,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -72,7 +72,7 @@ void GetPrintableType(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableType<typename std::remove_pointer<T>::type>(data);
+      GetPrintableType<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_type_impl.hpp
@@ -25,19 +25,19 @@ namespace cli {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     return "flag";
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
     return "int";
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
     return "double";
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
     return "string";
   else
     throw std::invalid_argument("unknown parameter type" + data.cppType);
@@ -49,11 +49,11 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
     return "int vector";
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
     return "string vector";
   else
     throw std::invalid_argument("unknown vector type " + data.cppType);
@@ -65,19 +65,19 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  if (std::is_same<T, arma::mat>::value)
+  if (std::is_same_v<T, arma::mat>)
     return "2-d matrix file";
-  else if (std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Mat<size_t>>)
     return "2-d index matrix file";
-  else if (std::is_same<T, arma::rowvec>::value)
+  else if (std::is_same_v<T, arma::rowvec>)
     return "1-d matrix file";
-  else if (std::is_same<T, arma::Row<size_t>>::value)
+  else if (std::is_same_v<T, arma::Row<size_t>>)
     return "1-d index matrix file";
-  else if (std::is_same<T, arma::vec>::value)
+  else if (std::is_same_v<T, arma::vec>)
     return "1-d matrix file";
-  else if (std::is_same<T, arma::Col<size_t>>::value)
+  else if (std::is_same_v<T, arma::Col<size_t>>)
     return "1-d index matrix file";
   else
     throw std::invalid_argument("unknown Armadillo type" + data.cppType);
@@ -89,8 +89,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "2-d categorical matrix file";
 }
@@ -101,8 +101,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return data.cppType + " file";
 }

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -27,10 +27,10 @@ namespace cli {
 template<typename T>
 T& GetRawParam(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0)
 {
   // No mapping is needed, so just cast it directly.
   return *std::any_cast<T>(&d.value);
@@ -42,10 +42,10 @@ T& GetRawParam(
 template<typename T>
 T& GetRawParam(
     util::ParamData& d,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* = 0)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* = 0)
 {
   // Don't load the matrix.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
@@ -59,8 +59,8 @@ T& GetRawParam(
 template<typename T>
 T*& GetRawParam(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Don't load the model.
   typedef std::tuple<T*, std::string> TupleType;
@@ -82,7 +82,7 @@ void GetRawParam(util::ParamData& d,
                  void* output)
 {
   // Cast to the correct type.
-  *((T**) output) = &GetRawParam<typename std::remove_pointer<T>::type>(
+  *((T**) output) = &GetRawParam<std::remove_pointer_t<T>>(
       const_cast<util::ParamData&>(d));
 }
 

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -45,7 +45,7 @@ T& GetRawParam(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* = 0)
+                                     arma::mat>>>* = 0)
 {
   // Don't load the matrix.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -52,9 +52,8 @@ void InPlaceCopyInternal(
     util::ParamData& input,
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same_v<T,
-                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>
-                 >* = 0)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*
+            = 0)
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
@@ -76,8 +75,7 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& d,
     util::ParamData& input,
-    const std::enable_if_t<
-        data::HasSerialize<T>::value>* = 0)
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -31,10 +31,10 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& /* d */,
     util::ParamData& /* input */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0)
 {
   // Nothing to do.
 }
@@ -50,11 +50,11 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& d,
     util::ParamData& input,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T,
-                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value
-                 >::type* = 0)
+        std::is_same_v<T,
+                     std::tuple<mlpack::data::DatasetInfo, arma::mat>>
+                 >* = 0)
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
@@ -76,8 +76,8 @@ template<typename T>
 void InPlaceCopyInternal(
     util::ParamData& d,
     util::ParamData& input,
-    const typename std::enable_if<
-        data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<
+        data::HasSerialize<T>::value>* = 0)
 {
   // Make the output filename the same as the input filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
@@ -102,7 +102,7 @@ void InPlaceCopy(util::ParamData& d,
                  void* /* output */)
 {
   // Cast to the correct type.
-  InPlaceCopyInternal<typename std::remove_pointer<T>::type>(
+  InPlaceCopyInternal<std::remove_pointer_t<T>>(
       const_cast<util::ParamData&>(d), *((util::ParamData*) input));
 }
 

--- a/src/mlpack/bindings/cli/map_parameter_name.hpp
+++ b/src/mlpack/bindings/cli/map_parameter_name.hpp
@@ -27,10 +27,10 @@ namespace cli {
 template<typename T>
 std::string MapParameterName(
     const std::string& identifier,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0)
 {
   return identifier;
 }
@@ -43,11 +43,11 @@ std::string MapParameterName(
 template<typename T>
 std::string MapParameterName(
     const std::string& identifier,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value ||
-        data::HasSerialize<T>::value>::type* /* junk */ = 0)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>> ||
+        data::HasSerialize<T>::value>* /* junk */ = 0)
 {
   return identifier + "_file";
 }
@@ -67,7 +67,7 @@ void MapParameterName(util::ParamData& d,
   // Store the mapped name in the output pointer, which is actually a string
   // pointer.
   *((std::string*) output) =
-      MapParameterName<typename std::remove_pointer<T>::type>(d.name);
+      MapParameterName<std::remove_pointer_t<T>>(d.name);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/map_parameter_name.hpp
+++ b/src/mlpack/bindings/cli/map_parameter_name.hpp
@@ -45,8 +45,7 @@ std::string MapParameterName(
     const std::string& identifier,
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>> ||
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo, arma::mat>> ||
         data::HasSerialize<T>::value>* /* junk */ = 0)
 {
   return identifier + "_file";

--- a/src/mlpack/bindings/cli/output_param.hpp
+++ b/src/mlpack/bindings/cli/output_param.hpp
@@ -26,11 +26,11 @@ namespace cli {
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Output a vector option (print to stdout).
@@ -38,7 +38,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Output a matrix option (this saves it to the given file).
@@ -46,7 +46,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Output a serializable class option (this saves it to the given file).
@@ -54,8 +54,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Output a mapped dataset.
@@ -63,8 +63,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Output an option.  This is the function that will be called by the IO
@@ -75,7 +75,7 @@ void OutputParam(util::ParamData& data,
                  const void* /* input */,
                  void* /* output */)
 {
-  OutputParamImpl<typename std::remove_pointer<T>::type>(data);
+  OutputParamImpl<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -24,11 +24,11 @@ namespace cli {
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::cout << data.name << ": " << *std::any_cast<T>(&data.value)
       << std::endl;
@@ -38,7 +38,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   std::cout << data.name << ": ";
   const T& t = *std::any_cast<T>(&data.value);
@@ -51,7 +51,7 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
   const T& output = std::get<0>(*std::any_cast<TupleType>(&data.value));
@@ -71,8 +71,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   // The const cast is necessary here because Serialize() can't ever be marked
   // const.  In this case we can assume it though, since we will be saving and
@@ -91,8 +91,8 @@ void OutputParamImpl(
 template<typename T>
 void OutputParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* /* junk */)
 {
   // Output the matrix with the mappings.
   typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;

--- a/src/mlpack/bindings/cli/print_type_doc.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc.hpp
@@ -73,8 +73,7 @@ void PrintTypeDoc(util::ParamData& data,
                   const void* /* input */,
                   void* output)
 {
-  *((std::string*) output) =
-      PrintTypeDoc<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/print_type_doc.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace cli {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -53,8 +53,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -74,7 +74,7 @@ void PrintTypeDoc(util::ParamData& data,
                   void* output)
 {
   *((std::string*) output) =
-      PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+      PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/cli/print_type_doc_impl.hpp
@@ -24,30 +24,30 @@ namespace cli {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // A flag type.
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     return "A boolean flag option.  If not specified, it is false; if "
         "specified, it is true.";
   }
   // An integer.
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
   {
     return "An integer (i.e., \"1\").";
   }
   // A floating point value.
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
   {
     return "A floating-point number (i.e., \"0.5\").";
   }
   // A string.
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
   {
     return "A character string (i.e., \"hello\").";
   }
@@ -64,13 +64,13 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
   {
     return "A vector of integers, separated by commas (i.e., \"1,2,3\").";
   }
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
   {
     return "A vector of strings, separated by commas (i.e., "
         "\"hello\",\"goodbye\").";
@@ -87,9 +87,9 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  if (std::is_same<T, arma::mat>::value)
+  if (std::is_same_v<T, arma::mat>)
   {
     return "A data matrix filename.  The file can be CSV (.csv), TSV (.csv), "
         "ASCII (space-separated values, .txt), Armadillo ASCII (.txt), PGM "
@@ -102,7 +102,7 @@ std::string PrintTypeDoc(
         "is found, the first row will be loaded as a data point.  All values of"
         " the matrix will be loaded as double-precision floating point data.";
   }
-  else if (std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Mat<size_t>>)
   {
     return "A data matrix filename, where the matrix holds only non-negative "
         "integer values.  This type is often used for labels or indices.  The "
@@ -117,15 +117,15 @@ std::string PrintTypeDoc(
         " loaded as a data point.  All values of the matrix will be loaded as "
         "unsigned integers.";
   }
-  else if (std::is_same<T, arma::rowvec>::value ||
-           std::is_same<T, arma::vec>::value)
+  else if (std::is_same_v<T, arma::rowvec> ||
+           std::is_same_v<T, arma::vec>)
   {
     return "A one-dimensional vector filename.  This file can take the same "
         "formats as the data matrix filenames; however, it must either contain "
         "one row and many columns, or one column and many rows.";
   }
-  else if (std::is_same<T, arma::Row<size_t>>::value ||
-           std::is_same<T, arma::Col<size_t>>::value)
+  else if (std::is_same_v<T, arma::Row<size_t>> ||
+           std::is_same_v<T, arma::Col<size_t>>)
   {
     return "A one-dimensional vector filename, where the matrix holds only non-"
         "negative integer values.  This type is typically used for labels or "
@@ -145,8 +145,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "A filename for a data matrix that can contain categorical "
       "(non-numeric) data.  If the file contains only numeric data, then the "
@@ -165,8 +165,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "A filename containing an mlpack model.  These can have one of three "
       "formats: binary (.bin), text (.txt), and XML (.xml).  The XML format "

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -27,11 +27,11 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const std::any& value,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T, bool>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T, bool>>* = 0)
 {
   // No mapping is needed.
   d.value = *std::any_cast<T>(&value);
@@ -44,7 +44,7 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const std::any& /* value */,
-    const typename std::enable_if<std::is_same<T, bool>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T, bool>>* = 0)
 {
   // Force set to the value of whether or not this was passed.
   d.value = d.wasPassed;
@@ -58,9 +58,9 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const std::any& value,
-    const typename std::enable_if<arma::is_arma_type<T>::value ||
-                                  std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value ||
+                                  std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
@@ -76,8 +76,8 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const std::any& value,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // We're setting the string filename.
   typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
@@ -96,7 +96,7 @@ void SetParam(
 template<typename T>
 void SetParam(util::ParamData& d, const void* input, void* /* output */)
 {
-  SetParam<typename std::remove_pointer<T>::type>(
+  SetParam<std::remove_pointer_t<T>>(
       const_cast<util::ParamData&>(d), *((std::any*) input));
 }
 

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -58,8 +58,7 @@ template<typename T>
 void SetParam(
     util::ParamData& d,
     const std::any& value,
-    const std::enable_if_t<arma::is_arma_type<T>::value ||
-                                  std::is_same_v<T,
+    const std::enable_if_t<arma::is_arma_type<T>::value || std::is_same_v<T,
         std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // We're setting the string filename.

--- a/src/mlpack/bindings/cli/string_type_param.hpp
+++ b/src/mlpack/bindings/cli/string_type_param.hpp
@@ -26,22 +26,22 @@ namespace cli {
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return a string containing the type of the parameter, for vector options.
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string containing the type of the parameter,
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return a string containing the type of a parameter.  This overload is used if

--- a/src/mlpack/bindings/cli/string_type_param_impl.hpp
+++ b/src/mlpack/bindings/cli/string_type_param_impl.hpp
@@ -23,8 +23,8 @@ namespace cli {
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*)
 {
   // Don't know what type this is.
   return "unknown";
@@ -35,7 +35,7 @@ std::string StringTypeParamImpl(
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   return "vector";
 }
@@ -45,7 +45,7 @@ std::string StringTypeParamImpl(
  */
 template<typename T>
 std::string StringTypeParamImpl(
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "string";
 }

--- a/src/mlpack/bindings/go/default_param.hpp
+++ b/src/mlpack/bindings/go/default_param.hpp
@@ -26,13 +26,13 @@ namespace go {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -40,7 +40,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return the default value of a string option.
@@ -48,8 +48,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value
-        >::type* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>
+        >* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -59,10 +59,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* = 0);
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -71,8 +71,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be
@@ -84,7 +84,7 @@ void DefaultParam(util::ParamData& data,
                   void* output)
 {
   std::string* outstr = (std::string*) output;
-  *outstr = DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+  *outstr = DefaultParamImpl<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/default_param.hpp
+++ b/src/mlpack/bindings/go/default_param.hpp
@@ -29,8 +29,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
     const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
     const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>* = 0,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
@@ -48,8 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const std::enable_if_t<std::is_same_v<T, std::string>
-        >* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>>* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -62,7 +60,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* = 0);
+                                     arma::mat>>>* = 0);
 
 /**
  * Return the default value of a model option (this returns the default

--- a/src/mlpack/bindings/go/default_param_impl.hpp
+++ b/src/mlpack/bindings/go/default_param_impl.hpp
@@ -27,8 +27,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>*,
     const std::enable_if_t<!util::IsStdVector<T>::value>*,
     const std::enable_if_t<!data::HasSerialize<T>::value>*,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>*,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
@@ -106,11 +105,10 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */)
+                                     arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same_v<T, arma::rowvec> ||
-      std::is_same_v<T, arma::vec>)
+  if (std::is_same_v<T, arma::rowvec> || std::is_same_v<T, arma::vec>)
   {
     return "mat.NewDense(1, 1, nil)";
   }

--- a/src/mlpack/bindings/go/default_param_impl.hpp
+++ b/src/mlpack/bindings/go/default_param_impl.hpp
@@ -24,16 +24,16 @@ namespace go {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     oss << "false";
   else
     oss << std::any_cast<T>(data.value);
@@ -47,12 +47,12 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
   const T& vector = std::any_cast<T>(data.value);
-  if (std::is_same<T, std::vector<std::string>>::value)
+  if (std::is_same_v<T, std::vector<std::string>>)
   {
     oss << "[]string{";
     if (vector.size() > 0)
@@ -67,7 +67,7 @@ std::string DefaultParamImpl(
 
     oss << "}";
   }
-  else if (std::is_same<T, std::vector<int>>::value)
+  else if (std::is_same_v<T, std::vector<int>>)
   {
     oss << "[]int{";
     if (vector.size() > 0)
@@ -91,7 +91,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, std::string>>*)
 {
   const std::string& s = *std::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -103,23 +103,23 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same<T, arma::rowvec>::value ||
-      std::is_same<T, arma::vec>::value)
+  if (std::is_same_v<T, arma::rowvec> ||
+      std::is_same_v<T, arma::vec>)
   {
     return "mat.NewDense(1, 1, nil)";
   }
-  else if (std::is_same<T, arma::Col<size_t>>::value ||
-           std::is_same<T, arma::Row<size_t>>::value)
+  else if (std::is_same_v<T, arma::Col<size_t>> ||
+           std::is_same_v<T, arma::Row<size_t>>)
   {
     return "mat.NewDense(1, 1, nil)";
   }
-  else if (std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Mat<size_t>>)
   {
     return "mat.NewDense(1, 1, nil)";
   }
@@ -135,8 +135,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "nil";
 }

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -73,12 +73,9 @@ inline std::string GetGoType<double>(
 template<>
 inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*)
 {

--- a/src/mlpack/bindings/go/get_go_type.hpp
+++ b/src/mlpack/bindings/go/get_go_type.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "unknown";
 }
@@ -37,11 +37,11 @@ inline std::string GetGoType(
 template<>
 inline std::string GetGoType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "int";
 }
@@ -49,11 +49,11 @@ inline std::string GetGoType<int>(
 template<>
 inline std::string GetGoType<float>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*,
-    const typename std::enable_if<!std::is_same<float,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<float>::value>*,
+    const std::enable_if_t<!data::HasSerialize<float>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<float>::value>*,
+    const std::enable_if_t<!std::is_same_v<float,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "float32";
 }
@@ -61,11 +61,11 @@ inline std::string GetGoType<float>(
 template<>
 inline std::string GetGoType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "float64";
 }
@@ -73,14 +73,14 @@ inline std::string GetGoType<double>(
 template<>
 inline std::string GetGoType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "string";
 }
@@ -88,11 +88,11 @@ inline std::string GetGoType<std::string>(
 template<>
 inline std::string GetGoType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "bool";
 }
@@ -100,7 +100,7 @@ inline std::string GetGoType<bool>(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   return "[]" + GetGoType<typename T::value_type>(d);
 }
@@ -108,9 +108,9 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   return "mat.Dense";
 }
@@ -118,8 +118,8 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "matrixWithInfo";
 }
@@ -127,8 +127,8 @@ inline std::string GetGoType(
 template<typename T>
 inline std::string GetGoType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   std::string goStrippedType, strippedType, printedType, defaultsType;
   StripType(d.cppType, goStrippedType, strippedType, printedType, defaultsType);

--- a/src/mlpack/bindings/go/get_printable_param.hpp
+++ b/src/mlpack/bindings/go/get_printable_param.hpp
@@ -115,8 +115,7 @@ void GetPrintableParam(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableParam<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/get_printable_param.hpp
+++ b/src/mlpack/bindings/go/get_printable_param.hpp
@@ -96,8 +96,8 @@ std::string GetPrintableParam(
   const arma::mat& matrix = std::get<1>(tuple);
 
   std::ostringstream oss;
-  oss << matrix.n_rows << "x" << matrix.n_cols << " matrix with dimension type "
-      << "information";
+  oss << matrix.n_rows << "x" << matrix.n_cols
+      << " matrix with dimension type information";
   return oss.str();
 }
 

--- a/src/mlpack/bindings/go/get_printable_param.hpp
+++ b/src/mlpack/bindings/go/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Get the matrix.
   const T& matrix = std::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << std::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // Get the matrix.
   const T& tuple = std::any_cast<T>(data.value);
@@ -116,7 +116,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -23,78 +23,78 @@ namespace go {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,
@@ -102,7 +102,7 @@ void GetPrintableType(util::ParamData& d,
                       void* output)
 {
   *((std::string*) output) =
-      GetPrintableType<typename std::remove_pointer<T>::type>(d);
+      GetPrintableType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/get_printable_type.hpp
+++ b/src/mlpack/bindings/go/get_printable_type.hpp
@@ -50,12 +50,9 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*);
 
@@ -101,8 +98,7 @@ void GetPrintableType(util::ParamData& d,
                       const void* /* input */,
                       void* output)
 {
-  *((std::string*) output) =
-      GetPrintableType<std::remove_pointer_t<T>>(d);
+  *((std::string*) output) = GetPrintableType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -59,12 +59,9 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*)
 {

--- a/src/mlpack/bindings/go/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/go/get_printable_type_impl.hpp
@@ -23,11 +23,11 @@ namespace go {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "unknown";
 }
@@ -35,11 +35,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "int";
 }
@@ -47,11 +47,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "float64";
 }
@@ -59,14 +59,14 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "string";
 }
@@ -74,11 +74,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "bool";
 }
@@ -86,9 +86,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "array of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -96,9 +96,9 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string type = "*mat.Dense";
   if (T::is_row || T::is_col)
@@ -110,8 +110,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "matrixWithInfo";
 }
@@ -119,10 +119,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string goStrippedType, strippedType, printedType, defaultsType;
   StripType(d.cppType, goStrippedType, strippedType, printedType, defaultsType);

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -64,12 +64,9 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*)
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*)
 {
   return "String";
 }
@@ -144,8 +141,7 @@ void GetType(util::ParamData& d,
              const void* /* input */,
              void* output)
 {
-  *((std::string*) output) =
-      GetType<std::remove_pointer_t<T>>(d);
+  *((std::string*) output) = GetType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/get_type.hpp
+++ b/src/mlpack/bindings/go/get_type.hpp
@@ -24,9 +24,9 @@ namespace go {
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   return "unknown";
 }
@@ -34,9 +34,9 @@ inline std::string GetType(
 template<>
 inline std::string GetType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*)
 {
   return "Int";
 }
@@ -44,9 +44,9 @@ inline std::string GetType<int>(
 template<>
 inline std::string GetType<float>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<float>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<float>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<float>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<float>::value>*,
+    const std::enable_if_t<!data::HasSerialize<float>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<float>::value>*)
 {
   return "Float";
 }
@@ -54,9 +54,9 @@ inline std::string GetType<float>(
 template<>
 inline std::string GetType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*)
 {
   return "Double";
 }
@@ -64,12 +64,12 @@ inline std::string GetType<double>(
 template<>
 inline std::string GetType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*)
 {
   return "String";
 }
@@ -77,9 +77,9 @@ inline std::string GetType<std::string>(
 template<>
 inline std::string GetType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*)
 {
   return "Bool";
 }
@@ -87,7 +87,7 @@ inline std::string GetType<bool>(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   return "Vec" + GetType<typename T::value_type>(d);
 }
@@ -95,10 +95,10 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   std::string type = "";
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_row)
       type = "Row";
@@ -107,7 +107,7 @@ inline std::string GetType(
     else
       type = "Mat";
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     if (T::is_row)
       type = "Urow";
@@ -123,8 +123,8 @@ inline std::string GetType(
 template<typename T>
 inline std::string GetType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   return d.cppType + "*";
 }
@@ -145,7 +145,7 @@ void GetType(util::ParamData& d,
              void* output)
 {
   *((std::string*) output) =
-      GetType<typename std::remove_pointer<T>::type>(d);
+      GetType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_defn_input.hpp
+++ b/src/mlpack/bindings/go/print_defn_input.hpp
@@ -28,10 +28,10 @@ namespace go {
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   if (d.required)
   {
@@ -46,7 +46,7 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // param_name *mat.Dense
   if (d.required)
@@ -62,8 +62,8 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // param_name *DataWithInfo
   if (d.required)
@@ -79,8 +79,8 @@ void PrintDefnInput(
 template<typename T>
 void PrintDefnInput(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;
@@ -113,7 +113,7 @@ void PrintDefnInput(util::ParamData& d,
                     const void* /* input */,
                     void* /* output */)
 {
-  PrintDefnInput<typename std::remove_pointer<T>::type>(d);
+  PrintDefnInput<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_defn_output.hpp
+++ b/src/mlpack/bindings/go/print_defn_output.hpp
@@ -27,10 +27,10 @@ namespace go {
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::cout << GetGoType<T>(d);
 }
@@ -41,7 +41,7 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // *mat.Dense
   std::cout << "*" << GetGoType<T>(d);
@@ -53,8 +53,8 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // *mat.Dense
   std::cout << "*" << GetGoType<T>(d);
@@ -66,8 +66,8 @@ void PrintDefnOutput(
 template<typename T>
 void PrintDefnOutput(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;
@@ -94,7 +94,7 @@ void PrintDefnOutput(util::ParamData& d,
                      const void* /* input */,
                      void* /* output */)
 {
-  PrintDefnOutput<typename std::remove_pointer<T>::type>(d);
+  PrintDefnOutput<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_doc.hpp
+++ b/src/mlpack/bindings/go/print_doc.hpp
@@ -45,8 +45,7 @@ void PrintDoc(util::ParamData& d,
   std::ostringstream oss;
   oss << " - ";
   oss << util::CamelCase(d.name, Lower) << " (";
-  oss << GetGoType<std::remove_pointer_t<T>>(d) << "): "
-      << d.desc;
+  oss << GetGoType<std::remove_pointer_t<T>>(d) << "): " << d.desc;
 
   // Print a default, if possible.
   if (!d.required)

--- a/src/mlpack/bindings/go/print_doc.hpp
+++ b/src/mlpack/bindings/go/print_doc.hpp
@@ -45,7 +45,7 @@ void PrintDoc(util::ParamData& d,
   std::ostringstream oss;
   oss << " - ";
   oss << util::CamelCase(d.name, Lower) << " (";
-  oss << GetGoType<typename std::remove_pointer<T>::type>(d) << "): "
+  oss << GetGoType<std::remove_pointer_t<T>>(d) << "): "
       << d.desc;
 
   // Print a default, if possible.

--- a/src/mlpack/bindings/go/print_input_processing.hpp
+++ b/src/mlpack/bindings/go/print_input_processing.hpp
@@ -29,15 +29,15 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -131,7 +131,7 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -206,8 +206,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -268,8 +268,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // First, get the correct classparamName if needed.
   std::string goStrippedType, strippedType, printedType, defaultsType;
@@ -340,7 +340,7 @@ void PrintInputProcessing(util::ParamData& d,
                           const void* input,
                           void* /* output */)
 {
-  PrintInputProcessing<typename std::remove_pointer<T>::type>(d,
+  PrintInputProcessing<std::remove_pointer_t<T>>(d,
       *((size_t*) input));
 }
 

--- a/src/mlpack/bindings/go/print_input_processing.hpp
+++ b/src/mlpack/bindings/go/print_input_processing.hpp
@@ -340,8 +340,7 @@ void PrintInputProcessing(util::ParamData& d,
                           const void* input,
                           void* /* output */)
 {
-  PrintInputProcessing<std::remove_pointer_t<T>>(d,
-      *((size_t*) input));
+  PrintInputProcessing<std::remove_pointer_t<T>>(d, *((size_t*) input));
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_method_config.hpp
+++ b/src/mlpack/bindings/go/print_method_config.hpp
@@ -29,15 +29,15 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -64,12 +64,12 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -96,13 +96,13 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -129,13 +129,13 @@ template<typename T>
 void PrintMethodConfig(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -171,7 +171,7 @@ void PrintMethodConfig(util::ParamData& d,
                        const void* input,
                        void* /* output */)
 {
-  PrintMethodConfig<typename std::remove_pointer<T>::type>(d,
+  PrintMethodConfig<std::remove_pointer_t<T>>(d,
       *((size_t*) input));
 }
 

--- a/src/mlpack/bindings/go/print_method_config.hpp
+++ b/src/mlpack/bindings/go/print_method_config.hpp
@@ -171,8 +171,7 @@ void PrintMethodConfig(util::ParamData& d,
                        const void* input,
                        void* /* output */)
 {
-  PrintMethodConfig<std::remove_pointer_t<T>>(d,
-      *((size_t*) input));
+  PrintMethodConfig<std::remove_pointer_t<T>>(d, *((size_t*) input));
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_method_init.hpp
+++ b/src/mlpack/bindings/go/print_method_init.hpp
@@ -193,8 +193,7 @@ void PrintMethodInit(util::ParamData& d,
                      const void* input,
                      void* /* output */)
 {
-  PrintMethodInit<std::remove_pointer_t<T>>(d,
-      *((size_t*) input));
+  PrintMethodInit<std::remove_pointer_t<T>>(d, *((size_t*) input));
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_method_init.hpp
+++ b/src/mlpack/bindings/go/print_method_init.hpp
@@ -29,15 +29,15 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -86,12 +86,12 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -118,13 +118,13 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -151,13 +151,13 @@ template<typename T>
 void PrintMethodInit(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
   std::string def = "nil";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "false";
 
   // Capitalize the first letter of parameter name so it is
@@ -193,7 +193,7 @@ void PrintMethodInit(util::ParamData& d,
                      const void* input,
                      void* /* output */)
 {
-  PrintMethodInit<typename std::remove_pointer<T>::type>(d,
+  PrintMethodInit<std::remove_pointer_t<T>>(d,
       *((size_t*) input));
 }
 

--- a/src/mlpack/bindings/go/print_output_processing.hpp
+++ b/src/mlpack/bindings/go/print_output_processing.hpp
@@ -29,10 +29,10 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -56,9 +56,9 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -84,8 +84,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -111,8 +111,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Get the type names we need to use.
   std::string goStrippedType, strippedType, printedType, defaultsType;
@@ -144,7 +144,7 @@ void PrintOutputProcessing(util::ParamData& d,
                            const void* /*input*/,
                            void* /* output */)
 {
-  PrintOutputProcessing<typename std::remove_pointer<T>::type>(d, 2);
+  PrintOutputProcessing<std::remove_pointer_t<T>>(d, 2);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_type_doc.hpp
+++ b/src/mlpack/bindings/go/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace go {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -53,8 +53,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -74,7 +74,7 @@ void PrintTypeDoc(util::ParamData& data,
                   void* output)
 {
   *((std::string*) output) =
-      PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+      PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_type_doc.hpp
+++ b/src/mlpack/bindings/go/print_type_doc.hpp
@@ -73,8 +73,7 @@ void PrintTypeDoc(util::ParamData& data,
                   const void* /* input */,
                   void* output)
 {
-  *((std::string*) output) =
-      PrintTypeDoc<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace go

--- a/src/mlpack/bindings/go/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/go/print_type_doc_impl.hpp
@@ -24,29 +24,29 @@ namespace go {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // A flag type.
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     return "A boolean flag option (`true` or `false`).";
   }
   // An integer.
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
   {
     return "An integer (i.e., `1`).";
   }
   // A floating point value.
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
   {
     return "A floating-point number (i.e., `0.5`).";
   }
   // A string.
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
   {
     return "A character string (i.e., `\"hello\"`).";
   }
@@ -63,13 +63,13 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
   {
     return "An array of integers; i.e., `[]int{0, 1, 2}`.";
   }
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
   {
     return "An array of strings; i.e., `[]string{\"hello\", \"goodbye\"}`.";
   }
@@ -85,7 +85,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   if (T::is_col || T::is_row)
   {
@@ -105,8 +105,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "A Tuple(matrixWithInfo) containing `float64` data (Data) along with a"
      " boolean array (Categoricals) indicating which dimensions are categorical"
@@ -122,8 +122,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "An mlpack model pointer.  This type holds a pointer to C++ memory "
       "containing the mlpack model.  Note that this means the mlpack model "

--- a/src/mlpack/bindings/julia/default_param.hpp
+++ b/src/mlpack/bindings/julia/default_param.hpp
@@ -29,8 +29,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
     const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
     const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>* = 0,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
@@ -48,8 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const std::enable_if_t<std::is_same_v<T, std::string>
-        >* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>>* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -62,7 +60,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* = 0);
+                                     arma::mat>>>* = 0);
 
 /**
  * Return the default value of a model option (this returns the default

--- a/src/mlpack/bindings/julia/default_param.hpp
+++ b/src/mlpack/bindings/julia/default_param.hpp
@@ -26,13 +26,13 @@ namespace julia {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -40,7 +40,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return the default value of a string option.
@@ -48,8 +48,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value
-        >::type* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>
+        >* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -59,10 +59,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* = 0);
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -71,8 +71,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be
@@ -84,7 +84,7 @@ void DefaultParam(util::ParamData& data,
                   void* output)
 {
   std::string* outstr = (std::string*) output;
-  *outstr = DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+  *outstr = DefaultParamImpl<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/default_param_impl.hpp
+++ b/src/mlpack/bindings/julia/default_param_impl.hpp
@@ -24,16 +24,16 @@ namespace julia {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     oss << "false";
   else
     oss << std::any_cast<T>(data.value);
@@ -47,13 +47,13 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
   const T& vector = std::any_cast<T>(data.value);
   oss << "[";
-  if (std::is_same<T, std::vector<std::string>>::value)
+  if (std::is_same_v<T, std::vector<std::string>>)
   {
     if (vector.size() > 0)
     {
@@ -90,7 +90,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, std::string>>*)
 {
   const std::string& s = *std::any_cast<std::string>(&data.value);
   return "\"" + s + "\"";
@@ -103,23 +103,23 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same<T, arma::rowvec>::value ||
-      std::is_same<T, arma::vec>::value)
+  if (std::is_same_v<T, arma::rowvec> ||
+      std::is_same_v<T, arma::vec>)
   {
     return "Float64[]";
   }
-  else if (std::is_same<T, arma::Col<size_t>>::value ||
-           std::is_same<T, arma::Row<size_t>>::value)
+  else if (std::is_same_v<T, arma::Col<size_t>> ||
+           std::is_same_v<T, arma::Row<size_t>>)
   {
     return "Int[]";
   }
-  else if (std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Mat<size_t>>)
   {
     return "zeros(Int, 0, 0)";
   }
@@ -135,8 +135,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "nothing";
 }

--- a/src/mlpack/bindings/julia/default_param_impl.hpp
+++ b/src/mlpack/bindings/julia/default_param_impl.hpp
@@ -27,8 +27,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>*,
     const std::enable_if_t<!util::IsStdVector<T>::value>*,
     const std::enable_if_t<!data::HasSerialize<T>::value>*,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>*,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
@@ -106,11 +105,10 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */)
+                                     arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same_v<T, arma::rowvec> ||
-      std::is_same_v<T, arma::vec>)
+  if (std::is_same_v<T, arma::rowvec> || std::is_same_v<T, arma::vec>)
   {
     return "Float64[]";
   }

--- a/src/mlpack/bindings/julia/get_julia_type.hpp
+++ b/src/mlpack/bindings/julia/get_julia_type.hpp
@@ -21,11 +21,11 @@ namespace julia {
 template<typename T>
 inline std::string GetJuliaType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   return "unknown_"; // This will cause an error most likely...
 }
@@ -33,11 +33,11 @@ inline std::string GetJuliaType(
 template<>
 inline std::string GetJuliaType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*)
 {
   return "Bool";
 }
@@ -45,11 +45,11 @@ inline std::string GetJuliaType<bool>(
 template<>
 inline std::string GetJuliaType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*)
 {
   return "Int";
 }
@@ -57,11 +57,11 @@ inline std::string GetJuliaType<int>(
 template<>
 inline std::string GetJuliaType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
-    const typename std::enable_if<!std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*,
+    const std::enable_if_t<!std::is_same_v<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*)
 {
   return "UInt";
 }
@@ -69,11 +69,11 @@ inline std::string GetJuliaType<size_t>(
 template<>
 inline std::string GetJuliaType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*)
 {
   // I suppose on some systems this may not be 64 bit.
   return "Float64";
@@ -82,14 +82,14 @@ inline std::string GetJuliaType<double>(
 template<>
 inline std::string GetJuliaType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*)
 {
   return "String";
 }
@@ -97,10 +97,10 @@ inline std::string GetJuliaType<std::string>(
 template<typename T>
 inline std::string GetJuliaType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   return "Vector{" + GetJuliaType<typename T::value_type>(d) + "}";
 }
@@ -108,14 +108,14 @@ inline std::string GetJuliaType(
 template<typename T>
 inline std::string GetJuliaType(
     util::ParamData& d,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // size_t matrices are special: we want to represent them in Julia as
   // Array{Int, X} not UInt because Julia displays UInts strangely.
-  if (std::is_same<typename T::elem_type, size_t>::value)
+  if (std::is_same_v<typename T::elem_type, size_t>)
     return std::string("Array{Int, ") + (T::is_col || T::is_row ? "1" : "2")
         + "}";
   else
@@ -126,8 +126,8 @@ inline std::string GetJuliaType(
 template<typename T>
 inline std::string GetJuliaType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   return "Tuple{Array{Bool, 1}, Array{Float64, 2}}";
 }
@@ -136,9 +136,9 @@ inline std::string GetJuliaType(
 template<typename T>
 inline std::string GetJuliaType(
     util::ParamData& d,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Serializable types are just held as a pointer to nothing, but they're
   // wrapped in a struct.

--- a/src/mlpack/bindings/julia/get_julia_type.hpp
+++ b/src/mlpack/bindings/julia/get_julia_type.hpp
@@ -82,14 +82,11 @@ inline std::string GetJuliaType<double>(
 template<>
 inline std::string GetJuliaType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*)
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*)
 {
   return "String";
 }

--- a/src/mlpack/bindings/julia/get_printable_param.hpp
+++ b/src/mlpack/bindings/julia/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Get the matrix.
   const T& matrix = std::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << std::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // Get the matrix.
   const T& tuple = std::any_cast<T>(data.value);
@@ -116,7 +116,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/get_printable_param.hpp
+++ b/src/mlpack/bindings/julia/get_printable_param.hpp
@@ -115,8 +115,7 @@ void GetPrintableParam(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableParam<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/get_printable_type.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type.hpp
@@ -23,11 +23,11 @@ namespace julia {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -35,7 +35,7 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -43,7 +43,7 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -51,8 +51,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -60,8 +60,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -72,7 +72,7 @@ void GetPrintableType(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableType<typename std::remove_pointer<T>::type>(data);
+      GetPrintableType<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/get_printable_type.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type.hpp
@@ -71,8 +71,7 @@ void GetPrintableType(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableType<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableType<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/julia/get_printable_type_impl.hpp
@@ -26,19 +26,19 @@ namespace julia {
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     return "Bool";
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
     return "Int";
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
     return "Float64";
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
     return "String";
   else
     throw std::invalid_argument("unknown parameter type " + data.cppType);
@@ -50,11 +50,11 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
     return "Array{Int, 1}";
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
     return "Array{String, 1}";
   else
     throw std::invalid_argument("unknown vector type " + data.cppType);
@@ -66,19 +66,19 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  if (std::is_same<T, arma::mat>::value)
+  if (std::is_same_v<T, arma::mat>)
     return "Float64 matrix-like";
-  else if (std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Mat<size_t>>)
     return "Int matrix-like";
-  else if (std::is_same<T, arma::rowvec>::value)
+  else if (std::is_same_v<T, arma::rowvec>)
     return "Float64 vector-like";
-  else if (std::is_same<T, arma::Row<size_t>>::value)
+  else if (std::is_same_v<T, arma::Row<size_t>>)
     return "Int vector-like";
-  else if (std::is_same<T, arma::vec>::value)
+  else if (std::is_same_v<T, arma::vec>)
     return "Float64 vector-like";
-  else if (std::is_same<T, arma::Col<size_t>>::value)
+  else if (std::is_same_v<T, arma::Col<size_t>>)
     return "Int vector-like";
   else
     throw std::invalid_argument("unknown Armadillo type " + data.cppType);
@@ -90,8 +90,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "Tuple{Array{Bool, 1}, Array{Float64, 2}}";
 }
@@ -102,8 +102,8 @@ std::string GetPrintableType(
 template<typename T>
 std::string GetPrintableType(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   std::string type = util::StripType(data.cppType);
   if (type == "mlpackModel")

--- a/src/mlpack/bindings/julia/print_input_param.hpp
+++ b/src/mlpack/bindings/julia/print_input_param.hpp
@@ -43,8 +43,7 @@ void PrintInputParam(util::ParamData& d,
     }
     else
     {
-      std::cout << "Union{"
-          << GetJuliaType<std::remove_pointer_t<T>>(d)
+      std::cout << "Union{" << GetJuliaType<std::remove_pointer_t<T>>(d)
           << ", Missing} = missing";
     }
   }

--- a/src/mlpack/bindings/julia/print_input_param.hpp
+++ b/src/mlpack/bindings/julia/print_input_param.hpp
@@ -39,12 +39,12 @@ void PrintInputParam(util::ParamData& d,
     // If it's required, then we need the type.
     if (d.required)
     {
-      std::cout << GetJuliaType<typename std::remove_pointer<T>::type>(d);
+      std::cout << GetJuliaType<std::remove_pointer_t<T>>(d);
     }
     else
     {
       std::cout << "Union{"
-          << GetJuliaType<typename std::remove_pointer<T>::type>(d)
+          << GetJuliaType<std::remove_pointer_t<T>>(d)
           << ", Missing} = missing";
     }
   }

--- a/src/mlpack/bindings/julia/print_input_processing.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing.hpp
@@ -24,10 +24,10 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the input processing for an Armadillo type.
@@ -36,9 +36,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the input processing for a serializable type.
@@ -47,10 +47,10 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the input processing (basically calling params.Get<>()) for a
@@ -60,8 +60,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the input processing (basically calling params.Get<>()) for a type.
@@ -72,7 +72,7 @@ void PrintInputProcessing(util::ParamData& d,
                           void* /* output */)
 {
   // Call out to the right overload.
-  PrintInputProcessing<typename std::remove_pointer<T>::type>(d,
+  PrintInputProcessing<std::remove_pointer_t<T>>(d,
       *((std::string*) input));
 }
 

--- a/src/mlpack/bindings/julia/print_input_processing.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing.hpp
@@ -72,8 +72,7 @@ void PrintInputProcessing(util::ParamData& d,
                           void* /* output */)
 {
   // Call out to the right overload.
-  PrintInputProcessing<std::remove_pointer_t<T>>(d,
-      *((std::string*) input));
+  PrintInputProcessing<std::remove_pointer_t<T>>(d, *((std::string*) input));
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/print_input_processing_impl.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing_impl.hpp
@@ -151,12 +151,12 @@ void PrintInputProcessing(
   std::string indent(extraIndent + 2, ' ');
   std::string type = util::StripType(d.cppType);
   std::cout << indent << "push!(modelPtrs, convert("
-      << GetJuliaType<std::remove_pointer_t<T>>(d) << ", "
-      << juliaName << ").ptr)" << std::endl;
+      << GetJuliaType<std::remove_pointer_t<T>>(d) << ", " << juliaName
+      << ").ptr)" << std::endl;
   std::cout << indent << functionName << "_internal.SetParam" << type
       << "(p, \"" << d.name << "\", convert("
-      << GetJuliaType<std::remove_pointer_t<T>>(d) << ", "
-      << juliaName << "))" << std::endl;
+      << GetJuliaType<std::remove_pointer_t<T>>(d) << ", " << juliaName
+      << "))" << std::endl;
 
   if (!d.required)
   {

--- a/src/mlpack/bindings/julia/print_input_processing_impl.hpp
+++ b/src/mlpack/bindings/julia/print_input_processing_impl.hpp
@@ -27,10 +27,10 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& /* functionName */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // "type" is a reserved keyword or function.
   const std::string juliaName = (d.name == "type") ? "type_" : d.name;
@@ -66,9 +66,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& /* functionName */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // "type" is a reserved keyword or function.
   const std::string juliaName = (d.name == "type") ? "type_" : d.name;
@@ -83,7 +83,7 @@ void PrintInputProcessing(
 
   // For an Armadillo type, we have to call a different overload for columns and
   // rows than for regular matrices.
-  std::string uChar = (std::is_same<typename T::elem_type, size_t>::value) ?
+  std::string uChar = (std::is_same_v<typename T::elem_type, size_t>) ?
       "U" : "";
   std::string indent(extraIndent + 2, ' ');
   std::string matTypeModifier = "";
@@ -125,10 +125,10 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // "type" is a reserved keyword or function.
   const std::string juliaName = (d.name == "type") ? "type_" : d.name;
@@ -151,11 +151,11 @@ void PrintInputProcessing(
   std::string indent(extraIndent + 2, ' ');
   std::string type = util::StripType(d.cppType);
   std::cout << indent << "push!(modelPtrs, convert("
-      << GetJuliaType<typename std::remove_pointer<T>::type>(d) << ", "
+      << GetJuliaType<std::remove_pointer_t<T>>(d) << ", "
       << juliaName << ").ptr)" << std::endl;
   std::cout << indent << functionName << "_internal.SetParam" << type
       << "(p, \"" << d.name << "\", convert("
-      << GetJuliaType<typename std::remove_pointer<T>::type>(d) << ", "
+      << GetJuliaType<std::remove_pointer_t<T>>(d) << ", "
       << juliaName << "))" << std::endl;
 
   if (!d.required)
@@ -172,8 +172,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const std::string& /* functionName */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // "type" is a reserved keyword or function.
   const std::string juliaName = (d.name == "type") ? "type_" : d.name;

--- a/src/mlpack/bindings/julia/print_model_type_import.hpp
+++ b/src/mlpack/bindings/julia/print_model_type_import.hpp
@@ -25,8 +25,8 @@ namespace julia {
 template<typename T>
 void PrintModelTypeImport(
     util::ParamData& /* d */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -37,7 +37,7 @@ void PrintModelTypeImport(
 template<typename T>
 void PrintModelTypeImport(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -48,8 +48,8 @@ void PrintModelTypeImport(
 template<typename T>
 void PrintModelTypeImport(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // We need to print, e.g.,
   // import ..<type>
@@ -67,7 +67,7 @@ void PrintModelTypeImport(util::ParamData& d,
                           const void* /* input */,
                           void* /* output */)
 {
-  PrintModelTypeImport<typename std::remove_pointer<T>::type>(d);
+  PrintModelTypeImport<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/print_output_processing.hpp
+++ b/src/mlpack/bindings/julia/print_output_processing.hpp
@@ -26,10 +26,10 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the output processing for an Armadillo type.
@@ -38,9 +38,9 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the output processing for a serializable type.
@@ -49,10 +49,10 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the output processing for a mat/DatasetInfo tuple type.
@@ -61,8 +61,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print the output processing (basically calling params.Get<>()) for a type.
@@ -73,7 +73,7 @@ void PrintOutputProcessing(util::ParamData& d,
                            void* /* output */)
 {
   // Call out to the right overload.
-  PrintOutputProcessing<typename std::remove_pointer<T>::type>(d,
+  PrintOutputProcessing<std::remove_pointer_t<T>>(d,
       *((std::string*) input));
 }
 

--- a/src/mlpack/bindings/julia/print_output_processing.hpp
+++ b/src/mlpack/bindings/julia/print_output_processing.hpp
@@ -73,8 +73,7 @@ void PrintOutputProcessing(util::ParamData& d,
                            void* /* output */)
 {
   // Call out to the right overload.
-  PrintOutputProcessing<std::remove_pointer_t<T>>(d,
-      *((std::string*) input));
+  PrintOutputProcessing<std::remove_pointer_t<T>>(d, *((std::string*) input));
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/print_output_processing_impl.hpp
+++ b/src/mlpack/bindings/julia/print_output_processing_impl.hpp
@@ -29,34 +29,34 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& /* functionName */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string type;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     type = "Bool";
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
     type = "Int";
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
     type = "Double";
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
     type = "String";
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
     type = "VectorStr";
-  else if (std::is_same<T, std::vector<int>>::value)
+  else if (std::is_same_v<T, std::vector<int>>)
     type = "VectorInt";
   else
     type = "Unknown";
 
   // Strings need a little special handling.
-  if (std::is_same<T, std::string>::value)
+  if (std::is_same_v<T, std::string>)
     std::cout << "Base.unsafe_string(";
 
   std::cout << "GetParam" << type << "(p, \"" << d.name << "\")";
 
-  if (std::is_same<T, std::string>::value)
+  if (std::is_same_v<T, std::string>)
     std::cout << ")";
 }
 
@@ -67,11 +67,11 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& /* functionName */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
-  std::string uChar = (std::is_same<typename T::elem_type, size_t>::value) ?
+  std::string uChar = (std::is_same_v<typename T::elem_type, size_t>) ?
       "U" : "";
   std::string matTypeSuffix = "";
   std::string extra = "";
@@ -100,10 +100,10 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& functionName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string type = util::StripType(d.cppType);
   std::cout << functionName << "_internal.GetParam"
@@ -117,8 +117,8 @@ template<typename T>
 void PrintOutputProcessing(
     util::ParamData& d,
     const std::string& /* functionName */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::cout << "GetParamMatWithInfo(p, \"" << d.name << "\", juliaOwnedMemory)";
 }

--- a/src/mlpack/bindings/julia/print_param_defn.hpp
+++ b/src/mlpack/bindings/julia/print_param_defn.hpp
@@ -171,8 +171,7 @@ void PrintParamDefn(util::ParamData& d,
                     const void* input,
                     void* /* output */)
 {
-  PrintParamDefn<std::remove_pointer_t<T>>(d,
-      *(std::string*) input);
+  PrintParamDefn<std::remove_pointer_t<T>>(d, *(std::string*) input);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/print_param_defn.hpp
+++ b/src/mlpack/bindings/julia/print_param_defn.hpp
@@ -26,8 +26,8 @@ template<typename T>
 void PrintParamDefn(
     util::ParamData& /* d */,
     const std::string& /* programName */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -39,7 +39,7 @@ template<typename T>
 void PrintParamDefn(
     util::ParamData& /* d */,
     const std::string& /* programName */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -51,8 +51,8 @@ template<typename T>
 void PrintParamDefn(
     util::ParamData& d,
     const std::string& programName,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // We need to print something of the form below:
   //
@@ -171,7 +171,7 @@ void PrintParamDefn(util::ParamData& d,
                     const void* input,
                     void* /* output */)
 {
-  PrintParamDefn<typename std::remove_pointer<T>::type>(d,
+  PrintParamDefn<std::remove_pointer_t<T>>(d,
       *(std::string*) input);
 }
 

--- a/src/mlpack/bindings/julia/print_type_doc.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc.hpp
@@ -73,8 +73,7 @@ void PrintTypeDoc(util::ParamData& data,
                   const void* /* input */,
                   void* output)
 {
-  *((std::string*) output) =
-      PrintTypeDoc<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/print_type_doc.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace julia {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -53,8 +53,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -74,7 +74,7 @@ void PrintTypeDoc(util::ParamData& data,
                   void* output)
 {
   *((std::string*) output) =
-      PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+      PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace julia

--- a/src/mlpack/bindings/julia/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/julia/print_type_doc_impl.hpp
@@ -24,29 +24,29 @@ namespace julia {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // A flag type.
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     return "A boolean flag option (`true` or `false`).";
   }
   // An integer.
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
   {
     return "An integer (i.e., `1`).";
   }
   // A floating point value.
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
   {
     return "A floating-point number (i.e., `0.5`).";
   }
   // A string.
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
   {
     return "A character string (i.e., `\"hello\"`).";
   }
@@ -63,13 +63,13 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
   {
     return "A vector of integers; i.e., `[0, 1, 2]`.";
   }
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
   {
     return "A vector of strings; i.e., `[\"hello\", \"goodbye\"]`.";
   }
@@ -85,9 +85,9 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_col || T::is_row)
     {
@@ -104,7 +104,7 @@ std::string PrintTypeDoc(
           "`false` when calling mlpack bindings.";
     }
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     if (T::is_col || T::is_row)
     {
@@ -135,8 +135,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "A 2-d array containing `Float64` data along with a boolean array "
       "indicating which dimensions are categorical (represented by `true`) and "
@@ -154,8 +154,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "An mlpack model pointer.  `<Model>` refers to the type of model that "
       "is being stored, so, e.g., for `CF()`, the type will be `CFModel`. "

--- a/src/mlpack/bindings/markdown/default_param.hpp
+++ b/src/mlpack/bindings/markdown/default_param.hpp
@@ -38,27 +38,27 @@ void DefaultParam(util::ParamData& data,
   if (BindingInfo::Language() == "cli")
   {
     *((std::string*) output) =
-        cli::DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+        cli::DefaultParamImpl<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "python")
   {
     *((std::string*) output) =
-        python::DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+        python::DefaultParamImpl<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "julia")
   {
     *((std::string*) output) =
-        julia::DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+        julia::DefaultParamImpl<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "go")
   {
     *((std::string*) output) =
-        go::DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+        go::DefaultParamImpl<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "r")
   {
     *((std::string*) output) =
-        r::DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+        r::DefaultParamImpl<std::remove_pointer_t<T>>(data);
   }
   else
   {

--- a/src/mlpack/bindings/markdown/get_printable_param.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param.hpp
@@ -115,8 +115,7 @@ void GetPrintableParam(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableParam<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace markdown

--- a/src/mlpack/bindings/markdown/get_printable_param.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Get the matrix.
   const T& matrix = std::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << std::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // Get the matrix.
   const T& tuple = std::any_cast<T>(data.value);
@@ -116,7 +116,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace markdown

--- a/src/mlpack/bindings/markdown/get_printable_param_name.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_name.hpp
@@ -26,10 +26,10 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -38,7 +38,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -47,8 +47,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -57,8 +57,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter's name as seen by the user.
@@ -70,7 +70,7 @@ void GetPrintableParamName(
     void* output)
 {
   *((std::string*) output) =
-      GetPrintableParamName<typename std::remove_pointer<T>::type>(d);
+      GetPrintableParamName<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace markdown

--- a/src/mlpack/bindings/markdown/get_printable_param_name_impl.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_name_impl.hpp
@@ -26,10 +26,10 @@ namespace markdown {
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "--" + data.name;
 }
@@ -41,7 +41,7 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   return "--" + data.name + "_file";
 }
@@ -53,8 +53,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "--" + data.name + "_file";
 }
@@ -66,8 +66,8 @@ std::string GetPrintableParamName(
 template<typename T>
 std::string GetPrintableParamName(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "--" + data.name + "_file";
 }

--- a/src/mlpack/bindings/markdown/get_printable_param_value.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_value.hpp
@@ -27,10 +27,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter name for a matrix type (where the user has to pass the file
@@ -40,7 +40,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Get the parameter name for a serializable model type (where the user has to
@@ -50,8 +50,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Get the parameter name for a mapped matrix type (where the user has to pass
@@ -61,8 +61,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& data,
     const std::string& value,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Get the parameter's name as seen by the user.
@@ -74,7 +74,7 @@ void GetPrintableParamValue(
     void* output)
 {
   *((std::string*) output) =
-      GetPrintableParamValue<typename std::remove_pointer<T>::type>(d,
+      GetPrintableParamValue<std::remove_pointer_t<T>>(d,
       *((std::string*) input));
 }
 

--- a/src/mlpack/bindings/markdown/get_printable_param_value_impl.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_param_value_impl.hpp
@@ -28,10 +28,10 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return input;
 }
@@ -44,7 +44,7 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   return input + ".csv";
 }
@@ -57,8 +57,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return input + ".bin";
 }
@@ -71,8 +71,8 @@ template<typename T>
 std::string GetPrintableParamValue(
     util::ParamData& /* data */,
     const std::string& input,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return input + ".arff";
 }

--- a/src/mlpack/bindings/markdown/get_printable_type.hpp
+++ b/src/mlpack/bindings/markdown/get_printable_type.hpp
@@ -37,27 +37,27 @@ void GetPrintableType(util::ParamData& data,
   if (BindingInfo::Language() == "cli")
   {
     *((std::string*) output) =
-        cli::GetPrintableType<typename std::remove_pointer<T>::type>(data);
+        cli::GetPrintableType<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "python")
   {
     *((std::string*) output) =
-        python::GetPrintableType<typename std::remove_pointer<T>::type>(data);
+        python::GetPrintableType<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "julia")
   {
     *((std::string*) output) =
-        julia::GetPrintableType<typename std::remove_pointer<T>::type>(data);
+        julia::GetPrintableType<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "go")
   {
     *((std::string*) output) =
-        go::GetPrintableType<typename std::remove_pointer<T>::type>(data);
+        go::GetPrintableType<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "r")
   {
     *((std::string*) output) =
-        r::GetPrintableType<typename std::remove_pointer<T>::type>(data);
+        r::GetPrintableType<std::remove_pointer_t<T>>(data);
   }
   else
   {

--- a/src/mlpack/bindings/markdown/is_serializable.hpp
+++ b/src/mlpack/bindings/markdown/is_serializable.hpp
@@ -25,7 +25,7 @@ namespace markdown {
  */
 template<typename T>
 bool IsSerializable(
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   return false;
 }
@@ -35,8 +35,8 @@ bool IsSerializable(
  */
 template<typename T>
 bool IsSerializable(
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   return true;
 }
@@ -49,7 +49,7 @@ void IsSerializable(util::ParamData& /* data */,
                     const void* /* input */,
                     void* output)
 {
-  *((bool*) output) = IsSerializable<typename std::remove_pointer<T>::type>();
+  *((bool*) output) = IsSerializable<std::remove_pointer_t<T>>();
 }
 
 } // namespace markdown

--- a/src/mlpack/bindings/markdown/print_type_doc.hpp
+++ b/src/mlpack/bindings/markdown/print_type_doc.hpp
@@ -34,23 +34,23 @@ std::string PrintTypeDoc(util::ParamData& data)
 {
   if (BindingInfo::Language() == "cli")
   {
-    return cli::PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+    return cli::PrintTypeDoc<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "python")
   {
-    return python::PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+    return python::PrintTypeDoc<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "julia")
   {
-    return julia::PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+    return julia::PrintTypeDoc<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "go")
   {
-    return go::PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+    return go::PrintTypeDoc<std::remove_pointer_t<T>>(data);
   }
   else if (BindingInfo::Language() == "r")
   {
-    return r::PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+    return r::PrintTypeDoc<std::remove_pointer_t<T>>(data);
   }
   else
   {

--- a/src/mlpack/bindings/python/default_param.hpp
+++ b/src/mlpack/bindings/python/default_param.hpp
@@ -29,8 +29,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
     const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
     const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>* = 0,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
@@ -48,8 +47,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const std::enable_if_t<std::is_same_v<T, std::string>
-        >* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>>* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -62,7 +60,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* = 0);
+                                     arma::mat>>>* = 0);
 
 /**
  * Return the default value of a model option (this returns the default

--- a/src/mlpack/bindings/python/default_param.hpp
+++ b/src/mlpack/bindings/python/default_param.hpp
@@ -26,13 +26,13 @@ namespace python {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return the default value of a vector option.
@@ -40,7 +40,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return the default value of a string option.
@@ -48,8 +48,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value
-        >::type* = 0);
+    const std::enable_if_t<std::is_same_v<T, std::string>
+        >* = 0);
 
 /**
  * Return the default value of a matrix option, a tuple option, a
@@ -59,10 +59,10 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* = 0);
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* = 0);
 
 /**
  * Return the default value of a model option (this returns the default
@@ -71,8 +71,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Return the default value of an option.  This is the function that will be
@@ -84,7 +84,7 @@ void DefaultParam(util::ParamData& data,
                   void* output)
 {
   std::string* outstr = (std::string*) output;
-  *outstr = DefaultParamImpl<typename std::remove_pointer<T>::type>(data);
+  *outstr = DefaultParamImpl<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/default_param_impl.hpp
+++ b/src/mlpack/bindings/python/default_param_impl.hpp
@@ -24,16 +24,16 @@ namespace python {
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<mlpack::data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     oss << "False";
   else
     oss << std::any_cast<T>(data.value);
@@ -47,13 +47,13 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   // Print each element in an array delimited by square brackets.
   std::ostringstream oss;
   const T& vector = std::any_cast<T>(data.value);
   oss << "[";
-  if (std::is_same<T, std::vector<std::string>>::value)
+  if (std::is_same_v<T, std::vector<std::string>>)
   {
     if (vector.size() > 0)
     {
@@ -90,7 +90,7 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T, std::string>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, std::string>>*)
 {
   const std::string& s = *std::any_cast<std::string>(&data.value);
   return "'" + s + "'";
@@ -103,23 +103,23 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<
+    const std::enable_if_t<
         arma::is_arma_type<T>::value ||
-        std::is_same<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>::value>::type* /* junk */)
+        std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
+                                   arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same<T, arma::rowvec>::value ||
-      std::is_same<T, arma::vec>::value)
+  if (std::is_same_v<T, arma::rowvec> ||
+      std::is_same_v<T, arma::vec>)
   {
     return "np.empty([0])";
   }
-  else if (std::is_same<T, arma::Col<size_t>>::value ||
-           std::is_same<T, arma::Row<size_t>>::value)
+  else if (std::is_same_v<T, arma::Col<size_t>> ||
+           std::is_same_v<T, arma::Row<size_t>>)
   {
     return "np.empty([0], dtype=np.uint64)";
   }
-  else if (std::is_same<T, arma::Mat<size_t>>::value)
+  else if (std::is_same_v<T, arma::Mat<size_t>>)
   {
     return "np.empty([0, 0], dtype=np.uint64)";
   }
@@ -135,8 +135,8 @@ std::string DefaultParamImpl(
 template<typename T>
 std::string DefaultParamImpl(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "None";
 }

--- a/src/mlpack/bindings/python/default_param_impl.hpp
+++ b/src/mlpack/bindings/python/default_param_impl.hpp
@@ -27,8 +27,7 @@ std::string DefaultParamImpl(
     const std::enable_if_t<!arma::is_arma_type<T>::value>*,
     const std::enable_if_t<!util::IsStdVector<T>::value>*,
     const std::enable_if_t<!data::HasSerialize<T>::value>*,
-    const std::enable_if_t<!std::is_same_v<T,
-        std::string>>*,
+    const std::enable_if_t<!std::is_same_v<T, std::string>>*,
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<mlpack::data::DatasetInfo, arma::mat>>>*)
 {
@@ -106,11 +105,10 @@ std::string DefaultParamImpl(
     const std::enable_if_t<
         arma::is_arma_type<T>::value ||
         std::is_same_v<T, std::tuple<mlpack::data::DatasetInfo,
-                                   arma::mat>>>* /* junk */)
+                                     arma::mat>>>* /* junk */)
 {
   // Get the filename and return it, or return an empty string.
-  if (std::is_same_v<T, arma::rowvec> ||
-      std::is_same_v<T, arma::vec>)
+  if (std::is_same_v<T, arma::rowvec> || std::is_same_v<T, arma::vec>)
   {
     return "np.empty([0])";
   }

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -23,9 +23,9 @@ namespace python {
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   return "unknown";
 }
@@ -33,9 +33,9 @@ inline std::string GetCythonType(
 template<>
 inline std::string GetCythonType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*)
 {
   return "int";
 }
@@ -43,9 +43,9 @@ inline std::string GetCythonType<int>(
 template<>
 inline std::string GetCythonType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*)
 {
   return "double";
 }
@@ -53,12 +53,12 @@ inline std::string GetCythonType<double>(
 template<>
 inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*)
 {
   return "string";
 }
@@ -66,9 +66,9 @@ inline std::string GetCythonType<std::string>(
 template<>
 inline std::string GetCythonType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*)
 {
   return "size_t";
 }
@@ -76,9 +76,9 @@ inline std::string GetCythonType<size_t>(
 template<>
 inline std::string GetCythonType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*)
 {
   return "cbool";
 }
@@ -86,7 +86,7 @@ inline std::string GetCythonType<bool>(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   return "vector[" + GetCythonType<typename T::value_type>(d) + "]";
 }
@@ -94,7 +94,7 @@ inline std::string GetCythonType(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   std::string type = "Mat";
   if (T::is_row)
@@ -108,8 +108,8 @@ inline std::string GetCythonType(
 template<typename T>
 inline std::string GetCythonType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   return d.cppType + "*";
 }

--- a/src/mlpack/bindings/python/get_cython_type.hpp
+++ b/src/mlpack/bindings/python/get_cython_type.hpp
@@ -53,12 +53,9 @@ inline std::string GetCythonType<double>(
 template<>
 inline std::string GetCythonType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*)
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*)
 {
   return "string";
 }

--- a/src/mlpack/bindings/python/get_printable_param.hpp
+++ b/src/mlpack/bindings/python/get_printable_param.hpp
@@ -115,8 +115,7 @@ void GetPrintableParam(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableParam<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/get_printable_param.hpp
+++ b/src/mlpack/bindings/python/get_printable_param.hpp
@@ -25,11 +25,11 @@ namespace python {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -42,7 +42,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -58,7 +58,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Get the matrix.
   const T& matrix = std::any_cast<T>(data.value);
@@ -74,8 +74,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   std::ostringstream oss;
   oss << data.cppType << " model at " << std::any_cast<T*>(data.value);
@@ -88,8 +88,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // Get the matrix.
   const T& tuple = std::any_cast<T>(data.value);
@@ -116,7 +116,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -23,87 +23,87 @@ namespace python {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
-    const typename std::enable_if<!std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*,
+    const std::enable_if_t<!std::is_same_v<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*);
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 template<typename T>
 void GetPrintableType(util::ParamData& d,
@@ -111,7 +111,7 @@ void GetPrintableType(util::ParamData& d,
                       void* output)
 {
   *((std::string*) output) =
-      GetPrintableType<typename std::remove_pointer<T>::type>(d);
+      GetPrintableType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/get_printable_type.hpp
+++ b/src/mlpack/bindings/python/get_printable_type.hpp
@@ -50,12 +50,9 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*);
 
@@ -110,8 +107,7 @@ void GetPrintableType(util::ParamData& d,
                       const void* /* input */,
                       void* output)
 {
-  *((std::string*) output) =
-      GetPrintableType<std::remove_pointer_t<T>>(d);
+  *((std::string*) output) = GetPrintableType<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -22,11 +22,11 @@ namespace python {
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "unknown";
 }
@@ -34,11 +34,11 @@ inline std::string GetPrintableType(
 template<>
 inline std::string GetPrintableType<int>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<int>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<int>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<int>::value>::type*,
-    const typename std::enable_if<!std::is_same<int,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<int>::value>*,
+    const std::enable_if_t<!data::HasSerialize<int>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<int>::value>*,
+    const std::enable_if_t<!std::is_same_v<int,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "int";
 }
@@ -46,11 +46,11 @@ inline std::string GetPrintableType<int>(
 template<>
 inline std::string GetPrintableType<double>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<double>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<double>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<double>::value>::type*,
-    const typename std::enable_if<!std::is_same<double,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<double>::value>*,
+    const std::enable_if_t<!data::HasSerialize<double>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<double>::value>*,
+    const std::enable_if_t<!std::is_same_v<double,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "float";
 }
@@ -58,14 +58,14 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const typename std::enable_if<
-        !util::IsStdVector<std::string>::value>::type*,
-    const typename std::enable_if<
-        !data::HasSerialize<std::string>::value>::type*,
-    const typename std::enable_if<
-        !arma::is_arma_type<std::string>::value>::type*,
-    const typename std::enable_if<!std::is_same<std::string,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<
+        !util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<
+        !data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<
+        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!std::is_same_v<std::string,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "str";
 }
@@ -73,11 +73,11 @@ inline std::string GetPrintableType<std::string>(
 template<>
 inline std::string GetPrintableType<size_t>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<size_t>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<size_t>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<size_t>::value>::type*,
-    const typename std::enable_if<!std::is_same<size_t,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<size_t>::value>*,
+    const std::enable_if_t<!data::HasSerialize<size_t>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<size_t>::value>*,
+    const std::enable_if_t<!std::is_same_v<size_t,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "int";
 }
@@ -85,11 +85,11 @@ inline std::string GetPrintableType<size_t>(
 template<>
 inline std::string GetPrintableType<bool>(
     util::ParamData& /* d */,
-    const typename std::enable_if<!util::IsStdVector<bool>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<bool>::value>::type*,
-    const typename std::enable_if<!arma::is_arma_type<bool>::value>::type*,
-    const typename std::enable_if<!std::is_same<bool,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!util::IsStdVector<bool>::value>*,
+    const std::enable_if_t<!data::HasSerialize<bool>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<bool>::value>*,
+    const std::enable_if_t<!std::is_same_v<bool,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "bool";
 }
@@ -97,9 +97,9 @@ inline std::string GetPrintableType<bool>(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "list of " + GetPrintableType<typename T::value_type>(d) + "s";
 }
@@ -107,17 +107,17 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::string type = "matrix";
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_row || T::is_col)
       type = "vector";
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     type = "int matrix";
     if (T::is_row || T::is_col)
@@ -130,8 +130,8 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& /* d */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "categorical matrix";
 }
@@ -139,10 +139,10 @@ inline std::string GetPrintableType(
 template<typename T>
 inline std::string GetPrintableType(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return d.cppType + "Type";
 }

--- a/src/mlpack/bindings/python/get_printable_type_impl.hpp
+++ b/src/mlpack/bindings/python/get_printable_type_impl.hpp
@@ -58,12 +58,9 @@ inline std::string GetPrintableType<double>(
 template<>
 inline std::string GetPrintableType<std::string>(
     util::ParamData& /* d */,
-    const std::enable_if_t<
-        !util::IsStdVector<std::string>::value>*,
-    const std::enable_if_t<
-        !data::HasSerialize<std::string>::value>*,
-    const std::enable_if_t<
-        !arma::is_arma_type<std::string>::value>*,
+    const std::enable_if_t<!util::IsStdVector<std::string>::value>*,
+    const std::enable_if_t<!data::HasSerialize<std::string>::value>*,
+    const std::enable_if_t<!arma::is_arma_type<std::string>::value>*,
     const std::enable_if_t<!std::is_same_v<std::string,
         std::tuple<data::DatasetInfo, arma::mat>>>*)
 {

--- a/src/mlpack/bindings/python/import_decl.hpp
+++ b/src/mlpack/bindings/python/import_decl.hpp
@@ -26,8 +26,8 @@ template<typename T>
 void ImportDecl(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // First, we have to parse the type.  If we have something like, e.g.,
   // 'LogisticRegression<>', we must convert this to 'LogisticRegression[T=*].'
@@ -53,8 +53,8 @@ template<typename T>
 void ImportDecl(
     util::ParamData& /* d */,
     const size_t /* indent */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   // Print nothing.
 }
@@ -66,7 +66,7 @@ template<typename T>
 void ImportDecl(
     util::ParamData& /* d */,
     const size_t /* indent */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Print nothing.
 }
@@ -84,7 +84,7 @@ void ImportDecl(util::ParamData& d,
                 const void* indent,
                 void* /* output */)
 {
-  ImportDecl<typename std::remove_pointer<T>::type>(d, *((size_t*) indent));
+  ImportDecl<std::remove_pointer_t<T>>(d, *((size_t*) indent));
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/is_serializable.hpp
+++ b/src/mlpack/bindings/python/is_serializable.hpp
@@ -21,7 +21,7 @@ namespace python {
 template<typename T>
 inline bool IsSerializable(
     util::ParamData& /* d */,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   return false;
 }
@@ -29,7 +29,7 @@ inline bool IsSerializable(
 template<typename T>
 inline bool IsSerializable(
     util::ParamData& /* d */,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   return true;
 }
@@ -40,7 +40,7 @@ void IsSerializable(util::ParamData& data,
                     void* output)
 {
   *((bool*) output) =
-      IsSerializable<typename std::remove_pointer<T>::type>(data);
+      IsSerializable<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/is_serializable.hpp
+++ b/src/mlpack/bindings/python/is_serializable.hpp
@@ -39,8 +39,7 @@ void IsSerializable(util::ParamData& data,
                     const void* /* input */,
                     void* output)
 {
-  *((bool*) output) =
-      IsSerializable<std::remove_pointer_t<T>>(data);
+  *((bool*) output) = IsSerializable<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_class_defn.hpp
+++ b/src/mlpack/bindings/python/print_class_defn.hpp
@@ -25,8 +25,8 @@ namespace python {
 template<typename T>
 void PrintClassDefn(
     util::ParamData& /* d */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -37,7 +37,7 @@ void PrintClassDefn(
 template<typename T>
 void PrintClassDefn(
     util::ParamData& /* d */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -48,8 +48,8 @@ void PrintClassDefn(
 template<typename T>
 void PrintClassDefn(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // First, we have to parse the type.  If we have something like, e.g.,
   // 'LogisticRegression<>', we must convert this to 'LogisticRegression[].'
@@ -153,7 +153,7 @@ void PrintClassDefn(util::ParamData& d,
                     const void* /* input */,
                     void* /* output */)
 {
-  PrintClassDefn<typename std::remove_pointer<T>::type>(d);
+  PrintClassDefn<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_defn.hpp
+++ b/src/mlpack/bindings/python/print_defn.hpp
@@ -32,7 +32,7 @@ void PrintDefn(util::ParamData& d,
   std::string name = GetValidName(d.name);
 
   std::cout << name;
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     std::cout << "=False";
   else if (!d.required)
     std::cout << "=None";

--- a/src/mlpack/bindings/python/print_doc.hpp
+++ b/src/mlpack/bindings/python/print_doc.hpp
@@ -42,7 +42,7 @@ void PrintDoc(util::ParamData& d,
   oss << " - ";
   oss << GetValidName(d.name);
   oss << " (";
-  oss << GetPrintableType<typename std::remove_pointer<T>::type>(d) << "): "
+  oss << GetPrintableType<std::remove_pointer_t<T>>(d) << "): "
       << d.desc;
 
   // Print a default, if possible.

--- a/src/mlpack/bindings/python/print_doc.hpp
+++ b/src/mlpack/bindings/python/print_doc.hpp
@@ -42,8 +42,7 @@ void PrintDoc(util::ParamData& d,
   oss << " - ";
   oss << GetValidName(d.name);
   oss << " (";
-  oss << GetPrintableType<std::remove_pointer_t<T>>(d) << "): "
-      << d.desc;
+  oss << GetPrintableType<std::remove_pointer_t<T>>(d) << "): " << d.desc;
 
   // Print a default, if possible.
   if (!d.required)

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -550,8 +550,7 @@ void PrintInputProcessing(util::ParamData& d,
                           const void* input,
                           void* /* output */)
 {
-  PrintInputProcessing<std::remove_pointer_t<T>>(d,
-      *((size_t*) input));
+  PrintInputProcessing<std::remove_pointer_t<T>>(d, *((size_t*) input));
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -32,11 +32,11 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // The copy_all_inputs parameter must be handled first, and therefore is
   // outside the scope of this code.
@@ -46,7 +46,7 @@ void PrintInputProcessing(
   const std::string prefix(indent, ' ');
 
   std::string def = "None";
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
     def = "False";
 
   // Make sure that we don't use names that are Python keywords.
@@ -165,11 +165,11 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0,
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -255,8 +255,8 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -383,9 +383,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // First, get the correct class name if needed.
   std::string strippedType, printedType, defaultsType;
@@ -458,9 +458,9 @@ template<typename T>
 void PrintInputProcessing(
     util::ParamData& d,
     const size_t indent,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   std::string name = GetValidName(d.name);
 
@@ -550,7 +550,7 @@ void PrintInputProcessing(util::ParamData& d,
                           const void* input,
                           void* /* output */)
 {
-  PrintInputProcessing<typename std::remove_pointer<T>::type>(d,
+  PrintInputProcessing<std::remove_pointer_t<T>>(d,
       *((size_t*) input));
 }
 

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -31,10 +31,10 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -88,7 +88,7 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -129,8 +129,8 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   const std::string prefix(indent, ' ');
 
@@ -171,8 +171,8 @@ void PrintOutputProcessing(
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Get the type names we need to use.
   std::string strippedType, printedType, defaultsType;
@@ -305,7 +305,7 @@ void PrintOutputProcessing(util::ParamData& d,
   typedef std::tuple<util::Params, std::tuple<size_t, bool>> TupleType;
   TupleType* tuple = (TupleType*) input;
 
-  PrintOutputProcessing<typename std::remove_pointer<T>::type>(
+  PrintOutputProcessing<std::remove_pointer_t<T>>(
       std::get<0>(*tuple), d, std::get<0>(std::get<1>(*tuple)),
       std::get<1>(std::get<1>(*tuple)));
 }

--- a/src/mlpack/bindings/python/print_type_doc.hpp
+++ b/src/mlpack/bindings/python/print_type_doc.hpp
@@ -25,11 +25,11 @@ namespace python {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a vector.
@@ -37,7 +37,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix option.
@@ -45,7 +45,7 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Return a string representing the command-line type of a matrix tuple option.
@@ -53,8 +53,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Return a string representing the command-line type of a model.
@@ -62,8 +62,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print the command-line type of an option into a string.
@@ -74,7 +74,7 @@ void PrintTypeDoc(util::ParamData& data,
                   void* output)
 {
   *((std::string*) output) =
-      PrintTypeDoc<typename std::remove_pointer<T>::type>(data);
+      PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_type_doc.hpp
+++ b/src/mlpack/bindings/python/print_type_doc.hpp
@@ -73,8 +73,7 @@ void PrintTypeDoc(util::ParamData& data,
                   const void* /* input */,
                   void* output)
 {
-  *((std::string*) output) =
-      PrintTypeDoc<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = PrintTypeDoc<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_type_doc_impl.hpp
+++ b/src/mlpack/bindings/python/print_type_doc_impl.hpp
@@ -24,29 +24,29 @@ namespace python {
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   // A flag type.
-  if (std::is_same<T, bool>::value)
+  if (std::is_same_v<T, bool>)
   {
     return "A boolean flag option (True or False).";
   }
   // An integer.
-  else if (std::is_same<T, int>::value)
+  else if (std::is_same_v<T, int>)
   {
     return "An integer (i.e., \"1\").";
   }
   // A floating point value.
-  else if (std::is_same<T, double>::value)
+  else if (std::is_same_v<T, double>)
   {
     return "A floating-point number (i.e., \"0.5\").";
   }
   // A string.
-  else if (std::is_same<T, std::string>::value)
+  else if (std::is_same_v<T, std::string>)
   {
     return "A character string (i.e., \"hello\").";
   }
@@ -63,13 +63,13 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
-  if (std::is_same<T, std::vector<int>>::value)
+  if (std::is_same_v<T, std::vector<int>>)
   {
     return "A list of integers; i.e., `[0, 1, 2]`.";
   }
-  else if (std::is_same<T, std::vector<std::string>>::value)
+  else if (std::is_same_v<T, std::vector<std::string>>)
   {
     return "A list of strings; i.e., `[\"hello\", \"goodbye\"]`.";
   }
@@ -85,9 +85,9 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  if (std::is_same<typename T::elem_type, double>::value)
+  if (std::is_same_v<typename T::elem_type, double>)
   {
     if (T::is_col || T::is_row)
     {
@@ -103,7 +103,7 @@ std::string PrintTypeDoc(
           "float64, it will be converted.";
     }
   }
-  else if (std::is_same<typename T::elem_type, size_t>::value)
+  else if (std::is_same_v<typename T::elem_type, size_t>)
   {
     if (T::is_col || T::is_row)
     {
@@ -131,8 +131,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   return "A 2-d arraylike containing data.  Like the regular 2-d matrices, this"
       " can be a list of lists, a numpy ndarray, or a pandas DataFrame. "
@@ -150,8 +150,8 @@ std::string PrintTypeDoc(
 template<typename T>
 std::string PrintTypeDoc(
     util::ParamData& /* data */,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   return "An mlpack model pointer.  This type can be pickled to or from disk, "
       "and internally holds a pointer to C++ memory containing the mlpack "

--- a/src/mlpack/bindings/tests/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/delete_allocated_memory.hpp
@@ -21,8 +21,8 @@ namespace tests {
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& /* d */,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   // Do nothing.
 }
@@ -30,7 +30,7 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   (*std::any_cast<T>(&d.value)).clear();
 }
@@ -38,8 +38,8 @@ void DeleteAllocatedMemoryImpl(
 template<typename T>
 void DeleteAllocatedMemoryImpl(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
   delete *std::any_cast<T*>(&d.value);
@@ -51,7 +51,7 @@ void DeleteAllocatedMemory(
     const void* /* input */,
     void* /* output */)
 {
-  DeleteAllocatedMemoryImpl<typename std::remove_pointer<T>::type>(d);
+  DeleteAllocatedMemoryImpl<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace tests

--- a/src/mlpack/bindings/tests/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/get_allocated_memory.hpp
@@ -51,8 +51,7 @@ void GetAllocatedMemory(util::ParamData& d,
                         const void* /* input */,
                         void* output)
 {
-  *((void**) output) =
-      GetAllocatedMemory<std::remove_pointer_t<T>>(d);
+  *((void**) output) = GetAllocatedMemory<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace tests

--- a/src/mlpack/bindings/tests/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/tests/get_allocated_memory.hpp
@@ -22,8 +22,8 @@ namespace tests {
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& /* d */,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0)
 {
   return NULL;
 }
@@ -31,7 +31,7 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0)
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0)
 {
   return (*std::any_cast<T>(&d.value)).memptr();
 }
@@ -39,8 +39,8 @@ void* GetAllocatedMemory(
 template<typename T>
 void* GetAllocatedMemory(
     util::ParamData& d,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Here we have a model; return its memory location.
   return *std::any_cast<T*>(&d.value);
@@ -52,7 +52,7 @@ void GetAllocatedMemory(util::ParamData& d,
                         void* output)
 {
   *((void**) output) =
-      GetAllocatedMemory<typename std::remove_pointer<T>::type>(d);
+      GetAllocatedMemory<std::remove_pointer_t<T>>(d);
 }
 
 } // namespace tests

--- a/src/mlpack/bindings/tests/get_printable_param.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param.hpp
@@ -77,8 +77,7 @@ void GetPrintableParam(util::ParamData& data,
                        const void* /* input */,
                        void* output)
 {
-  *((std::string*) output) =
-      GetPrintableParam<std::remove_pointer_t<T>>(data);
+  *((std::string*) output) = GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace tests

--- a/src/mlpack/bindings/tests/get_printable_param.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param.hpp
@@ -27,11 +27,11 @@ namespace tests {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type* = 0,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type* = 0,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<!util::IsStdVector<T>::value>* = 0,
+    const std::enable_if_t<!data::HasSerialize<T>::value>* = 0,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print a vector option, with spaces between it.
@@ -39,7 +39,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type* = 0);
+    const std::enable_if_t<util::IsStdVector<T>::value>* = 0);
 
 /**
  * Print a matrix option (this just prints the filename).
@@ -47,7 +47,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type* = 0);
+    const std::enable_if_t<arma::is_arma_type<T>::value>* = 0);
 
 /**
  * Print a serializable class option (this just prints the filename).
@@ -55,8 +55,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type* = 0,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type* = 0);
+    const std::enable_if_t<!arma::is_arma_type<T>::value>* = 0,
+    const std::enable_if_t<data::HasSerialize<T>::value>* = 0);
 
 /**
  * Print a mapped matrix option (this just prints the filename).
@@ -64,8 +64,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* = 0);
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* = 0);
 
 /**
  * Print an option into a std::string.  This should print a short, one-line
@@ -78,7 +78,7 @@ void GetPrintableParam(util::ParamData& data,
                        void* output)
 {
   *((std::string*) output) =
-      GetPrintableParam<typename std::remove_pointer<T>::type>(data);
+      GetPrintableParam<std::remove_pointer_t<T>>(data);
 }
 
 } // namespace tests

--- a/src/mlpack/bindings/tests/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/tests/get_printable_param_impl.hpp
@@ -22,11 +22,11 @@ namespace tests {
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<!util::IsStdVector<T>::value>::type*,
-    const typename std::enable_if<!data::HasSerialize<T>::value>::type*,
-    const typename std::enable_if<!std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<!util::IsStdVector<T>::value>*,
+    const std::enable_if_t<!data::HasSerialize<T>::value>*,
+    const std::enable_if_t<!std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>*)
 {
   std::ostringstream oss;
   oss << std::any_cast<T>(data.value);
@@ -37,7 +37,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<util::IsStdVector<T>::value>::type*)
+    const std::enable_if_t<util::IsStdVector<T>::value>*)
 {
   const T& t = std::any_cast<T>(data.value);
 
@@ -51,7 +51,7 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& /* data */,
-    const typename std::enable_if<arma::is_arma_type<T>::value>::type*)
+    const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
   return "matrix type";
 }
@@ -60,8 +60,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& data,
-    const typename std::enable_if<!arma::is_arma_type<T>::value>::type*,
-    const typename std::enable_if<data::HasSerialize<T>::value>::type*)
+    const std::enable_if_t<!arma::is_arma_type<T>::value>*,
+    const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   // Extract the string from the tuple that's being held.
   std::ostringstream oss;
@@ -73,8 +73,8 @@ std::string GetPrintableParam(
 template<typename T>
 std::string GetPrintableParam(
     util::ParamData& /* data */,
-    const typename std::enable_if<std::is_same<T,
-        std::tuple<data::DatasetInfo, arma::mat>>::value>::type* /* junk */)
+    const std::enable_if_t<std::is_same_v<T,
+        std::tuple<data::DatasetInfo, arma::mat>>>* /* junk */)
 {
   return "matrix/DatatsetInfo tuple";
 }

--- a/src/mlpack/core/cereal/is_loading.hpp
+++ b/src/mlpack/core/cereal/is_loading.hpp
@@ -28,26 +28,26 @@ struct is_cereal_archive
 {
   // Archive::is_loading is not implemented yet, so we can use std::is_same<>
   // to check if it is a loading archive.
-  constexpr static bool value = std::is_same<Archive,
-      cereal::BinaryInputArchive>::value ||
+  constexpr static bool value = std::is_same_v<Archive,
+      cereal::BinaryInputArchive> ||
 // #if (BINDING_TYPE != BINDING_TYPE_R)
-      std::is_same<Archive, cereal::JSONInputArchive>::value ||
+      std::is_same_v<Archive, cereal::JSONInputArchive> ||
 // #endif
-      std::is_same<Archive, cereal::XMLInputArchive>::value;
+      std::is_same_v<Archive, cereal::XMLInputArchive>;
 };
 
 template<typename Archive>
 bool is_loading(
-    const typename std::enable_if<
-        is_cereal_archive<Archive>::value, Archive>::type* = 0)
+    const std::enable_if_t<
+        is_cereal_archive<Archive>::value, Archive>* = 0)
 {
   return true;
 }
 
 template<typename Archive>
 bool is_loading(
-    const typename std::enable_if<
-      !is_cereal_archive<Archive>::value, Archive>::type* = 0)
+    const std::enable_if_t<
+      !is_cereal_archive<Archive>::value, Archive>* = 0)
 {
   return false;
 }

--- a/src/mlpack/core/cereal/is_loading.hpp
+++ b/src/mlpack/core/cereal/is_loading.hpp
@@ -38,16 +38,14 @@ struct is_cereal_archive
 
 template<typename Archive>
 bool is_loading(
-    const std::enable_if_t<
-        is_cereal_archive<Archive>::value, Archive>* = 0)
+    const std::enable_if_t<is_cereal_archive<Archive>::value, Archive>* = 0)
 {
   return true;
 }
 
 template<typename Archive>
 bool is_loading(
-    const std::enable_if_t<
-      !is_cereal_archive<Archive>::value, Archive>* = 0)
+    const std::enable_if_t<!is_cereal_archive<Archive>::value, Archive>* = 0)
 {
   return false;
 }

--- a/src/mlpack/core/cereal/is_saving.hpp
+++ b/src/mlpack/core/cereal/is_saving.hpp
@@ -29,26 +29,26 @@ struct is_cereal_archive_saving
 {
   // Archive::is_saving is not implemented yet, so we can use std::is_same<>
   // to check if it is a loading archive.
-  constexpr static bool value = std::is_same<Archive,
-      cereal::BinaryOutputArchive>::value ||
+  constexpr static bool value = std::is_same_v<Archive,
+      cereal::BinaryOutputArchive> ||
 // #if (BINDING_TYPE != BINDING_TYPE_R)
-      std::is_same<Archive, cereal::JSONOutputArchive>::value ||
+      std::is_same_v<Archive, cereal::JSONOutputArchive> ||
 // #endif
-      std::is_same<Archive, cereal::XMLOutputArchive>::value;
+      std::is_same_v<Archive, cereal::XMLOutputArchive>;
 };
 
 template<typename Archive>
 bool is_saving(
-    const typename std::enable_if<
-        is_cereal_archive_saving<Archive>::value, Archive>::type* = 0)
+    const std::enable_if_t<
+        is_cereal_archive_saving<Archive>::value, Archive>* = 0)
 {
   return true;
 }
 
 template<typename Archive>
 bool is_saving(
-    const typename std::enable_if<
-      !is_cereal_archive_saving<Archive>::value, Archive>::type* = 0)
+    const std::enable_if_t<
+      !is_cereal_archive_saving<Archive>::value, Archive>* = 0)
 {
   return false;
 }

--- a/src/mlpack/core/cv/cv_base.hpp
+++ b/src/mlpack/core/cv/cv_base.hpp
@@ -126,7 +126,7 @@ class CVBase
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = !MIE::TakesNumClasses,
-           typename = typename std::enable_if<Enabled>::type>
+           typename = std::enable_if_t<Enabled>>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,
                          const MLAlgorithmArgs&... args);
@@ -137,7 +137,7 @@ class CVBase
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = MIE::TakesNumClasses & !MIE::TakesDatasetInfo,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,
@@ -149,7 +149,7 @@ class CVBase
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = MIE::TakesNumClasses & MIE::TakesDatasetInfo,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void,
            typename = void>
   MLAlgorithm TrainModel(const MatType& xs,
@@ -162,7 +162,7 @@ class CVBase
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = !MIE::TakesNumClasses,
-           typename = typename std::enable_if<Enabled>::type>
+           typename = std::enable_if_t<Enabled>>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,
                          const WeightsType& weights,
@@ -174,7 +174,7 @@ class CVBase
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = MIE::TakesNumClasses & !MIE::TakesDatasetInfo,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,
@@ -187,7 +187,7 @@ class CVBase
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = MIE::TakesNumClasses & MIE::TakesDatasetInfo,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void,
            typename = void>
   MLAlgorithm TrainModel(const MatType& xs,
@@ -207,7 +207,7 @@ class CVBase
   template<bool ConstructableWithoutDatasetInfo,
            typename... MLAlgorithmArgs,
            typename =
-               typename std::enable_if<ConstructableWithoutDatasetInfo>::type>
+               std::enable_if_t<ConstructableWithoutDatasetInfo>>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,
                          const MLAlgorithmArgs&... args);
@@ -219,7 +219,7 @@ class CVBase
   template<bool ConstructableWithoutDatasetInfo,
            typename... MLAlgorithmArgs,
            typename =
-               typename std::enable_if<!ConstructableWithoutDatasetInfo>::type,
+               std::enable_if_t<!ConstructableWithoutDatasetInfo>,
            typename = void>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,

--- a/src/mlpack/core/cv/cv_base.hpp
+++ b/src/mlpack/core/cv/cv_base.hpp
@@ -206,8 +206,7 @@ class CVBase
    */
   template<bool ConstructableWithoutDatasetInfo,
            typename... MLAlgorithmArgs,
-           typename =
-               std::enable_if_t<ConstructableWithoutDatasetInfo>>
+           typename = std::enable_if_t<ConstructableWithoutDatasetInfo>>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,
                          const MLAlgorithmArgs&... args);
@@ -218,8 +217,7 @@ class CVBase
    */
   template<bool ConstructableWithoutDatasetInfo,
            typename... MLAlgorithmArgs,
-           typename =
-               std::enable_if_t<!ConstructableWithoutDatasetInfo>,
+           typename = std::enable_if_t<!ConstructableWithoutDatasetInfo>,
            typename = void>
   MLAlgorithm TrainModel(const MatType& xs,
                          const PredictionsType& ys,

--- a/src/mlpack/core/cv/cv_base_impl.hpp
+++ b/src/mlpack/core/cv/cv_base_impl.hpp
@@ -141,8 +141,8 @@ MLAlgorithm CVBase<MLAlgorithm,
                                             const MLAlgorithmArgs&... args)
 {
   static_assert(
-      std::is_constructible<MLAlgorithm, const MatType&, const PredictionsType&,
-          MLAlgorithmArgs...>::value,
+      std::is_constructible_v<MLAlgorithm,
+          const MatType&, const PredictionsType&, MLAlgorithmArgs...>,
       "The given MLAlgorithm is not constructible from the passed arguments");
 
   return MLAlgorithm(xs, ys, args...);
@@ -161,8 +161,9 @@ MLAlgorithm CVBase<MLAlgorithm,
                                             const MLAlgorithmArgs&... args)
 {
   static_assert(
-      std::is_constructible<MLAlgorithm, const MatType&, const PredictionsType&,
-          const size_t, MLAlgorithmArgs...>::value,
+      std::is_constructible_v<MLAlgorithm,
+          const MatType&, const PredictionsType&,
+          const size_t, MLAlgorithmArgs...>,
       "The given MLAlgorithm is not constructible from the passed arguments");
 
   return MLAlgorithm(xs, ys, numClasses, args...);
@@ -182,15 +183,16 @@ MLAlgorithm CVBase<MLAlgorithm,
                                             const MLAlgorithmArgs&... args)
 {
   static_assert(
-      std::is_constructible<MLAlgorithm, const MatType&,
+      std::is_constructible_v<MLAlgorithm, const MatType&,
           const data::DatasetInfo, const PredictionsType&, const size_t,
-              MLAlgorithmArgs...>::value,
+              MLAlgorithmArgs...>,
       "The given MLAlgorithm is not constructible with a data::DatasetInfo "
       "parameter and the passed arguments");
 
   static const bool constructableWithoutDatasetInfo =
-      std::is_constructible<MLAlgorithm, const MatType&, const PredictionsType&,
-          const size_t, MLAlgorithmArgs...>::value;
+      std::is_constructible_v<MLAlgorithm,
+          const MatType&, const PredictionsType&,
+          const size_t, MLAlgorithmArgs...>;
   return TrainModel<constructableWithoutDatasetInfo>(xs, ys, args...);
 }
 
@@ -208,8 +210,9 @@ MLAlgorithm CVBase<MLAlgorithm,
                                             const MLAlgorithmArgs&... args)
 {
   static_assert(
-      std::is_constructible<MLAlgorithm, const MatType&, const PredictionsType&,
-          const WeightsType&, MLAlgorithmArgs...>::value,
+      std::is_constructible_v<MLAlgorithm,
+          const MatType&, const PredictionsType&,
+          const WeightsType&, MLAlgorithmArgs...>,
       "The given MLAlgorithm is not constructible from the passed arguments");
 
   return MLAlgorithm(xs, ys, weights, args...);
@@ -229,8 +232,9 @@ MLAlgorithm CVBase<MLAlgorithm,
                                             const MLAlgorithmArgs&... args)
 {
   static_assert(
-      std::is_constructible<MLAlgorithm, const MatType&, const PredictionsType&,
-          const size_t, const WeightsType&, MLAlgorithmArgs...>::value,
+      std::is_constructible_v<MLAlgorithm,
+          const MatType&, const PredictionsType&,
+          const size_t, const WeightsType&, MLAlgorithmArgs...>,
       "The given MLAlgorithm is not constructible from the passed arguments");
 
   return MLAlgorithm(xs, ys, numClasses, weights, args...);
@@ -251,15 +255,16 @@ MLAlgorithm CVBase<MLAlgorithm,
                                            const MLAlgorithmArgs&... args)
 {
   static_assert(
-      std::is_constructible<MLAlgorithm, const MatType&,
+      std::is_constructible_v<MLAlgorithm, const MatType&,
           const data::DatasetInfo, const PredictionsType&, const size_t,
-              const WeightsType&, MLAlgorithmArgs...>::value,
+              const WeightsType&, MLAlgorithmArgs...>,
       "The given MLAlgorithm is not constructible with a data::DatasetInfo "
       "parameter and the passed arguments");
 
   static const bool constructableWithoutDatasetInfo =
-      std::is_constructible<MLAlgorithm, const MatType&, const PredictionsType&,
-          const size_t, const WeightsType&, MLAlgorithmArgs...>::value;
+      std::is_constructible_v<MLAlgorithm,
+          const MatType&, const PredictionsType&,
+          const size_t, const WeightsType&, MLAlgorithmArgs...>;
   return TrainModel<constructableWithoutDatasetInfo>(xs, ys, weights, args...);
 }
 

--- a/src/mlpack/core/cv/k_fold_cv.hpp
+++ b/src/mlpack/core/cv/k_fold_cv.hpp
@@ -189,7 +189,7 @@ class KFoldCV
    * the model type.
    */
   template<bool Enabled = !Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type>
+           typename = std::enable_if_t<Enabled>>
   void Shuffle();
 
   /**
@@ -197,7 +197,7 @@ class KFoldCV
    * model type.
    */
   template<bool Enabled = Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void>
   void Shuffle();
 
@@ -257,7 +257,7 @@ class KFoldCV
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = !Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type>
+           typename = std::enable_if_t<Enabled>>
   double TrainAndEvaluate(const MLAlgorithmArgs& ...mlAlgorithmArgs);
 
   /**
@@ -265,7 +265,7 @@ class KFoldCV
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void>
   double TrainAndEvaluate(const MLAlgorithmArgs& ...mlAlgorithmArgs);
 

--- a/src/mlpack/core/cv/meta_info_extractor.hpp
+++ b/src/mlpack/core/cv/meta_info_extractor.hpp
@@ -217,11 +217,11 @@ struct SelectMethodForm<MLAlgorithm, HasMethodForm, HMFs...>
     template<typename Form, typename... RemainingForms>
     struct Implementation<Form, RemainingForms...>
     {
-      using Type = typename std::conditional<
+      using Type = std::conditional_t<
           HasMethodForm<MLAlgorithm, Form::template Type,
               Form::MinNumberOfAdditionalArgs>::value,
           Form,
-          typename Implementation<RemainingForms...>::Type>::type;
+          typename Implementation<RemainingForms...>::Type>;
     };
 
    public:
@@ -305,9 +305,9 @@ class MetaInfoExtractor
 
   /* An indication whether a method form is selected */
   template<typename... MFs /* MethodForms */>
-  using Selects = typename std::conditional<
-      std::is_same<typename Select<MFs...>::Type, NotFoundMethodForm>::value,
-      std::false_type, std::true_type>::type;
+  using Selects = std::conditional_t<
+      std::is_same_v<typename Select<MFs...>::Type, NotFoundMethodForm>,
+      std::false_type, std::true_type>;
 
  public:
   /**
@@ -328,12 +328,12 @@ class MetaInfoExtractor
    * An indication whether PredictionsType has been identified (i.e. MLAlgorithm
    * is supported by MetaInfoExtractor).
    */
-  static const bool IsSupported = !std::is_same<PredictionsType, void*>::value;
+  static const bool IsSupported = !std::is_same_v<PredictionsType, void*>;
 
   /**
    * An indication whether MLAlgorithm supports weighted learning.
    */
-  static const bool SupportsWeights = !std::is_same<WeightsType, void*>::value;
+  static const bool SupportsWeights = !std::is_same_v<WeightsType, void*>;
 
   /**
    * An indication whether MLAlgorithm takes a data::DatasetInfo parameter.

--- a/src/mlpack/core/cv/simple_cv.hpp
+++ b/src/mlpack/core/cv/simple_cv.hpp
@@ -289,7 +289,7 @@ class SimpleCV
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = !Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type>
+           typename = std::enable_if_t<Enabled>>
   double TrainAndEvaluate(const MLAlgorithmArgs&... args);
 
   /**
@@ -297,7 +297,7 @@ class SimpleCV
    */
   template<typename... MLAlgorithmArgs,
            bool Enabled = Base::MIE::SupportsWeights,
-           typename = typename std::enable_if<Enabled>::type,
+           typename = std::enable_if_t<Enabled>,
            typename = void>
   double TrainAndEvaluate(const MLAlgorithmArgs&... args);
 };

--- a/src/mlpack/core/data/dataset_mapper_impl.hpp
+++ b/src/mlpack/core/data/dataset_mapper_impl.hpp
@@ -52,7 +52,7 @@ void CallMapFirstPass(
     const InputType& input,
     const size_t dimension,
     std::vector<Datatype>& types,
-    const typename std::enable_if<PolicyType::NeedsFirstPass>::type* = 0)
+    const std::enable_if_t<PolicyType::NeedsFirstPass>* = 0)
 {
   policy.template MapFirstPass<T>(input, dimension, types);
 }
@@ -64,7 +64,7 @@ void CallMapFirstPass(
     const InputType& /* input */,
     const size_t /* dimension */,
     std::vector<Datatype>& /* types */,
-    const typename std::enable_if<!PolicyType::NeedsFirstPass>::type* = 0)
+    const std::enable_if_t<!PolicyType::NeedsFirstPass>* = 0)
 {
   // Nothing to do here.
 }

--- a/src/mlpack/core/data/has_serialize.hpp
+++ b/src/mlpack/core/data/has_serialize.hpp
@@ -52,7 +52,7 @@ struct HasSerialize
   template<typename U, typename V, typename W> struct check;
   template<typename U> static yes& chk( // This matches classes.
       check<U,
-            typename std::enable_if_t<std::is_class<U>::value>*,
+            typename std::enable_if_t<std::is_class_v<U>>*,
             typename std::enable_if_t<HasSerializeFunction<U>::value>*>*);
   template<typename  > static no&  chk(...); // This matches non-classes.
 

--- a/src/mlpack/core/data/load_numeric_csv.hpp
+++ b/src/mlpack/core/data/load_numeric_csv.hpp
@@ -24,7 +24,7 @@ namespace data {
 template<typename eT>
 inline eT SafeNegInf(
     const bool neg,
-    const typename std::enable_if<std::is_unsigned<eT>::value>::type* = 0)
+    const std::enable_if_t<std::is_unsigned_v<eT>>* = 0)
 {
   // For an unsigned type, we cannot return negative infinity, so instead return
   // 0.
@@ -34,7 +34,7 @@ inline eT SafeNegInf(
 template<typename eT>
 inline eT SafeNegInf(
     const bool neg,
-    const typename std::enable_if<!std::is_unsigned<eT>::value>::type* = 0)
+    const std::enable_if_t<!std::is_unsigned_v<eT>>* = 0)
 {
   return neg ? -(std::numeric_limits<eT>::infinity()) :
       std::numeric_limits<eT>::infinity();
@@ -88,13 +88,13 @@ bool LoadCSV::ConvertToken(eT& val,
   // Convert the token into correct type.
   // If we have a eT as unsigned int,
   // it will convert all negative numbers to 0.
-  if (std::is_floating_point<eT>::value)
+  if (std::is_floating_point_v<eT>)
   {
     val = eT(std::strtod(str, &endptr));
   }
-  else if (std::is_integral<eT>::value)
+  else if (std::is_integral_v<eT>)
   {
-    if (std::is_signed<eT>::value)
+    if (std::is_signed_v<eT>)
       val = eT(std::strtoll(str, &endptr, 10));
     else
     {

--- a/src/mlpack/core/data/string_encoding.hpp
+++ b/src/mlpack/core/data/string_encoding.hpp
@@ -198,8 +198,8 @@ class StringEncoding
                     std::vector<std::vector<ElemType>>& output,
                     const TokenizerType& tokenizer,
                     PolicyType& policy,
-                    typename std::enable_if<StringEncodingPolicyTraits<
-                        PolicyType>::onePassEncoding>::type* = 0);
+                    std::enable_if_t<StringEncodingPolicyTraits<
+                        PolicyType>::onePassEncoding>* = 0);
 
  private:
   //! The encoding policy object.

--- a/src/mlpack/core/data/string_encoding_impl.hpp
+++ b/src/mlpack/core/data/string_encoding_impl.hpp
@@ -70,9 +70,9 @@ void StringEncoding<EncodingPolicyType, DictionaryType>::CreateMap(
   auto token = tokenizer(strView);
 
   static_assert(
-      std::is_same<typename std::remove_reference<decltype(token)>::type,
-                   typename std::remove_reference<typename DictionaryType::
-                      TokenType>::type>::value,
+      std::is_same_v<std::remove_reference_t<decltype(token)>,
+                   std::remove_reference_t<typename DictionaryType::
+                      TokenType>>,
       "The dictionary token type doesn't match the return value type "
       "of the tokenizer.");
 
@@ -116,9 +116,9 @@ EncodeHelper(const std::vector<std::string>& input,
     auto token = tokenizer(strView);
 
     static_assert(
-        std::is_same<typename std::remove_reference<decltype(token)>::type,
-                     typename std::remove_reference<typename DictionaryType::
-                        TokenType>::type>::value,
+        std::is_same_v<std::remove_reference_t<decltype(token)>,
+                     std::remove_reference_t<typename DictionaryType::
+                        TokenType>>,
         "The dictionary token type doesn't match the return value type "
         "of the tokenizer.");
 
@@ -163,8 +163,8 @@ EncodeHelper(const std::vector<std::string>& input,
              std::vector<std::vector<ElemType>>& output,
              const TokenizerType& tokenizer,
              PolicyType& policy,
-             typename std::enable_if<StringEncodingPolicyTraits<
-                 PolicyType>::onePassEncoding>::type*)
+             std::enable_if_t<StringEncodingPolicyTraits<
+                 PolicyType>::onePassEncoding>*)
 {
   policy.Reset();
 
@@ -176,9 +176,9 @@ EncodeHelper(const std::vector<std::string>& input,
     auto token = tokenizer(strView);
 
     static_assert(
-        std::is_same<typename std::remove_reference<decltype(token)>::type,
-                     typename std::remove_reference<typename DictionaryType::
-                        TokenType>::type>::value,
+        std::is_same_v<std::remove_reference_t<decltype(token)>,
+                     std::remove_reference_t<typename DictionaryType::
+                        TokenType>>,
         "The dictionary token type doesn't match the return value type "
         "of the tokenizer.");
 

--- a/src/mlpack/core/data/string_encoding_impl.hpp
+++ b/src/mlpack/core/data/string_encoding_impl.hpp
@@ -71,8 +71,8 @@ void StringEncoding<EncodingPolicyType, DictionaryType>::CreateMap(
 
   static_assert(
       std::is_same_v<std::remove_reference_t<decltype(token)>,
-                   std::remove_reference_t<typename DictionaryType::
-                      TokenType>>,
+                     std::remove_reference_t<typename DictionaryType::
+                        TokenType>>,
       "The dictionary token type doesn't match the return value type "
       "of the tokenizer.");
 
@@ -117,8 +117,8 @@ EncodeHelper(const std::vector<std::string>& input,
 
     static_assert(
         std::is_same_v<std::remove_reference_t<decltype(token)>,
-                     std::remove_reference_t<typename DictionaryType::
-                        TokenType>>,
+                       std::remove_reference_t<typename DictionaryType::
+                          TokenType>>,
         "The dictionary token type doesn't match the return value type "
         "of the tokenizer.");
 
@@ -177,8 +177,8 @@ EncodeHelper(const std::vector<std::string>& input,
 
     static_assert(
         std::is_same_v<std::remove_reference_t<decltype(token)>,
-                     std::remove_reference_t<typename DictionaryType::
-                        TokenType>>,
+                       std::remove_reference_t<typename DictionaryType::
+                          TokenType>>,
         "The dictionary token type doesn't match the return value type "
         "of the tokenizer.");
 

--- a/src/mlpack/core/distributions/discrete_distribution.hpp
+++ b/src/mlpack/core/distributions/discrete_distribution.hpp
@@ -153,7 +153,7 @@ class DiscreteDistribution
     {
       // Adding 0.5 helps ensure that we cast the floating point to a size_t
       // correctly.
-      const size_t obs = (std::is_floating_point<ObsType>::value) ?
+      const size_t obs = (std::is_floating_point_v<ObsType>) ?
           size_t(observation(dimension) + 0.5) : size_t(observation(dimension));
 
       // Ensure that the observation is within the bounds.

--- a/src/mlpack/core/distributions/discrete_distribution_impl.hpp
+++ b/src/mlpack/core/distributions/discrete_distribution_impl.hpp
@@ -83,7 +83,7 @@ inline void DiscreteDistribution<MatType, ObsMatType>::Train(
       // Add the probability of each observation.  The addition of 0.5 to the
       // observation is to turn the default flooring operation of the size_t
       // cast into a rounding observation.
-      const size_t obs = (std::is_floating_point<ObsType>::value) ?
+      const size_t obs = (std::is_floating_point_v<ObsType>) ?
           size_t(observations(i, r) + 0.5) : size_t(observations(i, r));
 
       // Ensure that the observation is within the bounds.
@@ -141,7 +141,7 @@ inline void DiscreteDistribution<MatType, ObsMatType>::Train(
       // Add the probability of each observation. The addition of 0.5
       // to the observation is to turn the default flooring operation
       // of the size_t cast into a rounding observation.
-      const size_t obs = (std::is_floating_point<ObsType>::value) ?
+      const size_t obs = (std::is_floating_point_v<ObsType>) ?
           size_t(observations(i, r) + 0.5) : size_t(observations(i, r));
 
       // Ensure that the observation is within the bounds.

--- a/src/mlpack/core/distributions/gamma_distribution.hpp
+++ b/src/mlpack/core/distributions/gamma_distribution.hpp
@@ -75,7 +75,7 @@ class GammaDistribution
    */
   GammaDistribution(const MatType& data,
                     const ElemType tol =
-                        std::is_same<ElemType, float>::value ? 1e-4 : 1e-8);
+                        std::is_same_v<ElemType, float> ? 1e-4 : 1e-8);
 
   /**
    * Construct the Gamma distribution given two vectors alpha and beta.
@@ -101,7 +101,7 @@ class GammaDistribution
    */
   void Train(const MatType& rdata,
              const ElemType tol =
-                 std::is_same<ElemType, float>::value ? 1e-4 : 1e-8);
+                 std::is_same_v<ElemType, float> ? 1e-4 : 1e-8);
 
   /**
    * Fits an alpha and beta parameter according to observation probabilities.
@@ -117,7 +117,7 @@ class GammaDistribution
   void Train(const MatType& observations,
              const VecType& probabilities,
              const ElemType tol =
-                 std::is_same<ElemType, float>::value ? 1e-4 : 1e-8);
+                 std::is_same_v<ElemType, float> ? 1e-4 : 1e-8);
 
   /**
    * This function trains (fits distribution parameters) to a dataset with
@@ -136,7 +136,7 @@ class GammaDistribution
              const VecType& meanLogxVec,
              const VecType& meanxVec,
              const ElemType tol =
-                 std::is_same<ElemType, float>::value ? 1e-4 : 1e-8);
+                 std::is_same_v<ElemType, float> ? 1e-4 : 1e-8);
 
   /**
    * This function returns the probability of a group of observations.

--- a/src/mlpack/core/hpt/cv_function.hpp
+++ b/src/mlpack/core/hpt/cv_function.hpp
@@ -130,7 +130,7 @@ class CVFunction
   template<size_t BoundArgIndex,
            size_t ParamIndex,
            typename... Args,
-           typename = 
+           typename =
                std::enable_if_t<(BoundArgIndex + ParamIndex < TotalArgs)>>
   inline double Evaluate(const arma::mat& parameters, const Args&... args);
 
@@ -140,7 +140,7 @@ class CVFunction
   template<size_t BoundArgIndex,
            size_t ParamIndex,
            typename... Args,
-           typename = 
+           typename =
                std::enable_if_t<BoundArgIndex + ParamIndex == TotalArgs>,
            typename = void>
   inline double Evaluate(const arma::mat& parameters, const Args&... args);

--- a/src/mlpack/core/hpt/cv_function.hpp
+++ b/src/mlpack/core/hpt/cv_function.hpp
@@ -130,8 +130,8 @@ class CVFunction
   template<size_t BoundArgIndex,
            size_t ParamIndex,
            typename... Args,
-           typename = typename
-               std::enable_if<(BoundArgIndex + ParamIndex < TotalArgs)>::type>
+           typename = 
+               std::enable_if_t<(BoundArgIndex + ParamIndex < TotalArgs)>>
   inline double Evaluate(const arma::mat& parameters, const Args&... args);
 
   /**
@@ -140,8 +140,8 @@ class CVFunction
   template<size_t BoundArgIndex,
            size_t ParamIndex,
            typename... Args,
-           typename = typename
-               std::enable_if<BoundArgIndex + ParamIndex == TotalArgs>::type,
+           typename = 
+               std::enable_if_t<BoundArgIndex + ParamIndex == TotalArgs>,
            typename = void>
   inline double Evaluate(const arma::mat& parameters, const Args&... args);
 
@@ -151,8 +151,8 @@ class CVFunction
   template<size_t BoundArgIndex,
            size_t ParamIndex,
            typename... Args,
-           typename = typename std::enable_if<
-               UseBoundArg<BoundArgIndex, ParamIndex>::value>::type>
+           typename = std::enable_if_t<
+               UseBoundArg<BoundArgIndex, ParamIndex>::value>>
   inline double PutNextArg(const arma::mat& parameters, const Args&... args);
 
   /**
@@ -162,8 +162,8 @@ class CVFunction
   template<size_t BoundArgIndex,
            size_t ParamIndex,
            typename... Args,
-           typename = typename std::enable_if<
-               !UseBoundArg<BoundArgIndex, ParamIndex>::value>::type,
+           typename = std::enable_if_t<
+               !UseBoundArg<BoundArgIndex, ParamIndex>::value>,
            typename = void>
   inline double PutNextArg(const arma::mat& parameters, const Args&... args);
 };

--- a/src/mlpack/core/hpt/deduce_hp_types.hpp
+++ b/src/mlpack/core/hpt/deduce_hp_types.hpp
@@ -51,7 +51,7 @@ struct DeduceHyperParameterTypes<T, Args...>
    * A type function to deduce the result hyper-parameter type for ArgumentType.
    */
   template<typename ArgumentType,
-           bool IsArithmetic = std::is_arithmetic<ArgumentType>::value>
+           bool IsArithmetic = std::is_arithmetic_v<ArgumentType>>
   struct ResultHPType;
 
   template<typename ArithmeticType>

--- a/src/mlpack/core/hpt/fixed.hpp
+++ b/src/mlpack/core/hpt/fixed.hpp
@@ -101,7 +101,7 @@ class IsPreFixedArg
   struct Implementation<PreFixedArg<Type>> : std::true_type {};
 
  public:
-  static const bool value = Implementation<typename std::decay<T>::type>::value;
+  static const bool value = Implementation<std::decay_t<T>>::value;
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/hpt/hpt.hpp
+++ b/src/mlpack/core/hpt/hpt.hpp
@@ -199,10 +199,10 @@ class HyperParameterTuner
   };
 
   //! A short alias for the full type of the cross-validation.
-  using CVType = typename std::conditional<Metric::NeedsMinimization,
+  using CVType = std::conditional_t<Metric::NeedsMinimization,
       CV<MLAlgorithm, Metric, MatType, PredictionsType, WeightsType>,
       CV<MLAlgorithm, Negated<Metric>, MatType, PredictionsType,
-          WeightsType>>::type;
+          WeightsType>>;
 
 
   //! The cross-validation object for assessing sets of hyper-parameters.
@@ -234,15 +234,15 @@ class HyperParameterTuner
    * PreFixedArg.
    */
   template<typename Tuple, size_t I>
-  using IsPreFixed = IsPreFixedArg<typename std::tuple_element<I, Tuple>::type>;
+  using IsPreFixed = IsPreFixedArg<std::tuple_element_t<I, Tuple>>;
 
   /**
    * A type function to check whether the element I of the tuple type is an
    * arithmetic type.
    */
   template<typename Tuple, size_t I>
-  using IsArithmetic = std::is_arithmetic<typename std::remove_reference<
-      typename std::tuple_element<I, Tuple>::type>::type>;
+  using IsArithmetic = std::is_arithmetic<std::remove_reference_t<
+      std::tuple_element_t<I, Tuple>>>;
 
   /**
    * The set of methods to initialize auxiliary objects (a CVFunction object and

--- a/src/mlpack/core/hpt/hpt.hpp
+++ b/src/mlpack/core/hpt/hpt.hpp
@@ -201,8 +201,7 @@ class HyperParameterTuner
   //! A short alias for the full type of the cross-validation.
   using CVType = std::conditional_t<Metric::NeedsMinimization,
       CV<MLAlgorithm, Metric, MatType, PredictionsType, WeightsType>,
-      CV<MLAlgorithm, Negated<Metric>, MatType, PredictionsType,
-          WeightsType>>;
+      CV<MLAlgorithm, Negated<Metric>, MatType, PredictionsType, WeightsType>>;
 
 
   //! The cross-validation object for assessing sets of hyper-parameters.

--- a/src/mlpack/core/hpt/hpt_impl.hpp
+++ b/src/mlpack/core/hpt/hpt_impl.hpp
@@ -130,8 +130,8 @@ void HyperParameterTuner<MLAlgorithm,
     data::DatasetMapper<data::IncrementPolicy, double>& datasetInfo,
     FixedArgs... fixedArgs)
 {
-  using PreFixedArgT = typename std::remove_reference<
-      typename std::tuple_element<I, ArgsTuple>::type>::type;
+  using PreFixedArgT = std::remove_reference_t<
+      std::tuple_element_t<I, ArgsTuple>>;
   using FixedArgT = FixedArg<typename PreFixedArgT::Type, I>;
 
   InitAndOptimize<I + 1>(args, bestParams, datasetInfo, fixedArgs...,

--- a/src/mlpack/core/math/digamma.hpp
+++ b/src/mlpack/core/math/digamma.hpp
@@ -27,7 +27,7 @@ namespace mlpack {
  * @param x Input for which digamma will be calculated.
  */
 template<std::size_t N, typename T>
-typename std::enable_if<N == 8, T>::type
+std::enable_if_t<N == 8, T>
 EvaluatePolyLarge(const T(&a)[N], const T& x)
 {
   T x2 = x * x;
@@ -60,7 +60,7 @@ EvaluatePolyLarge(const T(&a)[N], const T& x)
  * @param x Input for which digamma will be calculated.
  */
 template<std::size_t N, typename T>
-typename std::enable_if<N == 7, T>::type
+std::enable_if_t<N == 7, T>
 EvaluatePoly12(const T(&a)[N], const T& x)
 {
   T x2 = x * x;
@@ -91,7 +91,7 @@ EvaluatePoly12(const T(&a)[N], const T& x)
  * @param x Input for which digamma will be calculated.
  */
 template<std::size_t N, typename T>
-typename std::enable_if<N == 6, T>::type
+std::enable_if_t<N == 6, T>
 EvaluatePoly12(const T(&a)[N], const T& x)
 {
   T x2 = x * x;

--- a/src/mlpack/core/math/trigamma.hpp
+++ b/src/mlpack/core/math/trigamma.hpp
@@ -30,7 +30,7 @@ namespace mlpack {
  * @param x Input for which we have to calculate trigamma.
  */
 template<std::size_t N, typename T>
-typename std::enable_if<N == 6, T>::type
+std::enable_if_t<N == 6, T>
 EvaluatePolyPrec(const T(&a)[N], const T& x)
 {
   T x2 = x * x;
@@ -60,7 +60,7 @@ EvaluatePolyPrec(const T(&a)[N], const T& x)
  * @param x Input for which we have to calculate trigamma.
  */
 template<std::size_t N, typename T>
-typename std::enable_if<N == 7, T>::type
+std::enable_if_t<N == 7, T>
 EvaluatePolyPrec(const T(&a)[N], const T& x)
 {
   T x2 = x * x;

--- a/src/mlpack/core/tree/address.hpp
+++ b/src/mlpack/core/tree/address.hpp
@@ -58,7 +58,7 @@ void PointToAddress(AddressType& address, const VecType& point)
   // Check that the arguments are compatible.
   typedef std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>AddressElemType;
+                                    uint64_t> AddressElemType;
 
   static_assert(std::is_same_v<typename AddressType::elem_type,
       AddressElemType> == true, "The vector element type does not "
@@ -154,7 +154,7 @@ void AddressToPoint(VecType& point, const AddressType& address)
   // Check that the arguments are compatible.
   typedef std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>AddressElemType;
+                                    uint64_t> AddressElemType;
 
   static_assert(std::is_same_v<typename AddressType::elem_type,
       AddressElemType> == true, "The vector element type does not "

--- a/src/mlpack/core/tree/address.hpp
+++ b/src/mlpack/core/tree/address.hpp
@@ -56,12 +56,12 @@ void PointToAddress(AddressType& address, const VecType& point)
 {
   typedef typename VecType::elem_type VecElemType;
   // Check that the arguments are compatible.
-  typedef typename std::conditional<sizeof(VecElemType) * CHAR_BIT <= 32,
+  typedef std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>::type AddressElemType;
+                                    uint64_t>AddressElemType;
 
-  static_assert(std::is_same<typename AddressType::elem_type,
-      AddressElemType>::value == true, "The vector element type does not "
+  static_assert(std::is_same_v<typename AddressType::elem_type,
+      AddressElemType> == true, "The vector element type does not "
       "correspond to the address element type.");
   arma::Col<AddressElemType> result(point.n_elem);
 
@@ -152,12 +152,12 @@ void AddressToPoint(VecType& point, const AddressType& address)
 {
   typedef typename VecType::elem_type VecElemType;
   // Check that the arguments are compatible.
-  typedef typename std::conditional<sizeof(VecElemType) * CHAR_BIT <= 32,
+  typedef std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>::type AddressElemType;
+                                    uint64_t>AddressElemType;
 
-  static_assert(std::is_same<typename AddressType::elem_type,
-      AddressElemType>::value == true, "The vector element type does not "
+  static_assert(std::is_same_v<typename AddressType::elem_type,
+      AddressElemType> == true, "The vector element type does not "
       "correspond to the address element type.");
 
   constexpr size_t order = sizeof(AddressElemType) * CHAR_BIT;
@@ -230,8 +230,8 @@ void AddressToPoint(VecType& point, const AddressType& address)
 template<typename AddressType1, typename AddressType2>
 int CompareAddresses(const AddressType1& addr1, const AddressType2& addr2)
 {
-  static_assert(std::is_same<typename AddressType1::elem_type,
-      typename AddressType2::elem_type>::value == true, "Can't compare "
+  static_assert(std::is_same_v<typename AddressType1::elem_type,
+      typename AddressType2::elem_type> == true, "Can't compare "
       "addresses of distinct types");
 
   assert(addr1.n_elem == addr2.n_elem);

--- a/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
@@ -29,10 +29,10 @@ class UBTreeSplit
 {
  public:
   //! The type of an address element.
-  typedef typename std::conditional<
+  typedef std::conditional_t<
       sizeof(typename MatType::elem_type) * CHAR_BIT <= 32,
       uint32_t,
-      uint64_t>::type AddressElemType;
+      uint64_t>AddressElemType;
 
   //! An information about the partition.
   struct SplitInfo

--- a/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
@@ -32,7 +32,7 @@ class UBTreeSplit
   typedef std::conditional_t<
       sizeof(typename MatType::elem_type) * CHAR_BIT <= 32,
       uint32_t,
-      uint64_t>AddressElemType;
+      uint64_t> AddressElemType;
 
   //! An information about the partition.
   struct SplitInfo

--- a/src/mlpack/core/tree/build_tree.hpp
+++ b/src/mlpack/core/tree/build_tree.hpp
@@ -21,8 +21,7 @@ template<typename TreeType, typename MatType>
 TreeType* BuildTree(
     MatType&& dataset,
     std::vector<size_t>& oldFromNew,
-    const std::enable_if_t<
-        TreeTraits<TreeType>::RearrangesDataset>* = 0)
+    const std::enable_if_t<TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   return new TreeType(std::forward<MatType>(dataset), oldFromNew);
 }
@@ -32,8 +31,7 @@ template<typename TreeType, typename MatType>
 TreeType* BuildTree(
     MatType&& dataset,
     const std::vector<size_t>& /* oldFromNew */,
-    const std::enable_if_t<
-        !TreeTraits<TreeType>::RearrangesDataset>* = 0)
+    const std::enable_if_t<!TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   return new TreeType(std::forward<MatType>(dataset));
 }

--- a/src/mlpack/core/tree/build_tree.hpp
+++ b/src/mlpack/core/tree/build_tree.hpp
@@ -21,8 +21,8 @@ template<typename TreeType, typename MatType>
 TreeType* BuildTree(
     MatType&& dataset,
     std::vector<size_t>& oldFromNew,
-    const typename std::enable_if<
-        TreeTraits<TreeType>::RearrangesDataset>::type* = 0)
+    const std::enable_if_t<
+        TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   return new TreeType(std::forward<MatType>(dataset), oldFromNew);
 }
@@ -32,8 +32,8 @@ template<typename TreeType, typename MatType>
 TreeType* BuildTree(
     MatType&& dataset,
     const std::vector<size_t>& /* oldFromNew */,
-    const typename std::enable_if<
-        !TreeTraits<TreeType>::RearrangesDataset>::type* = 0)
+    const std::enable_if_t<
+        !TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   return new TreeType(std::forward<MatType>(dataset));
 }

--- a/src/mlpack/core/tree/cellbound.hpp
+++ b/src/mlpack/core/tree/cellbound.hpp
@@ -78,7 +78,7 @@ class CellBound
   //! uint32_t or uint64_t.
   typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>AddressElemType;
+                                    uint64_t> AddressElemType;
 
   /**
    * Empty constructor; creates a bound of dimensionality 0.

--- a/src/mlpack/core/tree/cellbound.hpp
+++ b/src/mlpack/core/tree/cellbound.hpp
@@ -76,9 +76,9 @@ class CellBound
  public:
   //! Depending on the precision of the tree element type, we may need to use
   //! uint32_t or uint64_t.
-  typedef typename std::conditional<sizeof(ElemType) * CHAR_BIT <= 32,
+  typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>::type AddressElemType;
+                                    uint64_t>AddressElemType;
 
   /**
    * Empty constructor; creates a bound of dimensionality 0.

--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
@@ -32,7 +32,7 @@ class DiscreteHilbertValue
   //! uint32_t or uint64_t.
   typedef std::conditional_t<sizeof(TreeElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>HilbertElemType;
+                                    uint64_t> HilbertElemType;
 
   //! Default constructor.
   DiscreteHilbertValue();

--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
@@ -30,9 +30,9 @@ class DiscreteHilbertValue
  public:
   //! Depending on the precision of the tree element type, we may need to use
   //! uint32_t or uint64_t.
-  typedef typename std::conditional<sizeof(TreeElemType) * CHAR_BIT <= 32,
+  typedef std::conditional_t<sizeof(TreeElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>::type HilbertElemType;
+                                    uint64_t>HilbertElemType;
 
   //! Default constructor.
   DiscreteHilbertValue();

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -53,7 +53,7 @@ template<typename DistanceType = EuclideanDistance,
 class RectangleTree
 {
   // The distance metric *must* be the euclidean distance.
-  static_assert(std::is_same<DistanceType, EuclideanDistance>::value,
+  static_assert(std::is_same_v<DistanceType, EuclideanDistance>,
       "RectangleTree: DistanceType must be EuclideanDistance.");
 
  public:

--- a/src/mlpack/core/util/ens_traits.hpp
+++ b/src/mlpack/core/util/ens_traits.hpp
@@ -55,8 +55,7 @@ struct IsEnsOptimizerInternal<OptimizerType, FunctionType, MatType, true>
 {
   // If OptimizerType is a reference type, then forming the types below will
   // fail.  So we need to strip the reference (and the const for good measure).
-  typedef std::remove_cv_t<
-      std::remove_reference_t<OptimizerType>>
+  typedef std::remove_cv_t<std::remove_reference_t<OptimizerType>>
       SafeOptimizerType;
 
   using OptimizeElemReturnForm =
@@ -85,9 +84,8 @@ template<typename CallbackType, typename... CallbackTypes>
 struct IsEnsCallbackTypes<CallbackType, CallbackTypes...>
 {
   constexpr static bool value =
-      std::is_class_v<std::remove_cv_t<
-          std::remove_reference_t<CallbackType>
-      >> && IsEnsCallbackTypes<CallbackTypes...>::value;
+      std::is_class_v<std::remove_cv_t<std::remove_reference_t<CallbackType>>>
+      && IsEnsCallbackTypes<CallbackTypes...>::value;
 };
 
 template<>

--- a/src/mlpack/core/util/ens_traits.hpp
+++ b/src/mlpack/core/util/ens_traits.hpp
@@ -45,7 +45,7 @@ struct IsEnsOptimizer
       OptimizerType,
       FunctionType,
       MatType,
-      std::is_class<OptimizerType>::value
+      std::is_class_v<OptimizerType>
   >::value;
 };
 
@@ -55,8 +55,8 @@ struct IsEnsOptimizerInternal<OptimizerType, FunctionType, MatType, true>
 {
   // If OptimizerType is a reference type, then forming the types below will
   // fail.  So we need to strip the reference (and the const for good measure).
-  typedef typename std::remove_cv<
-      typename std::remove_reference<OptimizerType>::type>::type
+  typedef std::remove_cv_t<
+      std::remove_reference_t<OptimizerType>>
       SafeOptimizerType;
 
   using OptimizeElemReturnForm =
@@ -85,9 +85,9 @@ template<typename CallbackType, typename... CallbackTypes>
 struct IsEnsCallbackTypes<CallbackType, CallbackTypes...>
 {
   constexpr static bool value =
-      std::is_class<typename std::remove_cv<
-          typename std::remove_reference<CallbackType>::type
-      >::type>::value && IsEnsCallbackTypes<CallbackTypes...>::value;
+      std::is_class_v<std::remove_cv_t<
+          std::remove_reference_t<CallbackType>
+      >> && IsEnsCallbackTypes<CallbackTypes...>::value;
 };
 
 template<>

--- a/src/mlpack/core/util/first_element_is_arma.hpp
+++ b/src/mlpack/core/util/first_element_is_arma.hpp
@@ -39,9 +39,7 @@ template<typename... CallbackTypes>
 struct FirstElementIsArma
 {
   static constexpr bool value = arma::is_arma_type<
-      std::remove_reference_t<
-          typename First<CallbackTypes...>::type
-      >>::value;
+      std::remove_reference_t<typename First<CallbackTypes...>::type>>::value;
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/util/first_element_is_arma.hpp
+++ b/src/mlpack/core/util/first_element_is_arma.hpp
@@ -39,9 +39,9 @@ template<typename... CallbackTypes>
 struct FirstElementIsArma
 {
   static constexpr bool value = arma::is_arma_type<
-      typename std::remove_reference<
+      std::remove_reference_t<
           typename First<CallbackTypes...>::type
-      >::type>::value;
+      >>::value;
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/util/prefixedoutstream.hpp
+++ b/src/mlpack/core/util/prefixedoutstream.hpp
@@ -134,7 +134,7 @@ class PrefixedOutStream
    * @param val The The data to be output.
    */
   template<typename T>
-  typename std::enable_if<!arma::is_arma_type<T>::value>::type
+  std::enable_if_t<!arma::is_arma_type<T>::value>
   BaseLogic(const T& val);
 
   /**
@@ -148,7 +148,7 @@ class PrefixedOutStream
    * @param val The The data to be output.
    */
   template<typename T>
-  typename std::enable_if<arma::is_arma_type<T>::value>::type
+  std::enable_if_t<arma::is_arma_type<T>::value>
   BaseLogic(const T& val);
 
   /**

--- a/src/mlpack/core/util/prefixedoutstream_impl.hpp
+++ b/src/mlpack/core/util/prefixedoutstream_impl.hpp
@@ -146,7 +146,7 @@ inline PrefixedOutStream& PrefixedOutStream::operator<<(
 
 // For non-Armadillo types.
 template<typename T>
-typename std::enable_if<!arma::is_arma_type<T>::value>::type
+std::enable_if_t<!arma::is_arma_type<T>::value>
 PrefixedOutStream::BaseLogic(const T& val)
 {
   // We will use this to track whether or not we need to terminate at the end of
@@ -254,7 +254,7 @@ PrefixedOutStream::BaseLogic(const T& val)
 
 // For Armadillo types.
 template<typename T>
-typename std::enable_if<arma::is_arma_type<T>::value>::type
+std::enable_if_t<arma::is_arma_type<T>::value>
 PrefixedOutStream::BaseLogic(const T& val)
 {
   // Extract printable object from the input.

--- a/src/mlpack/core/util/sfinae_utility.hpp
+++ b/src/mlpack/core/util/sfinae_utility.hpp
@@ -155,8 +155,7 @@ struct NAME                                                                    \
     using no = char[2];                                                        \
                                                                                \
     template<typename T, typename ResultType>                                  \
-    using EnableIfVoid =                                                       \
-        std::enable_if_t<std::is_void_v<T>, ResultType>;     \
+    using EnableIfVoid = std::enable_if_t<std::is_void_v<T>, ResultType>;      \
                                                                                \
     template<typename C>                                                       \
     static EnableIfVoid<decltype(MFD<C, MF, N>()(&C::METHOD)), yes&> chk(int); \
@@ -169,13 +168,13 @@ struct NAME                                                                    \
   template<size_t N>                                                           \
   struct WithGreaterOrEqualNumberOfAdditionalArgs                              \
   {                                                                            \
-    using type = typename std::conditional<                                    \
+    using type = std::conditional_t<                                           \
         WithNAdditionalArgs<N>::value,                                         \
         std::true_type,                                                        \
-        typename std::conditional<                                             \
+        std::conditional_t<                                                    \
             N < MAXN,                                                          \
             WithGreaterOrEqualNumberOfAdditionalArgs<N + 1>,                   \
-            std::false_type>::type>::type;                                     \
+            std::false_type>>;                                                 \
     static const bool value = type::value;                                     \
   };                                                                           \
                                                                                \

--- a/src/mlpack/core/util/sfinae_utility.hpp
+++ b/src/mlpack/core/util/sfinae_utility.hpp
@@ -156,7 +156,7 @@ struct NAME                                                                    \
                                                                                \
     template<typename T, typename ResultType>                                  \
     using EnableIfVoid =                                                       \
-        typename std::enable_if<std::is_void<T>::value, ResultType>::type;     \
+        std::enable_if_t<std::is_void_v<T>, ResultType>;     \
                                                                                \
     template<typename C>                                                       \
     static EnableIfVoid<decltype(MFD<C, MF, N>()(&C::METHOD)), yes&> chk(int); \
@@ -196,20 +196,19 @@ struct NAME                                                                    \
  * function in the given class name.
  * This can also be used in conjunction with std::enable_if.
  */
-#define HAS_ANY_METHOD_FORM(FUNC, NAME)                                      \
-template <typename T>                                                        \
-struct NAME                                                                  \
-{                                                                            \
-  template <typename Q = T>                                                  \
-  static typename                                                            \
-  std::enable_if<std::is_member_function_pointer<decltype(&Q::FUNC)>::value, \
-                 int>::type                                                  \
-  f(int) { return 1;}                                                      \
-                                                                             \
-  template <typename Q = T>                                                  \
-  static char f(char) { return 0; }                                        \
-                                                                             \
-  static const bool value = sizeof(f<T>(0)) != sizeof(char);                 \
+#define HAS_ANY_METHOD_FORM(FUNC, NAME)                                       \
+template <typename T>                                                         \
+struct NAME                                                                   \
+{                                                                             \
+  template <typename Q = T>                                                   \
+  static                                                                      \
+  std::enable_if_t<std::is_member_function_pointer_v<decltype(&Q::FUNC)>, int>\
+  f(int) { return 1;}                                                         \
+                                                                              \
+  template <typename Q = T>                                                   \
+  static char f(char) { return 0; }                                           \
+                                                                              \
+  static const bool value = sizeof(f<T>(0)) != sizeof(char);                  \
 };
 /*
  * A macro that can be used for passing arguments containing commas to other

--- a/src/mlpack/core/util/sfinae_utility.hpp
+++ b/src/mlpack/core/util/sfinae_utility.hpp
@@ -202,7 +202,7 @@ struct NAME                                                                   \
   template <typename Q = T>                                                   \
   static                                                                      \
   std::enable_if_t<std::is_member_function_pointer_v<decltype(&Q::FUNC)>, int>\
-  f(int) { return 1;}                                                         \
+  f(int) { return 1; }                                                        \
                                                                               \
   template <typename Q = T>                                                   \
   static char f(char) { return 0; }                                           \

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -39,8 +39,7 @@ inline void CheckSameSizes(
     const std::string& addInfo = "labels",
     const bool& isDataTranspose = false,
     const bool& isLabelTranspose = false,
-    const std::enable_if_t<
-        !std::is_integral_v<LabelsType>>* = 0)
+    const std::enable_if_t<!std::is_integral_v<LabelsType>>* = 0)
 {
   const size_t dataPoints = (isDataTranspose == true) ? data.n_rows :
       data.n_cols;

--- a/src/mlpack/core/util/size_checks.hpp
+++ b/src/mlpack/core/util/size_checks.hpp
@@ -39,8 +39,8 @@ inline void CheckSameSizes(
     const std::string& addInfo = "labels",
     const bool& isDataTranspose = false,
     const bool& isLabelTranspose = false,
-    const typename std::enable_if<
-        !std::is_integral<LabelsType>::value>::type* = 0)
+    const std::enable_if_t<
+        !std::is_integral_v<LabelsType>>* = 0)
 {
   const size_t dataPoints = (isDataTranspose == true) ? data.n_rows :
       data.n_cols;
@@ -67,7 +67,7 @@ inline void CheckSameSizes(
     const SizeType& size,
     const std::string& callerDescription,
     const std::string& addInfo = "labels",
-    const typename std::enable_if<std::is_integral<SizeType>::value>::type* = 0)
+    const std::enable_if_t<std::is_integral_v<SizeType>>* = 0)
 {
   if (data.n_cols != size)
   {
@@ -96,7 +96,7 @@ inline void CheckSameDimensionality(
     const DimType& dimension,
     const std::string& callerDescription,
     const std::string& addInfo = "dataset",
-    const typename std::enable_if<!std::is_integral<DimType>::value>::type* = 0)
+    const std::enable_if_t<!std::is_integral_v<DimType>>* = 0)
 {
   if (data.n_rows != dimension.n_rows)
   {
@@ -119,7 +119,7 @@ inline void CheckSameDimensionality(
     const DimType& dimension,
     const std::string& callerDescription,
     const std::string& addInfo = "dataset",
-    const typename std::enable_if<std::is_integral<DimType>::value>::type* = 0)
+    const std::enable_if_t<std::is_integral_v<DimType>>* = 0)
 {
   if (data.n_rows != dimension)
   {

--- a/src/mlpack/core/util/using.hpp
+++ b/src/mlpack/core/util/using.hpp
@@ -92,7 +92,7 @@ struct GetFillType
 // If the matrix type is a Bandicoot type, use Bandicoot fill objects instead.
 template<
     typename MatType,
-    typename = typename std::enable_if<is_coot_type<MatType>::value>::type*>
+    typename = std::enable_if_t<is_coot_type<MatType>::value>*>
 struct GetFillType
 {
   static constexpr const decltype(coot::fill::none)& none   = coot::fill::none;

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -131,8 +131,7 @@ class AdaBoost
            const size_t maxIterations = 100,
            const ElemType tolerance = 1e-6,
            const std::enable_if_t<
-              std::is_same_v<WeakLearnerType, WeakLearnerInType>
-           >* = 0);
+              std::is_same_v<WeakLearnerType, WeakLearnerInType>>* = 0);
 
   //! Get the maximum number of weak learners allowed in the model.
   size_t MaxIterations() const { return maxIterations; }

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -130,9 +130,9 @@ class AdaBoost
            const WeakLearnerInType& other,
            const size_t maxIterations = 100,
            const ElemType tolerance = 1e-6,
-           const typename std::enable_if<
-              std::is_same<WeakLearnerType, WeakLearnerInType>::value
-           >::type* = 0);
+           const std::enable_if_t<
+              std::is_same_v<WeakLearnerType, WeakLearnerInType>
+           >* = 0);
 
   //! Get the maximum number of weak learners allowed in the model.
   size_t MaxIterations() const { return maxIterations; }
@@ -189,8 +189,8 @@ class AdaBoost
       const std::optional<size_t> maxIterations = std::nullopt,
       const std::optional<double> tolerance = std::nullopt,
       // Necessary to distinguish from other overloads.
-      const typename std::enable_if<
-          std::is_same<WeakLearnerType, WeakLearnerInType>::value>::type* = 0);
+      const std::enable_if_t<
+          std::is_same_v<WeakLearnerType, WeakLearnerInType>>* = 0);
 
   /**
    * Train AdaBoost on the given dataset, using the given parameters.  The last

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -57,8 +57,8 @@ AdaBoost<WeakLearnerType, MatType>::AdaBoost(
     const WeakLearnerInType& other,
     const size_t maxIterations,
     const typename MatType::elem_type tol,
-    const typename std::enable_if<
-        std::is_same<WeakLearnerType, WeakLearnerInType>::value>::type*) :
+    const std::enable_if_t<
+        std::is_same_v<WeakLearnerType, WeakLearnerInType>>*) :
     maxIterations(maxIterations),
     tolerance(tol)
 {
@@ -102,8 +102,8 @@ typename MatType::elem_type AdaBoost<WeakLearnerType, MatType>::Train(
     const WeakLearnerInType& other,
     const std::optional<size_t> maxIterations,
     const std::optional<double> tolerance,
-    const typename std::enable_if<
-        std::is_same<WeakLearnerType, WeakLearnerInType>::value>::type*)
+    const std::enable_if_t<
+        std::is_same_v<WeakLearnerType, WeakLearnerInType>>*)
 {
   if (maxIterations.has_value())
     this->maxIterations = maxIterations.value();
@@ -229,7 +229,7 @@ void AdaBoost<WeakLearnerType, MatType>::serialize(Archive& ar,
 
     // In earlier versions, `alpha` was a vector of doubles---but it might not
     // be now.
-    if (std::is_same<ElemType, double>::value)
+    if (std::is_same_v<ElemType, double>)
     {
       ar(CEREAL_NVP(alpha)); // The easy case.
     }

--- a/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
@@ -48,8 +48,7 @@ class FFTConvolution
    * @param output Output data that contains the results of the convolution.
    */
   template<typename MatType, typename Border = BorderMode>
-  static std::enable_if_t<
-      std::is_same_v<Border, ValidConvolution>, void>
+  static std::enable_if_t<std::is_same_v<Border, ValidConvolution>, void>
   Convolution(const MatType& input,
               const MatType& filter,
               MatType& output,
@@ -83,8 +82,7 @@ class FFTConvolution
    * @param output Output data that contains the results of the convolution.
    */
   template<typename MatType, typename Border = BorderMode>
-  static std::enable_if_t<
-      std::is_same_v<Border, FullConvolution>, void>
+  static std::enable_if_t<std::is_same_v<Border, FullConvolution>, void>
   Convolution(const MatType& input,
               const MatType& filter,
               MatType& output,

--- a/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
@@ -48,8 +48,8 @@ class FFTConvolution
    * @param output Output data that contains the results of the convolution.
    */
   template<typename MatType, typename Border = BorderMode>
-  static typename std::enable_if<
-      std::is_same<Border, ValidConvolution>::value, void>::type
+  static std::enable_if_t<
+      std::is_same_v<Border, ValidConvolution>, void>
   Convolution(const MatType& input,
               const MatType& filter,
               MatType& output,
@@ -83,8 +83,8 @@ class FFTConvolution
    * @param output Output data that contains the results of the convolution.
    */
   template<typename MatType, typename Border = BorderMode>
-  static typename std::enable_if<
-      std::is_same<Border, FullConvolution>::value, void>::type
+  static std::enable_if_t<
+      std::is_same_v<Border, FullConvolution>, void>
   Convolution(const MatType& input,
               const MatType& filter,
               MatType& output,

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -49,8 +49,7 @@ class NaiveConvolution
    */
   template<typename InMatType, typename FilMatType, typename OutMatType,
       typename Border = BorderMode>
-  static std::enable_if_t<
-      std::is_same_v<Border, ValidConvolution>, void>
+  static std::enable_if_t<std::is_same_v<Border, ValidConvolution>, void>
   Convolution(const InMatType& input,
               const FilMatType& filter,
               OutMatType& output,
@@ -110,8 +109,7 @@ class NaiveConvolution
    */
   template<typename InMatType, typename FilMatType, typename OutMatType,
       typename Border = BorderMode>
-  static std::enable_if_t<
-      std::is_same_v<Border, FullConvolution>, void>
+  static std::enable_if_t<std::is_same_v<Border, FullConvolution>, void>
   Convolution(const InMatType& input,
               const FilMatType& filter,
               OutMatType& output,

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -49,8 +49,8 @@ class NaiveConvolution
    */
   template<typename InMatType, typename FilMatType, typename OutMatType,
       typename Border = BorderMode>
-  static typename std::enable_if<
-      std::is_same<Border, ValidConvolution>::value, void>::type
+  static std::enable_if_t<
+      std::is_same_v<Border, ValidConvolution>, void>
   Convolution(const InMatType& input,
               const FilMatType& filter,
               OutMatType& output,
@@ -110,8 +110,8 @@ class NaiveConvolution
    */
   template<typename InMatType, typename FilMatType, typename OutMatType,
       typename Border = BorderMode>
-  static typename std::enable_if<
-      std::is_same<Border, FullConvolution>::value, void>::type
+  static std::enable_if_t<
+      std::is_same_v<Border, FullConvolution>, void>
   Convolution(const InMatType& input,
               const FilMatType& filter,
               OutMatType& output,

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -487,8 +487,7 @@ class FFN
    */
   template<typename OptimizerType>
   std::enable_if_t<
-      ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
-  >
+      ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void>
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
   /**
@@ -501,8 +500,7 @@ class FFN
    */
   template<typename OptimizerType>
   std::enable_if_t<
-      !ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
-  >
+      !ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void>
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
   //! Instantiated output layer used to evaluate the network.

--- a/src/mlpack/methods/ann/ffn.hpp
+++ b/src/mlpack/methods/ann/ffn.hpp
@@ -486,9 +486,9 @@ class FFN
    * @param samples Number of datapoints in the dataset.
    */
   template<typename OptimizerType>
-  typename std::enable_if<
+  std::enable_if_t<
       ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
-  >::type
+  >
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
   /**
@@ -500,9 +500,9 @@ class FFN
    * @param samples Number of datapoints in the dataset.
    */
   template<typename OptimizerType>
-  typename std::enable_if<
+  std::enable_if_t<
       !ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
-  >::type
+  >
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
   //! Instantiated output layer used to evaluate the network.

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -694,9 +694,9 @@ template<typename OutputLayerType,
          typename InitializationRuleType,
          typename MatType>
 template<typename OptimizerType>
-typename std::enable_if<
+std::enable_if_t<
     ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
->::type
+>
 FFN<
     OutputLayerType,
     InitializationRuleType,
@@ -718,9 +718,9 @@ template<typename OutputLayerType,
          typename InitializationRuleType,
          typename MatType>
 template<typename OptimizerType>
-typename std::enable_if<
+std::enable_if_t<
     !ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
->::type
+>
 FFN<
     OutputLayerType,
     InitializationRuleType,

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -695,8 +695,7 @@ template<typename OutputLayerType,
          typename MatType>
 template<typename OptimizerType>
 std::enable_if_t<
-    ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
->
+    ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void>
 FFN<
     OutputLayerType,
     InitializationRuleType,
@@ -719,8 +718,7 @@ template<typename OutputLayerType,
          typename MatType>
 template<typename OptimizerType>
 std::enable_if_t<
-    !ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void
->
+    !ens::traits::HasMaxIterationsSignature<OptimizerType>::value, void>
 FFN<
     OutputLayerType,
     InitializationRuleType,

--- a/src/mlpack/methods/ann/not_adapted/brnn.hpp
+++ b/src/mlpack/methods/ann/not_adapted/brnn.hpp
@@ -89,9 +89,9 @@ class BRNN
    * @param samples Number of datapoints in the dataset.
    */
   template<typename OptimizerType>
-  typename std::enable_if<
+  std::enable_if_t<
       HasMaxIterations<OptimizerType, size_t&(OptimizerType::*)()>
-      ::value, void>::type
+      ::value, void>
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
   /**
@@ -103,9 +103,9 @@ class BRNN
    * @param samples Number of datapoints in the dataset.
    */
   template<typename OptimizerType>
-  typename std::enable_if<
+  std::enable_if_t<
       !HasMaxIterations<OptimizerType, size_t&(OptimizerType::*)()>
-      ::value, void>::type
+      ::value, void>
   WarnMessageMaxIterations(OptimizerType& optimizer, size_t samples) const;
 
   /**

--- a/src/mlpack/methods/ann/not_adapted/brnn_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/brnn_impl.hpp
@@ -78,9 +78,9 @@ template<typename OutputLayerType, typename MergeLayerType,
          typename MergeOutputType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename OptimizerType>
-typename std::enable_if<
+std::enable_if_t<
       HasMaxIterations<OptimizerType, size_t&(OptimizerType::*)()>
-      ::value, void>::type
+      ::value, void>
 BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     InitializationRuleType, CustomLayers...>::WarnMessageMaxIterations
 (OptimizerType& optimizer, size_t samples) const
@@ -102,9 +102,9 @@ template<typename OutputLayerType, typename MergeLayerType,
          typename MergeOutputType, typename InitializationRuleType,
          typename... CustomLayers>
 template<typename OptimizerType>
-typename std::enable_if<
+std::enable_if_t<
       !HasMaxIterations<OptimizerType, size_t&(OptimizerType::*)()>
-      ::value, void>::type
+      ::value, void>
 BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     InitializationRuleType, CustomLayers...>::WarnMessageMaxIterations
 (OptimizerType& /* optimizer */, size_t /* samples */) const
@@ -201,7 +201,7 @@ void BRNN<OutputLayerType, MergeLayerType, MergeOutputType,
     ResetParameters();
   }
 
-  if (std::is_same<MergeLayerType, Concat<>>::value)
+  if (std::is_same_v<MergeLayerType, Concat<>>)
   {
     results = zeros<arma::cube>(outputSize * 2, predictors.n_cols, rho);
   }
@@ -438,7 +438,7 @@ EvaluateWithGradient(const arma::mat& /* parameters */,
   }
 
   arma::cube results;
-  if (std::is_same<MergeLayerType, Concat<>>::value)
+  if (std::is_same_v<MergeLayerType, Concat<>>)
   {
     results = zeros<arma::cube>(outputSize * 2, batchSize, rho);
   }

--- a/src/mlpack/methods/ann/not_adapted/gan/gan.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/gan.hpp
@@ -135,7 +135,7 @@ class GAN
    */
   template<typename Policy = PolicyType>
   std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
-                          std::is_same_v<Policy, DCGAN>, double>
+                   std::is_same_v<Policy, DCGAN>, double>
   Evaluate(const arma::mat& parameters,
            const size_t i,
            const size_t batchSize);
@@ -149,8 +149,7 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  std::enable_if_t<std::is_same_v<Policy, WGAN>,
-                          double>
+  std::enable_if_t<std::is_same_v<Policy, WGAN>, double>
   Evaluate(const arma::mat& parameters,
            const size_t i,
            const size_t batchSize);
@@ -164,8 +163,7 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  std::enable_if_t<std::is_same_v<Policy, WGANGP>,
-                          double>
+  std::enable_if_t<std::is_same_v<Policy, WGANGP>, double>
   Evaluate(const arma::mat& parameters,
            const size_t i,
            const size_t batchSize);
@@ -182,7 +180,7 @@ class GAN
    */
   template<typename GradType, typename Policy = PolicyType>
   std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
-                          std::is_same_v<Policy, DCGAN>, double>
+                   std::is_same_v<Policy, DCGAN>, double>
   EvaluateWithGradient(const arma::mat& parameters,
                        const size_t i,
                        GradType& gradient,
@@ -199,8 +197,7 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename GradType, typename Policy = PolicyType>
-  std::enable_if_t<std::is_same_v<Policy, WGAN>,
-                          double>
+  std::enable_if_t<std::is_same_v<Policy, WGAN>, double>
   EvaluateWithGradient(const arma::mat& parameters,
                        const size_t i,
                        GradType& gradient,
@@ -217,8 +214,7 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename GradType, typename Policy = PolicyType>
-  std::enable_if_t<std::is_same_v<Policy, WGANGP>,
-                          double>
+  std::enable_if_t<std::is_same_v<Policy, WGANGP>, double>
   EvaluateWithGradient(const arma::mat& parameters,
                        const size_t i,
                        GradType& gradient,
@@ -236,7 +232,7 @@ class GAN
    */
   template<typename Policy = PolicyType>
   std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
-                          std::is_same_v<Policy, DCGAN>, void>
+                   std::is_same_v<Policy, DCGAN>, void>
   Gradient(const arma::mat& parameters,
            const size_t i,
            arma::mat& gradient,
@@ -270,8 +266,7 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  std::enable_if_t<std::is_same_v<Policy, WGANGP>,
-                          void>
+  std::enable_if_t<std::is_same_v<Policy, WGANGP>, void>
   Gradient(const arma::mat& parameters,
            const size_t i,
            arma::mat& gradient,

--- a/src/mlpack/methods/ann/not_adapted/gan/gan.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/gan.hpp
@@ -134,8 +134,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, StandardGAN>::value ||
-                          std::is_same<Policy, DCGAN>::value, double>::type
+  std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
+                          std::is_same_v<Policy, DCGAN>, double>
   Evaluate(const arma::mat& parameters,
            const size_t i,
            const size_t batchSize);
@@ -149,8 +149,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, WGAN>::value,
-                          double>::type
+  std::enable_if_t<std::is_same_v<Policy, WGAN>,
+                          double>
   Evaluate(const arma::mat& parameters,
            const size_t i,
            const size_t batchSize);
@@ -164,8 +164,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                          double>::type
+  std::enable_if_t<std::is_same_v<Policy, WGANGP>,
+                          double>
   Evaluate(const arma::mat& parameters,
            const size_t i,
            const size_t batchSize);
@@ -181,8 +181,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename GradType, typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, StandardGAN>::value ||
-                          std::is_same<Policy, DCGAN>::value, double>::type
+  std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
+                          std::is_same_v<Policy, DCGAN>, double>
   EvaluateWithGradient(const arma::mat& parameters,
                        const size_t i,
                        GradType& gradient,
@@ -199,8 +199,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename GradType, typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, WGAN>::value,
-                          double>::type
+  std::enable_if_t<std::is_same_v<Policy, WGAN>,
+                          double>
   EvaluateWithGradient(const arma::mat& parameters,
                        const size_t i,
                        GradType& gradient,
@@ -217,8 +217,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename GradType, typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                          double>::type
+  std::enable_if_t<std::is_same_v<Policy, WGANGP>,
+                          double>
   EvaluateWithGradient(const arma::mat& parameters,
                        const size_t i,
                        GradType& gradient,
@@ -235,8 +235,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, StandardGAN>::value ||
-                          std::is_same<Policy, DCGAN>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
+                          std::is_same_v<Policy, DCGAN>, void>
   Gradient(const arma::mat& parameters,
            const size_t i,
            arma::mat& gradient,
@@ -253,7 +253,7 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, WGAN>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, WGAN>, void>
   Gradient(const arma::mat& parameters,
            const size_t i,
            arma::mat& gradient,
@@ -270,8 +270,8 @@ class GAN
    * @param batchSize Variable to store the present number of inputs.
    */
   template<typename Policy = PolicyType>
-  typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                          void>::type
+  std::enable_if_t<std::is_same_v<Policy, WGANGP>,
+                          void>
   Gradient(const arma::mat& parameters,
            const size_t i,
            arma::mat& gradient,

--- a/src/mlpack/methods/ann/not_adapted/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/gan_impl.hpp
@@ -233,8 +233,8 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-typename std::enable_if<std::is_same<Policy, StandardGAN>::value ||
-                        std::is_same<Policy, DCGAN>::value, double>::type
+std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
+                        std::is_same_v<Policy, DCGAN>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
     const arma::mat& /* parameters */,
     const size_t i,
@@ -288,8 +288,8 @@ template<
   typename PolicyType
 >
 template<typename GradType, typename Policy>
-typename std::enable_if<std::is_same<Policy, StandardGAN>::value ||
-                        std::is_same<Policy, DCGAN>::value, double>::type
+std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
+                        std::is_same_v<Policy, DCGAN>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 EvaluateWithGradient(const arma::mat& /* parameters */,
                      const size_t i,
@@ -391,8 +391,8 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-typename std::enable_if<std::is_same<Policy, StandardGAN>::value ||
-                        std::is_same<Policy, DCGAN>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
+                        std::is_same_v<Policy, DCGAN>, void>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 Gradient(const arma::mat& parameters,
          const size_t i,

--- a/src/mlpack/methods/ann/not_adapted/gan/gan_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/gan_impl.hpp
@@ -234,7 +234,7 @@ template<
 >
 template<typename Policy>
 std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
-                        std::is_same_v<Policy, DCGAN>, double>
+                 std::is_same_v<Policy, DCGAN>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
     const arma::mat& /* parameters */,
     const size_t i,
@@ -289,7 +289,7 @@ template<
 >
 template<typename GradType, typename Policy>
 std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
-                        std::is_same_v<Policy, DCGAN>, double>
+                 std::is_same_v<Policy, DCGAN>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 EvaluateWithGradient(const arma::mat& /* parameters */,
                      const size_t i,
@@ -392,7 +392,7 @@ template<
 >
 template<typename Policy>
 std::enable_if_t<std::is_same_v<Policy, StandardGAN> ||
-                        std::is_same_v<Policy, DCGAN>, void>
+                 std::is_same_v<Policy, DCGAN>, void>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 Gradient(const arma::mat& parameters,
          const size_t i,

--- a/src/mlpack/methods/ann/not_adapted/gan/wgan_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/wgan_impl.hpp
@@ -27,7 +27,7 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGAN>::value, double>::type
+std::enable_if_t<std::is_same_v<Policy, WGAN>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
     const arma::mat& /* parameters */,
     const size_t i,
@@ -82,7 +82,7 @@ template<
   typename PolicyType
 >
 template<typename GradType, typename Policy>
-typename std::enable_if<std::is_same<Policy, WGAN>::value, double>::type
+std::enable_if_t<std::is_same_v<Policy, WGAN>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 EvaluateWithGradient(const arma::mat& /* parameters */,
                      const size_t i,
@@ -185,7 +185,7 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGAN>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, WGAN>, void>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 Gradient(const arma::mat& parameters,
          const size_t i,

--- a/src/mlpack/methods/ann/not_adapted/gan/wgangp_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/wgangp_impl.hpp
@@ -27,8 +27,7 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-std::enable_if_t<std::is_same_v<Policy, WGANGP>,
-                        double>
+std::enable_if_t<std::is_same_v<Policy, WGANGP>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
     const arma::mat& /* parameters */,
     const size_t i,
@@ -95,8 +94,7 @@ template<
   typename PolicyType
 >
 template<typename GradType, typename Policy>
-std::enable_if_t<std::is_same_v<Policy, WGANGP>,
-                        double>
+std::enable_if_t<std::is_same_v<Policy, WGANGP>, double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 EvaluateWithGradient(const arma::mat& /* parameters */,
                      const size_t i,
@@ -209,8 +207,7 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-std::enable_if_t<std::is_same_v<Policy, WGANGP>,
-                        void>
+std::enable_if_t<std::is_same_v<Policy, WGANGP>, void>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 Gradient(const arma::mat& parameters,
          const size_t i,

--- a/src/mlpack/methods/ann/not_adapted/gan/wgangp_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/gan/wgangp_impl.hpp
@@ -27,8 +27,8 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                        double>::type
+std::enable_if_t<std::is_same_v<Policy, WGANGP>,
+                        double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::Evaluate(
     const arma::mat& /* parameters */,
     const size_t i,
@@ -95,8 +95,8 @@ template<
   typename PolicyType
 >
 template<typename GradType, typename Policy>
-typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                        double>::type
+std::enable_if_t<std::is_same_v<Policy, WGANGP>,
+                        double>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 EvaluateWithGradient(const arma::mat& /* parameters */,
                      const size_t i,
@@ -209,8 +209,8 @@ template<
   typename PolicyType
 >
 template<typename Policy>
-typename std::enable_if<std::is_same<Policy, WGANGP>::value,
-                        void>::type
+std::enable_if_t<std::is_same_v<Policy, WGANGP>,
+                        void>
 GAN<Model, InitializationRuleType, Noise, PolicyType>::
 Gradient(const arma::mat& parameters,
          const size_t i,

--- a/src/mlpack/methods/ann/not_adapted/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/not_adapted/rbm/rbm.hpp
@@ -70,12 +70,12 @@ class RBM
 
   // Reset the network.
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
   Reset();
 
   // Reset the network.
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   Reset();
 
   /**
@@ -116,7 +116,7 @@ class RBM
    * @param input The visible neurons.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, double>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, double>
   FreeEnergy(const arma::Mat<ElemType>& input);
 
   /**
@@ -130,8 +130,8 @@ class RBM
    * @param input The visible layer neurons.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value,
-      double>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>,
+      double>
   FreeEnergy(const arma::Mat<ElemType>& input);
 
   /**
@@ -141,7 +141,7 @@ class RBM
    * @param gradient Stores the gradient of the RBM network.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
   Phase(const InputType& input, DataType& gradient);
 
   /**
@@ -151,7 +151,7 @@ class RBM
    * @param gradient Stores the gradient of the RBM network.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   Phase(const InputType& input, DataType& gradient);
 
   /**
@@ -162,7 +162,7 @@ class RBM
    * @param output The sampled hidden layer.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
   SampleHidden(const arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
@@ -176,7 +176,7 @@ class RBM
    * @param output Sampled slab neurons.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   SampleHidden(const arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
@@ -187,7 +187,7 @@ class RBM
    * @param output The sampled visible layer.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
   SampleVisible(arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
@@ -201,7 +201,7 @@ class RBM
    * @param output The sampled visible layer.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   SampleVisible(arma::Mat<ElemType>& input, arma::Mat<ElemType>& output);
 
   /**
@@ -211,7 +211,7 @@ class RBM
    * @param output Visible neuron activations.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
   VisibleMean(InputType& input, DataType& output);
 
   /**
@@ -223,7 +223,7 @@ class RBM
    * @param output Mean of the of the Normal distribution.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   VisibleMean(InputType& input, DataType& output);
 
   /**
@@ -233,7 +233,7 @@ class RBM
    * @param output Hidden neuron activations.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
   HiddenMean(const InputType& input, DataType& output);
 
   /**
@@ -247,7 +247,7 @@ class RBM
    * @param output Consists of both the spike samples and slab samples.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   HiddenMean(const InputType& input, DataType& output);
 
   /**
@@ -259,7 +259,7 @@ class RBM
    * @param spikeMean Indicates P(h|v).
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   SpikeMean(const InputType& visible, DataType& spikeMean);
 
   /**
@@ -268,7 +268,7 @@ class RBM
    * @param spike Sampled binary spike variables.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   SampleSpike(InputType& spikeMean, DataType& spike);
 
   /**
@@ -281,7 +281,7 @@ class RBM
    * @param slabMean The mean of the Normal distribution of slab neurons.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   SlabMean(const DataType& visible, DataType& spike, DataType& slabMean);
 
   /**
@@ -295,7 +295,7 @@ class RBM
    * @param slab Sampled slab variable from the Normal distribution.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
   SampleSlab(InputType& slabMean, DataType& slab);
 
   /**

--- a/src/mlpack/methods/ann/not_adapted/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/not_adapted/rbm/rbm.hpp
@@ -130,8 +130,7 @@ class RBM
    * @param input The visible layer neurons.
    */
   template<typename Policy = PolicyType, typename InputType = DataType>
-  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>,
-      double>
+  std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, double>
   FreeEnergy(const arma::Mat<ElemType>& input);
 
   /**

--- a/src/mlpack/methods/ann/not_adapted/rbm/rbm_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/rbm/rbm_impl.hpp
@@ -58,7 +58,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::Reset()
 {
   size_t shape = (visibleSize * hiddenSize) + visibleSize + hiddenSize;
@@ -108,7 +108,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, double>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, double>
 RBM<InitializationRuleType, DataType, PolicyType>::FreeEnergy(
     const arma::Mat<ElemType>& input)
 {
@@ -124,7 +124,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::Phase(
     const InputType& input,
     DataType& gradient)
@@ -161,7 +161,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SampleHidden(
     const arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
@@ -180,7 +180,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SampleVisible(
     arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
@@ -199,7 +199,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::VisibleMean(
     InputType& input,
     DataType& output)
@@ -215,7 +215,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, BinaryRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, BinaryRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::HiddenMean(
     const InputType& input,
     DataType& output)

--- a/src/mlpack/methods/ann/not_adapted/rbm/spike_slab_rbm_impl.hpp
+++ b/src/mlpack/methods/ann/not_adapted/rbm/spike_slab_rbm_impl.hpp
@@ -25,7 +25,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::Reset()
 {
   size_t shape = (visibleSize * hiddenSize * poolSize) + visibleSize +
@@ -65,7 +65,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, double>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, double>
 RBM<InitializationRuleType, DataType, PolicyType>::FreeEnergy(
     const arma::Mat<ElemType>& input)
 {
@@ -90,7 +90,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::Phase(
     const InputType& input,
     DataType& gradient)
@@ -123,7 +123,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SampleHidden(
     const arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
@@ -146,7 +146,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SampleVisible(
     arma::Mat<ElemType>& input,
     arma::Mat<ElemType>& output)
@@ -184,7 +184,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::VisibleMean(
     InputType& input,
     DataType& output)
@@ -209,7 +209,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::HiddenMean(
     const InputType& input,
     DataType& output)
@@ -231,7 +231,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SpikeMean(
     const InputType& visible,
     DataType& spikeMean)
@@ -250,7 +250,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SampleSpike(
     InputType& spikeMean,
     DataType& spike)
@@ -267,7 +267,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SlabMean(
     const DataType& visible,
     DataType& spike,
@@ -286,7 +286,7 @@ template<
   typename PolicyType
 >
 template<typename Policy, typename InputType>
-typename std::enable_if<std::is_same<Policy, SpikeSlabRBM>::value, void>::type
+std::enable_if_t<std::is_same_v<Policy, SpikeSlabRBM>, void>
 RBM<InitializationRuleType, DataType, PolicyType>::SampleSlab(
     InputType& slabMean,
     DataType& slab)

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
@@ -140,8 +140,7 @@ class BayesianLinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   BayesianLinearRegression(const MatType& data,
                            const ResponsesType& responses,
                            const bool centerData = true,
@@ -176,8 +175,7 @@ class BayesianLinearRegression
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const std::optional<bool> centerData = std::nullopt,
@@ -188,8 +186,7 @@ class BayesianLinearRegression
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool centerData,
@@ -232,8 +229,7 @@ class BayesianLinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   void Predict(const MatType& points,
                ResponsesType& predictions) const;
 
@@ -250,8 +246,7 @@ class BayesianLinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   void Predict(const MatType& points,
                ResponsesType& predictions,
                ResponsesType& std) const;
@@ -267,8 +262,7 @@ class BayesianLinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType RMSE(const MatType& data,
                 const ResponsesType& responses) const;
 

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
@@ -139,9 +139,9 @@ class BayesianLinearRegression
    */
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   BayesianLinearRegression(const MatType& data,
                            const ResponsesType& responses,
                            const bool centerData = true,
@@ -175,9 +175,9 @@ class BayesianLinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const std::optional<bool> centerData = std::nullopt,
@@ -187,9 +187,9 @@ class BayesianLinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool centerData,
@@ -231,9 +231,9 @@ class BayesianLinearRegression
    */
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   void Predict(const MatType& points,
                ResponsesType& predictions) const;
 
@@ -249,9 +249,9 @@ class BayesianLinearRegression
    */
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   void Predict(const MatType& points,
                ResponsesType& predictions,
                ResponsesType& std) const;
@@ -266,9 +266,9 @@ class BayesianLinearRegression
    **/
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType RMSE(const MatType& data,
                 const ResponsesType& responses) const;
 

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -130,7 +130,7 @@ class DecisionTree :
       const size_t maximumDepth = 0,
       DimensionSelectionType dimensionSelector = DimensionSelectionType(),
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Construct the decision tree on the given data and labels with weights,
@@ -161,7 +161,7 @@ class DecisionTree :
       const size_t maximumDepth = 0,
       DimensionSelectionType dimensionSelector = DimensionSelectionType(),
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Using the hyperparameters of another decision tree, train on the given data
@@ -193,7 +193,7 @@ class DecisionTree :
       const size_t minimumLeafSize = 10,
       const double minimumGainSplit = 1e-7,
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Take ownership of another decision tree and train on the given data and
@@ -225,7 +225,7 @@ class DecisionTree :
       const size_t maximumDepth = 0,
       DimensionSelectionType dimensionSelector = DimensionSelectionType(),
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Construct a decision tree without training it.  It will be a leaf node with
@@ -359,8 +359,8 @@ class DecisionTree :
                const size_t maximumDepth = 0,
                DimensionSelectionType dimensionSelector =
                    DimensionSelectionType(),
-               const std::enable_if_t<arma::is_arma_type<typename
-                   std::remove_reference<WeightsType>::type>::value>* = 0);
+               const std::enable_if_t<arma::is_arma_type<
+                   std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Train the decision tree on the given weighted data, assuming that all
@@ -391,8 +391,8 @@ class DecisionTree :
                const size_t maximumDepth = 0,
                DimensionSelectionType dimensionSelector =
                    DimensionSelectionType(),
-               const std::enable_if_t<arma::is_arma_type<typename
-                   std::remove_reference<WeightsType>::type>::value>* = 0);
+               const std::enable_if_t<arma::is_arma_type<
+                   std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Classify the given point, using the entire tree.  The predicted label is

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -536,8 +536,7 @@ double DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
-        arma::is_arma_type<
-        std::remove_reference_t<WeightsType>>::value>*)
+        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, labels, "DecisionTree::Train()");
@@ -581,8 +580,7 @@ double DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
-        arma::is_arma_type<
-        std::remove_reference_t<WeightsType>>::value>*)
+        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, labels, "DecisionTree::Train()");

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -37,8 +37,8 @@ DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector)
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -74,8 +74,8 @@ DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector)
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -112,11 +112,11 @@ DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<WeightsType>::type>::value>*)
+        std::remove_reference_t<WeightsType>>::value>*)
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -153,11 +153,11 @@ DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<WeightsType>::type>::value>*)
+        std::remove_reference_t<WeightsType>>::value>*)
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -193,13 +193,13 @@ DecisionTree<FitnessFunction,
     const size_t minimumLeafSize,
     const double minimumGainSplit,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<WeightsType>::type>::value>*):
+        std::remove_reference_t<WeightsType>>::value>*):
         NumericAuxiliarySplitInfo(other),
         CategoricalAuxiliarySplitInfo(other)
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -233,14 +233,13 @@ DecisionTree<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*):
+        std::remove_reference_t<WeightsType>>::value>*):
         NumericAuxiliarySplitInfo(other),
         CategoricalAuxiliarySplitInfo(other)  // other info does need to copy
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -458,8 +457,8 @@ double DecisionTree<FitnessFunction,
   // Sanity check on data.
   util::CheckSameSizes(data, labels, "DecisionTree::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -498,8 +497,8 @@ double DecisionTree<FitnessFunction,
   // Sanity check on data.
   util::CheckSameSizes(data, labels, "DecisionTree::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -538,15 +537,14 @@ double DecisionTree<FitnessFunction,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
         arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*)
+        std::remove_reference_t<WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, labels, "DecisionTree::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -584,15 +582,14 @@ double DecisionTree<FitnessFunction,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
         arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*)
+        std::remove_reference_t<WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, labels, "DecisionTree::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueLabelsType = typename std::decay<LabelsType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueLabelsType = std::decay_t<LabelsType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor.hpp
@@ -129,7 +129,7 @@ class DecisionTreeRegressor :
       const size_t maximumDepth = 0,
       DimensionSelectionType dimensionSelector = DimensionSelectionType(),
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Construct the decision tree on the given data and responses with weights,
@@ -158,7 +158,7 @@ class DecisionTreeRegressor :
       const size_t maximumDepth = 0,
       DimensionSelectionType dimensionSelector = DimensionSelectionType(),
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Take ownership of another decision tree and train on the given data and
@@ -188,7 +188,7 @@ class DecisionTreeRegressor :
       const size_t minimumLeafSize = 10,
       const double minimumGainSplit = 1e-7,
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Take ownership of another decision tree and train on the given data and
@@ -218,7 +218,7 @@ class DecisionTreeRegressor :
       const size_t maximumDepth = 0,
       DimensionSelectionType dimensionSelector = DimensionSelectionType(),
       const std::enable_if_t<arma::is_arma_type<
-          typename std::remove_reference<WeightsType>::type>::value>* = 0);
+          std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Copy another tree.  This may use a lot of memory---be sure that it's what
@@ -347,8 +347,8 @@ class DecisionTreeRegressor :
                DimensionSelectionType dimensionSelector =
                    DimensionSelectionType(),
                FitnessFunction fitnessFunction = FitnessFunction(),
-               const std::enable_if_t<arma::is_arma_type<typename
-                   std::remove_reference<WeightsType>::type>::value>* = 0);
+               const std::enable_if_t<arma::is_arma_type<
+                   std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Train the decision tree on the given weighted data, assuming that all
@@ -380,8 +380,8 @@ class DecisionTreeRegressor :
                DimensionSelectionType dimensionSelector =
                    DimensionSelectionType(),
                FitnessFunction fitnessFunction = FitnessFunction(),
-               const std::enable_if_t<arma::is_arma_type<typename
-                   std::remove_reference<WeightsType>::type>::value>* = 0);
+               const std::enable_if_t<arma::is_arma_type<
+                   std::remove_reference_t<WeightsType>>::value>* = 0);
 
   /**
    * Make prediction for the given point, using the entire tree.  The predicted

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
@@ -52,8 +52,8 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector) : splitInfo()
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -88,8 +88,8 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector) : splitInfo()
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -125,12 +125,12 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<WeightsType>::type>::value>*)
+        std::remove_reference_t<WeightsType>>::value>*)
     : splitInfo()
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   TrueMatType tmpData(std::move(data));
   TrueResponsesType tmpResponses(std::move(responses));
@@ -166,12 +166,12 @@ DecisionTreeRegressor<FitnessFunction,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
         arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*) : splitInfo()
+        std::remove_reference_t<
+        WeightsType>>::value>*) : splitInfo()
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -206,14 +206,14 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t minimumLeafSize,
     const double minimumGainSplit,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<WeightsType>::type>::value>*):
+        std::remove_reference_t<WeightsType>>::value>*):
         splitInfo(std::move(other.splitInfo)),
         NumericAuxiliarySplitInfo(other),
         CategoricalAuxiliarySplitInfo(other)
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -246,15 +246,15 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*):
+        std::remove_reference_t<
+        WeightsType>>::value>*):
         splitInfo(std::move(other.splitInfo)),
         NumericAuxiliarySplitInfo(other),
         CategoricalAuxiliarySplitInfo(other)   // other info does need to copy
 {
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -442,8 +442,8 @@ double DecisionTreeRegressor<FitnessFunction,
   // Sanity check on data.
   util::CheckSameSizes(data, responses, "DecisionTreeRegressor::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -482,8 +482,8 @@ double DecisionTreeRegressor<FitnessFunction,
   // Sanity check on data.
   util::CheckSameSizes(data, responses, "DecisionTreeRegressor::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -522,15 +522,15 @@ double DecisionTreeRegressor<FitnessFunction,
     FitnessFunction fitnessFunction,
     const std::enable_if_t<
         arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*)
+        std::remove_reference_t<
+        WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, responses, "DecisionTreeRegressor::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));
@@ -568,15 +568,15 @@ double DecisionTreeRegressor<FitnessFunction,
     FitnessFunction fitnessFunction,
     const std::enable_if_t<
         arma::is_arma_type<
-        typename std::remove_reference<
-        WeightsType>::type>::value>*)
+        std::remove_reference_t<
+        WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, responses, "DecisionTreeRegressor::Train()");
 
-  using TrueMatType = typename std::decay<MatType>::type;
-  using TrueResponsesType = typename std::decay<ResponsesType>::type;
-  using TrueWeightsType = typename std::decay<WeightsType>::type;
+  using TrueMatType = std::decay_t<MatType>;
+  using TrueResponsesType = std::decay_t<ResponsesType>;
+  using TrueWeightsType = std::decay_t<WeightsType>;
 
   // Copy or move data.
   TrueMatType tmpData(std::move(data));

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
@@ -165,8 +165,8 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
-        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*)
-    : splitInfo()
+        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*) :
+    splitInfo()
 {
   using TrueMatType = std::decay_t<MatType>;
   using TrueResponsesType = std::decay_t<ResponsesType>;
@@ -205,10 +205,10 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t minimumLeafSize,
     const double minimumGainSplit,
     const std::enable_if_t<arma::is_arma_type<
-        std::remove_reference_t<WeightsType>>::value>*):
-        splitInfo(std::move(other.splitInfo)),
-        NumericAuxiliarySplitInfo(other),
-        CategoricalAuxiliarySplitInfo(other)
+        std::remove_reference_t<WeightsType>>::value>*) :
+    splitInfo(std::move(other.splitInfo)),
+    NumericAuxiliarySplitInfo(other),
+    CategoricalAuxiliarySplitInfo(other)
 {
   using TrueMatType = std::decay_t<MatType>;
   using TrueResponsesType = std::decay_t<ResponsesType>;
@@ -245,10 +245,10 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        std::remove_reference_t<WeightsType>>::value>*)
-    : splitInfo(std::move(other.splitInfo)),
-      NumericAuxiliarySplitInfo(other),
-      CategoricalAuxiliarySplitInfo(other)   // other info does need to copy
+        std::remove_reference_t<WeightsType>>::value>*) :
+    splitInfo(std::move(other.splitInfo)),
+    NumericAuxiliarySplitInfo(other),
+    CategoricalAuxiliarySplitInfo(other)   // other info does need to copy
 {
   using TrueMatType = std::decay_t<MatType>;
   using TrueResponsesType = std::decay_t<ResponsesType>;

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
@@ -165,9 +165,8 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<
-        arma::is_arma_type<
-        std::remove_reference_t<
-        WeightsType>>::value>*) : splitInfo()
+        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*)
+    : splitInfo()
 {
   using TrueMatType = std::decay_t<MatType>;
   using TrueResponsesType = std::decay_t<ResponsesType>;
@@ -246,11 +245,10 @@ DecisionTreeRegressor<FitnessFunction,
     const size_t maximumDepth,
     DimensionSelectionType dimensionSelector,
     const std::enable_if_t<arma::is_arma_type<
-        std::remove_reference_t<
-        WeightsType>>::value>*):
-        splitInfo(std::move(other.splitInfo)),
-        NumericAuxiliarySplitInfo(other),
-        CategoricalAuxiliarySplitInfo(other)   // other info does need to copy
+        std::remove_reference_t<WeightsType>>::value>*)
+    : splitInfo(std::move(other.splitInfo)),
+      NumericAuxiliarySplitInfo(other),
+      CategoricalAuxiliarySplitInfo(other)   // other info does need to copy
 {
   using TrueMatType = std::decay_t<MatType>;
   using TrueResponsesType = std::decay_t<ResponsesType>;
@@ -521,9 +519,7 @@ double DecisionTreeRegressor<FitnessFunction,
     DimensionSelectionType dimensionSelector,
     FitnessFunction fitnessFunction,
     const std::enable_if_t<
-        arma::is_arma_type<
-        std::remove_reference_t<
-        WeightsType>>::value>*)
+        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, responses, "DecisionTreeRegressor::Train()");
@@ -567,9 +563,7 @@ double DecisionTreeRegressor<FitnessFunction,
     DimensionSelectionType dimensionSelector,
     FitnessFunction fitnessFunction,
     const std::enable_if_t<
-        arma::is_arma_type<
-        std::remove_reference_t<
-        WeightsType>>::value>*)
+        arma::is_arma_type<std::remove_reference_t<WeightsType>>::value>*)
 {
   // Sanity check on data.
   util::CheckSameSizes(data, responses, "DecisionTreeRegressor::Train()");

--- a/src/mlpack/methods/decision_tree/splits/best_binary_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/splits/best_binary_categorical_split_impl.hpp
@@ -157,7 +157,7 @@ double BestBinaryCategoricalSplit<FitnessFunction>::SplitIfBetter(
     AuxiliarySplitInfo& aux,
     FitnessFunction& fitnessFunction)
 {
-  static_assert(std::is_same<FitnessFunction, MSEGain>::value,
+  static_assert(std::is_same_v<FitnessFunction, MSEGain>,
       "BestBinaryCategoricalSplit: regression FitnessFunction must be "
       "MSEGain.");
   const size_t n = data.n_elem;

--- a/src/mlpack/methods/decision_tree/splits/best_binary_numeric_split.hpp
+++ b/src/mlpack/methods/decision_tree/splits/best_binary_numeric_split.hpp
@@ -108,9 +108,9 @@ class BestBinaryNumericSplit
    */
   template<bool UseWeights, typename VecType, typename ResponsesType,
            typename WeightVecType>
-  static typename std::enable_if<
+  static std::enable_if_t<
       !HasOptimizedBinarySplitForms<FitnessFunction, UseWeights>::value,
-      double>::type
+      double>
   SplitIfBetter(
       const double bestGain,
       const VecType& data,
@@ -145,9 +145,9 @@ class BestBinaryNumericSplit
    */
   template<bool UseWeights, typename VecType, typename ResponsesType,
           typename WeightVecType>
-  static typename std::enable_if<
+  static std::enable_if_t<
       HasOptimizedBinarySplitForms<FitnessFunction, UseWeights>::value,
-      double>::type
+      double>
   SplitIfBetter(
       const double bestGain,
       const VecType& data,

--- a/src/mlpack/methods/decision_tree/splits/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/splits/best_binary_numeric_split_impl.hpp
@@ -207,9 +207,9 @@ double BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
 template<typename FitnessFunction>
 template<bool UseWeights, typename VecType, typename ResponsesType,
          typename WeightVecType>
-typename std::enable_if<
+std::enable_if_t<
     !HasOptimizedBinarySplitForms<FitnessFunction, UseWeights>::value,
-    double>::type
+    double>
 BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     const double bestGain,
     const VecType& data,
@@ -363,9 +363,9 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
 template<typename FitnessFunction>
 template<bool UseWeights, typename VecType, typename ResponsesType,
          typename WeightVecType>
-typename std::enable_if<
+std::enable_if_t<
     HasOptimizedBinarySplitForms<FitnessFunction, UseWeights>::value,
-    double>::type
+    double>
 BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     const double bestGain,
     const VecType& data,

--- a/src/mlpack/methods/det/dtree_impl.hpp
+++ b/src/mlpack/methods/det/dtree_impl.hpp
@@ -29,8 +29,7 @@ void ExtractSplits(std::vector<std::pair<ElemType, size_t>>& splitVec,
                    const size_t end,
                    const size_t minLeafSize)
 {
-  static_assert(
-    std::is_same_v<typename MatType::elem_type, ElemType> == true,
+  static_assert(std::is_same_v<typename MatType::elem_type, ElemType>,
     "The ElemType does not correspond to the matrix's element type.");
 
   typedef std::pair<ElemType, size_t> SplitItem;

--- a/src/mlpack/methods/det/dtree_impl.hpp
+++ b/src/mlpack/methods/det/dtree_impl.hpp
@@ -30,7 +30,7 @@ void ExtractSplits(std::vector<std::pair<ElemType, size_t>>& splitVec,
                    const size_t minLeafSize)
 {
   static_assert(
-    std::is_same<typename MatType::elem_type, ElemType>::value == true,
+    std::is_same_v<typename MatType::elem_type, ElemType> == true,
     "The ElemType does not correspond to the matrix's element type.");
 
   typedef std::pair<ElemType, size_t> SplitItem;

--- a/src/mlpack/methods/gmm/em_fit_impl.hpp
+++ b/src/mlpack/methods/gmm/em_fit_impl.hpp
@@ -298,8 +298,8 @@ InitialClustering(const arma::mat& observations,
   std::vector<arma::vec> means(dists.size());
 
   // Conditional covariance instantiation.
-  std::vector<typename std::conditional<isDiagGaussDist,
-      arma::vec, arma::mat>::type> covs(dists.size());
+  std::vector<std::conditional_t<isDiagGaussDist, arma::vec, arma::mat>>
+      covs(dists.size());
 
   // Now calculate the means, covariances, and weights.
   weights.zeros();

--- a/src/mlpack/methods/gmm/em_fit_impl.hpp
+++ b/src/mlpack/methods/gmm/em_fit_impl.hpp
@@ -44,7 +44,7 @@ Estimate(const arma::mat& observations,
          arma::vec& weights,
          const bool useInitialModel)
 {
-  if (std::is_same<Distribution, DiagonalGaussianDistribution<>>::value)
+  if (std::is_same_v<Distribution, DiagonalGaussianDistribution<>>)
   {
     #ifdef _WIN32
       Log::Warn << "Cannot use arma::gmm_diag on Visual Studio due to OpenMP"
@@ -55,8 +55,8 @@ Estimate(const arma::mat& observations,
       return;
     #endif
   }
-  else if (std::is_same<CovarianceConstraintPolicy, DiagonalConstraint>::value
-      && std::is_same<Distribution, GaussianDistribution<>>::value)
+  else if (std::is_same_v<CovarianceConstraintPolicy, DiagonalConstraint>
+      && std::is_same_v<Distribution, GaussianDistribution<>>)
   {
     // EMFit::Estimate() using DiagonalConstraint with GaussianDistribution
     // makes use of slower implementation.
@@ -129,7 +129,7 @@ Estimate(const arma::mat& observations,
 
       // If the distribution is DiagonalGaussianDistribution, calculate the
       // covariance only with diagonal components.
-      if (std::is_same<Distribution, DiagonalGaussianDistribution<>>::value)
+      if (std::is_same_v<Distribution, DiagonalGaussianDistribution<>>)
       {
         arma::vec covariance = sum((tmp % tmp) %
             (ones<arma::vec>(observations.n_rows) *
@@ -240,7 +240,7 @@ Estimate(const arma::mat& observations,
 
       // If the distribution is DiagonalGaussianDistribution, calculate the
       // covariance only with diagonal components.
-      if (std::is_same<Distribution, DiagonalGaussianDistribution<>>::value)
+      if (std::is_same_v<Distribution, DiagonalGaussianDistribution<>>)
       {
         arma::vec cov = sum((tmp % tmp) %
             (ones<arma::vec>(observations.n_rows) *
@@ -292,8 +292,8 @@ InitialClustering(const arma::mat& observations,
   // Check if the type of Distribution is DiagonalGaussianDistribution.  If so,
   // we can get faster performance by using diagonal elements when calculating
   // the covariance.
-  const bool isDiagGaussDist = std::is_same<Distribution,
-      DiagonalGaussianDistribution<>>::value;
+  const bool isDiagGaussDist = std::is_same_v<Distribution,
+      DiagonalGaussianDistribution<>>;
 
   std::vector<arma::vec> means(dists.size());
 
@@ -437,7 +437,7 @@ ArmadilloGMMWrapper(const arma::mat& observations,
   // Armadillo's implementation.  If mlpack ever changes k-means defaults to use
   // something that is reliably quicker than the Lloyd iteration k-means update,
   // then this code maybe should be revisited.
-  if (!std::is_same<InitialClusteringType, KMeans<>>::value || useInitialModel)
+  if (!std::is_same_v<InitialClusteringType, KMeans<>> || useInitialModel)
   {
     // Use clusterer to get initial values.
     if (!useInitialModel)

--- a/src/mlpack/methods/gmm/positive_definite_constraint.hpp
+++ b/src/mlpack/methods/gmm/positive_definite_constraint.hpp
@@ -35,7 +35,7 @@ class PositiveDefiniteConstraint
   template<typename MatType>
   static void ApplyConstraint(
       MatType& covariance,
-      const typename std::enable_if<!IsVector<MatType>::value>::type*
+      const std::enable_if_t<!IsVector<MatType>::value>*
           /* junk */ = 0)
   {
     typedef typename MatType::elem_type ElemType;
@@ -82,7 +82,7 @@ class PositiveDefiniteConstraint
   template<typename VecType>
   static void ApplyConstraint(
       VecType& diagCovariance,
-      const typename std::enable_if<IsVector<VecType>::value>::type*
+      const std::enable_if_t<IsVector<VecType>::value>*
           /* junk */ = 0)
   {
     typedef typename VecType::elem_type ElemType;

--- a/src/mlpack/methods/gmm/positive_definite_constraint.hpp
+++ b/src/mlpack/methods/gmm/positive_definite_constraint.hpp
@@ -35,8 +35,7 @@ class PositiveDefiniteConstraint
   template<typename MatType>
   static void ApplyConstraint(
       MatType& covariance,
-      const std::enable_if_t<!IsVector<MatType>::value>*
-          /* junk */ = 0)
+      const std::enable_if_t<!IsVector<MatType>::value>* /* junk */ = 0)
   {
     typedef typename MatType::elem_type ElemType;
     typedef typename GetColType<MatType>::type VecType;
@@ -82,8 +81,7 @@ class PositiveDefiniteConstraint
   template<typename VecType>
   static void ApplyConstraint(
       VecType& diagCovariance,
-      const std::enable_if_t<IsVector<VecType>::value>*
-          /* junk */ = 0)
+      const std::enable_if_t<IsVector<VecType>::value>* /* junk */ = 0)
   {
     typedef typename VecType::elem_type ElemType;
 

--- a/src/mlpack/methods/kde/kde_impl.hpp
+++ b/src/mlpack/methods/kde/kde_impl.hpp
@@ -498,7 +498,7 @@ Evaluate(Tree* queryTree,
   }
 
   // Clean accumulated alpha if Monte Carlo estimations are available.
-  if (monteCarlo && std::is_same<KernelType, GaussianKernel>::value)
+  if (monteCarlo && std::is_same_v<KernelType, GaussianKernel>)
   {
     KDECleanRules<Tree> cleanRules;
     SingleTreeTraversalType<KDECleanRules<Tree>> cleanTraverser(cleanRules);
@@ -562,7 +562,7 @@ Evaluate(arma::vec& estimations)
   estimations.fill(arma::fill::zeros);
 
   // Clean accumulated alpha if Monte Carlo estimations are available.
-  if (monteCarlo && std::is_same<KernelType, GaussianKernel>::value)
+  if (monteCarlo && std::is_same_v<KernelType, GaussianKernel>)
   {
     KDECleanRules<Tree> cleanRules;
     SingleTreeTraversalType<KDECleanRules<Tree>> cleanTraverser(cleanRules);

--- a/src/mlpack/methods/kde/kde_model.hpp
+++ b/src/mlpack/methods/kde/kde_model.hpp
@@ -43,9 +43,9 @@ class KernelNormalizer
       KernelType& /* kernel */,
       const size_t /* dimension */,
       arma::vec& /* estimations */,
-      const typename std::enable_if<
-          !HasNormalizer<KernelType, double(KernelType::*)(size_t)>::value>::
-          type* = 0)
+      const std::enable_if_t<
+          !HasNormalizer<KernelType, double(KernelType::*)(size_t)>::value>*
+          = 0)
   { return; }
 
   //! Normalize kernels that have normalizer.
@@ -54,9 +54,9 @@ class KernelNormalizer
       KernelType& kernel,
       const size_t dimension,
       arma::vec& estimations,
-      const typename std::enable_if<
-          HasNormalizer<KernelType, double(KernelType::*)(size_t)>::value>::
-          type* = 0)
+      const std::enable_if_t<
+          HasNormalizer<KernelType, double(KernelType::*)(size_t)>::value>*
+          = 0)
   {
     estimations /= kernel.Normalizer(dimension);
   }

--- a/src/mlpack/methods/kde/kde_rules.hpp
+++ b/src/mlpack/methods/kde/kde_rules.hpp
@@ -159,7 +159,7 @@ class KDERules
 
   //! Whether the kernel used for the rule is the Gaussian Kernel.
   constexpr static bool kernelIsGaussian =
-      std::is_same<KernelType, GaussianKernel>::value;
+      std::is_same_v<KernelType, GaussianKernel>;
 
   //! Absolute error tolerance available for each reference point.
   const double absErrorTol;

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
@@ -27,8 +27,7 @@ template<typename TreeType, typename MatType>
 TreeType* BuildForcedLeafSizeTree(
     MatType&& dataset,
     std::vector<size_t>& oldFromNew,
-    const std::enable_if_t<
-        TreeTraits<TreeType>::RearrangesDataset>* = 0)
+    const std::enable_if_t<TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   // This is a hack.  I know this will be BinarySpaceTree, so force a leaf size
   // of one.
@@ -40,8 +39,7 @@ template<typename TreeType, typename MatType>
 TreeType* BuildForcedLeafSizeTree(
     MatType&& dataset,
     const std::vector<size_t>& /* oldFromNew */,
-    const std::enable_if_t<
-        !TreeTraits<TreeType>::RearrangesDataset>* = 0)
+    const std::enable_if_t<!TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   return new TreeType(std::forward<MatType>(dataset));
 }

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
@@ -27,8 +27,8 @@ template<typename TreeType, typename MatType>
 TreeType* BuildForcedLeafSizeTree(
     MatType&& dataset,
     std::vector<size_t>& oldFromNew,
-    const typename std::enable_if<
-        TreeTraits<TreeType>::RearrangesDataset>::type* = 0)
+    const std::enable_if_t<
+        TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   // This is a hack.  I know this will be BinarySpaceTree, so force a leaf size
   // of one.
@@ -40,8 +40,8 @@ template<typename TreeType, typename MatType>
 TreeType* BuildForcedLeafSizeTree(
     MatType&& dataset,
     const std::vector<size_t>& /* oldFromNew */,
-    const typename std::enable_if<
-        !TreeTraits<TreeType>::RearrangesDataset>::type* = 0)
+    const std::enable_if_t<
+        !TreeTraits<TreeType>::RearrangesDataset>* = 0)
 {
   return new TreeType(std::forward<MatType>(dataset));
 }

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -165,9 +165,9 @@ class LARS
    */
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   LARS(const MatType& data,
        const ResponsesType& responses,
        bool colMajor = true,
@@ -204,9 +204,9 @@ class LARS
    */
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   LARS(const MatType& data,
        const ResponsesType& responses,
        const bool colMajor,
@@ -296,12 +296,12 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type,
-           typename = typename std::enable_if<
-               !std::is_same<ResponsesType, arma::rowvec>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >,
+           typename = std::enable_if_t<
+               !std::is_same_v<ResponsesType, arma::rowvec>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor = true);
@@ -309,9 +309,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -320,9 +320,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -332,9 +332,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -345,9 +345,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -359,9 +359,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -374,9 +374,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -407,9 +407,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -419,9 +419,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -432,9 +432,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -446,9 +446,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -461,9 +461,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -477,9 +477,9 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -166,8 +166,7 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   LARS(const MatType& data,
        const ResponsesType& responses,
        bool colMajor = true,
@@ -205,8 +204,7 @@ class LARS
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   LARS(const MatType& data,
        const ResponsesType& responses,
        const bool colMajor,
@@ -297,11 +295,9 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >,
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>,
            typename = std::enable_if_t<
-               !std::is_same_v<ResponsesType, arma::rowvec>
-           >>
+               !std::is_same_v<ResponsesType, arma::rowvec>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor = true);
@@ -310,8 +306,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -321,8 +316,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -333,8 +327,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -346,8 +339,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -360,8 +352,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -375,8 +366,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -408,8 +398,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -420,8 +409,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -433,8 +421,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -447,8 +434,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -462,8 +448,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,
@@ -478,8 +463,7 @@ class LARS
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& data,
                  const ResponsesType& responses,
                  const bool colMajor,

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -43,9 +43,9 @@ class LinearRegression
    */
   template<typename MatType,
            typename ResponsesType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   LinearRegression(const MatType& predictors,
                    const ResponsesType& responses,
                    const double lambda = 0,
@@ -63,12 +63,12 @@ class LinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename WeightsType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type,
-           typename = typename std::enable_if<
-               std::is_same<typename WeightsType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >,
+           typename = std::enable_if_t<
+               std::is_same_v<typename WeightsType::elem_type, ElemType>
+           >>
   LinearRegression(const MatType& predictors,
                    const ResponsesType& responses,
                    const WeightsType& weights,
@@ -103,8 +103,8 @@ class LinearRegression
   double Train(const arma::mat& predictors,
                const arma::rowvec& responses,
                const T intercept,
-               const typename std::enable_if<std::is_same<T, bool>::value
-                   >::type* = 0);
+               const std::enable_if_t<std::is_same_v<T, bool>
+                   >* = 0);
 
   /**
    * Train the LinearRegression model on the given data and instance weights.
@@ -129,8 +129,8 @@ class LinearRegression
                const arma::rowvec& responses,
                const arma::rowvec& weights,
                const T intercept,
-               const typename std::enable_if<std::is_same<T, bool>::value
-                   >::type* = 0);
+               const std::enable_if_t<std::is_same_v<T, bool>
+                   >* = 0);
 
   /**
    * Train the LinearRegression model.  This is a dummy overload so that
@@ -157,9 +157,9 @@ class LinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& predictors,
                  const ResponsesType& responses,
                  const std::optional<double> lambda = std::nullopt,
@@ -192,12 +192,12 @@ class LinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename WeightsType,
-           typename = typename std::enable_if<
-               std::is_same<typename ResponsesType::elem_type, ElemType>::value
-           >::type,
-           typename = typename std::enable_if<
-               std::is_same<typename WeightsType::elem_type, ElemType>::value
-           >::type>
+           typename = std::enable_if_t<
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>
+           >,
+           typename = std::enable_if_t<
+               std::is_same_v<typename WeightsType::elem_type, ElemType>
+           >>
   ElemType Train(const MatType& predictors,
                  const ResponsesType& responses,
                  const WeightsType& weights,

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -44,8 +44,7 @@ class LinearRegression
   template<typename MatType,
            typename ResponsesType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   LinearRegression(const MatType& predictors,
                    const ResponsesType& responses,
                    const double lambda = 0,
@@ -64,11 +63,9 @@ class LinearRegression
            typename ResponsesType,
            typename WeightsType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >,
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>,
            typename = std::enable_if_t<
-               std::is_same_v<typename WeightsType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename WeightsType::elem_type, ElemType>>>
   LinearRegression(const MatType& predictors,
                    const ResponsesType& responses,
                    const WeightsType& weights,
@@ -103,8 +100,7 @@ class LinearRegression
   double Train(const arma::mat& predictors,
                const arma::rowvec& responses,
                const T intercept,
-               const std::enable_if_t<std::is_same_v<T, bool>
-                   >* = 0);
+               const std::enable_if_t<std::is_same_v<T, bool>>* = 0);
 
   /**
    * Train the LinearRegression model on the given data and instance weights.
@@ -129,8 +125,7 @@ class LinearRegression
                const arma::rowvec& responses,
                const arma::rowvec& weights,
                const T intercept,
-               const std::enable_if_t<std::is_same_v<T, bool>
-                   >* = 0);
+               const std::enable_if_t<std::is_same_v<T, bool>>* = 0);
 
   /**
    * Train the LinearRegression model.  This is a dummy overload so that
@@ -158,8 +153,7 @@ class LinearRegression
            typename ResponsesType,
            typename = void, /* so MetaInfoExtractor does not get confused */
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>>
   ElemType Train(const MatType& predictors,
                  const ResponsesType& responses,
                  const std::optional<double> lambda = std::nullopt,
@@ -193,11 +187,9 @@ class LinearRegression
            typename ResponsesType,
            typename WeightsType,
            typename = std::enable_if_t<
-               std::is_same_v<typename ResponsesType::elem_type, ElemType>
-           >,
+               std::is_same_v<typename ResponsesType::elem_type, ElemType>>,
            typename = std::enable_if_t<
-               std::is_same_v<typename WeightsType::elem_type, ElemType>
-           >>
+               std::is_same_v<typename WeightsType::elem_type, ElemType>>>
   ElemType Train(const MatType& predictors,
                  const ResponsesType& responses,
                  const WeightsType& weights,

--- a/src/mlpack/methods/linear_regression/linear_regression_impl.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_impl.hpp
@@ -51,7 +51,7 @@ inline double LinearRegression<ModelMatType>::Train(
     const arma::mat& predictors,
     const arma::rowvec& responses,
     const T intercept,
-    const typename std::enable_if<std::is_same<T, bool>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, bool>>*)
 {
   return Train(predictors, responses, arma::rowvec(), this->lambda, intercept);
 }
@@ -63,7 +63,7 @@ inline double LinearRegression<ModelMatType>::Train(
     const arma::rowvec& responses,
     const arma::rowvec& weights,
     const T intercept,
-    const typename std::enable_if<std::is_same<T, bool>::value>::type*)
+    const std::enable_if_t<std::is_same_v<T, bool>>*)
 {
   return Train(predictors, responses, weights, this->lambda, intercept);
 }

--- a/src/mlpack/methods/linear_svm/linear_svm.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm.hpp
@@ -135,14 +135,14 @@ class LinearSVM
    */
   template<typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType,
                LinearSVMFunction<arma::mat, ModelMatType>,
                ModelMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   [[deprecated("Will be removed in mlpack 5.0.0, use other constructors")]]
   LinearSVM(const arma::mat& data,
             const arma::Row<size_t>& labels,
@@ -173,11 +173,11 @@ class LinearSVM
    * @param optimizer Desired optimizer.
    */
   template<typename OptimizerType = ens::L_BFGS,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType,
                LinearSVMFunction<arma::mat, ModelMatType>,
                ModelMatType
-           >::value>::type>
+           >::value>>
   [[deprecated("Will be removed in mlpack 5.0.0, use other constructors")]]
   LinearSVM(const arma::mat& data,
             const arma::Row<size_t>& labels,
@@ -203,9 +203,9 @@ class LinearSVM
    */
   template<typename MatType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   LinearSVM(const MatType& data,
             const arma::Row<size_t>& labels,
             const size_t numClasses,
@@ -232,9 +232,9 @@ class LinearSVM
   template<typename MatType,
            typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   LinearSVM(const MatType& data,
             const arma::Row<size_t>& labels,
             const size_t numClasses,
@@ -259,9 +259,9 @@ class LinearSVM
    */
   template<typename MatType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,
@@ -269,9 +269,9 @@ class LinearSVM
 
   template<typename MatType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,
@@ -299,14 +299,14 @@ class LinearSVM
   template<typename MatType,
            typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType,
                LinearSVMFunction<MatType, ModelMatType>,
                ModelMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,
@@ -316,14 +316,14 @@ class LinearSVM
   template<typename MatType,
            typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType,
                LinearSVMFunction<MatType, ModelMatType>,
                ModelMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,

--- a/src/mlpack/methods/lmnn/lmnn.hpp
+++ b/src/mlpack/methods/lmnn/lmnn.hpp
@@ -101,8 +101,7 @@ class LMNN
                CallbackTypes...
            >::value>,
            typename = std::enable_if_t<
-               !FirstElementIsArma<CallbackTypes...>::value
-           >>
+               !FirstElementIsArma<CallbackTypes...>::value>>
   [[deprecated("Will be removed in mlpack 5.0.0.  Use the version that takes a "
                "dataset as a parameter.")]]
   void LearnDistance(arma::mat& outputMatrix, CallbackTypes&&... callbacks);

--- a/src/mlpack/methods/lmnn/lmnn.hpp
+++ b/src/mlpack/methods/lmnn/lmnn.hpp
@@ -97,12 +97,12 @@ class LMNN
    *      See https://www.ensmallen.org/docs.html#callback-documentation.
    */
   template<typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type,
-           typename = typename std::enable_if<
+           >::value>,
+           typename = std::enable_if_t<
                !FirstElementIsArma<CallbackTypes...>::value
-           >::type>
+           >>
   [[deprecated("Will be removed in mlpack 5.0.0.  Use the version that takes a "
                "dataset as a parameter.")]]
   void LearnDistance(arma::mat& outputMatrix, CallbackTypes&&... callbacks);
@@ -122,14 +122,14 @@ class LMNN
   template<typename MatType,
            typename LabelsType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<!IsEnsOptimizer<
+           typename = std::enable_if_t<!IsEnsOptimizer<
                typename First<CallbackTypes...>::type,
                LMNNFunction<MatType, LabelsType, DistanceType>,
                MatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   void LearnDistance(const MatType& dataset,
                      const LabelsType& labels,
                      MatType& outputMatrix,
@@ -152,11 +152,11 @@ class LMNN
            typename LabelsType,
            typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType,
                LMNNFunction<MatType, LabelsType, DistanceType>,
                MatType
-           >::value>::type>
+           >::value>>
   void LearnDistance(const MatType& dataset,
                      const LabelsType& labels,
                      MatType& outputMatrix,

--- a/src/mlpack/methods/local_coordinate_coding/lcc_impl.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc_impl.hpp
@@ -145,7 +145,7 @@ inline void LocalCoordinateCoding<MatType>::Encode(const MatType& data,
 
     bool useCholesky = false;
     // Normalization and fitting and intercept are disabled.
-    const double tol = std::is_same<typename MatType::elem_type, float>::value ?
+    const double tol = std::is_same_v<typename MatType::elem_type, float> ?
         1e-8 : 1e-16;
     LARS<MatType> lars(useCholesky, 0.5 * lambda, 0, tol, false, false);
 

--- a/src/mlpack/methods/logistic_regression/logistic_regression.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression.hpp
@@ -67,9 +67,9 @@ class LogisticRegression
    * @param lambda L2-regularization parameter.
    */
   template<typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   LogisticRegression(const MatType& predictors,
                      const arma::Row<size_t>& responses,
                      const double lambda = 0.0,
@@ -91,9 +91,9 @@ class LogisticRegression
    *     (L-BFGS).
    */
   template<typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   LogisticRegression(const MatType& predictors,
                      const arma::Row<size_t>& responses,
                      const RowType& initialPoint,
@@ -117,12 +117,12 @@ class LogisticRegression
    */
   template<typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, LogisticRegressionFunction<MatType>, RowType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   LogisticRegression(const MatType& predictors,
                      const arma::Row<size_t>& responses,
                      OptimizerType& optimizer,
@@ -147,12 +147,12 @@ class LogisticRegression
    */
   template<typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, LogisticRegressionFunction<MatType>, RowType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   LogisticRegression(const MatType& predictors,
                      const arma::Row<size_t>& responses,
                      OptimizerType& optimizer,
@@ -179,9 +179,9 @@ class LogisticRegression
    */
   template<typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& predictors,
                  const arma::Row<size_t>& responses,
                  CallbackTypes&&... callbacks);
@@ -206,9 +206,9 @@ class LogisticRegression
    */
   template<typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& predictors,
                  const arma::Row<size_t>& responses,
                  const double lambda,
@@ -234,12 +234,12 @@ class LogisticRegression
    */
   template<typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, LogisticRegressionFunction<MatType>, RowType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& predictors,
                  const arma::Row<size_t>& responses,
                  OptimizerType& optimizer,
@@ -266,12 +266,12 @@ class LogisticRegression
    */
   template<typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, LogisticRegressionFunction<MatType>, RowType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& predictors,
                  const arma::Row<size_t>& responses,
                  OptimizerType& optimizer,

--- a/src/mlpack/methods/lsh/lsh_search_impl.hpp
+++ b/src/mlpack/methods/lsh/lsh_search_impl.hpp
@@ -647,8 +647,7 @@ void LSHSearch<SortPolicy, MatType>::GetAdditionalProbingBins(
   std::priority_queue<
     std::pair<double, size_t>,        // contents: pairs of (score, index)
     std::vector<                      // container: vector of pairs
-      std::pair<double, size_t>
-      >,
+      std::pair<double, size_t>>,
     std::greater< std::pair<double, size_t> > // comparator of pairs
   > minHeap; // our minheap
 

--- a/src/mlpack/methods/mean_shift/mean_shift.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift.hpp
@@ -155,7 +155,7 @@ class MeanShift
    # @param centroid Store calculated centroid
    */
   template<bool ApplyKernel = UseKernel, typename MatType, typename VecType>
-  typename std::enable_if<ApplyKernel, bool>::type
+  std::enable_if_t<ApplyKernel, bool>
   CalculateCentroid(const MatType& data,
                     const std::vector<size_t>& neighbors,
                     const std::vector<typename MatType::elem_type>& distances,
@@ -170,7 +170,7 @@ class MeanShift
    # @param centroid Store calculated centroid
    */
   template<bool ApplyKernel = UseKernel, typename MatType, typename VecType>
-  typename std::enable_if<!ApplyKernel, bool>::type
+  std::enable_if_t<!ApplyKernel, bool>
   CalculateCentroid(const MatType& data,
                     const std::vector<size_t>& neighbors,
                     const std::vector<typename MatType::elem_type>&, /*unused*/

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -131,7 +131,7 @@ void MeanShift<UseKernel, KernelType>::GenSeeds(const MatType& data,
 // Calculate new centroid with given kernel.
 template<bool UseKernel, typename KernelType>
 template<bool ApplyKernel, typename MatType, typename VecType>
-typename std::enable_if<ApplyKernel, bool>::type
+std::enable_if_t<ApplyKernel, bool>
 MeanShift<UseKernel, KernelType>::CalculateCentroid(
     const MatType& data,
     const std::vector<size_t>& neighbors,
@@ -163,7 +163,7 @@ MeanShift<UseKernel, KernelType>::CalculateCentroid(
 // Calculate new centroid by mean.
 template<bool UseKernel, typename KernelType>
 template<bool ApplyKernel, typename MatType, typename VecType>
-typename std::enable_if<!ApplyKernel, bool>::type
+std::enable_if_t<!ApplyKernel, bool>
 MeanShift<UseKernel, KernelType>::CalculateCentroid(
     const MatType& data,
     const std::vector<size_t>& neighbors,

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -274,7 +274,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
   static_assert(std::is_same_v<ElemType,
-                             typename ProbabilitiesVecType::elem_type>,
+                               typename ProbabilitiesVecType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -349,7 +349,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
   static_assert(std::is_same_v<ElemType,
-                             typename ProbabilitiesMatType::elem_type>,
+                               typename ProbabilitiesMatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -35,7 +35,7 @@ NaiveBayesClassifier<ModelMatType>::NaiveBayesClassifier(
     trainingPoints(0), // Set when we call Train().
     epsilon(epsilon)
 {
-  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename MatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -82,7 +82,7 @@ void NaiveBayesClassifier<ModelMatType>::Train(
     const size_t numClasses,
     const bool incremental)
 {
-  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename MatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -178,7 +178,7 @@ template<typename VecType>
 void NaiveBayesClassifier<ModelMatType>::Train(const VecType& point,
                                                const size_t label)
 {
-  static_assert(std::is_same<ElemType, typename VecType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename VecType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -213,7 +213,7 @@ void NaiveBayesClassifier<ModelMatType>::LogLikelihood(
     const MatType& data,
     ModelMatType& logLikelihoods) const
 {
-  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename MatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -241,7 +241,7 @@ template<typename ModelMatType>
 template<typename VecType>
 size_t NaiveBayesClassifier<ModelMatType>::Classify(const VecType& point) const
 {
-  static_assert(std::is_same<ElemType, typename VecType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename VecType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -270,11 +270,11 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
     size_t& prediction,
     ProbabilitiesVecType& probabilities) const
 {
-  static_assert(std::is_same<ElemType, typename VecType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename VecType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
-  static_assert(std::is_same<ElemType,
-                             typename ProbabilitiesVecType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType,
+                             typename ProbabilitiesVecType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -312,7 +312,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
     const MatType& data,
     arma::Row<size_t>& predictions) const
 {
-  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename MatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 
@@ -345,11 +345,11 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
     arma::Row<size_t>& predictions,
     ProbabilitiesMatType& predictionProbs) const
 {
-  static_assert(std::is_same<ElemType, typename MatType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType, typename MatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
-  static_assert(std::is_same<ElemType,
-                             typename ProbabilitiesMatType::elem_type>::value,
+  static_assert(std::is_same_v<ElemType,
+                             typename ProbabilitiesMatType::elem_type>,
       "NaiveBayesClassifier: element type of given data must match the element "
       "type of the model!");
 

--- a/src/mlpack/methods/nca/nca.hpp
+++ b/src/mlpack/methods/nca/nca.hpp
@@ -81,11 +81,9 @@ class NCA
    */
   template<typename... CallbackTypes,
            typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>,
+               CallbackTypes...>::value>,
            typename = std::enable_if_t<
-               !FirstElementIsArma<CallbackTypes...>::value
-           >>
+               !FirstElementIsArma<CallbackTypes...>::value>>
   [[deprecated("Will be removed in mlpack 5.0.0.  Use the version that takes a "
                "dataset as a parameter.")]]
   void LearnDistance(arma::mat& outputMatrix, CallbackTypes&&... callbacks);
@@ -111,9 +109,8 @@ class NCA
                SoftmaxErrorFunction<MatType, LabelsType, DistanceType>,
                MatType
            >::value>,
-           typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>>
+           typename = std::enable_if_t<
+               IsEnsCallbackTypes<CallbackTypes...>::value>>
   void LearnDistance(const MatType& dataset,
                      const LabelsType& labels,
                      MatType& outputMatrix,

--- a/src/mlpack/methods/nca/nca.hpp
+++ b/src/mlpack/methods/nca/nca.hpp
@@ -80,12 +80,12 @@ class NCA
    *      See https://www.ensmallen.org/docs.html#callback-documentation.
    */
   template<typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type,
-           typename = typename std::enable_if<
+           >::value>,
+           typename = std::enable_if_t<
                !FirstElementIsArma<CallbackTypes...>::value
-           >::type>
+           >>
   [[deprecated("Will be removed in mlpack 5.0.0.  Use the version that takes a "
                "dataset as a parameter.")]]
   void LearnDistance(arma::mat& outputMatrix, CallbackTypes&&... callbacks);
@@ -106,14 +106,14 @@ class NCA
   template<typename MatType,
            typename LabelsType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<!IsEnsOptimizer<
+           typename = std::enable_if_t<!IsEnsOptimizer<
                typename First<CallbackTypes...>::type,
                SoftmaxErrorFunction<MatType, LabelsType, DistanceType>,
                MatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   void LearnDistance(const MatType& dataset,
                      const LabelsType& labels,
                      MatType& outputMatrix,
@@ -137,11 +137,11 @@ class NCA
            typename LabelsType,
            typename OptimizerType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType,
                SoftmaxErrorFunction<MatType, LabelsType, DistanceType>,
                MatType
-           >::value>::type>
+           >::value>>
   void LearnDistance(const MatType& dataset,
                      const LabelsType& labels,
                      MatType& outputMatrix,

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -48,7 +48,7 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
   static_assert(IsBaseMatType<VecType>::value,
       "PCA::Apply(): eigVal must be a vector type!");
   static_assert(std::is_same_v<typename MatType::elem_type,
-                             typename OutMatType::elem_type>,
+                               typename OutMatType::elem_type>,
       "PCA::Apply(): data and transformedData must have the same element "
       "types!");
 
@@ -82,7 +82,7 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
   static_assert(IsBaseMatType<VecType>::value,
       "PCA::Apply(): eigVal must be a vector type!");
   static_assert(std::is_same_v<typename MatType::elem_type,
-                             typename OutMatType::elem_type>,
+                               typename OutMatType::elem_type>,
       "PCA::Apply(): data and transformedData must have the same element "
       "types!");
 
@@ -105,7 +105,7 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
   static_assert(IsBaseMatType<OutMatType>::value,
       "PCA::Apply(): transformedData must be a matrix type!");
   static_assert(std::is_same_v<typename MatType::elem_type,
-                             typename OutMatType::elem_type>,
+                               typename OutMatType::elem_type>,
       "PCA::Apply(): data and transformedData must have the same element "
       "types!");
 

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -47,8 +47,8 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
       "PCA::Apply(): transformedData must be a matrix type!");
   static_assert(IsBaseMatType<VecType>::value,
       "PCA::Apply(): eigVal must be a vector type!");
-  static_assert(std::is_same<typename MatType::elem_type,
-                             typename OutMatType::elem_type>::value,
+  static_assert(std::is_same_v<typename MatType::elem_type,
+                             typename OutMatType::elem_type>,
       "PCA::Apply(): data and transformedData must have the same element "
       "types!");
 
@@ -81,8 +81,8 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
       "PCA::Apply(): transformedData must be a matrix type!");
   static_assert(IsBaseMatType<VecType>::value,
       "PCA::Apply(): eigVal must be a vector type!");
-  static_assert(std::is_same<typename MatType::elem_type,
-                             typename OutMatType::elem_type>::value,
+  static_assert(std::is_same_v<typename MatType::elem_type,
+                             typename OutMatType::elem_type>,
       "PCA::Apply(): data and transformedData must have the same element "
       "types!");
 
@@ -104,8 +104,8 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
   // Sanity checks on input types.
   static_assert(IsBaseMatType<OutMatType>::value,
       "PCA::Apply(): transformedData must be a matrix type!");
-  static_assert(std::is_same<typename MatType::elem_type,
-                             typename OutMatType::elem_type>::value,
+  static_assert(std::is_same_v<typename MatType::elem_type,
+                             typename OutMatType::elem_type>,
       "PCA::Apply(): data and transformedData must have the same element "
       "types!");
 

--- a/src/mlpack/methods/perceptron/perceptron.hpp
+++ b/src/mlpack/methods/perceptron/perceptron.hpp
@@ -92,8 +92,8 @@ class Perceptron
              const size_t numClasses,
              const WeightsType& instanceWeights,
              const size_t maxIterations = 1000,
-             const typename std::enable_if<
-                 arma::is_arma_type<WeightsType>::value>::type* = 0);
+             const std::enable_if_t<
+                 arma::is_arma_type<WeightsType>::value>* = 0);
 
   /**
    * Alternate constructor which copies parameters from an already initiated
@@ -114,8 +114,8 @@ class Perceptron
              const arma::Row<size_t>& labels,
              const size_t numClasses,
              const WeightsType& instanceWeights,
-             const typename std::enable_if<
-                 arma::is_arma_type<WeightsType>::value>::type* = 0);
+             const std::enable_if_t<
+                 arma::is_arma_type<WeightsType>::value>* = 0);
 
   /**
    * Train the perceptron on the given data for up to the given maximum number

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -83,8 +83,7 @@ Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Perceptron(
     const size_t numClasses,
     const WeightsType& instanceWeights,
     const size_t maxIterations,
-    const std::enable_if_t<
-        arma::is_arma_type<WeightsType>::value>*) :
+    const std::enable_if_t<arma::is_arma_type<WeightsType>::value>*) :
     maxIterations(maxIterations)
 {
   // Start training.
@@ -114,8 +113,7 @@ Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Perceptron(
     const arma::Row<size_t>& labels,
     const size_t numClasses,
     const WeightsType& instanceWeights,
-    const std::enable_if_t<
-        arma::is_arma_type<WeightsType>::value>*) :
+    const std::enable_if_t<arma::is_arma_type<WeightsType>::value>*) :
     maxIterations(other.maxIterations)
 {
   TrainInternal<true>(data, labels, numClasses, instanceWeights);

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -83,8 +83,8 @@ Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Perceptron(
     const size_t numClasses,
     const WeightsType& instanceWeights,
     const size_t maxIterations,
-    const typename std::enable_if<
-        arma::is_arma_type<WeightsType>::value>::type*) :
+    const std::enable_if_t<
+        arma::is_arma_type<WeightsType>::value>*) :
     maxIterations(maxIterations)
 {
   // Start training.
@@ -114,8 +114,8 @@ Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Perceptron(
     const arma::Row<size_t>& labels,
     const size_t numClasses,
     const WeightsType& instanceWeights,
-    const typename std::enable_if<
-        arma::is_arma_type<WeightsType>::value>::type*) :
+    const std::enable_if_t<
+        arma::is_arma_type<WeightsType>::value>*) :
     maxIterations(other.maxIterations)
 {
   TrainInternal<true>(data, labels, numClasses, instanceWeights);

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -93,12 +93,12 @@ class SoftmaxRegression
    */
   template<typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   SoftmaxRegression(const MatType& data,
                     const arma::Row<size_t>& labels,
                     const size_t numClasses,
@@ -125,12 +125,12 @@ class SoftmaxRegression
    */
   template<typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   SoftmaxRegression(const MatType& data,
                     const arma::Row<size_t>& labels,
                     const size_t numClasses,
@@ -158,15 +158,15 @@ class SoftmaxRegression
   template<typename OptimizerType = ens::L_BFGS,
            typename FirstCallbackType,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
-           >::value>::type,
-           typename = typename std::enable_if<
-              std::is_class<FirstCallbackType>::value
-           >::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<
+              std::is_class_v<FirstCallbackType>
+           >,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   [[deprecated("Will be removed in mlpack 5.0.0, use other Train() variants")]]
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
@@ -191,12 +191,12 @@ class SoftmaxRegression
    */
   template<typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,
@@ -221,12 +221,12 @@ class SoftmaxRegression
    */
   template<typename OptimizerType = ens::L_BFGS,
            typename... CallbackTypes,
-           typename = typename std::enable_if<IsEnsOptimizer<
+           typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
-           >::value>::type,
-           typename = typename std::enable_if<IsEnsCallbackTypes<
+           >::value>,
+           typename = std::enable_if_t<IsEnsCallbackTypes<
                CallbackTypes...
-           >::value>::type>
+           >::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -96,9 +96,8 @@ class SoftmaxRegression
            typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
            >::value>,
-           typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>>
+           typename = std::enable_if_t<
+               IsEnsCallbackTypes<CallbackTypes...>::value>>
   SoftmaxRegression(const MatType& data,
                     const arma::Row<size_t>& labels,
                     const size_t numClasses,
@@ -128,9 +127,8 @@ class SoftmaxRegression
            typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
            >::value>,
-           typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>>
+           typename = std::enable_if_t<
+               IsEnsCallbackTypes<CallbackTypes...>::value>>
   SoftmaxRegression(const MatType& data,
                     const arma::Row<size_t>& labels,
                     const size_t numClasses,
@@ -161,12 +159,9 @@ class SoftmaxRegression
            typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
            >::value>,
+           typename = std::enable_if_t<std::is_class_v<FirstCallbackType>>,
            typename = std::enable_if_t<
-              std::is_class_v<FirstCallbackType>
-           >,
-           typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>>
+               IsEnsCallbackTypes<CallbackTypes...>::value>>
   [[deprecated("Will be removed in mlpack 5.0.0, use other Train() variants")]]
   double Train(const MatType& data,
                const arma::Row<size_t>& labels,
@@ -194,9 +189,8 @@ class SoftmaxRegression
            typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
            >::value>,
-           typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>>
+           typename = std::enable_if_t<
+               IsEnsCallbackTypes<CallbackTypes...>::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,
@@ -224,9 +218,8 @@ class SoftmaxRegression
            typename = std::enable_if_t<IsEnsOptimizer<
                OptimizerType, SoftmaxRegressionFunction<MatType>, DenseMatType
            >::value>,
-           typename = std::enable_if_t<IsEnsCallbackTypes<
-               CallbackTypes...
-           >::value>>
+           typename = std::enable_if_t<
+               IsEnsCallbackTypes<CallbackTypes...>::value>>
   ElemType Train(const MatType& data,
                  const arma::Row<size_t>& labels,
                  const size_t numClasses,

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -299,8 +299,7 @@ void CheckPredictionsType()
 {
   using Extractor = MetaInfoExtractor<Class, PassedMT, PassedPT>;
   using ActualPT = typename Extractor::PredictionsType;
-  static_assert(std::is_same_v<ExpectedPT, ActualPT>,
-      "Should be the same");
+  static_assert(std::is_same_v<ExpectedPT, ActualPT>, "Should be the same");
 }
 
 /**

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -349,8 +349,7 @@ void CheckWeightsType()
 {
   using Extractor = MetaInfoExtractor<Class, PassedMT, PassedPT, PassedWT>;
   using ActualWT = typename Extractor::WeightsType;
-  static_assert(std::is_same_v<ExpectedWT, ActualWT>,
-      "Should be the same");
+  static_assert(std::is_same_v<ExpectedWT, ActualWT>, "Should be the same");
 }
 
 /**

--- a/src/mlpack/tests/cv_test.cpp
+++ b/src/mlpack/tests/cv_test.cpp
@@ -299,7 +299,7 @@ void CheckPredictionsType()
 {
   using Extractor = MetaInfoExtractor<Class, PassedMT, PassedPT>;
   using ActualPT = typename Extractor::PredictionsType;
-  static_assert(std::is_same<ExpectedPT, ActualPT>::value,
+  static_assert(std::is_same_v<ExpectedPT, ActualPT>,
       "Should be the same");
 }
 
@@ -350,7 +350,7 @@ void CheckWeightsType()
 {
   using Extractor = MetaInfoExtractor<Class, PassedMT, PassedPT, PassedWT>;
   using ActualWT = typename Extractor::WeightsType;
-  static_assert(std::is_same<ExpectedWT, ActualWT>::value,
+  static_assert(std::is_same_v<ExpectedWT, ActualWT>,
       "Should be the same");
 }
 

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -454,7 +454,7 @@ TEMPLATE_TEST_CASE("GaussianUnivariateProbabilityTest", "[DistributionTest]",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-7;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
   GaussianDistribution<MatType> g(VecType("0.0"), MatType("1.0"));
 
@@ -500,7 +500,7 @@ TEMPLATE_TEST_CASE("GaussianMultivariateProbabilityTest", "[DistributionTest]",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-7;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
   // Simple case.
   VecType mean = "0 0";
@@ -611,7 +611,7 @@ TEMPLATE_TEST_CASE("GaussianDistributionRandomTest", "[DistributionTest]",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 0.3 : 0.125;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.3 : 0.125;
 
   VecType mean("1.0 2.25");
   MatType cov("0.85 0.60;"
@@ -648,7 +648,7 @@ TEMPLATE_TEST_CASE("GaussianDistributionTrainTest", "[DistributionTest]", float,
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-3 : 1e-5;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-3 : 1e-5;
 
   VecType mean("1.0 3.0 0.0 2.5");
   MatType cov("3.0 0.0 1.0 4.0;"
@@ -695,7 +695,7 @@ TEMPLATE_TEST_CASE("GaussianDistributionTrainWithProbabilitiesTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 0.25 : 0.1;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.25 : 0.1;
 
   VecType mean = ("5.0");
   VecType cov = ("2.0");
@@ -739,8 +739,8 @@ TEMPLATE_TEST_CASE("GaussianDistributionWithProbabilties1Test",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol1 = (std::is_same<ElemType, float>::value) ? 1e-10 : 1e-17;
-  const ElemType tol2 = (std::is_same<ElemType, float>::value) ? 1e-2 : 1e-4;
+  const ElemType tol1 = (std::is_same_v<ElemType, float>) ? 1e-10 : 1e-17;
+  const ElemType tol2 = (std::is_same_v<ElemType, float>) ? 1e-2 : 1e-4;
 
   VecType mean = ("5.0");
   VecType cov  = ("4.0");
@@ -891,7 +891,7 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainWithProbabilitiesTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 0.03 : 0.015;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.03 : 0.015;
 
   ElemType alphaReal = 5.4;
   ElemType betaReal = 6.7;
@@ -986,7 +986,7 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainTwoDistProbabilities1Test",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 0.25 : 0.075;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.25 : 0.075;
 
   ElemType alphaReal = 5.4;
   ElemType betaReal = 6.7;
@@ -1275,7 +1275,7 @@ TEMPLATE_TEST_CASE("DiscreteDistributionTest", "[DistributionTest]",
   typedef typename arma::Col<ObsElemType> ObsVecType;
   typedef typename arma::Mat<ObsElemType> ObsMatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-8;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-8;
 
   // I assume that I am properly saving vectors, so, this should be
   // straightforward.
@@ -1600,7 +1600,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianUnivariateProbabilityTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-7;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
   DiagonalGaussianDistribution<MatType> d(VecType("0.0"), VecType("1.0"));
 
@@ -1640,7 +1640,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianMultivariateProbabilityTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-7;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
   VecType mean("0 0");
   VecType cov("2 2");
@@ -1706,7 +1706,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionRandomTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 0.2 : 0.1;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.2 : 0.1;
 
   VecType mean("2.5 1.25");
   VecType cov("0.50 0.25");
@@ -1739,7 +1739,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionTrainTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-3 : 1e-5;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-3 : 1e-5;
 
   VecType mean("2.5 1.5 8.2 3.1");
   VecType cov("1.2 3.1 8.3 4.3");
@@ -1778,7 +1778,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianUnbiasedEstimatorTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-7;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
   // Generate the observations.
   MatType observations("3 5 2 7;"
@@ -1816,7 +1816,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianWeightedParametersReductionTest",
   typedef typename arma::Col<ElemType> VecType;
   typedef typename arma::Mat<ElemType> MatType;
 
-  const ElemType tol = (std::is_same<ElemType, float>::value) ? 1e-4 : 1e-7;
+  const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
   VecType mean("2.5 1.5 8.2 3.1");
   VecType cov("1.2 3.1 8.3 4.3");

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -1244,8 +1244,7 @@ TEMPLATE_TEST_CASE("LARSSelectBetaTest", "[LARSTest]", arma::fmat, arma::mat)
 
   // Now step through numerous different lambda values.
   ElemType lastError = std::numeric_limits<ElemType>::max();
-  const ElemType errorTol = (std::is_same_v<ElemType, double>) ? 1e-8 :
-      0.05;
+  const ElemType errorTol = (std::is_same_v<ElemType, double>) ? 1e-8 : 0.05;
   for (ElemType i = 5.0; i >= -5.0; i -= 0.1)
   {
     const ElemType selLambda1 = std::pow(10.0, (ElemType) i);

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -35,7 +35,7 @@ void LARSVerifyCorrectness(const VecType& beta,
   size_t nDims = beta.n_elem;
 
   // floats require a much larger tolerance.
-  const ElemType tol = (std::is_same<ElemType, double>::value) ? 1e-8 : 5e-3;
+  const ElemType tol = (std::is_same_v<ElemType, double>) ? 1e-8 : 5e-3;
 
   for (size_t j = 0; j < nDims; ++j)
   {
@@ -1226,7 +1226,7 @@ TEMPLATE_TEST_CASE("LARSSelectBetaTest", "[LARSTest]", arma::fmat, arma::mat)
   typedef TestType MatType;
   typedef typename MatType::elem_type ElemType;
 
-  const ElemType tol = (std::is_same<ElemType, double>::value) ? 1e-5 : 5e-3;
+  const ElemType tol = (std::is_same_v<ElemType, double>) ? 1e-5 : 5e-3;
 
   // Train a model on a randomly generated problem.  Then, we will iterate
   // through different selected lambda values, ensuring that the error on the
@@ -1244,7 +1244,7 @@ TEMPLATE_TEST_CASE("LARSSelectBetaTest", "[LARSTest]", arma::fmat, arma::mat)
 
   // Now step through numerous different lambda values.
   ElemType lastError = std::numeric_limits<ElemType>::max();
-  const ElemType errorTol = (std::is_same<ElemType, double>::value) ? 1e-8 :
+  const ElemType errorTol = (std::is_same_v<ElemType, double>) ? 1e-8 :
       0.05;
   for (ElemType i = 5.0; i >= -5.0; i -= 0.1)
   {

--- a/src/mlpack/tests/lmnn_test.cpp
+++ b/src/mlpack/tests/lmnn_test.cpp
@@ -116,8 +116,8 @@ TEMPLATE_TEST_CASE("LMNNInitialPointTest", "[LMNNTest]", float, double)
   LMNNFunction<arma::Mat<ElemType>> lmnnfn(dataset, labels, 1, 0.5, 1);
 
   // Verify the initial point is the identity matrix.
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
-  const double margin = std::is_same<ElemType, float>::value ? 1e-4 : 1e-5;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
+  const double margin = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
   arma::Mat<ElemType> initialPoint = lmnnfn.GetInitialPoint();
   for (int row = 0; row < 5; row++)
   {
@@ -148,7 +148,7 @@ TEMPLATE_TEST_CASE("LMNNInitialEvaluationTest", "[LMNNTest]", float, double)
   ElemType objective = lmnnfn.Evaluate(arma::eye<arma::Mat<ElemType>>(2, 2));
 
   // Result calculated by hand.
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
   REQUIRE(objective == Approx(9.456).epsilon(eps));
 }
 
@@ -171,8 +171,8 @@ TEMPLATE_TEST_CASE("LMNNInitialGradientTest", "[LMNNTest]", float, double)
   lmnnfn.Gradient(coordinates, gradient);
 
   // Result calculated by hand.
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
-  const double margin = std::is_same<ElemType, float>::value ? 1e-4 : 1e-5;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
+  const double margin = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
   REQUIRE(gradient(0, 0) == Approx(-0.288).epsilon(eps));
   REQUIRE(gradient(1, 0) == Approx(0.0).margin(margin));
   REQUIRE(gradient(0, 1) == Approx(0.0).margin(margin));
@@ -198,8 +198,8 @@ TEMPLATE_TEST_CASE("LMNNInitialEvaluateWithGradientTest", "[LMNNTest]", float,
   arma::Mat<ElemType> coordinates = arma::eye<arma::Mat<ElemType>>(2, 2);
   ElemType objective = lmnnfn.EvaluateWithGradient(coordinates, gradient);
 
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
-  const double margin = std::is_same<ElemType, float>::value ? 1e-4 : 1e-5;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
+  const double margin = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
 
   // Result calculated by hand.
   REQUIRE(objective == Approx(9.456).epsilon(eps));
@@ -225,7 +225,7 @@ TEMPLATE_TEST_CASE("LMNNSeparableObjectiveTest", "[LMNNTest]", float, double)
   LMNNFunction<arma::Mat<ElemType>> lmnnfn(dataset, labels, 1, 0.6, 1);
 
   // Result calculated by hand.
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
   arma::Mat<ElemType> coordinates = arma::eye<arma::Mat<ElemType>>(2, 2);
   REQUIRE(lmnnfn.Evaluate(coordinates, 0, 1) == Approx(1.576).epsilon(eps));
   REQUIRE(lmnnfn.Evaluate(coordinates, 1, 1) == Approx(1.576).epsilon(eps));
@@ -254,8 +254,8 @@ TEMPLATE_TEST_CASE("LMNNSeparableGradientTest", "[LMNNTest]", float, double)
 
   lmnnfn.Gradient(coordinates, 0, gradient, 1);
 
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
-  const double margin = std::is_same<ElemType, float>::value ? 1e-4 : 1e-5;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
+  const double margin = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
 
   REQUIRE(gradient(0, 0) == Approx(-0.048).epsilon(eps));
   REQUIRE(gradient(0, 1) == Approx(0.0).margin(margin));
@@ -318,8 +318,8 @@ TEMPLATE_TEST_CASE("LMNNSeparableEvaluateWithGradientTest", "[LMNNTest]", float,
 
   ElemType objective = lmnnfn.EvaluateWithGradient(coordinates, 0, gradient, 1);
 
-  const double eps = std::is_same<ElemType, float>::value ? 1e-4 : 1e-7;
-  const double margin = std::is_same<ElemType, float>::value ? 1e-4 : 1e-5;
+  const double eps = std::is_same_v<ElemType, float> ? 1e-4 : 1e-7;
+  const double margin = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
 
   REQUIRE(objective == Approx(1.576).epsilon(eps));
 

--- a/src/mlpack/tests/main_tests/main_test_fixture.hpp
+++ b/src/mlpack/tests/main_tests/main_test_fixture.hpp
@@ -106,8 +106,7 @@ class MainTestFixture
   template<typename T>
   void SetInputParam(const std::string& name, T&& value)
   {
-    params.Get<std::remove_reference_t<T>>(name) =
-        std::forward<T>(value);
+    params.Get<std::remove_reference_t<T>>(name) = std::forward<T>(value);
     params.SetPassed(name);
   }
 

--- a/src/mlpack/tests/main_tests/main_test_fixture.hpp
+++ b/src/mlpack/tests/main_tests/main_test_fixture.hpp
@@ -106,7 +106,7 @@ class MainTestFixture
   template<typename T>
   void SetInputParam(const std::string& name, T&& value)
   {
-    params.Get<typename std::remove_reference<T>::type>(name) =
+    params.Get<std::remove_reference_t<T>>(name) =
         std::forward<T>(value);
     params.SetPassed(name);
   }

--- a/src/mlpack/tests/nca_test.cpp
+++ b/src/mlpack/tests/nca_test.cpp
@@ -41,8 +41,8 @@ TEMPLATE_TEST_CASE("SoftmaxInitialPoint", "[NCATest]", float, double)
 
   // Verify the initial point is the identity matrix.
   arma::Mat<eT> initialPoint = sef.GetInitialPoint();
-  const double eps = std::is_same<eT, float>::value ? 1e-4 : 1e-7;
-  const double margin = std::is_same<eT, float>::value ? 1e-4 : 1e-5;
+  const double eps = std::is_same_v<eT, float> ? 1e-4 : 1e-7;
+  const double margin = std::is_same_v<eT, float> ? 1e-4 : 1e-5;
   for (int row = 0; row < 5; row++)
   {
     for (int col = 0; col < 5; col++)
@@ -131,7 +131,7 @@ TEMPLATE_TEST_CASE("SoftmaxOptimalEvaluation", "[NCATest]", float, double)
 
   // Use a very close tolerance for optimality; we need to be sure this function
   // gives optimal results correctly.
-  const double eps = std::is_same<eT, float>::value ? 1e-6 : 1e-12;
+  const double eps = std::is_same_v<eT, float> ? 1e-6 : 1e-12;
   REQUIRE(objective == Approx(-4.0).epsilon(eps));
 }
 

--- a/src/mlpack/tests/pca_test.cpp
+++ b/src/mlpack/tests/pca_test.cpp
@@ -361,7 +361,7 @@ TEMPLATE_TEST_CASE("PCASubviewTest", "[PCATest]", ExactSVDPolicy,
   p.Apply(data.cols(0, 1999), transData3, eigval2, eigvec);
 
   // Only check for deterministic policies.
-  if (std::is_same<DecompositionPolicy, ExactSVDPolicy>::value)
+  if (std::is_same_v<DecompositionPolicy, ExactSVDPolicy>)
   {
     arma::mat trueTransData, trueEigvec;
     arma::vec trueEigval;
@@ -408,7 +408,7 @@ TEMPLATE_TEST_CASE("PCAExpressionTest", "[PCATest]", ExactSVDPolicy,
   p.Apply(2 * data + 1, transData3, eigval2, eigvec);
 
   // Only check for deterministic policies.
-  if (std::is_same<DecompositionPolicy, ExactSVDPolicy>::value)
+  if (std::is_same_v<DecompositionPolicy, ExactSVDPolicy>)
   {
     arma::mat trueTransData, trueEigvec;
     arma::vec trueEigval;
@@ -456,7 +456,7 @@ TEMPLATE_TEST_CASE("PCAFloatTest", "[PCATest]", ExactSVDPolicy,
 
   // Verify the PCA results based on the eigenvalues.  We don't check for
   // QUIC-SVD, since that method has a lot of noise.
-  if (!std::is_same<DecompositionPolicy, QUICSVDPolicy>::value)
+  if (!std::is_same_v<DecompositionPolicy, QUICSVDPolicy>)
   {
     for (size_t i = 0; i < eigVal.n_elem; ++i)
     {

--- a/src/mlpack/tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/sparse_coding_test.cpp
@@ -23,7 +23,7 @@ void SCVerifyCorrectness(const VecType& beta,
                          const VecType& errCorr,
                          double lambda)
 {
-  const double tol = std::is_same<typename VecType::elem_type, float>::value ?
+  const double tol = std::is_same_v<typename VecType::elem_type, float> ?
       1e-6 : 1e-12;
   size_t nDims = beta.n_elem;
   for (size_t j = 0; j < nDims; ++j)
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE("SparseCodingTestDictionaryStep", "[SparseCodingTest]",
 {
   typedef TestType MatType;
 
-  const double tol = std::is_same<typename MatType::elem_type, float>::value ?
+  const double tol = std::is_same_v<typename MatType::elem_type, float> ?
       0.01 : 1e-6;
 
   double lambda1 = 0.1;
@@ -215,7 +215,7 @@ TEMPLATE_TEST_CASE("SparseCodingTrainReturnObjective", "[SparseCodingTest]",
 {
   typedef TestType MatType;
 
-  const double tol = std::is_same<typename MatType::elem_type, float>::value ?
+  const double tol = std::is_same_v<typename MatType::elem_type, float> ?
       0.01 : 1e-6;
 
   double lambda1 = 0.1;

--- a/src/mlpack/tests/test_catch_tools.hpp
+++ b/src/mlpack/tests/test_catch_tools.hpp
@@ -23,8 +23,8 @@
 
 // Simple wrapper class to prevent copies of Armadillo matrices.
 template <typename MatType, typename ElemType = typename MatType::elem_type,
-          typename = std::enable_if_t<std::is_same<ElemType,
-              typename MatType::elem_type>::value>>
+          typename = std::enable_if_t<std::is_same_v<ElemType,
+              typename MatType::elem_type>>>
 class MatProxy
 {
  public:
@@ -54,9 +54,9 @@ class MatProxy<arma::Mat<ElemType>, ElemType>
 template <typename MatTypeA, typename MatTypeB,
     typename = std::enable_if_t<arma::is_arma_type<MatTypeA>::value
         && arma::is_arma_type<MatTypeB>::value
-        && std::is_same<typename MatTypeA::elem_type,
-                        typename MatTypeB::elem_type>::value
-        && !std::is_integral<typename MatTypeA::elem_type>::value>>
+        && std::is_same_v<typename MatTypeA::elem_type,
+                        typename MatTypeB::elem_type>
+        && !std::is_integral_v<typename MatTypeA::elem_type>>>
 inline void CheckMatrices(const MatTypeA& _a,
                           const MatTypeB& _b,
                           double tolerance = 1e-5)
@@ -103,8 +103,8 @@ inline void CheckFields(const FieldType& a,
 
 // Simple wrapper class to prevent copies of Armadillo cubes.
 template <typename CubeType, typename ElemType = typename CubeType::elem_type,
-    typename = std::enable_if_t<std::is_same<ElemType,
-        typename CubeType::elem_type>::value>>
+    typename = std::enable_if_t<std::is_same_v<ElemType,
+        typename CubeType::elem_type>>>
 class CubeProxy
 {
  public:
@@ -136,9 +136,9 @@ class CubeProxy<arma::Cube<ElemType>, ElemType>
 template <typename CubeTypeA, typename CubeTypeB,
     typename = std::enable_if_t<arma::is_arma_cube_type<CubeTypeA>::value
         && arma::is_arma_cube_type<CubeTypeB>::value
-        && std::is_same<typename CubeTypeA::elem_type,
-                        typename CubeTypeB::elem_type>::value
-        && !std::is_integral<typename CubeTypeA::elem_type>::value>,
+        && std::is_same_v<typename CubeTypeA::elem_type,
+                        typename CubeTypeB::elem_type>
+        && !std::is_integral_v<typename CubeTypeA::elem_type>>,
     typename = void>
 inline void CheckMatrices(const CubeTypeA& _a,
                           const CubeTypeB& _b,

--- a/src/mlpack/tests/test_catch_tools.hpp
+++ b/src/mlpack/tests/test_catch_tools.hpp
@@ -55,7 +55,7 @@ template <typename MatTypeA, typename MatTypeB,
     typename = std::enable_if_t<arma::is_arma_type<MatTypeA>::value
         && arma::is_arma_type<MatTypeB>::value
         && std::is_same_v<typename MatTypeA::elem_type,
-                        typename MatTypeB::elem_type>
+                          typename MatTypeB::elem_type>
         && !std::is_integral_v<typename MatTypeA::elem_type>>>
 inline void CheckMatrices(const MatTypeA& _a,
                           const MatTypeB& _b,
@@ -137,7 +137,7 @@ template <typename CubeTypeA, typename CubeTypeB,
     typename = std::enable_if_t<arma::is_arma_cube_type<CubeTypeA>::value
         && arma::is_arma_cube_type<CubeTypeB>::value
         && std::is_same_v<typename CubeTypeA::elem_type,
-                        typename CubeTypeB::elem_type>
+                          typename CubeTypeB::elem_type>
         && !std::is_integral_v<typename CubeTypeA::elem_type>>,
     typename = void>
 inline void CheckMatrices(const CubeTypeA& _a,

--- a/src/mlpack/tests/ub_tree_test.cpp
+++ b/src/mlpack/tests/ub_tree_test.cpp
@@ -44,9 +44,9 @@ template<typename TreeType>
 void CheckSplit(const TreeType& tree)
 {
   typedef typename TreeType::ElemType ElemType;
-  typedef typename std::conditional<sizeof(ElemType) * CHAR_BIT <= 32,
+  typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>::type AddressElemType;
+                                    uint64_t>AddressElemType;
 
   if (tree.IsLeaf())
     return;

--- a/src/mlpack/tests/ub_tree_test.cpp
+++ b/src/mlpack/tests/ub_tree_test.cpp
@@ -19,9 +19,9 @@ using namespace mlpack;
 TEST_CASE("AddressTest", "[UBTreeTest]")
 {
   typedef double ElemType;
-  typedef typename std::conditional<sizeof(ElemType) * CHAR_BIT <= 32,
+  typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>::type AddressElemType;
+                                    uint64_t> AddressElemType;
   arma::Mat<ElemType> dataset(8, 1000);
 
   dataset.randu();
@@ -46,7 +46,7 @@ void CheckSplit(const TreeType& tree)
   typedef typename TreeType::ElemType ElemType;
   typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
                                     uint32_t,
-                                    uint64_t>AddressElemType;
+                                    uint64_t> AddressElemType;
 
   if (tree.IsLeaf())
     return;


### PR DESCRIPTION
With newer standards the readability of template heavy code can
be improved a lot by using a form with trailing `_t` for `::type` and
`_v` for `::value` respectively. Especially for `::type` it also makes
the additional `typename` before the trait dispensable.