### PR TITLE
Modernize typedefs

### DIFF
--- a/doc/developer/elemtype.md
+++ b/doc/developer/elemtype.md
@@ -28,7 +28,7 @@ types cannot be used.
 easily defined as below:
 
 ```c++
-typedef typename MatType::elem_type ElemType;
+using ElemType = typename MatType::elem_type;
 ```
 
 and otherwise a template parameter with the name `ElemType` can be used.  It is

--- a/doc/developer/trees.md
+++ b/doc/developer/trees.md
@@ -202,7 +202,7 @@ class ExampleTree
  public:
   // This is the element type held by the matrix.
   // It will generally either be `double`, or `float`.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   //////////////////////
   //// Constructors ////

--- a/doc/tutorials/fastmks.md
+++ b/doc/tutorials/fastmks.md
@@ -386,8 +386,9 @@ IPMetric<PolynomialKernel> metric(pk);
 // the custom base of 1.5 (default is 1.3).  We have to be sure to use the right
 // type here -- FastMKS needs the FastMKSStat object as the tree's
 // StatisticType.
-typedef CoverTree<IPMetric<PolynomialKernel>, FirstPointIsRoot, FastMKSStat>
-    TreeType; // Convenience typedef.
+// Convenience typedef.
+using TreeType =
+    CoverTree<IPMetric<PolynomialKernel>, FirstPointIsRoot, FastMKSStat>;
 TreeType* tree = new TreeType(data, metric, 1.5);
 
 // Now initialize FastMKS with that statistic.  We don't need to specify the
@@ -455,7 +456,7 @@ extern arma::mat data;
 
 // The custom tree type.  We'll assume that the first template parameter is the
 // statistic type.
-typedef CustomTree<FastMKSStat> TreeType;
+using TreeType = CustomTree<FastMKSStat>;
 
 // The FastMKS constructor will create the tree.
 FastMKS<LinearKernel, arma::mat, TreeType> f(data);

--- a/doc/tutorials/neighbor_search.md
+++ b/doc/tutorials/neighbor_search.md
@@ -213,7 +213,7 @@ The `KNN` class is, specifically, a typedef of the more extensible
 distance.
 
 ```c++
-typedef NeighborSearch<NearestNeighborSort, EuclideanDistance> KNN;
+using KNN = NeighborSearch<NearestNeighborSort, EuclideanDistance>;
 ```
 
 Using the `KNN` class is particularly simple; first, the object must be

--- a/doc/user/core/trees/ball_tree.md
+++ b/doc/user/core/trees/ball_tree.md
@@ -553,9 +553,9 @@ find the number of leaf nodes with fewer than 10 children.
 // above).
 
 // This convenient typedef saves us a long type name!
-typedef mlpack::BallTree<mlpack::EuclideanDistance,
-                         mlpack::EmptyStatistic,
-                         arma::fmat> TreeType;
+using TreeType = mlpack::BallTree<mlpack::EuclideanDistance,
+                                  mlpack::EmptyStatistic,
+                                  arma::fmat>;
 
 TreeType tree;
 mlpack::data::Load("tree.bin", "tree", tree);

--- a/doc/user/core/trees/binary_space_tree.md
+++ b/doc/user/core/trees/binary_space_tree.md
@@ -1850,11 +1850,11 @@ arma::mat dataset;
 mlpack::data::Load("corel-histogram.csv", dataset, true);
 
 // Convenience typedef for the tree type.
-typedef mlpack::BinarySpaceTree<mlpack::EuclideanDistance,
-                                mlpack::EmptyStatistic,
-                                arma::mat,
-                                mlpack::HRectBound,
-                                mlpack::MidpointSplit> TreeType;
+using TreeType = mlpack::BinarySpaceTree<mlpack::EuclideanDistance,
+                                         mlpack::EmptyStatistic,
+                                         arma::mat,
+                                         mlpack::HRectBound,
+                                         mlpack::MidpointSplit>;
 
 // Build trees on the first half and the second half of points.
 TreeType tree1(dataset.cols(0, dataset.n_cols / 2));
@@ -1947,11 +1947,11 @@ manually and find the number of leaf nodes with less than 10 children.
 // above).
 
 // This convenient typedef saves us a long type name!
-typedef mlpack::BinarySpaceTree<mlpack::EuclideanDistance,
-                                mlpack::EmptyStatistic,
-                                arma::fmat,
-                                mlpack::HRectBound,
-                                mlpack::MidpointSplit> TreeType;
+using TreeType = mlpack::BinarySpaceTree<mlpack::EuclideanDistance,
+                                         mlpack::EmptyStatistic,
+                                         arma::fmat,
+                                         mlpack::HRectBound,
+                                         mlpack::MidpointSplit>;
 
 TreeType tree;
 mlpack::data::Load("tree.bin", "tree", tree);

--- a/doc/user/core/trees/kdtree.md
+++ b/doc/user/core/trees/kdtree.md
@@ -547,9 +547,9 @@ find the number of leaf nodes with fewer than 10 children.
 // above).
 
 // This convenient typedef saves us a long type name!
-typedef mlpack::KDTree<mlpack::EuclideanDistance,
-                       mlpack::EmptyStatistic,
-                       arma::fmat> TreeType;
+using TreeType = mlpack::KDTree<mlpack::EuclideanDistance,
+                                mlpack::EmptyStatistic,
+                                arma::fmat>;
 
 TreeType tree;
 mlpack::data::Load("tree.bin", "tree", tree);

--- a/doc/user/core/trees/mean_split_ball_tree.md
+++ b/doc/user/core/trees/mean_split_ball_tree.md
@@ -551,9 +551,9 @@ find the number of leaf nodes with fewer than 10 children.
 // above).
 
 // This convenient typedef saves us a long type name!
-typedef mlpack::MeanSplitBallTree<mlpack::EuclideanDistance,
-                                  mlpack::EmptyStatistic,
-                                  arma::fmat> TreeType;
+using TreeType = mlpack::MeanSplitBallTree<mlpack::EuclideanDistance,
+                                           mlpack::EmptyStatistic,
+                                           arma::fmat>;
 
 TreeType tree;
 mlpack::data::Load("tree.bin", "tree", tree);

--- a/doc/user/core/trees/mean_split_kdtree.md
+++ b/doc/user/core/trees/mean_split_kdtree.md
@@ -560,9 +560,9 @@ manually and find the number of leaf nodes with fewer than 10 children.
 // above).
 
 // This convenient typedef saves us a long type name!
-typedef mlpack::MeanSplitKDTree<mlpack::EuclideanDistance,
-                                mlpack::EmptyStatistic,
-                                arma::fmat> TreeType;
+using TreeType = mlpack::MeanSplitKDTree<mlpack::EuclideanDistance,
+                                         mlpack::EmptyStatistic,
+                                         arma::fmat>;
 
 TreeType tree;
 mlpack::data::Load("tree.bin", "tree", tree);

--- a/doc/user/core/trees/vptree.md
+++ b/doc/user/core/trees/vptree.md
@@ -558,9 +558,9 @@ find the number of leaf nodes with less than 10 children.
 // above).
 
 // This convenient typedef saves us a long type name!
-typedef mlpack::VPTree<mlpack::EuclideanDistance,
-                       mlpack::EmptyStatistic,
-                       arma::fmat> TreeType;
+using TreeType = mlpack::VPTree<mlpack::EuclideanDistance,
+                                mlpack::EmptyStatistic,
+                                arma::fmat>;
 
 TreeType tree;
 mlpack::data::Load("tree.bin", "tree", tree);

--- a/doc/user/matrices.md
+++ b/doc/user/matrices.md
@@ -256,10 +256,10 @@ arma::Row<size_t> labels =
 
 // Train in the constructor, using floating-point data.
 // The weak learner type is now a floating-point Perceptron.
-typedef mlpack::Perceptron<
+using PerceptronType = mlpack::Perceptron<
     mlpack::SimpleWeightUpdate,
     mlpack::ZeroInitialization,
-    arma::fmat> PerceptronType;
+    arma::fmat>;
 mlpack::AdaBoost<PerceptronType, arma::fmat> ab(dataset, labels, 5);
 
 // Create test data (500 points).

--- a/doc/user/methods/adaboost.md
+++ b/doc/user/methods/adaboost.md
@@ -418,9 +418,9 @@ arma::Row<size_t> labels =
 
 // Train in the constructor, using floating-point data.
 // The weak learner type is now a floating-point Perceptron.
-typedef mlpack::Perceptron<mlpack::SimpleWeightUpdate,
-                           mlpack::ZeroInitialization,
-                           arma::fmat> PerceptronType;
+using PerceptronType = mlpack::Perceptron<mlpack::SimpleWeightUpdate,
+                                          mlpack::ZeroInitialization,
+                                          arma::fmat>;
 mlpack::AdaBoost<PerceptronType, arma::fmat> ab(dataset, labels, 5);
 
 // Create test data (500 points).

--- a/doc/user/methods/amf.md
+++ b/doc/user/methods/amf.md
@@ -659,8 +659,9 @@ mlpack::RandomAcolInitialization<5> initW;
 mlpack::RandomAMFInitialization initH;
 
 // Combine the two initializations so we can pass it to the AMF class.
-typedef mlpack::MergeInitialization<mlpack::RandomAcolInitialization<5>,
-                                    mlpack::RandomAMFInitialization> InitType;
+using InitType =
+    mlpack::MergeInitialization<mlpack::RandomAcolInitialization<5>,
+                                mlpack::RandomAMFInitialization>;
 InitType init(initW, initH);
 
 // Create an AMF object with the custom initialization.

--- a/src/mlpack/bindings/R/print_R.cpp
+++ b/src/mlpack/bindings/R/print_R.cpp
@@ -35,7 +35,7 @@ void PrintR(util::Params& params,
   const util::BindingDetails& doc = params.Doc();
 
   map<string, util::ParamData>& parameters = params.Parameters();
-  typedef map<string, util::ParamData>::iterator ParamIter;
+  using ParamIter = map<string, util::ParamData>::iterator;
 
   // First, let's get a list of input and output options.  We'll take two passes
   // so that the required input options are the first in the list.

--- a/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
+++ b/src/mlpack/bindings/R/tests/test_r_binding_main.cpp
@@ -195,7 +195,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
-    typedef tuple<data::DatasetInfo, arma::mat> TupleType;
+    using TupleType = tuple<data::DatasetInfo, arma::mat>;
     TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);

--- a/src/mlpack/bindings/cli/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/delete_allocated_memory.hpp
@@ -42,7 +42,7 @@ void DeleteAllocatedMemoryImpl(
     const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
-  typedef std::tuple<T*, std::string> TupleType;
+  using TupleType =  std::tuple<T*, std::string>;
   delete std::get<0>(*std::any_cast<TupleType>(&d.value));
 }
 

--- a/src/mlpack/bindings/cli/delete_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/delete_allocated_memory.hpp
@@ -42,7 +42,7 @@ void DeleteAllocatedMemoryImpl(
     const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Delete the allocated memory (hopefully we actually own it).
-  using TupleType =  std::tuple<T*, std::string>;
+  using TupleType = std::tuple<T*, std::string>;
   delete std::get<0>(*std::any_cast<TupleType>(&d.value));
 }
 

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -44,7 +44,7 @@ void* GetAllocatedMemory(
 {
   // Here we have a model, which is a tuple, and we need the address of the
   // memory.
-  using TupleType =  std::tuple<T*, std::string>;
+  using TupleType = std::tuple<T*, std::string>;
   return std::get<0>(*std::any_cast<TupleType>(&d.value));
 }
 

--- a/src/mlpack/bindings/cli/get_allocated_memory.hpp
+++ b/src/mlpack/bindings/cli/get_allocated_memory.hpp
@@ -44,7 +44,7 @@ void* GetAllocatedMemory(
 {
   // Here we have a model, which is a tuple, and we need the address of the
   // memory.
-  typedef std::tuple<T*, std::string> TupleType;
+  using TupleType =  std::tuple<T*, std::string>;
   return std::get<0>(*std::any_cast<TupleType>(&d.value));
 }
 

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -51,7 +51,7 @@ T& GetParam(
   // contains the filename.  It's possible we could load empty matrices many
   // times, but I am not bothered by that---it shouldn't be something that
   // happens.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T, typename ParameterType<T>::type>;
   TupleType& tuple = *std::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<0>(std::get<1>(tuple));
   T& matrix = std::get<0>(tuple);
@@ -85,7 +85,7 @@ T& GetParam(
 {
   // If this is an input parameter, we need to load both the matrix and the
   // dataset info.
-  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
+  using TupleType = std::tuple<T, std::tuple<std::string, size_t, size_t>>;
   TupleType* tuple = std::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<0>(std::get<1>(*tuple));
   T& t = std::get<0>(*tuple);
@@ -115,7 +115,7 @@ T*& GetParam(
 {
   // If the model is an input model, we have to load it from file.  'value'
   // contains the filename.
-  typedef std::tuple<T*, std::string> TupleType;
+  using TupleType =  std::tuple<T*, std::string>;
   TupleType* tuple = std::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<1>(*tuple);
   if (d.input && !d.loaded)

--- a/src/mlpack/bindings/cli/get_param.hpp
+++ b/src/mlpack/bindings/cli/get_param.hpp
@@ -115,7 +115,7 @@ T*& GetParam(
 {
   // If the model is an input model, we have to load it from file.  'value'
   // contains the filename.
-  using TupleType =  std::tuple<T*, std::string>;
+  using TupleType = std::tuple<T*, std::string>;
   TupleType* tuple = std::any_cast<TupleType>(&d.value);
   const std::string& value = std::get<1>(*tuple);
   if (d.input && !d.loaded)

--- a/src/mlpack/bindings/cli/get_printable_param_impl.hpp
+++ b/src/mlpack/bindings/cli/get_printable_param_impl.hpp
@@ -77,7 +77,7 @@ std::string GetPrintableParam(
         std::tuple<data::DatasetInfo, arma::mat>>>* /* junk */)
 {
   // Extract the string from the tuple that's being held.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T, typename ParameterType<T>::type>;
   const TupleType* tuple = std::any_cast<TupleType>(&data.value);
 
   std::ostringstream oss;
@@ -105,7 +105,7 @@ std::string GetPrintableParam(
     const std::enable_if_t<data::HasSerialize<T>::value>*)
 {
   // Extract the string from the tuple that's being held.
-  typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T*, typename ParameterType<T>::type>;
   const TupleType* tuple = std::any_cast<TupleType>(&data.value);
 
   std::ostringstream oss;

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -48,7 +48,7 @@ T& GetRawParam(
                                      arma::mat>>>* = 0)
 {
   // Don't load the matrix.
-  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
+  using TupleType = std::tuple<T, std::tuple<std::string, size_t, size_t>>;
   T& value = std::get<0>(*std::any_cast<TupleType>(&d.value));
   return value;
 }
@@ -63,7 +63,7 @@ T*& GetRawParam(
     const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Don't load the model.
-  typedef std::tuple<T*, std::string> TupleType;
+  using TupleType =  std::tuple<T*, std::string>;
   T*& value = std::get<0>(*std::any_cast<TupleType>(&d.value));
   return value;
 }

--- a/src/mlpack/bindings/cli/get_raw_param.hpp
+++ b/src/mlpack/bindings/cli/get_raw_param.hpp
@@ -63,7 +63,7 @@ T*& GetRawParam(
     const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Don't load the model.
-  using TupleType =  std::tuple<T*, std::string>;
+  using TupleType = std::tuple<T*, std::string>;
   T*& value = std::get<0>(*std::any_cast<TupleType>(&d.value));
   return value;
 }

--- a/src/mlpack/bindings/cli/in_place_copy.hpp
+++ b/src/mlpack/bindings/cli/in_place_copy.hpp
@@ -56,7 +56,7 @@ void InPlaceCopyInternal(
             = 0)
 {
   // Make the output filename the same as the input filename.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T, typename ParameterType<T>::type>;
   TupleType& tuple = *std::any_cast<TupleType>(&d.value);
   std::string& value = std::get<0>(std::get<1>(tuple));
 
@@ -78,7 +78,7 @@ void InPlaceCopyInternal(
     const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // Make the output filename the same as the input filename.
-  typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T*, typename ParameterType<T>::type>;
   TupleType& tuple = *std::any_cast<TupleType>(&d.value);
   std::string& value = std::get<1>(tuple);
 

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -53,7 +53,7 @@ void OutputParamImpl(
     util::ParamData& data,
     const std::enable_if_t<arma::is_arma_type<T>::value>*)
 {
-  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
+  using TupleType = std::tuple<T, std::tuple<std::string, size_t, size_t>>;
   const T& output = std::get<0>(*std::any_cast<TupleType>(&data.value));
   const std::string& filename =
       std::get<0>(std::get<1>(*std::any_cast<TupleType>(&data.value)));
@@ -77,7 +77,7 @@ void OutputParamImpl(
   // The const cast is necessary here because Serialize() can't ever be marked
   // const.  In this case we can assume it though, since we will be saving and
   // not loading.
-  typedef std::tuple<T*, std::string> TupleType;
+  using TupleType =  std::tuple<T*, std::string>;
   T*& output = const_cast<T*&>(std::get<0>(*std::any_cast<TupleType>(
       &data.value)));
   const std::string& filename =
@@ -95,7 +95,7 @@ void OutputParamImpl(
         std::tuple<data::DatasetInfo, arma::mat>>>* /* junk */)
 {
   // Output the matrix with the mappings.
-  typedef std::tuple<T, std::tuple<std::string, size_t, size_t>> TupleType;
+  using TupleType = std::tuple<T, std::tuple<std::string, size_t, size_t>>;
   const T& tuple = std::get<0>(*std::any_cast<TupleType>(&data.value));
   const std::string& filename =
       std::get<0>(std::get<1>(*std::any_cast<TupleType>(&data.value)));

--- a/src/mlpack/bindings/cli/output_param_impl.hpp
+++ b/src/mlpack/bindings/cli/output_param_impl.hpp
@@ -77,7 +77,7 @@ void OutputParamImpl(
   // The const cast is necessary here because Serialize() can't ever be marked
   // const.  In this case we can assume it though, since we will be saving and
   // not loading.
-  using TupleType =  std::tuple<T*, std::string>;
+  using TupleType = std::tuple<T*, std::string>;
   T*& output = const_cast<T*&>(std::get<0>(*std::any_cast<TupleType>(
       &data.value)));
   const std::string& filename =

--- a/src/mlpack/bindings/cli/parameter_type.hpp
+++ b/src/mlpack/bindings/cli/parameter_type.hpp
@@ -23,14 +23,14 @@ namespace cli {
 template<bool HasSerialize, typename T>
 struct ParameterTypeDeducer
 {
-  typedef T type;
+  using type = T;
 };
 
 // If we have a serialize() function, then the type is a string.
 template<typename T>
 struct ParameterTypeDeducer<true, T>
 {
-  typedef std::string type;
+  using type = std::string;
 };
 
 /**
@@ -41,8 +41,8 @@ struct ParameterTypeDeducer<true, T>
 template<typename T>
 struct ParameterType
 {
-  typedef typename ParameterTypeDeducer<data::HasSerialize<T>::value, T>::type
-      type;
+  using type =
+      typename ParameterTypeDeducer<data::HasSerialize<T>::value, T>::type;
 };
 
 /**
@@ -53,7 +53,7 @@ struct ParameterType
 template<typename eT>
 struct ParameterType<arma::Col<eT>>
 {
-  typedef std::tuple<std::string, size_t, size_t> type;
+  using type = std::tuple<std::string, size_t, size_t>;
 };
 
 /**
@@ -65,7 +65,7 @@ struct ParameterType<arma::Col<eT>>
 template<typename eT>
 struct ParameterType<arma::Row<eT>>
 {
-  typedef std::tuple<std::string, size_t, size_t> type;
+  using type = std::tuple<std::string, size_t, size_t>;
 };
 
 /**
@@ -76,7 +76,7 @@ struct ParameterType<arma::Row<eT>>
 template<typename eT>
 struct ParameterType<arma::Mat<eT>>
 {
-  typedef std::tuple<std::string, size_t, size_t> type;
+  using type = std::tuple<std::string, size_t, size_t>;
 };
 
 /**
@@ -86,7 +86,7 @@ template<typename eT, typename PolicyType>
 struct ParameterType<std::tuple<mlpack::data::DatasetMapper<PolicyType,
                          std::string>, arma::Mat<eT>>>
 {
-  typedef std::tuple<std::string, size_t, size_t> type;
+  using type = std::tuple<std::string, size_t, size_t>;
 };
 
 } // namespace cli

--- a/src/mlpack/bindings/cli/set_param.hpp
+++ b/src/mlpack/bindings/cli/set_param.hpp
@@ -62,7 +62,7 @@ void SetParam(
         std::tuple<data::DatasetInfo, arma::mat>>>* = 0)
 {
   // We're setting the string filename.
-  typedef std::tuple<T, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T, typename ParameterType<T>::type>;
   TupleType& tuple = *std::any_cast<TupleType>(&d.value);
   std::get<0>(std::get<1>(tuple)) = std::any_cast<std::string>(value);
 }
@@ -79,7 +79,7 @@ void SetParam(
     const std::enable_if_t<data::HasSerialize<T>::value>* = 0)
 {
   // We're setting the string filename.
-  typedef std::tuple<T*, typename ParameterType<T>::type> TupleType;
+  using TupleType = std::tuple<T*, typename ParameterType<T>::type>;
   TupleType& tuple = *std::any_cast<TupleType>(&d.value);
   std::get<1>(tuple) = std::any_cast<std::string>(value);
 }

--- a/src/mlpack/bindings/go/mlpack/capi/arma_util.cpp
+++ b/src/mlpack/bindings/go/mlpack/capi/arma_util.cpp
@@ -377,7 +377,7 @@ void mlpackToArmaMatWithInfo(void* params,
 int mlpackArmaMatWithInfoElements(void* params, const char* identifier)
 {
   util::Params& p = *((util::Params*) params);
-  typedef std::tuple<data::DatasetInfo, arma::mat> TupleType;
+  using TupleType = std::tuple<data::DatasetInfo, arma::mat>;
   return std::get<1>(p.Get<TupleType>(identifier)).n_elem;
 }
 
@@ -387,7 +387,7 @@ int mlpackArmaMatWithInfoElements(void* params, const char* identifier)
 int mlpackArmaMatWithInfoRows(void* params, const char* identifier)
 {
   util::Params& p = *((util::Params*) params);
-  typedef std::tuple<data::DatasetInfo, arma::mat> TupleType;
+  using TupleType = std::tuple<data::DatasetInfo, arma::mat>;
   return std::get<1>(p.Get<TupleType>(identifier)).n_rows;
 }
 
@@ -397,7 +397,7 @@ int mlpackArmaMatWithInfoRows(void* params, const char* identifier)
 int mlpackArmaMatWithInfoCols(void* params, const char* identifier)
 {
   util::Params& p = *((util::Params*) params);
-  typedef std::tuple<data::DatasetInfo, arma::mat> TupleType;
+  using TupleType = std::tuple<data::DatasetInfo, arma::mat>;
   return std::get<1>(p.Get<TupleType>(identifier)).n_cols;
 }
 
@@ -408,7 +408,7 @@ int mlpackArmaMatWithInfoCols(void* params, const char* identifier)
 void* mlpackArmaPtrMatWithInfoPtr(void* params, const char* identifier)
 {
   util::Params& p = *((util::Params*) params);
-  typedef std::tuple<data::DatasetInfo, arma::mat> TupleType;
+  using TupleType = std::tuple<data::DatasetInfo, arma::mat>;
   arma::mat& m = std::get<1>(p.Get<TupleType>(identifier));
   if (m.is_empty())
   {

--- a/src/mlpack/bindings/go/print_go.cpp
+++ b/src/mlpack/bindings/go/print_go.cpp
@@ -43,7 +43,7 @@ void PrintGo(util::Params& params,
              const std::string& bindingName)
 {
   std::map<std::string, util::ParamData>& parameters = params.Parameters();
-  typedef std::map<std::string, util::ParamData>::iterator ParamIter;
+  using ParamIter = std::map<std::string, util::ParamData>::iterator;
 
   // Split into input and output parameters.  Take two passes on the input
   // parameters, so that we get the required ones first.

--- a/src/mlpack/bindings/go/tests/test_go_binding_main.cpp
+++ b/src/mlpack/bindings/go/tests/test_go_binding_main.cpp
@@ -191,7 +191,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
-    typedef tuple<data::DatasetInfo, arma::mat> TupleType;
+    using TupleType = tuple<data::DatasetInfo, arma::mat>;
     TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);

--- a/src/mlpack/bindings/julia/print_jl.cpp
+++ b/src/mlpack/bindings/julia/print_jl.cpp
@@ -34,7 +34,7 @@ void PrintJL(const string& bindingName,
   const BindingDetails& doc = p.Doc();
 
   map<string, ParamData>& parameters = p.Parameters();
-  typedef map<string, ParamData>::iterator ParamIter;
+  using ParamIter = map<string, ParamData>::iterator;
 
   // First, let's get a list of input and output options.  We'll take two passes
   // so that the required input options are the first in the list.

--- a/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
+++ b/src/mlpack/bindings/julia/tests/test_julia_binding_main.cpp
@@ -193,7 +193,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
-    typedef tuple<data::DatasetInfo, arma::mat> TupleType;
+    using TupleType = tuple<data::DatasetInfo, arma::mat>;
     TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);

--- a/src/mlpack/bindings/python/mlpack/io_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/io_util.hpp
@@ -89,8 +89,8 @@ inline void SetParamWithInfo(util::Params& params,
                              T& matrix,
                              const bool* dims)
 {
-  typedef typename std::tuple<data::DatasetInfo, T> TupleType;
-  typedef typename T::elem_type eT;
+  using TupleType = std::tuple<data::DatasetInfo, T>;
+  using eT = typename T::elem_type;
 
   // The true type of the parameter is std::tuple<T, DatasetInfo>.
   const size_t dimensions = matrix.n_rows;
@@ -149,7 +149,7 @@ T& GetParamWithInfo(util::Params& params,
                     const std::string& paramName)
 {
   // T will be the Armadillo type.
-  typedef std::tuple<data::DatasetInfo, T> TupleType;
+  using TupleType = std::tuple<data::DatasetInfo, T>;
   return std::get<1>(params.Get<TupleType>(paramName));
 }
 

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -302,7 +302,7 @@ void PrintOutputProcessing(util::ParamData& d,
                            const void* input,
                            void* /* output */)
 {
-  typedef std::tuple<util::Params, std::tuple<size_t, bool>> TupleType;
+  using TupleType = std::tuple<util::Params, std::tuple<size_t, bool>>;
   TupleType* tuple = (TupleType*) input;
 
   PrintOutputProcessing<std::remove_pointer_t<T>>(

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -40,7 +40,7 @@ void PrintPYX(const util::BindingDetails& doc,
   util::Params params = IO::Parameters(bindingName);
 
   std::map<std::string, util::ParamData>& parameters = params.Parameters();
-  typedef std::map<std::string, util::ParamData>::iterator ParamIter;
+  using ParamIter = std::map<std::string, util::ParamData>::iterator;
 
   // Split into input and output parameters.  Take two passes on the input
   // parameters, so that we get the required ones first.
@@ -258,7 +258,7 @@ void PrintPYX(const util::BindingDetails& doc,
   cout << "  result = {}" << endl;
   cout << endl;
 
-  typedef std::tuple<util::Params, std::tuple<size_t, bool>> TupleType;
+  using TupleType = std::tuple<util::Params, std::tuple<size_t, bool>>;
 
   for (size_t i = 0; i < outputOptions.size(); ++i)
   {

--- a/src/mlpack/bindings/python/tests/test_python_binding.py
+++ b/src/mlpack/bindings/python/tests/test_python_binding.py
@@ -293,7 +293,7 @@ class TestPythonBinding(unittest.TestCase):
     """
     Test a Pandas Series input paramter
     """
-    x =  pd.Series(np.random.rand(100))
+    x = pd.Series(np.random.rand(100))
     z = copy.deepcopy(x)
 
     output = test_python_binding(string_in='hello',
@@ -313,7 +313,7 @@ class TestPythonBinding(unittest.TestCase):
     """
     Test a Pandas Series input paramter
     """
-    x =  pd.Series(np.random.rand(100))
+    x = pd.Series(np.random.rand(100))
 
     output = test_python_binding(string_in='hello',
                                  int_in=12,

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -235,7 +235,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timer */)
   // All numeric elements should be multiplied by 3.
   if (params.Has("matrix_and_info_in"))
   {
-    typedef tuple<data::DatasetInfo, arma::mat> TupleType;
+    using TupleType = tuple<data::DatasetInfo, arma::mat>;
     TupleType tuple = std::move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);

--- a/src/mlpack/bindings/tests/test_function_map.hpp
+++ b/src/mlpack/bindings/tests/test_function_map.hpp
@@ -26,8 +26,8 @@ class TestFunctionMap
 {
  public:
   // Convenience typedef.
-  typedef std::map<std::string, std::map<std::string,
-      void (*)(util::ParamData&, const void*, void*)>> FunctionMapType;
+  using FunctionMapType = std::map<std::string, std::map<std::string,
+      void (*)(util::ParamData&, const void*, void*)>>;
 
   //! Get the instantiated TestFunctionMap object.
   static TestFunctionMap& GetSingleton();

--- a/src/mlpack/core/data/check_categorical_param.hpp
+++ b/src/mlpack/core/data/check_categorical_param.hpp
@@ -22,7 +22,7 @@ namespace data {
 inline void CheckCategoricalParam(util::Params& params,
                                   const std::string& paramName)
 {
-  typedef typename std::tuple<DatasetInfo, arma::mat> TupleType;
+  using TupleType = std::tuple<DatasetInfo, arma::mat>;
   arma::mat& matrix = std::get<1>(params.Get<TupleType>(paramName));
 
   // This comes from Params::CheckInputMatrix().

--- a/src/mlpack/core/data/dataset_mapper.hpp
+++ b/src/mlpack/core/data/dataset_mapper.hpp
@@ -170,8 +170,8 @@ class DatasetMapper
   std::vector<Datatype> types;
 
   // Forward mapping type.
-  using ForwardMapType = typename std::unordered_map<InputType, typename
-      PolicyType::MappedType>;
+  using ForwardMapType = std::unordered_map<InputType,
+      typename PolicyType::MappedType>;
 
   // Reverse mapping type.  Multiple inputs may map to a single output, hence
   // the need for std::vector.

--- a/src/mlpack/core/data/load_arff_impl.hpp
+++ b/src/mlpack/core/data/load_arff_impl.hpp
@@ -160,8 +160,8 @@ void LoadARFF(const std::string& filename,
   }
 
   // Make sure all strings are mapped, if we have any.
-  typedef std::map<size_t, std::vector<std::string>>::const_iterator
-      IteratorType;
+  using IteratorType =
+      std::map<size_t, std::vector<std::string>>::const_iterator;
   for (IteratorType it = categoryStrings.begin(); it != categoryStrings.end();
       ++it)
   {

--- a/src/mlpack/core/data/map_policies/increment_policy.hpp
+++ b/src/mlpack/core/data/map_policies/increment_policy.hpp
@@ -122,7 +122,7 @@ class IncrementPolicy
       if (numMappings == 0)
         types[dimension] = Datatype::categorical;
 
-      typedef typename std::pair<InputType, MappedType> PairType;
+      using PairType = std::pair<InputType, MappedType>;
       maps[dimension].first.insert(PairType(input, numMappings));
 
       // Do we need to create the second map?

--- a/src/mlpack/core/data/map_policies/missing_policy.hpp
+++ b/src/mlpack/core/data/map_policies/missing_policy.hpp
@@ -112,7 +112,7 @@ class MissingPolicy
           maps[dimension].first.count(string) == 0)
       {
         // This string does not exist yet.
-        typedef std::pair<std::string, MappedType> PairType;
+        using PairType = std::pair<std::string, MappedType>;
         maps[dimension].first.insert(PairType(string, value));
 
         // Insert right mapping too.

--- a/src/mlpack/core/data/string_encoding_policies/tf_idf_encoding_policy.hpp
+++ b/src/mlpack/core/data/string_encoding_policies/tf_idf_encoding_policy.hpp
@@ -158,7 +158,7 @@ class TfIdfEncodingPolicy
         InverseDocumentFrequency<typename MatType::elem_type>(
             output.n_cols, numContainingStrings[value]);
 
-    output(value - 1, line) =  tf * idf;
+    output(value - 1, line) = tf * idf;
   }
 
   /**
@@ -188,7 +188,7 @@ class TfIdfEncodingPolicy
     const ElemType idf = InverseDocumentFrequency<ElemType>(
         output.size(), numContainingStrings[value]);
 
-    output[line][value - 1] =  tf * idf;
+    output[line][value - 1] = tf * idf;
   }
 
   /*

--- a/src/mlpack/core/distances/iou_distance.hpp
+++ b/src/mlpack/core/distances/iou_distance.hpp
@@ -66,7 +66,7 @@ class IoUDistance
   static typename VecTypeA::elem_type Evaluate(const VecTypeA& a,
                                                const VecTypeB& b)
   {
-    typedef typename VecTypeA::elem_type ElemType;
+    using ElemType = typename VecTypeA::elem_type;
 
     return (ElemType) (1.0 - IoU<UseCoordinates>::Evaluate(a, b));
   }

--- a/src/mlpack/core/distances/lmetric.hpp
+++ b/src/mlpack/core/distances/lmetric.hpp
@@ -97,23 +97,23 @@ class LMetric
 /**
  * The Manhattan (L1) distance.
  */
-typedef LMetric<1, false> ManhattanDistance;
+using ManhattanDistance = LMetric<1, false>;
 
 /**
  * The squared Euclidean (L2) distance.  Note that this is not technically a
  * metric!  But it can sometimes be used when distances are required.
  */
-typedef LMetric<2, false> SquaredEuclideanDistance;
+using SquaredEuclideanDistance = LMetric<2, false>;
 
 /**
  * The Euclidean (L2) distance.
  */
-typedef LMetric<2, true> EuclideanDistance;
+using EuclideanDistance = LMetric<2, true>;
 
 /**
  * The L-infinity distance.
  */
-typedef LMetric<INT_MAX, false> ChebyshevDistance;
+using ChebyshevDistance = LMetric<2147483647, false>;
 
 
 } // namespace mlpack

--- a/src/mlpack/core/distances/mahalanobis_distance.hpp
+++ b/src/mlpack/core/distances/mahalanobis_distance.hpp
@@ -59,7 +59,7 @@ template<bool TakeRoot = true, typename MatType = arma::mat>
 class MahalanobisDistance
 {
  public:
-  typedef typename GetColType<MatType>::type VecType;
+  using VecType = typename GetColType<MatType>::type;
 
   /**
    * Initialize the Mahalanobis distance with the empty matrix as Q.

--- a/src/mlpack/core/distributions/diagonal_gaussian_distribution.hpp
+++ b/src/mlpack/core/distributions/diagonal_gaussian_distribution.hpp
@@ -22,8 +22,8 @@ class DiagonalGaussianDistribution
 {
  public:
   // Convenience typedefs.
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename MatType::elem_type ElemType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
 
  private:
   //! Mean of the distribution.

--- a/src/mlpack/core/distributions/discrete_distribution.hpp
+++ b/src/mlpack/core/distributions/discrete_distribution.hpp
@@ -54,10 +54,10 @@ class DiscreteDistribution
 {
  public:
   // Convenience typedefs.
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename MatType::elem_type ElemType;
-  typedef typename GetColType<ObsMatType>::type ObsVecType;
-  typedef typename ObsMatType::elem_type ObsType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+  using ObsVecType = typename GetColType<ObsMatType>::type;
+  using ObsType = typename ObsMatType::elem_type;
 
   /**
    * Default constructor, which creates a distribution that has no

--- a/src/mlpack/core/distributions/gamma_distribution.hpp
+++ b/src/mlpack/core/distributions/gamma_distribution.hpp
@@ -54,8 +54,8 @@ class GammaDistribution
 {
  public:
   // Convenience typedefs.
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename MatType::elem_type ElemType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Construct the Gamma distribution with the given number of dimensions

--- a/src/mlpack/core/distributions/gaussian_distribution.hpp
+++ b/src/mlpack/core/distributions/gaussian_distribution.hpp
@@ -25,8 +25,8 @@ class GaussianDistribution
 {
  public:
   // Convenience typedefs for derived types of MatType.
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename MatType::elem_type ElemType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
 
  private:
   //! Mean of the distribution.

--- a/src/mlpack/core/distributions/laplace_distribution.hpp
+++ b/src/mlpack/core/distributions/laplace_distribution.hpp
@@ -52,8 +52,8 @@ class LaplaceDistribution
 {
  public:
   // Convenience typedefs.
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename MatType::elem_type ElemType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Default constructor, which creates a Laplace distribution with zero

--- a/src/mlpack/core/distributions/regression_distribution.hpp
+++ b/src/mlpack/core/distributions/regression_distribution.hpp
@@ -32,9 +32,9 @@ class RegressionDistribution
 {
  public:
   // Convenience typedefs.
-  typedef typename MatType::elem_type ElemType;
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename GetRowType<MatType>::type RowType;
+  using ElemType = typename MatType::elem_type;
+  using VecType = typename GetColType<MatType>::type;
+  using RowType = typename GetRowType<MatType>::type;
 
  private:
   //! Regression function for representing conditional mean.

--- a/src/mlpack/core/kernels/cosine_similarity.hpp
+++ b/src/mlpack/core/kernels/cosine_similarity.hpp
@@ -58,7 +58,7 @@ class KernelTraits<CosineSimilarity>
 };
 
 // This name is deprecated and can be removed in mlpack 5.0.0.
-typedef CosineSimilarity CosineDistance;
+using CosineDistance = CosineSimilarity;
 
 } // namespace mlpack
 

--- a/src/mlpack/core/math/ccov_impl.hpp
+++ b/src/mlpack/core/math/ccov_impl.hpp
@@ -59,7 +59,7 @@ inline arma::Mat<std::complex<T>> ColumnCovariance(
     Log::Fatal << "ColumnCovariance(): normType must be 0 or 1" << std::endl;
   }
 
-  typedef typename std::complex<T> eT;
+  using eT = std::complex<T>;
 
   arma::Mat<eT> out;
 

--- a/src/mlpack/core/math/log_add_impl.hpp
+++ b/src/mlpack/core/math/log_add_impl.hpp
@@ -65,7 +65,7 @@ typename T::elem_type AccuLog(const T& x)
   if (maxVal == -std::numeric_limits<typename T::elem_type>::infinity())
     return maxVal;
 
-  return maxVal + std::log(sum(exp(x - maxVal)));;
+  return maxVal + std::log(sum(exp(x - maxVal)));
 }
 
 /**

--- a/src/mlpack/core/math/range.hpp
+++ b/src/mlpack/core/math/range.hpp
@@ -17,7 +17,7 @@ namespace mlpack {
 template<typename T>
 class RangeType;
 
-typedef RangeType<double> Range;
+using Range = RangeType<double>;
 
 /**
  * Simple real-valued range.  It contains an upper and lower bound.

--- a/src/mlpack/core/metrics/bleu_impl.hpp
+++ b/src/mlpack/core/metrics/bleu_impl.hpp
@@ -53,7 +53,7 @@ ElemType BLEU<ElemType, PrecisionType>::Evaluate(
 {
   // WordVector is a string container type.
   // Also, TranslationCorpusType is an array of such containers.
-  typedef typename TranslationCorpusType::value_type WordVector;
+  using WordVector = typename TranslationCorpusType::value_type;
 
   // matchesByOrder: It catches how many times sequence of a particular order
   // is encountered in both reference corpus and translation corpus.

--- a/src/mlpack/core/metrics/non_maximal_suppression_impl.hpp
+++ b/src/mlpack/core/metrics/non_maximal_suppression_impl.hpp
@@ -83,7 +83,7 @@ void NMS<UseCoordinates>::Evaluate(
         sortedIndices);
 
     BoundingBoxesType x1 = boundingBoxes.submat(arma::uvec(1).fill(0),
-        sortedIndices);;
+        sortedIndices);
 
     BoundingBoxesType y2 = boundingBoxes.submat(arma::uvec(1).fill(3),
         sortedIndices);

--- a/src/mlpack/core/tree/address.hpp
+++ b/src/mlpack/core/tree/address.hpp
@@ -54,11 +54,11 @@ namespace mlpack {
 template<typename AddressType, typename VecType>
 void PointToAddress(AddressType& address, const VecType& point)
 {
-  typedef typename VecType::elem_type VecElemType;
+  using VecElemType = typename VecType::elem_type;
   // Check that the arguments are compatible.
-  typedef std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
-                                    uint32_t,
-                                    uint64_t> AddressElemType;
+  using AddressElemType =
+      std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
+                         uint32_t, uint64_t>;
 
   static_assert(std::is_same_v<typename AddressType::elem_type,
       AddressElemType> == true, "The vector element type does not "
@@ -150,11 +150,11 @@ void PointToAddress(AddressType& address, const VecType& point)
 template<typename AddressType, typename VecType>
 void AddressToPoint(VecType& point, const AddressType& address)
 {
-  typedef typename VecType::elem_type VecElemType;
+  using VecElemType = typename VecType::elem_type;
   // Check that the arguments are compatible.
-  typedef std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
-                                    uint32_t,
-                                    uint64_t> AddressElemType;
+  using AddressElemType =
+      std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
+                         uint32_t, uint64_t>;
 
   static_assert(std::is_same_v<typename AddressType::elem_type,
       AddressElemType> == true, "The vector element type does not "

--- a/src/mlpack/core/tree/ballbound.hpp
+++ b/src/mlpack/core/tree/ballbound.hpp
@@ -33,7 +33,7 @@ class BallBound
 {
  public:
   //! A public version of the vector type.
-  typedef VecType Vec;
+  using Vec = VecType;
 
  private:
   //! The radius of the ball bound.

--- a/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/binary_space_tree.hpp
@@ -55,11 +55,11 @@ class BinarySpaceTree
 {
  public:
   //! So other classes can use TreeType::Mat.
-  typedef MatType Mat;
+  using Mat = MatType;
   //! The type of element held in MatType.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
-  typedef SplitType<BoundType<DistanceType, ElemType>, MatType> Split;
+  using Split = SplitType<BoundType<DistanceType, ElemType>, MatType>;
 
  private:
   //! The left child node.

--- a/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/breadth_first_dual_tree_traverser.hpp
@@ -50,8 +50,8 @@ class BinarySpaceTree<DistanceType, StatisticType, MatType, BoundType,
    */
   BreadthFirstDualTreeTraverser(RuleType& rule);
 
-  typedef QueueFrame<BinarySpaceTree, typename RuleType::TraversalInfoType>
-      QueueFrameType;
+  using QueueFrameType =
+      QueueFrame<BinarySpaceTree, typename RuleType::TraversalInfoType>;
 
   /**
    * Traverse the two trees.  This does not reset the number of prunes.

--- a/src/mlpack/core/tree/binary_space_tree/rp_tree_max_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/rp_tree_max_split.hpp
@@ -32,7 +32,7 @@ class RPTreeMaxSplit
 {
  public:
   //! The element type held by the matrix type.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   //! An information about the partition.
   struct SplitInfo
   {

--- a/src/mlpack/core/tree/binary_space_tree/rp_tree_mean_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/rp_tree_mean_split.hpp
@@ -32,7 +32,7 @@ class RPTreeMeanSplit
 {
  public:
   //! The element type held by the matrix type.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   //! An information about the partition.
   struct SplitInfo
   {

--- a/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/ub_tree_split.hpp
@@ -29,10 +29,9 @@ class UBTreeSplit
 {
  public:
   //! The type of an address element.
-  typedef std::conditional_t<
+  using AddressElemType = std::conditional_t<
       sizeof(typename MatType::elem_type) * CHAR_BIT <= 32,
-      uint32_t,
-      uint64_t> AddressElemType;
+      uint32_t, uint64_t>;
 
   //! An information about the partition.
   struct SplitInfo

--- a/src/mlpack/core/tree/binary_space_tree/vantage_point_split.hpp
+++ b/src/mlpack/core/tree/binary_space_tree/vantage_point_split.hpp
@@ -32,9 +32,9 @@ class VantagePointSplit
 {
  public:
   //! The matrix element type.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   //! The bounding shape type.
-  typedef typename BoundType::DistanceType DistanceType;
+  using DistanceType = typename BoundType::DistanceType;
   //! A struct that contains an information about the split.
   struct SplitInfo
   {

--- a/src/mlpack/core/tree/cellbound.hpp
+++ b/src/mlpack/core/tree/cellbound.hpp
@@ -76,9 +76,8 @@ class CellBound
  public:
   //! Depending on the precision of the tree element type, we may need to use
   //! uint32_t or uint64_t.
-  typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
-                                    uint32_t,
-                                    uint64_t> AddressElemType;
+  using AddressElemType = std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
+                                             uint32_t, uint64_t>;
 
   /**
    * Empty constructor; creates a bound of dimensionality 0.

--- a/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
+++ b/src/mlpack/core/tree/cosine_tree/cosine_tree.hpp
@@ -32,7 +32,7 @@ template<typename MatType = arma::mat>
 class CosineTree
 {
  public:
-  typedef typename GetDenseColType<MatType>::type VecType;
+  using VecType = typename GetDenseColType<MatType>::type;
 
   /**
    * CosineTree constructor for the root node of the tree. It initializes the

--- a/src/mlpack/core/tree/cover_tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree.hpp
@@ -99,9 +99,9 @@ class CoverTree
 {
  public:
   //! So that other classes can access the matrix type.
-  typedef MatType Mat;
+  using Mat = MatType;
   //! The type held by the matrix type.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Create the cover tree with the given dataset and given base.

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
@@ -72,8 +72,8 @@ SingleTreeTraverser<RuleType>::Traverse(
 {
   // This is a non-recursive implementation (which should be faster than a
   // recursive implementation).
-  typedef CoverTreeMapEntry<DistanceType, StatisticType, MatType,
-      RootPointPolicy> MapEntryType;
+  using MapEntryType = CoverTreeMapEntry<DistanceType, StatisticType, MatType,
+      RootPointPolicy>;
 
   // We will use this map as a priority queue.  Each key represents the scale,
   // and then the vector is all the nodes in that scale which need to be

--- a/src/mlpack/core/tree/hollow_ball_bound.hpp
+++ b/src/mlpack/core/tree/hollow_ball_bound.hpp
@@ -33,7 +33,7 @@ class HollowBallBound
 {
  public:
   //! A public version of the metric type.
-  typedef TDistanceType DistanceType;
+  using DistanceType = TDistanceType;
 
  private:
   //! The inner and the outer radii of the bound.

--- a/src/mlpack/core/tree/octree/octree.hpp
+++ b/src/mlpack/core/tree/octree/octree.hpp
@@ -25,9 +25,9 @@ class Octree
 {
  public:
   //! So other classes can use TreeType::Mat.
-  typedef MatType Mat;
+  using Mat = MatType;
   //! The type of element held in MatType.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   //! A single-tree traverser; see single_tree_traverser.hpp.
   template<typename RuleType>

--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
@@ -30,9 +30,9 @@ class DiscreteHilbertValue
  public:
   //! Depending on the precision of the tree element type, we may need to use
   //! uint32_t or uint64_t.
-  typedef std::conditional_t<sizeof(TreeElemType) * CHAR_BIT <= 32,
-                                    uint32_t,
-                                    uint64_t> HilbertElemType;
+  using HilbertElemType =
+      std::conditional_t<sizeof(TreeElemType) * CHAR_BIT <= 32,
+                         uint32_t, uint64_t>;
 
   //! Default constructor.
   DiscreteHilbertValue();

--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value_impl.hpp
@@ -152,7 +152,7 @@ DiscreteHilbertValue<TreeElemType>::
 CalculateValue(const VecType& pt,
                typename std::enable_if_t<IsVector<VecType>::value>*)
 {
-  typedef typename VecType::elem_type VecElemType;
+  using VecElemType = typename VecType::elem_type;
   arma::Col<HilbertElemType> res(pt.n_rows);
   // Calculate the number of bits for the exponent.
   const int numExpBits = std::ceil(std::log2(

--- a/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/hilbert_r_tree_auxiliary_information.hpp
@@ -22,7 +22,7 @@ class HilbertRTreeAuxiliaryInformation
 {
  public:
   //! The element type held by the tree.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   //! Default constructor
   HilbertRTreeAuxiliaryInformation();
 

--- a/src/mlpack/core/tree/rectangle_tree/minimal_coverage_sweep.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/minimal_coverage_sweep.hpp
@@ -33,7 +33,7 @@ class MinimalCoverageSweep
   template<typename TreeType>
   struct SweepCost
   {
-    typedef typename TreeType::ElemType type;
+    using type = typename TreeType::ElemType;
   };
 
   /**

--- a/src/mlpack/core/tree/rectangle_tree/minimal_coverage_sweep_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/minimal_coverage_sweep_impl.hpp
@@ -24,8 +24,8 @@ SweepNonLeafNode(const size_t axis,
                  const TreeType* node,
                  typename TreeType::ElemType& axisCut)
 {
-  typedef typename TreeType::ElemType ElemType;
-  typedef HRectBound<EuclideanDistance, ElemType> BoundType;
+  using ElemType = typename TreeType::ElemType;
+  using BoundType = HRectBound<EuclideanDistance, ElemType>;
 
   std::vector<std::pair<ElemType, size_t>> sorted(node->NumChildren());
 
@@ -88,8 +88,8 @@ SweepLeafNode(const size_t axis,
               const TreeType* node,
               typename TreeType::ElemType& axisCut)
 {
-  typedef typename TreeType::ElemType ElemType;
-  typedef HRectBound<EuclideanDistance, ElemType> BoundType;
+  using ElemType = typename TreeType::ElemType;
+  using BoundType = HRectBound<EuclideanDistance, ElemType>;
 
   std::vector<std::pair<ElemType, size_t>> sorted(node->Count());
 

--- a/src/mlpack/core/tree/rectangle_tree/minimal_splits_number_sweep.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/minimal_splits_number_sweep.hpp
@@ -34,7 +34,7 @@ class MinimalSplitsNumberSweep
   template<typename>
   struct SweepCost
   {
-    typedef size_t type;
+    using type = size_t;
   };
 
   /**

--- a/src/mlpack/core/tree/rectangle_tree/minimal_splits_number_sweep_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/minimal_splits_number_sweep_impl.hpp
@@ -24,7 +24,7 @@ size_t MinimalSplitsNumberSweep<SplitPolicy>::SweepNonLeafNode(
     const TreeType* node,
     typename TreeType::ElemType& axisCut)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   std::vector<std::pair<ElemType, size_t>> sorted(node->NumChildren());
 

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information.hpp
@@ -24,9 +24,9 @@ class RPlusPlusTreeAuxiliaryInformation
 {
  public:
   //! The element type held by the tree.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   //! The bound type held by the auxiliary information.
-  typedef HRectBound<EuclideanDistance, ElemType> BoundType;
+  using BoundType = HRectBound<EuclideanDistance, ElemType>;
 
   //! Construct the auxiliary information object.
   RPlusPlusTreeAuxiliaryInformation();

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_plus_tree_auxiliary_information_impl.hpp
@@ -104,7 +104,7 @@ void RPlusPlusTreeAuxiliaryInformation<TreeType>::SplitAuxiliaryInfo(
     const size_t axis,
     const typename TreeType::ElemType cut)
 {
-  typedef HRectBound<EuclideanDistance, ElemType> Bound;
+  using Bound = HRectBound<EuclideanDistance, ElemType>;
   Bound& treeOneBound = treeOne->AuxiliaryInfo().OuterBound();
   Bound& treeTwoBound = treeTwo->AuxiliaryInfo().OuterBound();
 

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_descent_heuristic_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_descent_heuristic_impl.hpp
@@ -22,7 +22,7 @@ template<typename TreeType>
 size_t RPlusTreeDescentHeuristic::ChooseDescentNode(TreeType* node,
                                                     const size_t point)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   size_t bestIndex = 0;
   bool success = true;
 

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split.hpp
@@ -31,7 +31,7 @@ template<typename SplitPolicyType,
 class RPlusTreeSplit
 {
  public:
-  typedef SplitPolicyType SplitPolicy;
+  using SplitPolicy = SplitPolicyType;
   /**
    * Split a leaf node using the "default" algorithm.  If necessary, this split
    * will propagate upwards through the tree.

--- a/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_plus_tree_split_impl.hpp
@@ -25,7 +25,7 @@ template<typename TreeType>
 void RPlusTreeSplit<SplitPolicyType, SweepType>::
 SplitLeafNode(TreeType* tree, std::vector<bool>& relevels)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   if (tree->Count() == 1)
   {
@@ -122,7 +122,7 @@ template<typename TreeType>
 bool RPlusTreeSplit<SplitPolicyType, SweepType>::
 SplitNonLeafNode(TreeType* tree, std::vector<bool>& relevels)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   // If we are splitting the root node, we need will do things differently so
   // that the constructor and other methods don't confuse the end user by giving
   // an address of another node.
@@ -333,9 +333,8 @@ PartitionNode(const TreeType* node, size_t& minCutAxis,
     return false; // No partition required.
 
   // Define the type of the sweep cost.
-  typedef typename
-      SweepType<SplitPolicyType>::template SweepCost<TreeType>::type
-      SweepCostType;
+  using SweepCostType = typename
+      SweepType<SplitPolicyType>::template SweepCost<TreeType>::type;
 
   SweepCostType minCost = std::numeric_limits<SweepCostType>::max();
   minCutAxis = node->Bound().Dim();

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_descent_heuristic_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_descent_heuristic_impl.hpp
@@ -23,7 +23,7 @@ inline size_t RStarTreeDescentHeuristic::ChooseDescentNode(
     const size_t point)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   bool tiedOne = false;
   std::vector<ElemType> originalScores(node->NumChildren());
@@ -164,7 +164,7 @@ inline size_t RStarTreeDescentHeuristic::ChooseDescentNode(
     const TreeType* insertedNode)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   std::vector<ElemType> scores(node->NumChildren());
   std::vector<ElemType> vols(node->NumChildren());

--- a/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_star_tree_split_impl.hpp
@@ -28,7 +28,7 @@ size_t RStarTreeSplit::ReinsertPoints(TreeType* tree,
                                       std::vector<bool>& relevels)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   // Check if we need to reinsert.
   if (relevels[tree->TreeDepth() - 1])
@@ -83,8 +83,8 @@ void RStarTreeSplit::PickLeafSplit(TreeType* tree,
                                    size_t& bestIndex)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
-  typedef HRectBound<EuclideanDistance, ElemType> BoundType;
+  using ElemType = typename TreeType::ElemType;
+  using BoundType = HRectBound<EuclideanDistance, ElemType>;
 
   bestAxis = 0;
   bestIndex = 0;
@@ -176,7 +176,7 @@ template<typename TreeType>
 void RStarTreeSplit::SplitLeafNode(TreeType *tree, std::vector<bool>& relevels)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   // If there's no need to split, don't.
   if (tree->Count() <= tree->MaxLeafSize())
@@ -272,8 +272,8 @@ bool RStarTreeSplit::SplitNonLeafNode(
     std::vector<bool>& relevels)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
-  typedef HRectBound<EuclideanDistance, ElemType> BoundType;
+  using ElemType = typename TreeType::ElemType;
+  using BoundType = HRectBound<EuclideanDistance, ElemType>;
 
   // Reinsertion isn't done for non-leaf nodes; the paper doesn't seem to make
   // it clear how to reinsert an entire node without reinserting each of the

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_descent_heuristic_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_descent_heuristic_impl.hpp
@@ -22,7 +22,7 @@ inline size_t RTreeDescentHeuristic::ChooseDescentNode(const TreeType* node,
                                                        const size_t point)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   ElemType minScore = std::numeric_limits<ElemType>::max();
   int bestIndex = 0;
@@ -66,7 +66,7 @@ inline size_t RTreeDescentHeuristic::ChooseDescentNode(
     const TreeType* insertedNode)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   ElemType minScore = std::numeric_limits<ElemType>::max();
   int bestIndex = 0;

--- a/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/r_tree_split_impl.hpp
@@ -195,7 +195,7 @@ template<typename TreeType>
 void RTreeSplit::GetBoundSeeds(const TreeType *tree, int& iRet, int& jRet)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   ElemType worstPairScore = -1.0;
   for (size_t i = 0; i < tree->NumChildren(); ++i)
@@ -230,7 +230,7 @@ void RTreeSplit::AssignPointDestNode(TreeType* oldTree,
                                      const int intJ)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   size_t end = oldTree->Count();
 
@@ -366,7 +366,7 @@ void RTreeSplit::AssignNodeDestNode(TreeType* oldTree,
                                     const int intJ)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   size_t end = oldTree->NumChildren();
   assert(end > 1); // If this isn't true, the tree is really weird.

--- a/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/rectangle_tree.hpp
@@ -58,11 +58,11 @@ class RectangleTree
 
  public:
   //! So other classes can use TreeType::Mat.
-  typedef MatType Mat;
+  using Mat = MatType;
   //! The element type held by the matrix type.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   //! The auxiliary information type held by the tree.
-  typedef AuxiliaryInformationType<RectangleTree> AuxiliaryInformation;
+  using AuxiliaryInformation = AuxiliaryInformationType<RectangleTree>;
  private:
   //! The max number of child nodes a non-leaf node can have.
   size_t maxNumChildren;

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_auxiliary_information.hpp
@@ -165,7 +165,7 @@ class XTreeAuxiliaryInformation
    * The X tree requires that the tree records it's "split history".  To make
    * this easy, we use the following structure.
    */
-  using SplitHistoryStruct = struct SplitHistoryStruct
+  struct SplitHistoryStruct
   {
     int lastDimension;
     std::vector<bool> history;

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_auxiliary_information.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_auxiliary_information.hpp
@@ -165,7 +165,7 @@ class XTreeAuxiliaryInformation
    * The X tree requires that the tree records it's "split history".  To make
    * this easy, we use the following structure.
    */
-  typedef struct SplitHistoryStruct
+  using SplitHistoryStruct = struct SplitHistoryStruct
   {
     int lastDimension;
     std::vector<bool> history;
@@ -201,7 +201,7 @@ class XTreeAuxiliaryInformation
       ar(CEREAL_NVP(lastDimension));
       ar(CEREAL_NVP(history));
     }
-  } SplitHistoryStruct;
+  };
 
  private:
     //! The max number of child nodes a non-leaf normal node can have.

--- a/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/x_tree_split_impl.hpp
@@ -28,7 +28,7 @@ template<typename TreeType>
 void XTreeSplit::SplitLeafNode(TreeType *tree, std::vector<bool>& relevels)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   if (tree->Count() <= tree->MaxLeafSize())
     return;
@@ -123,8 +123,8 @@ template<typename TreeType>
 bool XTreeSplit::SplitNonLeafNode(TreeType *tree, std::vector<bool>& relevels)
 {
   // Convenience typedef.
-  typedef typename TreeType::ElemType ElemType;
-  typedef HRectBound<EuclideanDistance, ElemType> BoundType;
+  using ElemType = typename TreeType::ElemType;
+  using BoundType = HRectBound<EuclideanDistance, ElemType>;
 
   // The X tree paper doesn't explain how to handle the split history when
   // reinserting nodes and reinserting nodes seems to hurt the performance, so

--- a/src/mlpack/core/tree/space_split/hyperplane.hpp
+++ b/src/mlpack/core/tree/space_split/hyperplane.hpp
@@ -30,9 +30,9 @@ class HyperplaneBase
 {
  public:
   //! Useful typedef for the bound type.
-  typedef BoundT BoundType;
+  using BoundType = BoundT;
   //! Useful typedef for the projection vector type.
-  typedef ProjVectorT ProjVectorType;
+  using ProjVectorType = ProjVectorT;
 
  private:
   //! Projection vector.

--- a/src/mlpack/core/tree/spill_tree/spill_tree.hpp
+++ b/src/mlpack/core/tree/spill_tree/spill_tree.hpp
@@ -73,11 +73,11 @@ class SpillTree
 {
  public:
   //! So other classes can use TreeType::Mat.
-  typedef MatType Mat;
+  using Mat = MatType;
   //! The type of element held in MatType.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   //! The bound type.
-  typedef typename HyperplaneType<DistanceType>::BoundType BoundType;
+  using BoundType = typename HyperplaneType<DistanceType>::BoundType;
 
  private:
   //! The left child node.

--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -122,19 +122,19 @@ struct IsVector<arma::SpSubview_row<eT> >
 template<typename MatType>
 struct GetRowType
 {
-  typedef arma::Row<typename MatType::elem_type> type;
+  using type = arma::Row<typename MatType::elem_type>;
 };
 
 template<typename eT>
 struct GetRowType<arma::Mat<eT>>
 {
-  typedef arma::Row<eT> type;
+  using type = arma::Row<eT>;
 };
 
 template<typename eT>
 struct GetRowType<arma::SpMat<eT>>
 {
-  typedef arma::SpRow<eT> type;
+  using type = arma::SpRow<eT>;
 };
 
 // Get the column vector type corresponding to a given MatType.
@@ -142,25 +142,25 @@ struct GetRowType<arma::SpMat<eT>>
 template<typename MatType>
 struct GetColType
 {
-  typedef arma::Col<typename MatType::elem_type> type;
+  using type = arma::Col<typename MatType::elem_type>;
 };
 
 template<typename MatType>
 struct GetUColType
 {
-  typedef arma::Col<arma::uword> type;
+  using type = arma::Col<arma::uword>;
 };
 
 template<typename eT>
 struct GetColType<arma::Mat<eT>>
 {
-  typedef arma::Col<eT> type;
+  using type = arma::Col<eT>;
 };
 
 template<typename eT>
 struct GetColType<arma::SpMat<eT>>
 {
-  typedef arma::SpCol<eT> type;
+  using type = arma::SpCol<eT>;
 };
 
 // Get the dense row vector type corresponding to a given MatType.
@@ -168,13 +168,13 @@ struct GetColType<arma::SpMat<eT>>
 template<typename MatType>
 struct GetDenseRowType
 {
-  typedef typename GetRowType<MatType>::type type;
+  using type = typename GetRowType<MatType>::type;
 };
 
 template<typename eT>
 struct GetDenseRowType<arma::SpMat<eT>>
 {
-  typedef arma::Row<eT> type;
+  using type = arma::Row<eT>;
 };
 
 // Get the dense column vector type corresponding to a given MatType.
@@ -182,13 +182,13 @@ struct GetDenseRowType<arma::SpMat<eT>>
 template<typename MatType>
 struct GetDenseColType
 {
-  typedef typename GetColType<MatType>::type type;
+  using type = typename GetColType<MatType>::type;
 };
 
 template<typename eT>
 struct GetDenseColType<arma::SpMat<eT>>
 {
-  typedef arma::Col<eT> type;
+  using type = arma::Col<eT>;
 };
 
 // Get the dense matrix type corresponding to a given MatType.
@@ -196,19 +196,19 @@ struct GetDenseColType<arma::SpMat<eT>>
 template<typename MatType>
 struct GetDenseMatType
 {
-  typedef arma::Mat<typename MatType::elem_type> type;
+  using type = arma::Mat<typename MatType::elem_type>;
 };
 
 template<typename MatType>
 struct GetUDenseMatType
 {
-  typedef arma::Mat<arma::uword> type;
+  using type = arma::Mat<arma::uword>;
 };
 
 template<typename eT>
 struct GetDenseMatType<arma::SpMat<eT>>
 {
-  typedef arma::Mat<eT> type;
+  using type = arma::Mat<eT>;
 };
 
 // Get the cube type corresponding to a given MatType.
@@ -219,7 +219,7 @@ struct GetCubeType;
 template<typename eT>
 struct GetCubeType<arma::Mat<eT>>
 {
-  typedef arma::Cube<eT> type;
+  using type = arma::Cube<eT>;
 };
 
 // Get the sparse matrix type corresponding to a given MatType.
@@ -227,13 +227,13 @@ struct GetCubeType<arma::Mat<eT>>
 template<typename MatType>
 struct GetSparseMatType
 {
-  typedef arma::SpMat<typename MatType::elem_type> type;
+  using type = arma::SpMat<typename MatType::elem_type>;
 };
 
 template<typename eT>
 struct GetSparseMatType<arma::SpMat<eT>>
 {
-  typedef arma::SpMat<eT> type;
+  using type = arma::SpMat<eT>;
 };
 
 // Get whether or not the given type is a base matrix type (e.g. not an

--- a/src/mlpack/core/util/ens_traits.hpp
+++ b/src/mlpack/core/util/ens_traits.hpp
@@ -55,8 +55,8 @@ struct IsEnsOptimizerInternal<OptimizerType, FunctionType, MatType, true>
 {
   // If OptimizerType is a reference type, then forming the types below will
   // fail.  So we need to strip the reference (and the const for good measure).
-  typedef std::remove_cv_t<std::remove_reference_t<OptimizerType>>
-      SafeOptimizerType;
+  using SafeOptimizerType =
+      std::remove_cv_t<std::remove_reference_t<OptimizerType>>;
 
   using OptimizeElemReturnForm =
       typename MatType::elem_type(SafeOptimizerType::*)(FunctionType&,

--- a/src/mlpack/core/util/first_element_is_arma.hpp
+++ b/src/mlpack/core/util/first_element_is_arma.hpp
@@ -21,14 +21,14 @@ namespace mlpack {
 template<typename... CallbackTypes>
 struct First
 {
-  typedef void type;
+  using type = void;
 };
 
 // This matches whenever CallbackTypes has one or more elements.
 template<typename T, typename... CallbackTypes>
 struct First<T, CallbackTypes...>
 {
-  typedef T type;
+  using type = T;
 };
 
 // This utility template struct detects whether the first element in a

--- a/src/mlpack/core/util/io.hpp
+++ b/src/mlpack/core/util/io.hpp
@@ -277,8 +277,8 @@ class IO
   std::map<std::string, std::map<std::string, util::ParamData>> parameters;
   //! Map of functions.  Note that this is not specific to a binding, so we only
   //! have one.
-  typedef std::map<std::string, std::map<std::string,
-      void (*)(util::ParamData&, const void*, void*)>> FunctionMapType;
+  using FunctionMapType = std::map<std::string, std::map<std::string,
+      void (*)(util::ParamData&, const void*, void*)>>;
   FunctionMapType functionMap;
 
   //! Ensure only one thread can modify the docs map at a time.

--- a/src/mlpack/core/util/params.hpp
+++ b/src/mlpack/core/util/params.hpp
@@ -28,8 +28,8 @@ class Params
 {
  public:
   // Convenience typedef for function maps.
-  typedef std::map<std::string, std::map<std::string,
-      void (*)(ParamData&, const void*, void*)>> FunctionMapType;
+  using FunctionMapType = std::map<std::string, std::map<std::string,
+      void (*)(ParamData&, const void*, void*)>>;
 
   /**
    * Create a new Params class.  In general this should only be called via

--- a/src/mlpack/core/util/timers.hpp
+++ b/src/mlpack/core/util/timers.hpp
@@ -27,9 +27,9 @@
   // uint64_t isn't defined on every windows.
   #if !defined(HAVE_UINT64_T)
     #if SIZEOF_UNSIGNED_LONG == 8
-      typedef unsigned long uint64_t;
+      using uint64_t = unsigned long;
     #else
-      typedef unsigned long long uint64_t;
+      using uint64_t = unsigned long long;
     #endif // SIZEOF_UNSIGNED_LONG
   #endif // HAVE_UINT64_T
 #endif

--- a/src/mlpack/core/util/timers_impl.hpp
+++ b/src/mlpack/core/util/timers_impl.hpp
@@ -110,7 +110,7 @@ inline std::string Timers::Print(const std::chrono::microseconds& totalDuration)
 
   // Also output convenient day/hr/min/sec.
   // The following line is a custom duration for a day.
-  typedef std::chrono::duration<int, std::ratio<60 * 60 * 24, 1>> days;
+  using days = std::chrono::duration<int, std::ratio<60 * 60 * 24, 1>>;
   days d = std::chrono::duration_cast<days>(totalDuration);
   std::chrono::hours h = std::chrono::duration_cast<std::chrono::hours>(
       totalDuration % days(1));

--- a/src/mlpack/methods/adaboost/adaboost.hpp
+++ b/src/mlpack/methods/adaboost/adaboost.hpp
@@ -80,7 +80,7 @@ template<typename WeakLearnerType = Perceptron<>,
 class AdaBoost
 {
  public:
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Create the AdaBoost object without training.  Be sure to call Train()

--- a/src/mlpack/methods/amf/amf.hpp
+++ b/src/mlpack/methods/amf/amf.hpp
@@ -129,9 +129,9 @@ class AMF
   UpdateRuleType update;
 }; // class AMF
 
-typedef AMF<SimpleResidueTermination,
-            RandomAcolInitialization<>,
-            NMFALSUpdate> NMFALSFactorizer;
+using NMFALSFactorizer = AMF<SimpleResidueTermination,
+                             RandomAcolInitialization<>,
+                             NMFALSUpdate>;
 
 //! Convenience typedefs.
 

--- a/src/mlpack/methods/amf/update_rules/incremental_iterators.hpp
+++ b/src/mlpack/methods/amf/update_rules/incremental_iterators.hpp
@@ -49,7 +49,7 @@ void IncrementVIter(const MatType& V,
                     size_t& currentUserIndex,
                     size_t& currentItemIndex)
 {
-  typedef typename MatType::elem_type eT;
+  using eT = typename MatType::elem_type;
 
   // For dense matrices, 0s may be represented, so increment until we find the
   // next nonzero value.

--- a/src/mlpack/methods/ann/activation_functions/bipolar_sigmoid_function.hpp
+++ b/src/mlpack/methods/ann/activation_functions/bipolar_sigmoid_function.hpp
@@ -75,7 +75,7 @@ class BipolarSigmoidFunction
                     const OutputVecType& y,
                     DerivVecType& dy)
   {
-    dy =  (1.0 - pow(y, 2)) / 2.0;
+    dy = (1.0 - pow(y, 2)) / 2.0;
   }
 }; // class BipolarSigmoidFunction
 

--- a/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/fft_convolution.hpp
@@ -134,7 +134,7 @@ class FFTConvolution
       CubeType& output,
       const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
-    typedef typename GetDenseMatType<CubeType>::type MatType;
+    using MatType = typename GetDenseMatType<CubeType>::type;
     MatType convOutput;
     FFTConvolution<BorderMode>::Convolution(input.slice(0), filter.slice(0),
         convOutput);

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -60,7 +60,7 @@ class NaiveConvolution
               const bool appending = false,
               const typename std::enable_if_t<IsMatrix<InMatType>::value>* = 0)
   {
-    typedef typename InMatType::elem_type eT;
+    using eT = typename InMatType::elem_type;
     // Compute the output size.  The filterRows and filterCols computation must
     // take into account the fact that dilation only adds rows or columns
     // *between* filter elements.  So, e.g., a dilation of 2 on a kernel size of
@@ -163,7 +163,7 @@ class NaiveConvolution
       const bool appending = false,
       const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
-    typedef typename GetDenseMatType<CubeType>::type MatType;
+    using MatType = typename GetDenseMatType<CubeType>::type;
     MatType convOutput;
     NaiveConvolution<BorderMode>::Convolution(input.slice(0), filter.slice(0),
         convOutput, dW, dH, dilationW, dilationH, appending);

--- a/src/mlpack/methods/ann/convolution_rules/svd_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/svd_convolution.hpp
@@ -56,7 +56,7 @@ class SVDConvolution
       MatType& output,
       const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
-    typedef typename GetColType<MatType>::type ColType;
+    using ColType = typename GetColType<MatType>::type;
     // Use the naive convolution in case the filter isn't two dimensional or the
     // filter is bigger than the input.
     if (filter.n_rows > input.n_rows || filter.n_cols > input.n_cols ||
@@ -122,7 +122,7 @@ class SVDConvolution
       CubeType& output,
       const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
-    typedef typename GetDenseMatType<CubeType>::type MatType;
+    using MatType = typename GetDenseMatType<CubeType>::type;
     MatType convOutput;
     SVDConvolution<BorderMode>::Convolution(input.slice(0), filter.slice(0),
         convOutput);

--- a/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/kathirvalavakumar_subavathi_init.hpp
@@ -83,7 +83,7 @@ class KathirvalavakumarSubavathiInitialization
   template<typename MatType>
   void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
-    typedef typename GetRowType<MatType>::type RowType;
+    using RowType = typename GetRowType<MatType>::type;
     RowType b = s * sqrt(3 / (rows * dataSum));
     const double theta = b.min();
     RandomInitialization randomInit(-theta, theta);
@@ -100,7 +100,7 @@ class KathirvalavakumarSubavathiInitialization
   void Initialize(MatType& W,
       const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
-    typedef typename GetRowType<MatType>::type RowType;
+    using RowType = typename GetRowType<MatType>::type;
     RowType b = s * sqrt(3 / (W.n_rows * dataSum));
     const double theta = b.min();
     RandomInitialization randomInit(-theta, theta);

--- a/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
+++ b/src/mlpack/methods/ann/init_rules/orthogonal_init.hpp
@@ -42,7 +42,7 @@ class OrthogonalInitialization
   void Initialize(MatType& W, const size_t rows, const size_t cols)
   {
     MatType V;
-    typedef typename GetColType<MatType>::type ColType;
+    using ColType = typename GetColType<MatType>::type;
     ColType s;
 
     svd_econ(W, s, V, randu<MatType>(rows, cols));
@@ -60,7 +60,7 @@ class OrthogonalInitialization
       const typename std::enable_if_t<IsMatrix<MatType>::value>* = 0)
   {
     MatType V;
-    typedef typename GetColType<MatType>::type ColType;
+    using ColType = typename GetColType<MatType>::type;
     ColType s;
 
     svd_econ(W, s, V, randu<MatType>(W.n_rows, W.n_cols));

--- a/src/mlpack/methods/ann/layer/adaptive_max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_max_pooling.hpp
@@ -129,7 +129,7 @@ class AdaptiveMaxPoolingType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Adaptive max pooling layer.
-typedef AdaptiveMaxPoolingType<arma::mat> AdaptiveMaxPooling;
+using AdaptiveMaxPooling = AdaptiveMaxPoolingType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/adaptive_mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/adaptive_mean_pooling.hpp
@@ -130,7 +130,7 @@ class AdaptiveMeanPoolingType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Adaptive mean pooling layer.
-typedef AdaptiveMeanPoolingType<arma::mat> AdaptiveMeanPooling;
+using AdaptiveMeanPooling = AdaptiveMeanPoolingType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/add.hpp
+++ b/src/mlpack/methods/ann/layer/add.hpp
@@ -111,7 +111,7 @@ class AddType : public Layer<MatType>
 }; // class Add
 
 // Standard Add layer.
-typedef AddType<arma::mat> Add;
+using Add = AddType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/add_merge.hpp
+++ b/src/mlpack/methods/ann/layer/add_merge.hpp
@@ -95,7 +95,7 @@ class AddMergeType : public MultiLayer<MatType>
   void serialize(Archive& ar, const uint32_t /* version */);
 };
 
-typedef AddMergeType<arma::mat> AddMerge;
+using AddMerge = AddMergeType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/alpha_dropout.hpp
+++ b/src/mlpack/methods/ann/layer/alpha_dropout.hpp
@@ -147,7 +147,7 @@ class AlphaDropoutType : public Layer<MatType>
   double b;
 }; // class AlphaDropoutType
 
-typedef AlphaDropoutType<arma::mat> AlphaDropout;
+using AlphaDropout = AlphaDropoutType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/base_layer.hpp
+++ b/src/mlpack/methods/ann/layer/base_layer.hpp
@@ -131,7 +131,7 @@ class BaseLayer : public Layer<MatType>
 /**
  * Standard Sigmoid-Layer using the logistic activation function.
  */
-typedef BaseLayer<LogisticFunction, arma::mat> Sigmoid;
+using Sigmoid = BaseLayer<LogisticFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using SigmoidType = BaseLayer<LogisticFunction, MatType>;
@@ -139,7 +139,7 @@ using SigmoidType = BaseLayer<LogisticFunction, MatType>;
 /**
  * Standard rectified linear unit non-linearity layer.
  */
-typedef BaseLayer<RectifierFunction, arma::mat> ReLU;
+using ReLU = BaseLayer<RectifierFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using ReLUType = BaseLayer<RectifierFunction, MatType>;
@@ -147,7 +147,7 @@ using ReLUType = BaseLayer<RectifierFunction, MatType>;
 /**
  * Standard hyperbolic tangent layer.
  */
-typedef BaseLayer<TanhFunction, arma::mat> TanH;
+using TanH = BaseLayer<TanhFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using TanHType = BaseLayer<TanhFunction, MatType>;
@@ -155,7 +155,7 @@ using TanHType = BaseLayer<TanhFunction, MatType>;
 /**
  * Standard Softplus-Layer using the Softplus activation function.
  */
-typedef BaseLayer<SoftplusFunction, arma::mat> SoftPlus;
+using SoftPlus = BaseLayer<SoftplusFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using SoftPlusType = BaseLayer<SoftplusFunction, MatType>;
@@ -163,7 +163,7 @@ using SoftPlusType = BaseLayer<SoftplusFunction, MatType>;
 /**
  * Standard HardSigmoid-Layer using the HardSigmoid activation function.
  */
-typedef BaseLayer<HardSigmoidFunction, arma::mat> HardSigmoid;
+using HardSigmoid = BaseLayer<HardSigmoidFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using HardSigmoidType = BaseLayer<HardSigmoidFunction, MatType>;
@@ -171,7 +171,7 @@ using HardSigmoidType = BaseLayer<HardSigmoidFunction, MatType>;
 /**
  * Standard Swish-Layer using the Swish activation function.
  */
-typedef BaseLayer<SwishFunction, arma::mat> Swish;
+using Swish = BaseLayer<SwishFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using SwishType = BaseLayer<SwishFunction, MatType>;
@@ -179,7 +179,7 @@ using SwishType = BaseLayer<SwishFunction, MatType>;
 /**
  * Standard Mish-Layer using the Mish activation function.
  */
-typedef BaseLayer<MishFunction, arma::mat> Mish;
+using Mish = BaseLayer<MishFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using MishType = BaseLayer<MishFunction, MatType>;
@@ -187,7 +187,7 @@ using MishType = BaseLayer<MishFunction, MatType>;
 /**
  * Standard LiSHT-Layer using the LiSHT activation function.
  */
-typedef BaseLayer<LiSHTFunction, arma::mat> LiSHT;
+using LiSHT = BaseLayer<LiSHTFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using LiSHTType = BaseLayer<LiSHTFunction, MatType>;
@@ -195,7 +195,7 @@ using LiSHTType = BaseLayer<LiSHTFunction, MatType>;
 /**
  * Standard GELU-Layer using the GELU activation function.
  */
-typedef BaseLayer<GELUFunction, arma::mat> GELU;
+using GELU = BaseLayer<GELUFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using GELUType = BaseLayer<GELUFunction, MatType>;
@@ -203,7 +203,7 @@ using GELUType = BaseLayer<GELUFunction, MatType>;
 /**
  * Standard Elliot-Layer using the Elliot activation function.
  */
-typedef BaseLayer<ElliotFunction, arma::mat> Elliot;
+using Elliot = BaseLayer<ElliotFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using ElliotType = BaseLayer<ElliotFunction, MatType>;
@@ -211,7 +211,7 @@ using ElliotType = BaseLayer<ElliotFunction, MatType>;
 /**
  * Standard ELiSH-Layer using the ELiSH activation function.
  */
-typedef BaseLayer<ElishFunction, arma::mat> Elish;
+using Elish = BaseLayer<ElishFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using ElishType = BaseLayer<ElishFunction, MatType>;
@@ -219,7 +219,7 @@ using ElishType = BaseLayer<ElishFunction, MatType>;
 /**
  * Standard Gaussian-Layer using the Gaussian activation function.
  */
-typedef BaseLayer<GaussianFunction, arma::mat> Gaussian;
+using Gaussian = BaseLayer<GaussianFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using GaussianType = BaseLayer<GaussianFunction, MatType>;
@@ -227,7 +227,7 @@ using GaussianType = BaseLayer<GaussianFunction, MatType>;
 /**
  * Standard HardSwish-Layer using the HardSwish activation function.
  */
-typedef BaseLayer<HardSwishFunction, arma::mat> HardSwish;
+using HardSwish = BaseLayer<HardSwishFunction, arma::mat>;
 
 template <typename MatType = arma::mat>
 using HardSwishType = BaseLayer<HardSwishFunction, MatType>;
@@ -235,7 +235,7 @@ using HardSwishType = BaseLayer<HardSwishFunction, MatType>;
 /**
  * Standard TanhExp-Layer using the TanhExp activation function.
  */
-typedef BaseLayer<TanhExpFunction, arma::mat> TanhExp;
+using TanhExp = BaseLayer<TanhExpFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using TanhExpType = BaseLayer<TanhExpFunction, MatType>;
@@ -243,7 +243,7 @@ using TanhExpType = BaseLayer<TanhExpFunction, MatType>;
 /**
  * Standard SILU-Layer using the SILU activation function.
  */
-typedef BaseLayer<SILUFunction, arma::mat> SILU;
+using SILU = BaseLayer<SILUFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using SILUType = BaseLayer<SILUFunction, MatType>;
@@ -251,7 +251,7 @@ using SILUType = BaseLayer<SILUFunction, MatType>;
 /**
  * Standard Hyper Sinh layer.
  */
-typedef BaseLayer<HyperSinhFunction, arma::mat> HyperSinh;
+using HyperSinh = BaseLayer<HyperSinhFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using HyperSinhType = BaseLayer<HyperSinhFunction, MatType>;
@@ -259,7 +259,7 @@ using HyperSinhType = BaseLayer<HyperSinhFunction, MatType>;
 /**
  * Standard Bipolar Sigmoid layer.
  */
-typedef BaseLayer<BipolarSigmoidFunction, arma::mat> BipolarSigmoid;
+using BipolarSigmoid = BaseLayer<BipolarSigmoidFunction, arma::mat>;
 
 template<typename MatType = arma::mat>
 using BipolarSigmoidType = BaseLayer<BipolarSigmoidFunction, MatType>;

--- a/src/mlpack/methods/ann/layer/batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/batch_norm.hpp
@@ -275,7 +275,7 @@ class BatchNormType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Adaptive max pooling layer.
-typedef BatchNormType<arma::mat> BatchNorm;
+using BatchNorm = BatchNormType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/c_relu.hpp
+++ b/src/mlpack/methods/ann/layer/c_relu.hpp
@@ -101,7 +101,7 @@ class CReLUType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard CReLU layer.
-typedef CReLUType<arma::mat> CReLU;
+using CReLU = CReLUType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/celu.hpp
+++ b/src/mlpack/methods/ann/layer/celu.hpp
@@ -131,7 +131,7 @@ class CELUType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard CELU layer.
-typedef CELUType<arma::mat> CELU;
+using CELU = CELUType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/concat.hpp
+++ b/src/mlpack/methods/ann/layer/concat.hpp
@@ -228,7 +228,7 @@ class ConcatType : public MultiLayer<MatType>
 }; // class ConcatType.
 
 // Standard Concat layer.
-typedef ConcatType<arma::mat> Concat;
+using Concat = ConcatType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/concatenate.hpp
+++ b/src/mlpack/methods/ann/layer/concatenate.hpp
@@ -99,7 +99,7 @@ class ConcatenateType : public Layer<MatType>
 }; // class Concatenate
 
 // Standard Concatenate layer.
-typedef ConcatenateType<arma::mat> Concatenate;
+using Concatenate = ConcatenateType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -73,7 +73,7 @@ template <
 class ConvolutionType : public Layer<MatType>
 {
  public:
-  typedef typename GetCubeType<MatType>::type CubeType;
+  using CubeType = typename GetCubeType<MatType>::type;
 
   //! Create the ConvolutionType object.
   ConvolutionType();
@@ -397,12 +397,10 @@ class ConvolutionType : public Layer<MatType>
 }; // class Convolution
 
 // Standard Convolution layer.
-typedef ConvolutionType<
-    NaiveConvolution<ValidConvolution>,
-    NaiveConvolution<FullConvolution>,
-    NaiveConvolution<ValidConvolution>,
-    arma::mat
-> Convolution;
+using Convolution = ConvolutionType<NaiveConvolution<ValidConvolution>,
+                                    NaiveConvolution<FullConvolution>,
+                                    NaiveConvolution<ValidConvolution>,
+                                    arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/dropconnect.hpp
+++ b/src/mlpack/methods/ann/layer/dropconnect.hpp
@@ -152,7 +152,7 @@ class DropConnectType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard DropConnect layer.
-typedef DropConnectType<arma::mat> DropConnect;
+using DropConnect = DropConnectType<arma::mat>;
 
 }  // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/dropout.hpp
+++ b/src/mlpack/methods/ann/layer/dropout.hpp
@@ -120,7 +120,7 @@ class DropoutType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Dropout layer.
-typedef DropoutType<arma::mat> Dropout;
+using Dropout = DropoutType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/elu.hpp
+++ b/src/mlpack/methods/ann/layer/elu.hpp
@@ -198,10 +198,10 @@ class ELUType : public Layer<MatType>
 // Convenience typedefs.
 
 // ELU layer.
-typedef ELUType<arma::mat> ELU;
+using ELU = ELUType<arma::mat>;
 
 // SELU layer.
-typedef ELUType<arma::mat> SELU;
+using SELU = ELUType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/flexible_relu.hpp
+++ b/src/mlpack/methods/ann/layer/flexible_relu.hpp
@@ -160,7 +160,7 @@ class FlexibleReLUType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard flexible ReLU layer.
-typedef FlexibleReLUType<arma::mat> FlexibleReLU;
+using FlexibleReLU = FlexibleReLUType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/ftswish.hpp
+++ b/src/mlpack/methods/ann/layer/ftswish.hpp
@@ -108,7 +108,7 @@ class FTSwishType : public Layer<MatType>
 }; // class FTSwishType
 
 // Convenience typedefs.
-typedef FTSwishType<arma::mat> FTSwish;
+using FTSwish = FTSwishType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/grouped_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/grouped_convolution.hpp
@@ -77,7 +77,7 @@ template <
 class GroupedConvolutionType : public Layer<MatType>
 {
  public:
-  typedef typename GetCubeType<MatType>::type CubeType;
+  using CubeType = typename GetCubeType<MatType>::type;
 
   //! Create the GroupedConvolutionType object.
   GroupedConvolutionType();
@@ -417,12 +417,11 @@ class GroupedConvolutionType : public Layer<MatType>
 }; // class Convolution
 
 // Standard Convolution layer.
-typedef GroupedConvolutionType<
+using GroupedConvolution = GroupedConvolutionType<
     NaiveConvolution<ValidConvolution>,
     NaiveConvolution<FullConvolution>,
     NaiveConvolution<ValidConvolution>,
-    arma::mat
-> GroupedConvolution;
+    arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/hard_tanh.hpp
+++ b/src/mlpack/methods/ann/layer/hard_tanh.hpp
@@ -127,7 +127,7 @@ class HardTanHType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard HardTanH layer.
-typedef HardTanHType<arma::mat> HardTanH;
+using HardTanH = HardTanHType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/identity.hpp
+++ b/src/mlpack/methods/ann/layer/identity.hpp
@@ -89,7 +89,7 @@ class IdentityType : public Layer<MatType>
 
 // Convenience typedefs.
 
-typedef IdentityType<arma::mat> Identity;
+using Identity = IdentityType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/layer_norm.hpp
+++ b/src/mlpack/methods/ann/layer/layer_norm.hpp
@@ -176,7 +176,7 @@ class LayerNormType : public Layer<MatType>
 }; // class LayerNormType
 
 // Standard LayerNorm type
-typedef LayerNormType<arma::mat> LayerNorm;
+using LayerNorm = LayerNormType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/leaky_relu.hpp
+++ b/src/mlpack/methods/ann/layer/leaky_relu.hpp
@@ -105,7 +105,7 @@ class LeakyReLUType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard LeakyReLU layer.
-typedef LeakyReLUType<arma::mat> LeakyReLU;
+using LeakyReLU = LeakyReLUType<arma::mat>;
 
 
 } // namespace mlpack

--- a/src/mlpack/methods/ann/layer/linear.hpp
+++ b/src/mlpack/methods/ann/layer/linear.hpp
@@ -167,7 +167,7 @@ class LinearType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Linear layer using no regularization.
-typedef LinearType<arma::mat, NoRegularizer> Linear;
+using Linear = LinearType<arma::mat, NoRegularizer>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/linear3d.hpp
+++ b/src/mlpack/methods/ann/layer/linear3d.hpp
@@ -150,7 +150,7 @@ class Linear3DType : public Layer<MatType>
 }; // class Linear
 
 // Standard Linear3D layer.
-typedef Linear3DType<arma::mat, NoRegularizer> Linear3D;
+using Linear3D = Linear3DType<arma::mat, NoRegularizer>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/linear3d_impl.hpp
+++ b/src/mlpack/methods/ann/layer/linear3d_impl.hpp
@@ -98,7 +98,7 @@ template<typename MatType, typename RegularizerType>
 void Linear3DType<MatType, RegularizerType>::Forward(
     const MatType& input, MatType& output)
 {
-  typedef typename arma::Cube<typename MatType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename MatType::elem_type>;
 
   const size_t nPoints = input.n_rows / this->inputDimensions[0];
   const size_t batchSize = input.n_cols;
@@ -123,7 +123,7 @@ void Linear3DType<MatType, RegularizerType>::Backward(
     const MatType& gy,
     MatType& g)
 {
-  typedef typename arma::Cube<typename MatType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename MatType::elem_type>;
 
   if (gy.n_rows % outSize != 0)
   {
@@ -151,7 +151,7 @@ void Linear3DType<MatType, RegularizerType>::Gradient(
     const MatType& error,
     MatType& gradient)
 {
-  typedef typename arma::Cube<typename MatType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename MatType::elem_type>;
 
   if (error.n_rows % outSize != 0)
     Log::Fatal << "Propagated error matrix has invalid dimension!" << std::endl;

--- a/src/mlpack/methods/ann/layer/linear_no_bias.hpp
+++ b/src/mlpack/methods/ann/layer/linear_no_bias.hpp
@@ -136,7 +136,7 @@ class LinearNoBiasType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Linear without bias layer using no regularization.
-typedef LinearNoBiasType<arma::mat, NoRegularizer> LinearNoBias;
+using LinearNoBias = LinearNoBiasType<arma::mat, NoRegularizer>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/log_softmax.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax.hpp
@@ -104,7 +104,7 @@ class LogSoftMaxType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Linear layer using no regularization.
-typedef LogSoftMaxType<arma::mat> LogSoftMax;
+using LogSoftMax = LogSoftMaxType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/lstm.hpp
+++ b/src/mlpack/methods/ann/layer/lstm.hpp
@@ -273,7 +273,7 @@ class LSTMType : public RecurrentLayer<MatType>
 // Convenience typedefs.
 
 // Standard LSTM layer.
-typedef LSTMType<arma::mat> LSTM;
+using LSTM = LSTMType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/max_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/max_pooling.hpp
@@ -308,7 +308,7 @@ class MaxPoolingType : public Layer<MatType>
 }; // class MaxPoolingType
 
 // Standard MaxPooling layer.
-typedef MaxPoolingType<arma::mat> MaxPooling;
+using MaxPooling = MaxPoolingType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/mean_pooling.hpp
+++ b/src/mlpack/methods/ann/layer/mean_pooling.hpp
@@ -171,7 +171,7 @@ class MeanPoolingType : public Layer<MatType>
 }; // class MeanPoolingType
 
 // Standard MeanPooling layer.
-typedef MeanPoolingType<arma::mat> MeanPooling;
+using MeanPooling = MeanPoolingType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/multihead_attention.hpp
+++ b/src/mlpack/methods/ann/layer/multihead_attention.hpp
@@ -265,7 +265,7 @@ class MultiheadAttentionType : public Layer<MatType>
 
  private:
   //! Element Type of the output.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   //! Target sequence length.
   size_t tgtSeqLen;
@@ -343,7 +343,7 @@ class MultiheadAttentionType : public Layer<MatType>
 }; // class MultiheadAttention
 
 // Standard MultiheadAttention layer using no regularization.
-typedef MultiheadAttentionType<arma::mat, NoRegularizer> MultiheadAttention;
+using MultiheadAttention = MultiheadAttentionType<arma::mat, NoRegularizer>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/multihead_attention_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multihead_attention_impl.hpp
@@ -73,7 +73,7 @@ template <typename MatType, typename RegularizerType>
 void MultiheadAttentionType<MatType, RegularizerType>::
 Forward(const MatType& input, MatType& output)
 {
-  typedef typename arma::Cube<typename MatType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename MatType::elem_type>;
 
   if (input.n_rows != embedDim *
       (selfAttention ? srcSeqLen : (tgtSeqLen + 2 * srcSeqLen)))
@@ -187,7 +187,7 @@ Backward(const MatType& /* input */,
          const MatType& gy,
          MatType& g)
 {
-  typedef typename arma::Cube<typename MatType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename MatType::elem_type>;
 
   if (gy.n_rows != tgtSeqLen * embedDim)
   {
@@ -306,7 +306,7 @@ Gradient(const MatType& input,
          const MatType& error,
          MatType& gradient)
 {
-  typedef typename arma::Cube<typename MatType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename MatType::elem_type>;
 
   if (input.n_rows != embedDim * (selfAttention ? srcSeqLen :
       (tgtSeqLen + 2 * srcSeqLen)))

--- a/src/mlpack/methods/ann/layer/nearest_interpolation.hpp
+++ b/src/mlpack/methods/ann/layer/nearest_interpolation.hpp
@@ -102,7 +102,7 @@ class NearestInterpolationType : public Layer<MatType>
   std::vector<double> scaleFactors;
 }; // class NearestInterpolation
 
-typedef NearestInterpolationType<arma::mat> NearestInterpolation;
+using NearestInterpolation = NearestInterpolationType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/noisylinear.hpp
+++ b/src/mlpack/methods/ann/layer/noisylinear.hpp
@@ -152,7 +152,7 @@ class NoisyLinearType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard noisy linear layer.
-typedef NoisyLinearType<arma::mat> NoisyLinear;
+using NoisyLinear = NoisyLinearType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/bicubic_interpolation.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/bicubic_interpolation.hpp
@@ -145,7 +145,7 @@ class BicubicInterpolation
 
  private:
   //! Element Type of the input.
-  typedef typename OutputDataType::elem_type ElemType;
+  using ElemType = typename OutputDataType::elem_type;
 
   //! Locally stored row size of the input.
   size_t inRowSize;

--- a/src/mlpack/methods/ann/layer/not_adapted/bilinear_interpolation.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/bilinear_interpolation.hpp
@@ -116,7 +116,7 @@ class BilinearInterpolationType : public Layer<InputType, OutputType>
 }; // class BilinearInterpolation
 
 // Standard BilinearInterpolation layer.
-typedef BilinearInterpolationType<arma::mat, arma::mat> BilinearInterpolation;
+using BilinearInterpolation = BilinearInterpolationType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/constant.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/constant.hpp
@@ -103,7 +103,7 @@ class ConstantType : public Layer<InputType, OutputType>
 // Convenience typedefs.
 
 // Standard HardShrink layer.
-typedef ConstantType<arma::mat, arma::mat> Constant;
+using Constant = ConstantType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/fast_lstm.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/fast_lstm.hpp
@@ -68,8 +68,8 @@ class FastLSTMType : public Layer<InputType, OutputType>
 {
  public:
   // Convenience typedefs.
-  typedef typename InputType::elem_type InputET;
-  typedef typename OutputType::elem_type OutputET;
+  using InputET = typename InputType::elem_type;
+  using OutputET = typename OutputType::elem_type;
 
   //! Create the FastLSTMType object.
   FastLSTMType();
@@ -305,7 +305,7 @@ class FastLSTMType : public Layer<InputType, OutputType>
 }; // class FastLSTMType.
 
 // Standard FastLSTM layer.
-typedef FastLSTMType<arma::mat, arma::mat> FastLSTM;
+using FastLSTM = FastLSTMType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/glimpse.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/glimpse.hpp
@@ -407,7 +407,7 @@ class GlimpseType : public Layer<InputType, OutputType>
 }; // class GlimpseType
 
 // Standard Glimpse layer.
-typedef GlimpseType<arma::mat, arma::mat> Glimpse;
+using Glimpse = GlimpseType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/hardshrink.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/hardshrink.hpp
@@ -98,7 +98,7 @@ class HardShrinkType : public Layer<InputType, OutputType>
 // Convenience typedefs.
 
 // Standard HardShrink layer.
-typedef HardShrinkType<arma::mat, arma::mat> HardShrink;
+using HardShrink = HardShrinkType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/highway.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/highway.hpp
@@ -145,7 +145,7 @@ class HighwayType : public MultiLayer<InputType, OutputType>
 }; // class HighwayType
 
 // Standard Highway layer.
-typedef HighwayType<arma::mat, arma::mat> Highway;
+using Highway = HighwayType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/join.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/join.hpp
@@ -88,7 +88,7 @@ class JoinType : public Layer<InputType, OutputType>
 }; // class JoinType
 
 //Standard Join layer.
-typedef JoinType<arma::mat, arma::mat> Join;
+using Join = JoinType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/lookup.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/lookup.hpp
@@ -128,8 +128,8 @@ class LookupType : public Layer<InputType, OutputType>
 // Alias for using as embedding layer.
 // template<typename MatType = arma::mat>
 // using Embedding = Lookup<MatType, MatType>;
-typedef LookupType<arma::mat, arma::mat> Lookup;
-typedef LookupType<arma::mat, arma::mat> Embedding;
+using Lookup = LookupType<arma::mat, arma::mat>;
+using Embedding = LookupType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/lookup_impl.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/lookup_impl.hpp
@@ -67,7 +67,7 @@ void LookupType<InputType, OutputType>::Gradient(
     const OutputType& error,
     OutputType& gradient)
 {
-  typedef typename arma::Cube<typename OutputType::elem_type> CubeType;
+  using CubeType = arma::Cube<typename OutputType::elem_type>;
   const size_t seqLength = input.n_rows;
   const size_t batchSize = input.n_cols;
 

--- a/src/mlpack/methods/ann/layer/not_adapted/multiply_constant.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/multiply_constant.hpp
@@ -93,7 +93,7 @@ class MultiplyConstantType : public Layer<InputType, OutputType>
 // Convenience typedefs.
 
 // Standard MultiplyConstant layer.
-typedef MultiplyConstantType<arma::mat, arma::mat> MultiplyConstant;
+using MultiplyConstant = MultiplyConstantType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/multiply_merge.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/multiply_merge.hpp
@@ -125,7 +125,7 @@ class MultiplyMergeType : public MultiLayer<InputType, OutputType>
 }; // class MultiplyMergeType
 
 // Standard MultiplyMerge layer.
-typedef MultiplyMergeType<arma::mat, arma::mat> MultiplyMerge;
+using MultiplyMerge = MultiplyMergeType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/positional_encoding.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/positional_encoding.hpp
@@ -111,7 +111,7 @@ class PositionalEncodingType : public Layer<InputType, OutputType>
 }; // class PositionalEncodingTest
 
 // Standard PositionalEncoding layer.
-typedef PositionalEncodingType<arma::mat, arma::mat> PositionalEncoding;
+using PositionalEncoding = PositionalEncodingType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/reinforce_normal.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/reinforce_normal.hpp
@@ -95,7 +95,7 @@ class ReinforceNormalType : public Layer<InputType, OutputType>
 }; // class ReinforceNormalType.
 
 // Standard ReinforceNormal layer.
-typedef ReinforceNormalType<arma::mat, arma::mat> ReinforceNormal;
+using ReinforceNormal = ReinforceNormalType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/reparametrization.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/reparametrization.hpp
@@ -190,7 +190,7 @@ class ReparametrizationType : public Layer<InputType, OutputType>
 }; // class ReparametrizationType
 
 // Standard Reparametrization layer.
-typedef ReparametrizationType<arma::mat, arma::mat> Reparametrization;
+using Reparametrization = ReparametrizationType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/select.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/select.hpp
@@ -107,7 +107,7 @@ class SelectType : public Layer<InputType, OutputType>
 }; // class SelectType
 
 // Standard Select layer.
-typedef SelectType<arma::mat, arma::mat> Select;
+using Select = SelectType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/sequential.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/sequential.hpp
@@ -135,10 +135,10 @@ class SequentialType : public MultiLayer<InputType, OutputType>
 }; // class SequentialType
 
 // Standard Sequential layer.
-typedef SequentialType<arma::mat, arma::mat, false> Sequential;
+using Sequential = SequentialType<arma::mat, arma::mat, false>;
 
 // Standard Residual layer.
-typedef SequentialType<arma::mat, arma::mat, true> Residual;
+using Residual = SequentialType<arma::mat, arma::mat, true>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/softshrink.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/softshrink.hpp
@@ -101,7 +101,7 @@ class SoftShrinkType : public Layer<InputType, OutputType>
 // Convenience typedefs.
 
 // Standard SoftShrink layer.
-typedef SoftShrinkType<arma::mat, arma::mat> SoftShrink;
+using SoftShrink = SoftShrinkType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/spatial_dropout.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/spatial_dropout.hpp
@@ -126,7 +126,7 @@ class SpatialDropoutType : public Layer<InputType, OutputType>
 // Convenience typedefs.
 
 // Standard SpatialDropout layer.
-typedef SpatialDropoutType<arma::mat, arma::mat> SpatialDropout;
+using SpatialDropout = SpatialDropoutType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/subview.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/subview.hpp
@@ -187,7 +187,7 @@ class SubviewType : public Layer<InputType, OutputType>
 }; // class SubviewType
 
 // Standard Subview layer.
-typedef SubviewType<arma::mat, arma::mat> Subview;
+using Subview = SubviewType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/transposed_convolution.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/transposed_convolution.hpp
@@ -455,13 +455,12 @@ class TransposedConvolutionType : public Layer<InputType, OutputType>
 }; // class TransposedConvolutionType
 
 // Standard TransposedConvolution
-typedef TransposedConvolutionType<
-  NaiveConvolution<ValidConvolution>,
-  NaiveConvolution<ValidConvolution>,
-  NaiveConvolution<ValidConvolution>,
-  arma::mat,
-  arma::mat
-> TransposedConvolution;
+using TransposedConvolution = TransposedConvolutionType<
+    NaiveConvolution<ValidConvolution>,
+    NaiveConvolution<ValidConvolution>,
+    NaiveConvolution<ValidConvolution>,
+    arma::mat,
+    arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/transposed_convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/transposed_convolution_impl.hpp
@@ -232,7 +232,7 @@ void TransposedConvolutionType<
     {
       inputPaddedTemp = arma::Cube<typename InputType::elem_type>(
           inputExpandedTemp.memptr(), inputExpandedTemp.n_rows,
-          inputExpandedTemp.n_cols, inputExpandedTemp.n_slices, false, false);;
+          inputExpandedTemp.n_cols, inputExpandedTemp.n_slices, false, false);
     }
   }
   else if (paddingForward.PadWLeft() != 0 ||

--- a/src/mlpack/methods/ann/layer/not_adapted/virtual_batch_norm.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/virtual_batch_norm.hpp
@@ -174,7 +174,7 @@ class VirtualBatchNormType : public Layer<InputType, OutputType>
 }; // class VirtualBatchNormType
 
 // Standard VirtualBatchNorm layer.
-typedef VirtualBatchNormType<arma::mat, arma::mat> VirtualBatchNorm;
+using VirtualBatchNorm = VirtualBatchNormType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/not_adapted/weight_norm.hpp
+++ b/src/mlpack/methods/ann/layer/not_adapted/weight_norm.hpp
@@ -170,7 +170,7 @@ class WeightNormType : public Layer<InputType, OutputType>
 }; // class WeightNormType.
 
 // Standard WeightNorm layer.
-typedef WeightNormType<arma::mat, arma::mat> WeightNorm;
+using WeightNorm = WeightNormType<arma::mat, arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/padding.hpp
+++ b/src/mlpack/methods/ann/layer/padding.hpp
@@ -127,7 +127,7 @@ class PaddingType : public Layer<MatType>
 }; // class PaddingType
 
 // Standard Padding layer.
-typedef PaddingType<arma::mat> Padding;
+using Padding = PaddingType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/parametric_relu.hpp
+++ b/src/mlpack/methods/ann/layer/parametric_relu.hpp
@@ -145,7 +145,7 @@ class PReLUType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard PReLU layer.
-typedef PReLUType<arma::mat> PReLU;
+using PReLU = PReLUType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/radial_basis_function.hpp
+++ b/src/mlpack/methods/ann/layer/radial_basis_function.hpp
@@ -121,7 +121,7 @@ class RBFType : public Layer<MatType>
   MatType distances;
 }; // class RBFType
 
-typedef RBFType<arma::mat> RBF;
+using RBF = RBFType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/relu6.hpp
+++ b/src/mlpack/methods/ann/layer/relu6.hpp
@@ -93,7 +93,7 @@ class ReLU6Type : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard ReLU6 layer.
-typedef ReLU6Type<arma::mat> ReLU6;
+using ReLU6 = ReLU6Type<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/repeat.hpp
+++ b/src/mlpack/methods/ann/layer/repeat.hpp
@@ -34,8 +34,8 @@ class RepeatType : public Layer<MatType>
 {
  public:
   //! Get Specific Col type, not only arma
-  typedef typename GetUColType<MatType>::type UintCol;
-  typedef typename GetUDenseMatType<MatType>::type UintMat;
+  using UintCol = typename GetUColType<MatType>::type;
+  using UintMat = typename GetUDenseMatType<MatType>::type;
   /**
    * Create the Repeat object.  Multiples will be empty (e.g. 1s for all
    * dimensions), so this is the equivalent of an Identity Layer.
@@ -147,7 +147,7 @@ class RepeatType : public Layer<MatType>
 }; // class RepeatType.
 
 // Standard Repeat layer.
-typedef RepeatType<arma::mat> Repeat;
+using Repeat = RepeatType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/softmax.hpp
+++ b/src/mlpack/methods/ann/layer/softmax.hpp
@@ -82,7 +82,7 @@ class SoftmaxType : public Layer<MatType>
 }; // class SoftmaxType
 
 // Convenience typedef.
-typedef SoftmaxType<arma::mat> Softmax;
+using Softmax = SoftmaxType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/layer/softmin.hpp
+++ b/src/mlpack/methods/ann/layer/softmin.hpp
@@ -81,7 +81,7 @@ class SoftminType : public Layer<MatType>
 // Convenience typedefs.
 
 // Standard Softmin layer using no regularization.
-typedef SoftminType<arma::mat> Softmin;
+using Softmin = SoftminType<arma::mat>;
 
 
 } // namespace mlpack

--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
@@ -89,12 +89,12 @@ class BCELossType
 }; // class BCELossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef BCELossType<arma::mat> BCELoss;
+using BCELoss = BCELossType<arma::mat>;
 
 /**
  * Alias of BCELossType.
  */
-typedef BCELossType<arma::mat> CrossEntropyError;
+using CrossEntropyError = BCELossType<arma::mat>;
 
 template<typename MatType = arma::mat>
 using CrossEntropyErrorType = BCELossType<MatType>;

--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss_impl.hpp
@@ -29,7 +29,7 @@ typename MatType::elem_type BCELossType<MatType>::Forward(
     const MatType& prediction,
     const MatType& target)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   ElemType lossSum = -accu(target % log(prediction + eps) +
       (1. - target) % log(1. - prediction + eps));

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss.hpp
@@ -106,7 +106,7 @@ class CosineEmbeddingLossType
 }; // class CosineEmbeddingLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef CosineEmbeddingLossType<arma::mat> CosineEmbeddingLoss;
+using CosineEmbeddingLoss = CosineEmbeddingLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
@@ -30,7 +30,7 @@ typename MatType::elem_type CosineEmbeddingLossType<MatType>::Forward(
     const MatType& prediction,
     const MatType& target)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   const size_t cols = prediction.n_cols;
   const size_t batchSize = prediction.n_elem / cols;
@@ -67,7 +67,7 @@ void CosineEmbeddingLossType<MatType>::Backward(
     const MatType& target,
     MatType& loss)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   const size_t cols = prediction.n_cols;
   const size_t batchSize = prediction.n_elem / cols;

--- a/src/mlpack/methods/ann/loss_functions/dice_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/dice_loss.hpp
@@ -90,7 +90,7 @@ class DiceLossType
 }; // class DiceLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef DiceLossType<arma::mat> DiceLoss;
+using DiceLoss = DiceLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
+++ b/src/mlpack/methods/ann/loss_functions/earth_mover_distance.hpp
@@ -78,7 +78,7 @@ class EarthMoverDistanceType
 }; // class EarthMoverDistanceType
 
 // Default typedef for typical `arma::mat` usage.
-typedef EarthMoverDistanceType<arma::mat> EarthMoverDistance;
+using EarthMoverDistance = EarthMoverDistanceType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/empty_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/empty_loss.hpp
@@ -61,7 +61,7 @@ class EmptyLossType
 }; // class EmptyLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef EmptyLossType<arma::mat> EmptyLoss;
+using EmptyLoss = EmptyLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_embedding_loss.hpp
@@ -81,7 +81,7 @@ class HingeEmbeddingLossType
 }; // class HingeEmbeddingLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef HingeEmbeddingLossType<arma::mat> HingeEmbeddingLoss;
+using HingeEmbeddingLoss = HingeEmbeddingLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/hinge_loss.hpp
@@ -82,7 +82,7 @@ class HingeLossType
 }; // class HingeLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef HingeLossType<arma::mat> HingeLoss;
+using HingeLoss = HingeLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss.hpp
@@ -91,7 +91,7 @@ class HuberLossType
 }; // class HuberLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef HuberLossType<arma::mat> HuberLoss;
+using HuberLoss = HuberLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
@@ -32,7 +32,7 @@ typename MatType::elem_type HuberLossType<MatType>::Forward(
     const MatType& prediction,
     const MatType& target)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   ElemType lossSum = 0;
   for (size_t i = 0; i < prediction.n_elem; ++i)
   {
@@ -53,7 +53,7 @@ void HuberLossType<MatType>::Backward(
     const MatType& target,
     MatType& loss)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   loss.set_size(size(prediction));
   for (size_t i = 0; i < loss.n_elem; ++i)

--- a/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
+++ b/src/mlpack/methods/ann/loss_functions/kl_divergence.hpp
@@ -91,7 +91,7 @@ class KLDivergenceType
 }; // class KLDivergenceType
 
 // Default typedef for typical `arma::mat` usage.
-typedef KLDivergenceType<arma::mat> KLDivergence;
+using KLDivergence = KLDivergenceType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/l1_loss.hpp
@@ -79,7 +79,7 @@ class L1LossType
 }; // class L1LossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef L1LossType<arma::mat> L1Loss;
+using L1Loss = L1LossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/log_cosh_loss.hpp
@@ -94,7 +94,7 @@ class LogCoshLossType
 }; // class LogCoshLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef LogCoshLossType<arma::mat> LogCoshLoss;
+using LogCoshLoss = LogCoshLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/margin_ranking_loss.hpp
@@ -91,7 +91,7 @@ class MarginRankingLossType
 }; // class MarginRankingLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef MarginRankingLossType<arma::mat> MarginRankingLoss;
+using MarginRankingLoss = MarginRankingLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/mean_absolute_percentage_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_absolute_percentage_error.hpp
@@ -78,7 +78,7 @@ class MeanAbsolutePercentageErrorType
 }; // class MeanAbsolutePercentageErrorType
 
 // Default typedef for typical `arma::mat` usage.
-typedef MeanAbsolutePercentageErrorType<arma::mat> MeanAbsolutePercentageError;
+using MeanAbsolutePercentageError = MeanAbsolutePercentageErrorType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error.hpp
@@ -80,7 +80,7 @@ class MeanBiasErrorType
 }; // class MeanBiasErrorType
 
 // Default typedef for typical `arma::mat` usage.
-typedef MeanBiasErrorType<arma::mat> MeanBiasError;
+using MeanBiasError = MeanBiasErrorType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_error.hpp
@@ -78,7 +78,7 @@ class MeanSquaredErrorType
 }; // class MeanSquaredErrorType
 
 // Default typedef for typical `arma::mat` usage.
-typedef MeanSquaredErrorType<arma::mat> MeanSquaredError;
+using MeanSquaredError = MeanSquaredErrorType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_squared_logarithmic_error.hpp
@@ -78,7 +78,8 @@ class MeanSquaredLogarithmicErrorType
 }; // class MeanSquaredLogarithmicErrorType
 
 // Default typedef for typical `arma::mat` usage.
-typedef MeanSquaredLogarithmicErrorType<arma::mat> MeanSquaredLogarithmicError;
+using MeanSquaredLogarithmicError =
+    MeanSquaredLogarithmicErrorType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss.hpp
@@ -105,7 +105,7 @@ class MultiLabelSoftMarginLossType
 }; // class MultiLabelSoftMarginLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef MultiLabelSoftMarginLossType<arma::mat> MultiLabelSoftMarginLoss;
+using MultiLabelSoftMarginLoss = MultiLabelSoftMarginLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood.hpp
@@ -85,7 +85,7 @@ class NegativeLogLikelihoodType
 }; // class NegativeLogLikelihoodType
 
 // Default typedef for typical `arma::mat` usage.
-typedef NegativeLogLikelihoodType<arma::mat> NegativeLogLikelihood;
+using NegativeLogLikelihood = NegativeLogLikelihoodType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/negative_log_likelihood_impl.hpp
@@ -31,7 +31,7 @@ double NegativeLogLikelihoodType<MatType>::Forward(
     const MatType& prediction,
     const MatType& target)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   ElemType lossSum = 0;
   for (size_t i = 0; i < prediction.n_cols; ++i)
   {

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss.hpp
@@ -136,7 +136,7 @@ class PoissonNLLLossType
 }; // class PoissonNLLLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef PoissonNLLLossType<arma::mat> PoissonNLLLoss;
+using PoissonNLLLoss = PoissonNLLLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/reconstruction_loss.hpp
@@ -87,7 +87,7 @@ class ReconstructionLossType
 }; // class ReconstructionLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef ReconstructionLossType<arma::mat> ReconstructionLoss;
+using ReconstructionLoss = ReconstructionLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error.hpp
@@ -98,7 +98,7 @@ class SigmoidCrossEntropyErrorType
 }; // class SigmoidCrossEntropyErrorType
 
 // Default typedef for typical `arma::mat` usage.
-typedef SigmoidCrossEntropyErrorType<arma::mat> SigmoidCrossEntropyError;
+using SigmoidCrossEntropyError = SigmoidCrossEntropyErrorType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/sigmoid_cross_entropy_error_impl.hpp
@@ -33,7 +33,7 @@ SigmoidCrossEntropyErrorType<MatType>::Forward(
     const MatType& prediction,
     const MatType& target)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   ElemType maximum = 0;
   for (size_t i = 0; i < prediction.n_elem; ++i)
   {

--- a/src/mlpack/methods/ann/loss_functions/soft_margin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/soft_margin_loss.hpp
@@ -85,7 +85,7 @@ class SoftMarginLossType
 }; // class SoftMarginLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef SoftMarginLossType<arma::mat> SoftMarginLoss;
+using SoftMarginLoss = SoftMarginLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/triplet_margin_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/triplet_margin_loss.hpp
@@ -89,7 +89,7 @@ class TripletMarginLossType
 }; // class TripletMarginLoss
 
 // Default typedef for typical `arma::mat` usage.
-typedef TripletMarginLossType<arma::mat> TripletMarginLoss;
+using TripletMarginLoss = TripletMarginLossType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/loss_functions/vr_class_reward.hpp
+++ b/src/mlpack/methods/ann/loss_functions/vr_class_reward.hpp
@@ -112,7 +112,7 @@ class VRClassRewardType
 }; // class VRClassRewardType
 
 // Default typedef for typical `arma::mat` usage.
-typedef VRClassRewardType<arma::mat> VRClassReward;
+using VRClassReward = VRClassRewardType<arma::mat>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/ann/not_adapted/rbm/rbm.hpp
+++ b/src/mlpack/methods/ann/not_adapted/rbm/rbm.hpp
@@ -38,7 +38,7 @@ class RBM
 {
  public:
   using NetworkType = RBM<InitializationRuleType, DataType, PolicyType>;
-  typedef typename DataType::elem_type ElemType;
+  using ElemType = typename DataType::elem_type;
 
   /**
    * Initialize all the parameters of the network using initializeRule.

--- a/src/mlpack/methods/ann/regularizer/lregularizer.hpp
+++ b/src/mlpack/methods/ann/regularizer/lregularizer.hpp
@@ -58,12 +58,12 @@ class LRegularizer
 /**
  * The L1 Regularizer.
  */
-typedef LRegularizer<1> L1Regularizer;
+using L1Regularizer = LRegularizer<1>;
 
 /**
  * The L2 Regularizer.
  */
-typedef LRegularizer<2> L2Regularizer;
+using L2Regularizer = LRegularizer<2>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/approx_kfn/drusilla_select_impl.hpp
+++ b/src/mlpack/methods/approx_kfn/drusilla_select_impl.hpp
@@ -119,7 +119,7 @@ void DrusillaSelect<MatType>::Train(
     }
 
     // Find the top m elements using a priority queue.
-    typedef std::pair<double, size_t> Candidate;
+    using Candidate = std::pair<double, size_t>;
     struct CandidateCmp
     {
       bool operator()(const Candidate& c1, const Candidate& c2)

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression.hpp
@@ -99,9 +99,9 @@ template<typename ModelMatType = arma::mat>
 class BayesianLinearRegression
 {
  public:
-  typedef typename ModelMatType::elem_type ElemType;
-  typedef typename GetDenseColType<ModelMatType>::type DenseVecType;
-  typedef typename GetDenseRowType<ModelMatType>::type DenseRowType;
+  using ElemType = typename ModelMatType::elem_type;
+  using DenseVecType = typename GetDenseColType<ModelMatType>::type;
+  using DenseRowType = typename GetDenseRowType<ModelMatType>::type;
 
   /**
    * Set the parameters of Bayesian Ridge regression object. The regularization

--- a/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression_impl.hpp
+++ b/src/mlpack/methods/bayesian_linear_regression/bayesian_linear_regression_impl.hpp
@@ -121,7 +121,7 @@ BayesianLinearRegression<ModelMatType>::Train(
 
   // Initialize the hyperparameters and begin with an infinitely broad prior.
   alpha = ((ElemType) 1e-6);
-  beta =  ((ElemType) 1 / (var(t, 1) * 0.1));
+  beta = ((ElemType) 1 / (var(t, 1) * 0.1));
 
   unsigned short i = 0;
   ElemType crit = ((ElemType) 1.0);

--- a/src/mlpack/methods/cf/cf.hpp
+++ b/src/mlpack/methods/cf/cf.hpp
@@ -272,7 +272,7 @@ class CFType
   NormalizationType normalization;
 
   //! Candidate represents a possible recommendation (value, item).
-  typedef std::pair<double, size_t> Candidate;
+  using Candidate = std::pair<double, size_t>;
 
   //! Compare two candidates based on the value.
   struct CandidateCmp {
@@ -283,7 +283,7 @@ class CFType
   };
 }; // class CFType
 
-typedef CFType<> CF;
+using CF = CFType<>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/cf/cf_impl.hpp
+++ b/src/mlpack/methods/cf/cf_impl.hpp
@@ -227,8 +227,8 @@ GetRecommendations(const size_t numRecs,
     // Default candidate: the smallest possible value and invalid item number.
     const Candidate def = std::make_pair(-DBL_MAX, cleanedData.n_rows);
     std::vector<Candidate> vect(numRecs, def);
-    typedef std::priority_queue<Candidate, std::vector<Candidate>, CandidateCmp>
-        CandidateList;
+    using CandidateList =
+        std::priority_queue<Candidate, std::vector<Candidate>, CandidateCmp>;
     CandidateList pqueue(CandidateCmp(), std::move(vect));
 
     // Look through the ratings column corresponding to the current user.

--- a/src/mlpack/methods/cf/cf_model.hpp
+++ b/src/mlpack/methods/cf/cf_model.hpp
@@ -87,7 +87,7 @@ template<typename DecompositionPolicy, typename NormalizationPolicy>
 class CFWrapper : public CFWrapperBase
 {
  protected:
-  typedef CFType<DecompositionPolicy, NormalizationPolicy> CFModelType;
+  using CFModelType = CFType<DecompositionPolicy, NormalizationPolicy>;
 
  public:
   //! Create the CFWrapper object, using default parameters to initialize the

--- a/src/mlpack/methods/cf/svd_wrapper.hpp
+++ b/src/mlpack/methods/cf/svd_wrapper.hpp
@@ -81,7 +81,7 @@ class SVDWrapper
 }; // class SVDWrapper
 
 //! add simple typedefs
-typedef SVDWrapper<DummyClass> ArmaSVDFactorizer;
+using ArmaSVDFactorizer = SVDWrapper<DummyClass>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/dbscan/dbscan.hpp
+++ b/src/mlpack/methods/dbscan/dbscan.hpp
@@ -52,9 +52,9 @@ class DBSCAN
 {
  public:
   //! Easy access to the MatType.
-  typedef typename RangeSearchType::Mat MatType;
+  using MatType = typename RangeSearchType::Mat;
   //! Easy access to Element Type of the matrix.
-  typedef typename RangeSearchType::Mat::elem_type ElemType;
+  using ElemType = typename RangeSearchType::Mat::elem_type;
   /**
    * Construct the DBSCAN object with the given parameters.  The batchMode
    * parameter should be set to false in the case where RAM issues will be

--- a/src/mlpack/methods/decision_tree/decision_tree.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree.hpp
@@ -39,11 +39,11 @@ class DecisionTree :
 {
  public:
   //! Allow access to the numeric split type.
-  typedef NumericSplitType<FitnessFunction> NumericSplit;
+  using NumericSplit = NumericSplitType<FitnessFunction>;
   //! Allow access to the categorical split type.
-  typedef CategoricalSplitType<FitnessFunction> CategoricalSplit;
+  using CategoricalSplit = CategoricalSplitType<FitnessFunction>;
   //! Allow access to the dimension selection type.
-  typedef DimensionSelectionType DimensionSelection;
+  using DimensionSelection = DimensionSelectionType;
 
   /**
    * Construct the decision tree on the given data and labels, where the data
@@ -507,10 +507,9 @@ class DecisionTree :
   //! Note that this class will also hold the members of the NumericSplit and
   //! CategoricalSplit AuxiliarySplitInfo classes, since it inherits from them.
   //! We'll define some convenience typedefs here.
-  typedef typename NumericSplit::AuxiliarySplitInfo
-      NumericAuxiliarySplitInfo;
-  typedef typename CategoricalSplit::AuxiliarySplitInfo
-      CategoricalAuxiliarySplitInfo;
+  using NumericAuxiliarySplitInfo = typename NumericSplit::AuxiliarySplitInfo;
+  using CategoricalAuxiliarySplitInfo =
+      typename CategoricalSplit::AuxiliarySplitInfo;
 
   /**
    * Calculate the class probabilities of the given labels.
@@ -596,11 +595,11 @@ using DecisionStump = DecisionTree<FitnessFunction,
  * Convenience typedef for ID3 decision stumps (single level decision trees made
  * with the ID3 algorithm).
  */
-typedef DecisionTree<InformationGain,
-                     BestBinaryNumericSplit,
-                     AllCategoricalSplit,
-                     AllDimensionSelect,
-                     true> ID3DecisionStump;
+using ID3DecisionStump = DecisionTree<InformationGain,
+                                      BestBinaryNumericSplit,
+                                      AllCategoricalSplit,
+                                      AllDimensionSelect,
+                                      true>;
 } // namespace mlpack
 
 // Include implementation.

--- a/src/mlpack/methods/decision_tree/decision_tree_main.cpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_main.cpp
@@ -151,7 +151,7 @@ PARAM_MODEL_OUT(DecisionTreeModel, "output_model", "Output for trained decision"
     " tree.", "M");
 
 // Convenience typedef.
-typedef tuple<DatasetInfo, arma::mat> TupleType;
+using TupleType = tuple<DatasetInfo, arma::mat>;
 
 void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
 {

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor.hpp
@@ -39,11 +39,11 @@ class DecisionTreeRegressor :
 {
  public:
   //! Allow access to the numeric split type.
-  typedef NumericSplitType<FitnessFunction> NumericSplit;
+  using NumericSplit = NumericSplitType<FitnessFunction>;
   //! Allow access to the categorical split type.
-  typedef CategoricalSplitType<FitnessFunction> CategoricalSplit;
+  using CategoricalSplit = CategoricalSplitType<FitnessFunction>;
   //! Allow access to the dimension selection type.
-  typedef DimensionSelectionType DimensionSelection;
+  using DimensionSelection = DimensionSelectionType;
 
   /**
    * Construct a decision tree without training it.  It will be a leaf node.
@@ -455,10 +455,9 @@ class DecisionTreeRegressor :
   //! Note that this class will also hold the members of the NumericSplit and
   //! CategoricalSplit AuxiliarySplitInfo classes, since it inherits from them.
   //! We'll define some convenience typedefs here.
-  typedef typename NumericSplit::AuxiliarySplitInfo
-      NumericAuxiliarySplitInfo;
-  typedef typename CategoricalSplit::AuxiliarySplitInfo
-      CategoricalAuxiliarySplitInfo;
+  using NumericAuxiliarySplitInfo = typename NumericSplit::AuxiliarySplitInfo;
+  using CategoricalAuxiliarySplitInfo =
+      typename CategoricalSplit::AuxiliarySplitInfo;
 
   /**
    * Corresponding to the public Train() method, this method is designed for

--- a/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_regressor_impl.hpp
@@ -939,7 +939,7 @@ DecisionTreeRegressor<FitnessFunction,
     return prediction;
   }
 
-  typedef typename VecType::elem_type ElemType;
+  using ElemType = typename VecType::elem_type;
   return (ElemType) children[CalculateDirection(point)]->Predict(point);
 }
 
@@ -958,7 +958,7 @@ void DecisionTreeRegressor<FitnessFunction,
 >::Predict(const MatType& data,
            PredVecType& predictions) const
 {
-  typedef typename PredVecType::elem_type ElemType;
+  using ElemType = typename PredVecType::elem_type;
 
   predictions.set_size(data.n_cols);
   // If the tree's root is leaf.

--- a/src/mlpack/methods/decision_tree/fitness_functions/mse_gain.hpp
+++ b/src/mlpack/methods/decision_tree/fitness_functions/mse_gain.hpp
@@ -151,8 +151,8 @@ class MSEGain
                             const WeightVecType& weights,
                             const size_t minimum)
   {
-    typedef typename ResponsesType::elem_type RType;
-    typedef typename WeightVecType::elem_type WType;
+    using RType = typename ResponsesType::elem_type;
+    using WType = typename WeightVecType::elem_type;
 
     // Initializing data members to cache statistics.
     leftMean = 0.0;
@@ -230,8 +230,8 @@ class MSEGain
                   const WeightVecType& weights,
                   const size_t index)
   {
-    typedef typename ResponsesType::elem_type RType;
-    typedef typename WeightVecType::elem_type WType;
+    using RType = typename ResponsesType::elem_type;
+    using WType = typename WeightVecType::elem_type;
 
     if (UseWeights)
     {

--- a/src/mlpack/methods/decision_tree/splits/best_binary_categorical_split.hpp
+++ b/src/mlpack/methods/decision_tree/splits/best_binary_categorical_split.hpp
@@ -65,10 +65,10 @@ class BestBinaryCategoricalSplit
   // No extra info needed for split.
   class AuxiliarySplitInfo { };
   // Allow access to the numeric split type.
-  typedef BestBinaryNumericSplit<FitnessFunction> NumericSplit;
+  using NumericSplit = BestBinaryNumericSplit<FitnessFunction>;
   // For calls to the numeric splitter.
-  typedef typename BestBinaryNumericSplit<FitnessFunction>
-      ::AuxiliarySplitInfo NumericAux;
+  using NumericAux =
+      typename BestBinaryNumericSplit<FitnessFunction>::AuxiliarySplitInfo;
 
   /**
    * Check if we can split a node.  If we can split a node in a way that

--- a/src/mlpack/methods/decision_tree/splits/best_binary_categorical_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/splits/best_binary_categorical_split_impl.hpp
@@ -180,7 +180,7 @@ double BestBinaryCategoricalSplit<FitnessFunction>::SplitIfBetter(
   }
   for (size_t i = 0; i < numCategories; ++i)
   {
-    categoryResponse[i] =  categoryCounts[i] == 0 ? 0 :
+    categoryResponse[i] = categoryCounts[i] == 0 ? 0 :
         categoryResponse[i] / categoryCounts[i];
   }
 

--- a/src/mlpack/methods/decision_tree/splits/best_binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/decision_tree/splits/best_binary_numeric_split_impl.hpp
@@ -221,8 +221,8 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     AuxiliarySplitInfo& /* aux */,
     FitnessFunction& fitnessFunction)
 {
-  typedef typename ResponsesType::elem_type RType;
-  typedef typename WeightVecType::elem_type WType;
+  using RType = typename ResponsesType::elem_type;
+  using WType = typename WeightVecType::elem_type;
 
   // First sanity check: if we don't have enough points, we can't split.
   if (data.n_elem < (minimumLeafSize * 2))
@@ -377,8 +377,8 @@ BestBinaryNumericSplit<FitnessFunction>::SplitIfBetter(
     AuxiliarySplitInfo& /* aux */,
     FitnessFunction& fitnessFunction)
 {
-  typedef typename ResponsesType::elem_type RType;
-  typedef typename WeightVecType::elem_type WType;
+  using RType = typename ResponsesType::elem_type;
+  using WType = typename WeightVecType::elem_type;
 
   // First sanity check: if we don't have enough points, we can't split.
   if (data.n_elem < (minimumLeafSize * 2))

--- a/src/mlpack/methods/decision_tree/utils.hpp
+++ b/src/mlpack/methods/decision_tree/utils.hpp
@@ -25,8 +25,8 @@ inline void WeightedSum(const VecType& values,
                         double& accWeights,
                         double& weightedMean)
 {
-  typedef typename VecType::elem_type VType;
-  typedef typename WeightVecType::elem_type WType;
+  using VType = typename VecType::elem_type;
+  using WType = typename WeightVecType::elem_type;
 
   WType totalWeights[4] = { 0.0, 0.0, 0.0, 0.0 };
   VType weightedSum[4] = { 0.0, 0.0, 0.0, 0.0 };

--- a/src/mlpack/methods/det/dt_utils.hpp
+++ b/src/mlpack/methods/det/dt_utils.hpp
@@ -132,8 +132,8 @@ class PathCacher
   size_t NumNodes() const { return pathCache.size(); }
 
  protected:
-  typedef std::list<std::pair<bool, int>>          PathType;
-  typedef std::vector<std::pair<int, std::string>> PathCacheType;
+  using PathType = std::list<std::pair<bool, int>>;
+  using PathCacheType = std::vector<std::pair<int, std::string>>;
 
   PathType      path;
   PathFormat    format;

--- a/src/mlpack/methods/det/dtree.hpp
+++ b/src/mlpack/methods/det/dtree.hpp
@@ -46,11 +46,11 @@ class DTree
 {
  public:
   //! The actual, underlying type we're working with.
-  typedef typename MatType::elem_type  ElemType;
+  using ElemType = typename MatType::elem_type;
   //! The type of vector we are using.
-  typedef typename GetColType<MatType>::type   VecType;
+  using VecType = typename GetColType<MatType>::type;
   //! The statistic type we are holding.
-  typedef typename arma::Col<ElemType> StatType;
+  using StatType = arma::Col<ElemType>;
 
   /**
    * Create an empty density estimation tree.

--- a/src/mlpack/methods/det/dtree_impl.hpp
+++ b/src/mlpack/methods/det/dtree_impl.hpp
@@ -32,7 +32,7 @@ void ExtractSplits(std::vector<std::pair<ElemType, size_t>>& splitVec,
   static_assert(std::is_same_v<typename MatType::elem_type, ElemType>,
     "The ElemType does not correspond to the matrix's element type.");
 
-  typedef std::pair<ElemType, size_t> SplitItem;
+  using SplitItem = std::pair<ElemType, size_t>;
   const typename MatType::row_type dimVec =
       arma::sort(data(dim, arma::span(start, end - 1)));
 
@@ -61,7 +61,7 @@ void ExtractSplits(std::vector<std::pair<ElemType, size_t>>& splitVec,
                    const size_t end,
                    const size_t minLeafSize)
 {
-  typedef std::pair<ElemType, size_t> SplitItem;
+  using SplitItem = std::pair<ElemType, size_t>;
   arma::rowvec dimVec = data(dim, arma::span(start, end - 1));
 
   // We sort these, in-place (it's a copy of the data, anyways).
@@ -92,7 +92,7 @@ void ExtractSplits(std::vector<std::pair<ElemType, size_t>>& splitVec,
   // It's common sense, but we also use it in a check later.
   Log::Assert(minLeafSize > 0);
 
-  typedef std::pair<ElemType, size_t> SplitItem;
+  using SplitItem = std::pair<ElemType, size_t>;
   const size_t n_elem = end - start;
 
   // Construct a vector of values.
@@ -434,7 +434,7 @@ bool DTree<MatType, TagType>::FindSplit(const MatType& data,
                                         double& rightError,
                                         const size_t minLeafSize) const
 {
-  typedef std::pair<ElemType, size_t> SplitItem;
+  using SplitItem = std::pair<ElemType, size_t>;
 
   // Ensure the dimensionality of the data is the same as the dimensionality of
   // the bounding rectangle.

--- a/src/mlpack/methods/emst/dtb.hpp
+++ b/src/mlpack/methods/emst/dtb.hpp
@@ -80,7 +80,7 @@ class DualTreeBoruvka
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<DistanceType, DTBStat, MatType> Tree;
+  using Tree = TreeType<DistanceType, DTBStat, MatType>;
 
  private:
   //! Permutations of points during tree building.

--- a/src/mlpack/methods/emst/dtb_impl.hpp
+++ b/src/mlpack/methods/emst/dtb_impl.hpp
@@ -98,7 +98,7 @@ void DualTreeBoruvka<DistanceType, MatType, TreeType>::ComputeMST(
 {
   totalDist = 0; // Reset distance.
 
-  typedef DTBRules<DistanceType, Tree> RuleType;
+  using RuleType = DTBRules<DistanceType, Tree>;
   RuleType rules(data, connections, neighborsDistances, neighborsInComponent,
                  neighborsOutComponent, distance);
   while (edges.size() < (data.n_cols - 1))

--- a/src/mlpack/methods/emst/dtb_rules.hpp
+++ b/src/mlpack/methods/emst/dtb_rules.hpp
@@ -81,7 +81,7 @@ class DTBRules
                  TreeType& referenceNode,
                  const double oldScore) const;
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }
   TraversalInfoType& TraversalInfo() { return traversalInfo; }

--- a/src/mlpack/methods/fastmks/fastmks.hpp
+++ b/src/mlpack/methods/fastmks/fastmks.hpp
@@ -61,7 +61,7 @@ class FastMKS
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<IPMetric<KernelType>, FastMKSStat, MatType> Tree;
+  using Tree = TreeType<IPMetric<KernelType>, FastMKSStat, MatType>;
 
   /**
    * Create the FastMKS object with an empty reference set and default kernel.
@@ -332,7 +332,7 @@ class FastMKS
   IPMetric<KernelType> distance;
 
   //! Candidate represents a possible candidate point (value, index).
-  typedef std::pair<double, size_t> Candidate;
+  using Candidate = std::pair<double, size_t>;
 
   //! Compare two candidates based on the value.
   struct CandidateCmp {
@@ -343,8 +343,8 @@ class FastMKS
   };
 
   //! Use a priority queue to represent the list of candidate points.
-  typedef std::priority_queue<Candidate, std::vector<Candidate>,
-      CandidateCmp> CandidateList;
+  using CandidateList = std::priority_queue<Candidate, std::vector<Candidate>,
+      CandidateCmp>;
 };
 
 } // namespace mlpack

--- a/src/mlpack/methods/fastmks/fastmks_impl.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_impl.hpp
@@ -472,7 +472,7 @@ void FastMKS<KernelType, MatType, TreeType>::Search(
   {
     // Create rules object (this will store the results).  This constructor
     // precalculates each self-kernel value.
-    typedef FastMKSRules<KernelType, Tree> RuleType;
+    using RuleType = FastMKSRules<KernelType, Tree>;
     RuleType rules(*referenceSet, querySet, k, distance.Kernel());
 
     typename Tree::template SingleTreeTraverser<RuleType> traverser(rules);
@@ -533,7 +533,7 @@ void FastMKS<KernelType, MatType, TreeType>::Search(
   indices.set_size(k, queryTree->Dataset().n_cols);
   kernels.set_size(k, queryTree->Dataset().n_cols);
 
-  typedef FastMKSRules<KernelType, Tree> RuleType;
+  using RuleType = FastMKSRules<KernelType, Tree>;
   RuleType rules(*referenceSet, queryTree->Dataset(), k, distance.Kernel());
 
   typename Tree::template DualTreeTraverser<RuleType> traverser(rules);
@@ -602,7 +602,7 @@ void FastMKS<KernelType, MatType, TreeType>::Search(
   {
     // Create rules object (this will store the results).  This constructor
     // precalculates each self-kernel value.
-    typedef FastMKSRules<KernelType, Tree> RuleType;
+    using RuleType = FastMKSRules<KernelType, Tree>;
     RuleType rules(*referenceSet, *referenceSet, k, distance.Kernel());
 
     typename Tree::template SingleTreeTraverser<RuleType> traverser(rules);

--- a/src/mlpack/methods/fastmks/fastmks_rules.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_rules.hpp
@@ -118,7 +118,7 @@ class FastMKSRules
   //! Modify the number of times Score() was called.
   size_t& Scores() { return scores; }
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }
   TraversalInfoType& TraversalInfo() { return traversalInfo; }
@@ -134,7 +134,7 @@ class FastMKSRules
   const typename TreeType::Mat& querySet;
 
   //! Candidate represents a possible candidate point (value, index).
-  typedef std::pair<double, size_t> Candidate;
+  using Candidate = std::pair<double, size_t>;
 
   //! Compare two candidates based on the value.
   struct CandidateCmp {

--- a/src/mlpack/methods/fastmks/fastmks_rules_impl.hpp
+++ b/src/mlpack/methods/fastmks/fastmks_rules_impl.hpp
@@ -476,7 +476,7 @@ double FastMKSRules<KernelType, TreeType>::CalculateBound(TreeType& queryNode)
     // where p_j^*(p_q) is the j'th kernel candidate for query point p_q and
     // k_j^*(p_q) is K(p_q, p_j^*(p_q)).
     double worstPointCandidateKernel = DBL_MAX;
-    typedef std::vector<Candidate>::const_iterator iter;
+    using iter = std::vector<Candidate>::const_iterator;
     for (iter it = candidatesPoints.begin(); it != candidatesPoints.end(); ++it)
     {
       const double candidateKernel = it->first - queryDescendantDistance *

--- a/src/mlpack/methods/gmm/gmm_train_main.cpp
+++ b/src/mlpack/methods/gmm/gmm_train_main.cpp
@@ -228,7 +228,7 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     const int samplings = params.Get<int>("samplings");
     const double percentage = params.Get<double>("percentage");
 
-    typedef KMeans<SquaredEuclideanDistance, RefinedStart> KMeansType;
+    using KMeansType = KMeans<SquaredEuclideanDistance, RefinedStart>;
 
     KMeansType k(kmeansMaxIterations, SquaredEuclideanDistance(),
         RefinedStart(samplings, percentage));

--- a/src/mlpack/methods/gmm/positive_definite_constraint.hpp
+++ b/src/mlpack/methods/gmm/positive_definite_constraint.hpp
@@ -37,8 +37,8 @@ class PositiveDefiniteConstraint
       MatType& covariance,
       const std::enable_if_t<!IsVector<MatType>::value>* /* junk */ = 0)
   {
-    typedef typename MatType::elem_type ElemType;
-    typedef typename GetColType<MatType>::type VecType;
+    using ElemType = typename MatType::elem_type;
+    using VecType = typename GetColType<MatType>::type;
 
     // What we want to do is make sure that the matrix is positive definite and
     // that the condition number isn't too large.  We also need to ensure that
@@ -83,7 +83,7 @@ class PositiveDefiniteConstraint
       VecType& diagCovariance,
       const std::enable_if_t<IsVector<VecType>::value>* /* junk */ = 0)
   {
-    typedef typename VecType::elem_type ElemType;
+    using ElemType = typename VecType::elem_type;
 
     // If the matrix is not positive definite or if the condition number is
     // large, we must project it back onto the cone of positive definite

--- a/src/mlpack/methods/hoeffding_trees/binary_numeric_split.hpp
+++ b/src/mlpack/methods/hoeffding_trees/binary_numeric_split.hpp
@@ -47,7 +47,7 @@ class BinaryNumericSplit
 {
  public:
   //! The splitting information required by the BinaryNumericSplit.
-  typedef BinaryNumericSplitInfo<ObservationType> SplitInfo;
+  using SplitInfo = BinaryNumericSplitInfo<ObservationType>;
 
   /**
    * Create the BinaryNumericSplit object with the given number of classes.

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_categorical_split.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_categorical_split.hpp
@@ -44,7 +44,7 @@ class HoeffdingCategoricalSplit
 {
  public:
   //! The type of split information required by the HoeffdingCategoricalSplit.
-  typedef CategoricalSplitInfo SplitInfo;
+  using SplitInfo = CategoricalSplitInfo;
 
   /**
    * Create the HoeffdingCategoricalSplit given a number of categories for this

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_numeric_split.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_numeric_split.hpp
@@ -53,7 +53,7 @@ class HoeffdingNumericSplit
 {
  public:
   //! The splitting information type required by the HoeffdingNumericSplit.
-  typedef NumericSplitInfo<ObservationType> SplitInfo;
+  using SplitInfo = NumericSplitInfo<ObservationType>;
 
   /**
    * Create the HoeffdingNumericSplit class, and specify some basic parameters

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree.hpp
@@ -68,9 +68,9 @@ class HoeffdingTree
 {
  public:
   //! Allow access to the numeric split type.
-  typedef NumericSplitType<FitnessFunction> NumericSplit;
+  using NumericSplit = NumericSplitType<FitnessFunction>;
   //! Allow access to the categorical split type.
-  typedef CategoricalSplitType<FitnessFunction> CategoricalSplit;
+  using CategoricalSplit = CategoricalSplitType<FitnessFunction>;
 
   /**
    * Construct a Hoeffding tree with no data and no information.  Be sure to

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_main.cpp
@@ -133,7 +133,7 @@ PARAM_INT_IN("observations_before_binning", "If the 'domingos' split strategy "
     "performed.", "o", 100);
 
 // Convenience typedef.
-typedef tuple<DatasetInfo, arma::mat> TupleType;
+using TupleType = tuple<DatasetInfo, arma::mat>;
 
 void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
 {

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_tree_model.hpp
@@ -37,17 +37,17 @@ class HoeffdingTreeModel
   };
 
   //! Convenience typedef for GINI_HOEFFDING tree type.
-  typedef HoeffdingTree<GiniImpurity, HoeffdingDoubleNumericSplit,
-      HoeffdingCategoricalSplit> GiniHoeffdingTreeType;
+  using GiniHoeffdingTreeType = HoeffdingTree<GiniImpurity,
+      HoeffdingDoubleNumericSplit, HoeffdingCategoricalSplit>;
   //! Convenience typedef for GINI_BINARY tree type.
-  typedef HoeffdingTree<GiniImpurity, BinaryDoubleNumericSplit,
-      HoeffdingCategoricalSplit> GiniBinaryTreeType;
+  using GiniBinaryTreeType = HoeffdingTree<GiniImpurity,
+      BinaryDoubleNumericSplit, HoeffdingCategoricalSplit>;
   //! Convenience typedef for INFO_HOEFFDING tree type.
-  typedef HoeffdingTree<HoeffdingInformationGain, HoeffdingDoubleNumericSplit,
-      HoeffdingCategoricalSplit> InfoHoeffdingTreeType;
+  using InfoHoeffdingTreeType = HoeffdingTree<HoeffdingInformationGain,
+      HoeffdingDoubleNumericSplit, HoeffdingCategoricalSplit>;
   //! Convenience typedef for INFO_BINARY tree type.
-  typedef HoeffdingTree<HoeffdingInformationGain, BinaryDoubleNumericSplit,
-      HoeffdingCategoricalSplit> InfoBinaryTreeType;
+  using InfoBinaryTreeType = HoeffdingTree<HoeffdingInformationGain,
+      BinaryDoubleNumericSplit, HoeffdingCategoricalSplit>;
 
   /**
    * Construct the Hoeffding tree model, but don't initialize any tree.

--- a/src/mlpack/methods/hoeffding_trees/typedef.hpp
+++ b/src/mlpack/methods/hoeffding_trees/typedef.hpp
@@ -17,7 +17,7 @@
 
 namespace mlpack {
 
-typedef StreamingDecisionTree<HoeffdingTree<>> HoeffdingTreeType;
+using HoeffdingTreeType = StreamingDecisionTree<HoeffdingTree<>>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/kde/kde.hpp
+++ b/src/mlpack/methods/kde/kde.hpp
@@ -85,7 +85,7 @@ class KDE
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<DistanceType, KDEStat, MatType> Tree;
+  using Tree = TreeType<DistanceType, KDEStat, MatType>;
 
   /**
    * Initialize KDE object using custom instantiated Metric and Kernel objects.

--- a/src/mlpack/methods/kde/kde_impl.hpp
+++ b/src/mlpack/methods/kde/kde_impl.hpp
@@ -413,7 +413,7 @@ Evaluate(MatType querySet, arma::vec& estimations)
     }
 
     // Evaluate.
-    typedef KDERules<DistanceType, KernelType, Tree> RuleType;
+    using RuleType = KDERules<DistanceType, KernelType, Tree>;
     RuleType rules = RuleType(referenceTree->Dataset(),
                               querySet,
                               estimations,
@@ -506,7 +506,7 @@ Evaluate(Tree* queryTree,
   }
 
   // Evaluate.
-  typedef KDERules<DistanceType, KernelType, Tree> RuleType;
+  using RuleType = KDERules<DistanceType, KernelType, Tree>;
   RuleType rules = RuleType(referenceTree->Dataset(),
                             queryTree->Dataset(),
                             estimations,
@@ -570,7 +570,7 @@ Evaluate(arma::vec& estimations)
   }
 
   // Evaluate.
-  typedef KDERules<DistanceType, KernelType, Tree> RuleType;
+  using RuleType = KDERules<DistanceType, KernelType, Tree>;
   RuleType rules = RuleType(referenceTree->Dataset(),
                             referenceTree->Dataset(),
                             estimations,

--- a/src/mlpack/methods/kde/kde_model.hpp
+++ b/src/mlpack/methods/kde/kde_model.hpp
@@ -212,7 +212,7 @@ class KDEWrapper : public KDEWrapperBase
   }
 
  protected:
-  typedef KDE<KernelType, EuclideanDistance, arma::mat, TreeType> KDEType;
+  using KDEType = KDE<KernelType, EuclideanDistance, arma::mat, TreeType>;
 
   //! The instantiated KDE object that we are wrapping.
   KDEType kde;

--- a/src/mlpack/methods/kde/kde_rules.hpp
+++ b/src/mlpack/methods/kde/kde_rules.hpp
@@ -78,7 +78,7 @@ class KDERules
                  TreeType& referenceNode,
                  const double oldScore) const;
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   //! Get traversal information.
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }
@@ -210,7 +210,7 @@ class KDECleanRules
                  TreeType& /* referenceNode*/ ,
                  const double oldScore) const { return oldScore; }
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   //! Get traversal information.
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans.hpp
@@ -41,7 +41,7 @@ class DualTreeKMeans
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<DistanceType, DualTreeKMeansStatistic, MatType> Tree;
+  using Tree = TreeType<DistanceType, DualTreeKMeansStatistic, MatType>;
 
   template<typename TreeDistanceType,
            typename IgnoredStatType,

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_impl.hpp
@@ -143,7 +143,7 @@ double DualTreeKMeans<DistanceType, MatType, TreeType>::Iterate(
 
   // We won't use the KNN class here because we have our own set of rules.
   lastIterationCentroids = centroids;
-  typedef DualTreeKMeansRules<DistanceType, Tree> RuleType;
+  using RuleType = DualTreeKMeansRules<DistanceType, Tree>;
   RuleType rules(nns.ReferenceTree().Dataset(), dataset, assignments,
       upperBounds, lowerBounds, distance, prunedPoints, oldFromNewCentroids,
       visited);

--- a/src/mlpack/methods/kmeans/dual_tree_kmeans_rules.hpp
+++ b/src/mlpack/methods/kmeans/dual_tree_kmeans_rules.hpp
@@ -43,7 +43,7 @@ class DualTreeKMeansRules
                  TreeType& referenceNode,
                  const double oldScore);
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   TraversalInfoType& TraversalInfo() { return traversalInfo; }
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }

--- a/src/mlpack/methods/kmeans/pelleg_moore_kmeans.hpp
+++ b/src/mlpack/methods/kmeans/pelleg_moore_kmeans.hpp
@@ -69,7 +69,7 @@ class PellegMooreKMeans
   size_t& DistanceCalculations() { return distanceCalculations; }
 
   //! Convenience typedef for the tree.
-  typedef KDTree<DistanceType, PellegMooreKMeansStatistic, MatType> TreeType;
+  using TreeType = KDTree<DistanceType, PellegMooreKMeansStatistic, MatType>;
 
  private:
   //! The original dataset reference.

--- a/src/mlpack/methods/kmeans/pelleg_moore_kmeans_impl.hpp
+++ b/src/mlpack/methods/kmeans/pelleg_moore_kmeans_impl.hpp
@@ -49,7 +49,7 @@ double PellegMooreKMeans<DistanceType, MatType>::Iterate(
   counts.zeros(centroids.n_cols);
 
   // Create rules object.
-  typedef PellegMooreKMeansRules<DistanceType, TreeType> RulesType;
+  using RulesType = PellegMooreKMeansRules<DistanceType, TreeType>;
   RulesType rules(dataset, centroids, newCentroids, counts, distance);
 
   // Use single-tree traverser.

--- a/src/mlpack/methods/lars/lars.hpp
+++ b/src/mlpack/methods/lars/lars.hpp
@@ -86,9 +86,9 @@ template<typename ModelMatType = arma::mat>
 class LARS
 {
  public:
-  typedef typename GetColType<ModelMatType>::type ModelColType;
-  typedef typename GetDenseMatType<ModelMatType>::type DenseMatType;
-  typedef typename ModelMatType::elem_type ElemType;
+  using ModelColType = typename GetColType<ModelMatType>::type;
+  using DenseMatType = typename GetDenseMatType<ModelMatType>::type;
+  using ElemType = typename ModelMatType::elem_type;
 
   /**
    * Set the parameters to LARS.  Both lambda1 and lambda2 default to 0.

--- a/src/mlpack/methods/linear_regression/linear_regression.hpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.hpp
@@ -30,8 +30,8 @@ template<typename ModelMatType = arma::mat>
 class LinearRegression
 {
  public:
-  typedef typename GetColType<ModelMatType>::type ModelColType;
-  typedef typename ModelMatType::elem_type ElemType;
+  using ModelColType = typename GetColType<ModelMatType>::type;
+  using ElemType = typename ModelMatType::elem_type;
 
   /**
    * Creates the model.

--- a/src/mlpack/methods/linear_svm/linear_svm.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm.hpp
@@ -79,9 +79,9 @@ template<typename ModelMatType = arma::mat>
 class LinearSVM
 {
  public:
-  typedef typename ModelMatType::elem_type ElemType;
-  typedef typename GetDenseMatType<ModelMatType>::type DenseMatType;
-  typedef typename GetDenseColType<ModelMatType>::type DenseColType;
+  using ElemType = typename ModelMatType::elem_type;
+  using DenseMatType = typename GetDenseMatType<ModelMatType>::type;
+  using DenseColType = typename GetDenseColType<ModelMatType>::type;
 
   /**
    * Initialize the Linear SVM without performing training.  Default

--- a/src/mlpack/methods/linear_svm/linear_svm_function.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_function.hpp
@@ -27,11 +27,11 @@ template<typename MatType = arma::mat, typename ParametersType = arma::mat>
 class LinearSVMFunction
 {
  public:
-  typedef typename ParametersType::elem_type ElemType;
-  typedef typename GetDenseMatType<ParametersType>::type DenseMatType;
-  typedef typename GetSparseMatType<ParametersType>::type SparseMatType;
-  typedef typename GetDenseColType<SparseMatType>::type DenseColType;
-  typedef typename GetDenseRowType<ParametersType>::type DenseRowType;
+  using ElemType = typename ParametersType::elem_type;
+  using DenseMatType = typename GetDenseMatType<ParametersType>::type;
+  using SparseMatType = typename GetSparseMatType<ParametersType>::type;
+  using DenseColType = typename GetDenseColType<SparseMatType>::type;
+  using DenseRowType = typename GetDenseRowType<ParametersType>::type;
 
   /**
    * Construct the Linear SVM objective function with given parameters.

--- a/src/mlpack/methods/lmnn/constraints.hpp
+++ b/src/mlpack/methods/lmnn/constraints.hpp
@@ -34,18 +34,18 @@ class Constraints
 {
  public:
   //! Convenience typedef.
-  typedef NeighborSearch<NearestNeighborSort, DistanceType, MatType> KNN;
+  using KNN = NeighborSearch<NearestNeighborSort, DistanceType, MatType>;
 
   // Convenience typedef for element type of data.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   // Convenience typedef for column vector of data.
-  typedef typename GetColType<MatType>::type VecType;
+  using VecType = typename GetColType<MatType>::type;
   // Convenience typedef for cube of data.
-  typedef typename GetCubeType<MatType>::type CubeType;
+  using CubeType = typename GetCubeType<MatType>::type;
   // Convenience typedef for dense matrix of indices.
-  typedef typename GetUDenseMatType<MatType>::type UMatType;
+  using UMatType = typename GetUDenseMatType<MatType>::type;
   // Convenience typedef for dense vector of indices.
-  typedef typename GetColType<UMatType>::type UVecType;
+  using UVecType = typename GetColType<UMatType>::type;
 
   /**
    * Constructor for creating a Constraints instance.

--- a/src/mlpack/methods/lmnn/constraints_impl.hpp
+++ b/src/mlpack/methods/lmnn/constraints_impl.hpp
@@ -402,7 +402,7 @@ void Constraints<MatType, LabelsType, DistanceType>::Triplets(
   UMatType impostors(k, dataset.n_cols);
   Impostors(impostors, dataset, labels, norms);
 
-  UMatType targetNeighbors(k, dataset.n_cols);;
+  UMatType targetNeighbors(k, dataset.n_cols);
   TargetNeighbors(targetNeighbors, dataset, labels, norms);
 
   outputMatrix = UMatType(3, k * k * N);

--- a/src/mlpack/methods/lmnn/lmnn_function.hpp
+++ b/src/mlpack/methods/lmnn/lmnn_function.hpp
@@ -47,15 +47,15 @@ template<typename MatType = arma::mat,
 class LMNNFunction
 {
   // Convenience typedef for element type of data.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   // Convenience typedef for column vector of data.
-  typedef typename GetColType<MatType>::type VecType;
+  using VecType = typename GetColType<MatType>::type;
   // Convenience typedef for cube of data.
-  typedef typename GetCubeType<MatType>::type CubeType;
+  using CubeType = typename GetCubeType<MatType>::type;
   // Convenience typedef for dense matrix of indices.
-  typedef typename GetUDenseMatType<MatType>::type UMatType;
+  using UMatType = typename GetUDenseMatType<MatType>::type;
   // Convenience typedef for dense vector of indices.
-  typedef typename GetColType<UMatType>::type UVecType;
+  using UVecType = typename GetColType<UMatType>::type;
 
  public:
   /**

--- a/src/mlpack/methods/local_coordinate_coding/lcc.hpp
+++ b/src/mlpack/methods/local_coordinate_coding/lcc.hpp
@@ -79,8 +79,8 @@ template<typename MatType = arma::mat>
 class LocalCoordinateCoding
 {
  public:
-  typedef typename GetColType<MatType>::type ColType;
-  typedef typename GetRowType<MatType>::type RowType;
+  using ColType = typename GetColType<MatType>::type;
+  using RowType = typename GetRowType<MatType>::type;
 
   /**
    * Set the parameters to LocalCoordinateCoding, and train the dictionary.

--- a/src/mlpack/methods/logistic_regression/logistic_regression.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression.hpp
@@ -37,9 +37,9 @@ template<typename MatType = arma::mat>
 class LogisticRegression
 {
  public:
-  typedef typename MatType::elem_type ElemType;
-  typedef typename GetDenseRowType<MatType>::type RowType;
-  typedef typename GetDenseColType<MatType>::type ColType;
+  using ElemType = typename MatType::elem_type;
+  using RowType = typename GetDenseRowType<MatType>::type;
+  using ColType = typename GetDenseColType<MatType>::type;
 
   /**
    * Construct the LogisticRegression class without performing any training.

--- a/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
+++ b/src/mlpack/methods/logistic_regression/logistic_regression_function_impl.hpp
@@ -77,7 +77,7 @@ LogisticRegressionFunction<MatType>::Evaluate(
   //   f(w) = sum(y log(sig(w'x)) + (1 - y) log(sig(1 - w'x))).
   // We want to minimize this function.  L2-regularization is just lambda
   // multiplied by the squared l2-norm of the parameters then divided by two.
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Specifying these here makes the code below a little bit cleaner, and avoids
   // accidentally casting an entire expression to `double`, e.g., by the use of
@@ -123,7 +123,7 @@ LogisticRegressionFunction<MatType>::Evaluate(
     const size_t begin,
     const size_t batchSize) const
 {
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Specifying these here makes the code below a little bit cleaner, and avoids
   // accidentally casting an entire expression to `double`, e.g., by the use of
@@ -159,7 +159,7 @@ void LogisticRegressionFunction<MatType>::Gradient(
     const CoordinatesType& parameters,
     GradType& gradient) const
 {
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Regularization term.
   GradType regularization;
@@ -189,7 +189,7 @@ void LogisticRegressionFunction<MatType>::Gradient(
                 GradType& gradient,
                 const size_t batchSize) const
 {
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Regularization term.
   GradType regularization;
@@ -226,7 +226,7 @@ void LogisticRegressionFunction<MatType>::PartialGradient(
     const size_t j,
     GradType& gradient) const
 {
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Specifying this here makes the code below a little bit cleaner, and avoids
   // accidentally casting an entire expression to `double`, e.g., by the use of
@@ -256,7 +256,7 @@ LogisticRegressionFunction<MatType>::EvaluateWithGradient(
     const CoordinatesType& parameters,
     GradType& gradient) const
 {
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Specifying these here makes the code below a little bit cleaner, and avoids
   // accidentally casting an entire expression to `double`, e.g., by the use of
@@ -299,7 +299,7 @@ LogisticRegressionFunction<MatType>::EvaluateWithGradient(
     GradType& gradient,
     const size_t batchSize) const
 {
-  typedef typename CoordinatesType::elem_type ElemType;
+  using ElemType = typename CoordinatesType::elem_type;
 
   // Specifying these here makes the code below a little bit cleaner, and avoids
   // accidentally casting an entire expression to `double`, e.g., by the use of

--- a/src/mlpack/methods/lsh/lsh_search.hpp
+++ b/src/mlpack/methods/lsh/lsh_search.hpp
@@ -462,7 +462,7 @@ class LSHSearch
   size_t distanceEvaluations;
 
   //! Candidate represents a possible candidate neighbor (distance, index).
-  typedef std::pair<double, size_t> Candidate;
+  using Candidate = std::pair<double, size_t>;
 
   //! Compare two candidates based on the distance.
   struct CandidateCmp {
@@ -473,8 +473,8 @@ class LSHSearch
   };
 
   //! Use a priority queue to represent the list of candidate neighbors.
-  typedef std::priority_queue<Candidate, std::vector<Candidate>, CandidateCmp>
-      CandidateList;
+  using CandidateList = std::priority_queue<Candidate, std::vector<Candidate>,
+      CandidateCmp>;
 }; // class LSHSearch
 
 } // namespace mlpack

--- a/src/mlpack/methods/lsh/lsh_search_impl.hpp
+++ b/src/mlpack/methods/lsh/lsh_search_impl.hpp
@@ -834,7 +834,7 @@ void LSHSearch<SortPolicy, MatType>::ReturnIndicesFromTable(
     {
       for (size_t p = 0; p < T + 1; ++p)
       {
-        const size_t hashInd =  hashMat(p, i); // Find the query's bucket.
+        const size_t hashInd = hashMat(p, i); // Find the query's bucket.
         const size_t tableRow = bucketRowInHashTable[hashInd];
 
         if (tableRow < secondHashSize)

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -94,8 +94,8 @@ void MeanShift<UseKernel, KernelType>::GenSeeds(const MatType& data,
                                                 const int minFreq,
                                                 CentroidsType& seeds)
 {
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename GetColType<CentroidsType>::type CentroidVecType;
+  using VecType = typename GetColType<MatType>::type;
+  using CentroidVecType = typename GetColType<CentroidsType>::type;
   std::map<VecType, int, less<VecType> > allSeeds;
   for (size_t i = 0; i < data.n_cols; ++i)
   {
@@ -138,7 +138,7 @@ MeanShift<UseKernel, KernelType>::CalculateCentroid(
     const std::vector<typename MatType::elem_type>& distances,
     VecType& centroid)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   ElemType sumWeight = 0;
   for (size_t i = 0; i < neighbors.size(); ++i)
@@ -189,8 +189,8 @@ inline void MeanShift<UseKernel, KernelType>::Cluster(
     bool useSeeds)
 {
   // Convenience typedefs.
-  typedef typename MatType::elem_type ElemType;
-  typedef typename GetColType<MatType>::type VecType;
+  using ElemType = typename MatType::elem_type;
+  using VecType = typename GetColType<MatType>::type;
 
   if (radius <= 0)
   {

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier.hpp
@@ -58,7 +58,7 @@ class NaiveBayesClassifier
 {
  public:
   // Convenience typedef.
-  typedef typename ModelMatType::elem_type ElemType;
+  using ElemType = typename ModelMatType::elem_type;
 
   /**
    * Initializes the classifier as per the input and then trains it by

--- a/src/mlpack/methods/nca/nca_softmax_error_function.hpp
+++ b/src/mlpack/methods/nca/nca_softmax_error_function.hpp
@@ -47,9 +47,9 @@ class SoftmaxErrorFunction
 {
  public:
   // Convenience typedef for element type of data.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
   // Convenience typedef for column vector of data.
-  typedef typename GetColType<MatType>::type VecType;
+  using VecType = typename GetColType<MatType>::type;
 
   /**
    * Initialize with the given kernel; useful when the kernel has some state to

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -26,7 +26,7 @@ using namespace mlpack;
 using namespace mlpack::util;
 
 // Convenience typedef.
-typedef NSModel<FurthestNS> KFNModel;
+using KFNModel = NSModel<FurthestNS>;
 
 // Program Name.
 BINDING_USER_NAME("k-Furthest-Neighbors Search");

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -26,7 +26,7 @@ using namespace mlpack;
 using namespace mlpack::util;
 
 // Convenience typedef.
-typedef NSModel<NearestNeighborSort> KNNModel;
+using KNNModel = NSModel<NearestNeighborSort>;
 
 // Program Name.
 BINDING_USER_NAME("k-Nearest-Neighbors Search");

--- a/src/mlpack/methods/neighbor_search/neighbor_search.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search.hpp
@@ -81,9 +81,9 @@ class NeighborSearch
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<DistanceType, NeighborSearchStat<SortPolicy>, MatType> Tree;
+  using Tree = TreeType<DistanceType, NeighborSearchStat<SortPolicy>, MatType>;
   //! The type of element held in MatType.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Initialize the NeighborSearch object, passing a reference dataset (this is

--- a/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_impl.hpp
@@ -411,7 +411,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   neighborPtr->set_size(k, querySet.n_cols);
   distancePtr->set_size(k, querySet.n_cols);
 
-  typedef NeighborSearchRules<SortPolicy, DistanceType, Tree> RuleType;
+  using RuleType = NeighborSearchRules<SortPolicy, DistanceType, Tree>;
 
   switch (searchMode)
   {
@@ -610,7 +610,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   distances.set_size(k, querySet.n_cols);
 
   // Create the helper object for the traversal.
-  typedef NeighborSearchRules<SortPolicy, DistanceType, Tree> RuleType;
+  using RuleType = NeighborSearchRules<SortPolicy, DistanceType, Tree>;
   RuleType rules(*referenceSet, querySet, k, distance, epsilon, sameSet);
 
   // Create the traverser.
@@ -693,7 +693,7 @@ DualTreeTraversalType, SingleTreeTraversalType>::Search(
   distancePtr->set_size(k, referenceSet->n_cols);
 
   // Create the helper object for the traversal.
-  typedef NeighborSearchRules<SortPolicy, DistanceType, Tree> RuleType;
+  using RuleType = NeighborSearchRules<SortPolicy, DistanceType, Tree>;
   RuleType rules(*referenceSet, *referenceSet, k, distance, epsilon,
       true /* don't return the same point as nearest neighbor */);
 

--- a/src/mlpack/methods/neighbor_search/neighbor_search_rules.hpp
+++ b/src/mlpack/methods/neighbor_search/neighbor_search_rules.hpp
@@ -35,7 +35,7 @@ class NeighborSearchRules
 {
  public:
   //! The type of element held in MatType.
-  typedef typename TreeType::Mat::elem_type ElemType;
+  using ElemType = typename TreeType::Mat::elem_type;
 
   /**
    * Construct the NeighborSearchRules object.  This is usually done from within
@@ -155,7 +155,7 @@ class NeighborSearchRules
   size_t& Scores() { return scores; }
 
   //! Convenience typedef.
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   //! Get the traversal info.
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }
@@ -174,7 +174,7 @@ class NeighborSearchRules
   const typename TreeType::Mat& querySet;
 
   //! Candidate represents a possible candidate neighbor (distance, index).
-  typedef std::pair<double, size_t> Candidate;
+  using Candidate = std::pair<double, size_t>;
 
   //! Compare two candidates based on the distance.
   struct CandidateCmp {
@@ -185,8 +185,8 @@ class NeighborSearchRules
   };
 
   //! Use a priority queue to represent the list of candidate neighbors.
-  typedef std::priority_queue<Candidate, std::vector<Candidate>, CandidateCmp>
-      CandidateList;
+  using CandidateList = std::priority_queue<Candidate, std::vector<Candidate>,
+      CandidateCmp>;
 
   //! Set of candidate neighbors for each point.
   std::vector<CandidateList> candidates;

--- a/src/mlpack/methods/neighbor_search/ns_model.hpp
+++ b/src/mlpack/methods/neighbor_search/ns_model.hpp
@@ -164,12 +164,12 @@ class NSWrapper : public NSWrapperBase
 
  protected:
   // Convenience typedef for the neighbor search type held by this class.
-  typedef NeighborSearch<SortPolicy,
-                         EuclideanDistance,
-                         arma::mat,
-                         TreeType,
-                         DualTreeTraversalType,
-                         SingleTreeTraversalType> NSType;
+  using NSType = NeighborSearch<SortPolicy,
+                                EuclideanDistance,
+                                arma::mat,
+                                TreeType,
+                                DualTreeTraversalType,
+                                SingleTreeTraversalType>;
 
   //! The instantiated NeighborSearch object that we are wrapping.
   NSType ns;

--- a/src/mlpack/methods/neighbor_search/typedef.hpp
+++ b/src/mlpack/methods/neighbor_search/typedef.hpp
@@ -28,13 +28,13 @@ namespace mlpack {
  * The KNN class is the k-nearest-neighbors method.  It returns L2 distances
  * (Euclidean distances) for each of the k nearest neighbors.
  */
-typedef NeighborSearch<NearestNeighborSort, EuclideanDistance> KNN;
+using KNN = NeighborSearch<NearestNeighborSort, EuclideanDistance>;
 
 /**
  * The KFN class is the k-furthest-neighbors method.  It returns L2 distances
  * (Euclidean distances) for each of the k furthest neighbors.
  */
-typedef NeighborSearch<FurthestNeighborSort, EuclideanDistance> KFN;
+using KFN = NeighborSearch<FurthestNeighborSort, EuclideanDistance>;
 
 /**
  * The DefeatistKNN class is the k-nearest-neighbors method considering
@@ -63,7 +63,7 @@ using DefeatistKNN = NeighborSearch<
  * search on SPTree.  It returns L2 distances (Euclidean distances) for each of
  * the k nearest neighbors found.
  */
-typedef DefeatistKNN<SPTree> SpillKNN;
+using SpillKNN = DefeatistKNN<SPTree>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/pca/pca_impl.hpp
+++ b/src/mlpack/methods/pca/pca_impl.hpp
@@ -111,7 +111,7 @@ void PCA<DecompositionPolicy>::Apply(const MatType& data,
 
   // It's possible a user didn't pass in a matrix but instead an expression, but
   // we need a type that we can store.
-  typedef typename GetDenseColType<MatType>::type BaseColType;
+  using BaseColType = typename GetDenseColType<MatType>::type;
 
   OutMatType eigvec;
   BaseColType eigVal;
@@ -152,8 +152,8 @@ double PCA<DecompositionPolicy>::Apply(const MatType& data,
     throw std::invalid_argument(oss.str());
   }
 
-  typedef typename GetDenseMatType<MatType>::type BaseMatType;
-  typedef typename GetDenseColType<MatType>::type BaseColType;
+  using BaseMatType = typename GetDenseMatType<MatType>::type;
+  using BaseColType = typename GetDenseColType<MatType>::type;
 
   BaseMatType eigvec;
   BaseColType eigVal;
@@ -231,8 +231,8 @@ double PCA<DecompositionPolicy>::Apply(const MatType& data,
     throw std::invalid_argument(oss.str());
   }
 
-  typedef typename GetDenseMatType<MatType>::type BaseMatType;
-  typedef typename GetDenseColType<MatType>::type BaseColType;
+  using BaseMatType = typename GetDenseMatType<MatType>::type;
+  using BaseColType = typename GetDenseColType<MatType>::type;
 
   BaseMatType eigvec;
   BaseColType eigVal;

--- a/src/mlpack/methods/perceptron/perceptron.hpp
+++ b/src/mlpack/methods/perceptron/perceptron.hpp
@@ -35,7 +35,7 @@ class Perceptron
 {
  public:
   //! The element type used in the Perceptron.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Constructor: create the perceptron with the given number of classes and

--- a/src/mlpack/methods/radical/radical_impl.hpp
+++ b/src/mlpack/methods/radical/radical_impl.hpp
@@ -45,7 +45,7 @@ inline typename VecType::elem_type Radical::Vasicek(
     VecType& z,
     const size_t m) const
 {
-  typedef typename VecType::elem_type ElemType;
+  using ElemType = typename VecType::elem_type;
 
   z = sort(z);
 
@@ -75,8 +75,8 @@ inline typename MatType::elem_type Radical::Apply2D(const MatType& matX,
                                                     MatType& candidate,
                                                     util::Timers& timers)
 {
-  typedef typename GetColType<MatType>::type VecType;
-  typedef typename MatType::elem_type ElemType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
 
   timers.Start("radical_copy_and_perturb");
   CopyAndPerturb(perturbed, matX);
@@ -123,7 +123,7 @@ inline void Radical::Apply(const MatType& matXT,
                            MatType& matW,
                            util::Timers& timers)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   // matX is nPoints by nDims (although less intuitive than columns being
   // points, and although this is the transpose of the ICA literature, this
@@ -232,7 +232,7 @@ inline void WhitenFeatureMajorMatrix(const MatType& matX,
                                      MatType& matXWhitened,
                                      MatType& matWhitening)
 {
-  typedef typename GetColType<MatType>::type VecType;
+  using VecType = typename GetColType<MatType>::type;
 
   MatType matU, matV;
   VecType s;

--- a/src/mlpack/methods/random_forest/random_forest.hpp
+++ b/src/mlpack/methods/random_forest/random_forest.hpp
@@ -43,8 +43,8 @@ class RandomForest
 {
  public:
   //! Allow access to the underlying decision tree type.
-  typedef DecisionTree<FitnessFunction, NumericSplitType, CategoricalSplitType,
-      DimensionSelectionType> DecisionTreeType;
+  using DecisionTreeType = DecisionTree<FitnessFunction, NumericSplitType,
+      CategoricalSplitType, DimensionSelectionType>;
 
   /**
    * Construct the random forest without any training or specifying the number

--- a/src/mlpack/methods/range_search/range_search.hpp
+++ b/src/mlpack/methods/range_search/range_search.hpp
@@ -45,11 +45,11 @@ class RangeSearch
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<DistanceType, RangeSearchStat, MatType> Tree;
+  using Tree = TreeType<DistanceType, RangeSearchStat, MatType>;
   //! The type of Matrix.
-  typedef MatType Mat;
+  using Mat = MatType;
   //! The type of element held in MatType.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Initialize the RangeSearch object with a given reference dataset (this is

--- a/src/mlpack/methods/range_search/range_search_impl.hpp
+++ b/src/mlpack/methods/range_search/range_search_impl.hpp
@@ -332,7 +332,7 @@ void RangeSearch<DistanceType, MatType, TreeType>::Search(
   distancePtr->resize(querySet.n_cols);
 
   // Create the helper object for the traversal.
-  typedef RangeSearchRules<DistanceType, Tree> RuleType;
+  using RuleType = RangeSearchRules<DistanceType, Tree>;
 
   // Reset counts.
   baseCases = 0;
@@ -486,7 +486,7 @@ void RangeSearch<DistanceType, MatType, TreeType>::Search(
   distances.resize(querySet.n_cols);
 
   // Create the helper object for the traversal.
-  typedef RangeSearchRules<DistanceType, Tree> RuleType;
+  using RuleType = RangeSearchRules<DistanceType, Tree>;
   RuleType rules(*referenceSet, queryTree->Dataset(), range, *neighborPtr,
       distances, distance);
 
@@ -549,7 +549,7 @@ void RangeSearch<DistanceType, MatType, TreeType>::Search(
   distancePtr->resize(referenceSet->n_cols);
 
   // Create the helper object for the traversal.
-  typedef RangeSearchRules<DistanceType, Tree> RuleType;
+  using RuleType = RangeSearchRules<DistanceType, Tree>;
   RuleType rules(*referenceSet, *referenceSet, range, *neighborPtr,
       *distancePtr, distance, true /* don't return the query in the results */);
 

--- a/src/mlpack/methods/range_search/range_search_rules.hpp
+++ b/src/mlpack/methods/range_search/range_search_rules.hpp
@@ -28,9 +28,9 @@ class RangeSearchRules
 {
  public:
   //! Easy access to MatType.
-  typedef typename TreeType::Mat MatType;
+  using MatType = typename TreeType::Mat;
   //! The type of element held in MatType.
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   /**
    * Construct the RangeSearchRules object.  This is usually done from within
@@ -111,7 +111,7 @@ class RangeSearchRules
                    TreeType& referenceNode,
                    const ElemType oldScore) const;
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }
   TraversalInfoType& TraversalInfo() { return traversalInfo; }

--- a/src/mlpack/methods/range_search/rs_model.hpp
+++ b/src/mlpack/methods/range_search/rs_model.hpp
@@ -145,7 +145,7 @@ class RSWrapper : public RSWrapperBase
   }
 
  protected:
-  typedef RangeSearch<EuclideanDistance, arma::mat, TreeType> RSType;
+  using RSType = RangeSearch<EuclideanDistance, arma::mat, TreeType>;
 
   //! The instantiated RangeSearch object that we are wrapping.
   RSType rs;

--- a/src/mlpack/methods/rann/ra_model.hpp
+++ b/src/mlpack/methods/rann/ra_model.hpp
@@ -193,10 +193,10 @@ class RAWrapper : public RAWrapperBase
   }
 
  protected:
-  typedef RASearch<NearestNeighborSort,
-                   EuclideanDistance,
-                   arma::mat,
-                   TreeType> RAType;
+  using RAType = RASearch<NearestNeighborSort,
+                          EuclideanDistance,
+                          arma::mat,
+                          TreeType>;
 
   //! The instantiated RASearch object that we are wrapping.
   RAType ra;

--- a/src/mlpack/methods/rann/ra_search.hpp
+++ b/src/mlpack/methods/rann/ra_search.hpp
@@ -74,7 +74,7 @@ class RASearch
 {
  public:
   //! Convenience typedef.
-  typedef TreeType<DistanceType, RAQueryStat<SortPolicy>, MatType> Tree;
+  using Tree = TreeType<DistanceType, RAQueryStat<SortPolicy>, MatType>;
 
   /**
    * Initialize the RASearch object, passing both a reference dataset (this is

--- a/src/mlpack/methods/rann/ra_search_impl.hpp
+++ b/src/mlpack/methods/rann/ra_search_impl.hpp
@@ -260,7 +260,7 @@ Search(const MatType& querySet,
   neighborPtr->set_size(k, querySet.n_cols);
   distancePtr->set_size(k, querySet.n_cols);
 
-  typedef RASearchRules<SortPolicy, DistanceType, Tree> RuleType;
+  using RuleType = RASearchRules<SortPolicy, DistanceType, Tree>;
 
   if (naive)
   {
@@ -424,7 +424,7 @@ void RASearch<SortPolicy, DistanceType, MatType, TreeType>::Search(
   distances.set_size(k, querySet.n_cols);
 
   // Create the helper object for the tree traversal.
-  typedef RASearchRules<SortPolicy, DistanceType, Tree> RuleType;
+  using RuleType = RASearchRules<SortPolicy, DistanceType, Tree>;
   RuleType rules(*referenceSet, queryTree->Dataset(), k, distance, tau, alpha,
       naive, sampleAtLeaves, firstLeafExact, singleSampleLimit, false);
 
@@ -476,7 +476,7 @@ void RASearch<SortPolicy, DistanceType, MatType, TreeType>::Search(
   distancePtr->set_size(k, referenceSet->n_cols);
 
   // Create the helper object for the tree traversal.
-  typedef RASearchRules<SortPolicy, DistanceType, Tree> RuleType;
+  using RuleType = RASearchRules<SortPolicy, DistanceType, Tree>;
   RuleType rules(*referenceSet, *referenceSet, k, distance, tau, alpha, naive,
       sampleAtLeaves, firstLeafExact, singleSampleLimit, true /* same sets */);
 

--- a/src/mlpack/methods/rann/ra_search_rules.hpp
+++ b/src/mlpack/methods/rann/ra_search_rules.hpp
@@ -235,7 +235,7 @@ class RASearchRules
       return sum(numSamplesMade);
   }
 
-  typedef typename mlpack::TraversalInfo<TreeType> TraversalInfoType;
+  using TraversalInfoType = mlpack::TraversalInfo<TreeType>;
 
   const TraversalInfoType& TraversalInfo() const { return traversalInfo; }
   TraversalInfoType& TraversalInfo() { return traversalInfo; }
@@ -253,7 +253,7 @@ class RASearchRules
   const arma::mat& querySet;
 
   //! Candidate represents a possible candidate neighbor (distance, index).
-  typedef std::pair<double, size_t> Candidate;
+  using Candidate = std::pair<double, size_t>;
 
   //! Compare two candidates based on the distance.
   struct CandidateCmp {
@@ -264,8 +264,8 @@ class RASearchRules
   };
 
   //! Use a priority queue to represent the list of candidate neighbors.
-  typedef std::priority_queue<Candidate, std::vector<Candidate>, CandidateCmp>
-      CandidateList;
+  using CandidateList = std::priority_queue<Candidate, std::vector<Candidate>,
+      CandidateCmp>;
 
   //! Set of candidate neighbors for each point.
   std::vector<CandidateList> candidates;

--- a/src/mlpack/methods/rann/ra_typedef.hpp
+++ b/src/mlpack/methods/rann/ra_typedef.hpp
@@ -32,7 +32,7 @@ namespace mlpack {
  * while the search can be performed multiple times with different approximation
  * levels.
  */
-typedef RASearch<> KRANN;
+using KRANN = RASearch<>;
 
 /**
  * The KRAFN class is the k-rank-approximate-farthest-neighbors method.  It
@@ -43,7 +43,7 @@ typedef RASearch<> KRANN;
  * while the search can be performed multiple times with different approximation
  * levels.
  */
-typedef RASearch<FurthestNeighborSort> KRAFN;
+using KRAFN = RASearch<FurthestNeighborSort>;
 
 } // namespace mlpack
 

--- a/src/mlpack/methods/softmax_regression/softmax_regression.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression.hpp
@@ -58,10 +58,10 @@ template<typename MatType = arma::mat>
 class SoftmaxRegression
 {
  public:
-  typedef typename MatType::elem_type ElemType;
-  typedef typename GetDenseMatType<MatType>::type DenseMatType;
-  typedef typename GetDenseRowType<MatType>::type DenseRowType;
-  typedef typename GetDenseColType<MatType>::type DenseColType;
+  using ElemType = typename MatType::elem_type;
+  using DenseMatType = typename GetDenseMatType<MatType>::type;
+  using DenseRowType = typename GetDenseRowType<MatType>::type;
+  using DenseColType = typename GetDenseColType<MatType>::type;
 
   /**
    * Initialize the SoftmaxRegression without performing training.  Default

--- a/src/mlpack/methods/softmax_regression/softmax_regression_function.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_function.hpp
@@ -22,9 +22,9 @@ template<typename MatType = arma::mat>
 class SoftmaxRegressionFunction
 {
  public:
-  typedef typename MatType::elem_type ElemType;
-  typedef typename GetDenseMatType<MatType>::type DenseMatType;
-  typedef typename GetSparseMatType<MatType>::type SpMatType;
+  using ElemType = typename MatType::elem_type;
+  using DenseMatType = typename GetDenseMatType<MatType>::type;
+  using SpMatType = typename GetSparseMatType<MatType>::type;
 
   /**
    * Construct the Softmax Regression objective function with the given

--- a/src/mlpack/methods/sparse_coding/sparse_coding.hpp
+++ b/src/mlpack/methods/sparse_coding/sparse_coding.hpp
@@ -115,8 +115,8 @@ template<typename MatType = arma::mat>
 class SparseCoding
 {
  public:
-  typedef typename GetColType<MatType>::type ColType;
-  typedef typename GetRowType<MatType>::type RowType;
+  using ColType = typename GetColType<MatType>::type;
+  using RowType = typename GetRowType<MatType>::type;
 
   /**
    * Set the parameters to SparseCoding.  lambda2 defaults to 0.  This

--- a/src/mlpack/tests/adaboost_test.cpp
+++ b/src/mlpack/tests/adaboost_test.cpp
@@ -26,8 +26,8 @@ using namespace mlpack;
  */
 TEMPLATE_TEST_CASE("HammingLossBoundIris", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
 
@@ -47,8 +47,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundIris", "[AdaBoostTest]", mat, fmat)
   // Define parameters for AdaBoost.
   size_t iterations = 100;
   eT tolerance = 2e-10;
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   AdaBoost<PerceptronType, MatType> a;
   eT ztProduct = a.Train(inputData, labels.row(0), numClasses, iterations,
       tolerance, perceptronIter);
@@ -71,8 +71,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundIris", "[AdaBoostTest]", mat, fmat)
  */
 TEMPLATE_TEST_CASE("WeakLearnerErrorIris", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("iris.csv", inputData))
@@ -89,8 +89,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorIris", "[AdaBoostTest]", mat, fmat)
   int perceptronIter = 400;
 
   Row<size_t> perceptronPrediction(labels.n_cols);
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
   p.Classify(inputData, perceptronPrediction);
 
@@ -120,8 +120,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorIris", "[AdaBoostTest]", mat, fmat)
 TEMPLATE_TEST_CASE("HammingLossBoundVertebralColumn", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("vc2.csv", inputData))
@@ -136,8 +136,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundVertebralColumn", "[AdaBoostTest]", mat,
   // Define your own weak learner, perceptron in this case.
   // Run the perceptron for perceptronIter iterations.
   size_t perceptronIter = 800;
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
 
   // Define parameters for AdaBoost.
@@ -166,8 +166,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundVertebralColumn", "[AdaBoostTest]", mat,
 TEMPLATE_TEST_CASE("WeakLearnerErrorVertebralColumn", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("vc2.csv", inputData))
@@ -184,8 +184,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorVertebralColumn", "[AdaBoostTest]", mat,
   size_t perceptronIter = 800;
 
   Row<size_t> perceptronPrediction(labels.n_cols);
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
   p.Classify(inputData, perceptronPrediction);
 
@@ -215,8 +215,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorVertebralColumn", "[AdaBoostTest]", mat,
 TEMPLATE_TEST_CASE("HammingLossBoundNonLinearSepData", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("train_nonlinsep.txt", inputData))
@@ -231,8 +231,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundNonLinearSepData", "[AdaBoostTest]", mat,
   // Define your own weak learner, perceptron in this case.
   // Run the perceptron for perceptronIter iterations.
   size_t perceptronIter = 800;
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
 
   // Define parameters for AdaBoost.
@@ -261,8 +261,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundNonLinearSepData", "[AdaBoostTest]", mat,
 TEMPLATE_TEST_CASE("WeakLearnerErrorNonLinearSepData", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("train_nonlinsep.txt", inputData))
@@ -279,8 +279,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorNonLinearSepData", "[AdaBoostTest]", mat,
   size_t perceptronIter = 800;
 
   Row<size_t> perceptronPrediction(labels.n_cols);
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
   p.Classify(inputData, perceptronPrediction);
 
@@ -309,8 +309,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorNonLinearSepData", "[AdaBoostTest]", mat,
  */
 TEMPLATE_TEST_CASE("HammingLossIris_DS", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("iris.csv", inputData))
@@ -351,8 +351,8 @@ TEMPLATE_TEST_CASE("HammingLossIris_DS", "[AdaBoostTest]", mat, fmat)
  */
 TEMPLATE_TEST_CASE("WeakLearnerErrorIris_DS", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("iris.csv", inputData))
@@ -402,8 +402,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorIris_DS", "[AdaBoostTest]", mat, fmat)
 TEMPLATE_TEST_CASE("HammingLossBoundVertebralColumn_DS", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("vc2.csv", inputData))
@@ -448,8 +448,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundVertebralColumn_DS", "[AdaBoostTest]", mat,
 TEMPLATE_TEST_CASE("WeakLearnerErrorVertebralColumn_DS", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("vc2.csv", inputData))
@@ -494,8 +494,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorVertebralColumn_DS", "[AdaBoostTest]", mat,
 TEMPLATE_TEST_CASE("HammingLossBoundNonLinearSepData_DS", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("train_nonlinsep.txt", inputData))
@@ -540,8 +540,8 @@ TEMPLATE_TEST_CASE("HammingLossBoundNonLinearSepData_DS", "[AdaBoostTest]", mat,
 TEMPLATE_TEST_CASE("WeakLearnerErrorNonLinearSepData_DS", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("train_nonlinsep.txt", inputData))
@@ -587,8 +587,8 @@ TEMPLATE_TEST_CASE("WeakLearnerErrorNonLinearSepData_DS", "[AdaBoostTest]", mat,
  */
 TEMPLATE_TEST_CASE("ClassifyTest_VERTEBRALCOL", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("vc2.csv", inputData))
@@ -614,8 +614,8 @@ TEMPLATE_TEST_CASE("ClassifyTest_VERTEBRALCOL", "[AdaBoostTest]", mat, fmat)
   const size_t numClasses = max(labels.row(0)) + 1;
 
   Row<size_t> perceptronPrediction(labels.n_cols);
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
   p.Classify(inputData, perceptronPrediction);
 
@@ -661,8 +661,8 @@ TEMPLATE_TEST_CASE("ClassifyTest_VERTEBRALCOL", "[AdaBoostTest]", mat, fmat)
  */
 TEMPLATE_TEST_CASE("ClassifyTest_NONLINSEP", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("train_nonlinsep.txt", inputData))
@@ -732,8 +732,8 @@ TEMPLATE_TEST_CASE("ClassifyTest_NONLINSEP", "[AdaBoostTest]", mat, fmat)
  */
 TEMPLATE_TEST_CASE("ClassifyTest_IRIS", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   MatType inputData;
   if (!data::Load("iris_train.csv", inputData))
@@ -748,8 +748,8 @@ TEMPLATE_TEST_CASE("ClassifyTest_IRIS", "[AdaBoostTest]", mat, fmat)
   // Run the perceptron for perceptronIter iterations.
   size_t perceptronIter = 800;
 
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
 
   // Define parameters for AdaBoost.
@@ -803,8 +803,8 @@ TEMPLATE_TEST_CASE("ClassifyTest_IRIS", "[AdaBoostTest]", mat, fmat)
  */
 TEMPLATE_TEST_CASE("TrainTest", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   // First train on the iris dataset.
   MatType inputData;
@@ -818,8 +818,8 @@ TEMPLATE_TEST_CASE("TrainTest", "[AdaBoostTest]", mat, fmat)
   const size_t numClasses = max(labels.row(0)) + 1;
 
   size_t perceptronIter = 800;
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   PerceptronType p(inputData, labels.row(0), numClasses, perceptronIter);
 
   // Now train AdaBoost.
@@ -862,7 +862,7 @@ TEMPLATE_TEST_CASE("TrainTest", "[AdaBoostTest]", mat, fmat)
 
 TEMPLATE_TEST_CASE("PerceptronSerializationTest", "[AdaBoostTest]", fmat, mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Build an AdaBoost object.
   MatType data = randu<MatType>(10, 500);
@@ -872,8 +872,8 @@ TEMPLATE_TEST_CASE("PerceptronSerializationTest", "[AdaBoostTest]", fmat, mat)
   for (size_t i = 250; i < 500; ++i)
     labels[i] = 1;
 
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   AdaBoost<PerceptronType, MatType> ab(data, labels, 2, 50, 1e-10, 800);
 
   // Now create another dataset to train with.
@@ -919,7 +919,7 @@ TEMPLATE_TEST_CASE("PerceptronSerializationTest", "[AdaBoostTest]", fmat, mat)
 TEMPLATE_TEST_CASE("ID3DecisionStumpSerializationTest", "[AdaBoostTest]", mat,
     fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Build an AdaBoost object.
   MatType data = randu<MatType>(10, 500);
@@ -970,7 +970,7 @@ TEMPLATE_TEST_CASE("ID3DecisionStumpSerializationTest", "[AdaBoostTest]", mat,
 
 TEMPLATE_TEST_CASE("AdaBoostSinglePointClassify", "[AdaBoostTest]", mat, fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create random data.
   MatType data = randu<MatType>(10, 100);
@@ -978,8 +978,8 @@ TEMPLATE_TEST_CASE("AdaBoostSinglePointClassify", "[AdaBoostTest]", mat, fmat)
   Row<size_t> labels = randi<Row<size_t>>(100, distr_param(0, 3));
 
   // Train a model.
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   AdaBoost<PerceptronType, MatType> ab(data, labels, 4);
 
   // Ensure that we can get single-point classifications.
@@ -994,8 +994,8 @@ TEMPLATE_TEST_CASE("AdaBoostSinglePointClassify", "[AdaBoostTest]", mat, fmat)
 TEMPLATE_TEST_CASE("AdaBoostSinglePointClassifyWithProbs", "[AdaBoostTest]",
     mat, fmat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type eT;
+  using MatType = TestType;
+  using eT = typename MatType::elem_type;
 
   // Create random data.
   MatType data = randu<MatType>(10, 100);
@@ -1003,8 +1003,8 @@ TEMPLATE_TEST_CASE("AdaBoostSinglePointClassifyWithProbs", "[AdaBoostTest]",
   Row<size_t> labels = randi<Row<size_t>>(100, distr_param(0, 3));
 
   // Train a model.
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   AdaBoost<PerceptronType, MatType> ab(data, labels, 4);
 
   // Ensure that we can get single-point classifications.
@@ -1023,7 +1023,7 @@ TEMPLATE_TEST_CASE("AdaBoostSinglePointClassifyWithProbs", "[AdaBoostTest]",
 // hyperparameters.
 TEMPLATE_TEST_CASE("AdaBoostParamsConstructor", "[AdaBoostTest]", fmat, mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   MatType inputData;
   if (!data::Load("iris.csv", inputData))
@@ -1038,8 +1038,8 @@ TEMPLATE_TEST_CASE("AdaBoostParamsConstructor", "[AdaBoostTest]", fmat, mat)
   // Create two AdaBoost models.  One does not allow the perceptron to train for
   // more than one iteration, and therefore should get less accuracy than the
   // one we let train in full.
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
 
   AdaBoost<PerceptronType, MatType> a1(inputData, labels, numClasses, 2, 1e-6,
       1 /* perceptron max iterations */);
@@ -1061,15 +1061,15 @@ TEMPLATE_TEST_CASE("AdaBoostParamsConstructor", "[AdaBoostTest]", fmat, mat)
 // Ensure that all Train() overloads work correctly.
 TEMPLATE_TEST_CASE("AdaBoostTrainOverloads", "[AdaBoostTest]", fmat, mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create random data.
   MatType data = randu<MatType>(10, 100);
   // Create random labels.
   Row<size_t> labels = randi<Row<size_t>>(100, distr_param(0, 3));
 
-  typedef Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>
-      PerceptronType;
+  using PerceptronType =
+      Perceptron<SimpleWeightUpdate, ZeroInitialization, MatType>;
   AdaBoost<PerceptronType, MatType> a1, a2, a3, a4;
   a1.MaxIterations() = 65;
   a1.Tolerance() = 2e-4;

--- a/src/mlpack/tests/aknn_test.cpp
+++ b/src/mlpack/tests/aknn_test.cpp
@@ -292,8 +292,8 @@ TEST_CASE("AKNNSparseKNNKDTreeTest", "[AKNNTest]")
   arma::mat denseQuery(queryDataset);
   arma::mat denseReference(referenceDataset);
 
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::sp_mat,
-      KDTree> SparseKNN;
+  using SparseKNN = NeighborSearch<NearestNeighborSort, EuclideanDistance,
+      arma::sp_mat, KDTree>;
 
   SparseKNN aknn(referenceDataset, DUAL_TREE_MODE, 0.05);
   arma::mat distancesSparse;
@@ -316,7 +316,7 @@ TEST_CASE("AKNNSparseKNNKDTreeTest", "[AKNNTest]")
  */
 TEST_CASE("AKNNModelTest", "[AKNNTest]")
 {
-  typedef NSModel<NearestNeighborSort> KNNModel;
+  using KNNModel = NSModel<NearestNeighborSort>;
   util::Timers timers;
 
   arma::mat queryData = arma::randu<arma::mat>(10, 50);
@@ -404,7 +404,7 @@ TEST_CASE("AKNNModelTest", "[AKNNTest]")
  */
 TEST_CASE("AKNNModelMonochromaticTest", "[AKNNTest]")
 {
-  typedef NSModel<NearestNeighborSort> KNNModel;
+  using KNNModel = NSModel<NearestNeighborSort>;
   util::Timers timers;
 
   arma::mat referenceData = arma::randu<arma::mat>(10, 200);

--- a/src/mlpack/tests/ann/layer/repeat.cpp
+++ b/src/mlpack/tests/ann/layer/repeat.cpp
@@ -24,7 +24,7 @@ using namespace mlpack;
  */
 TEMPLATE_TEST_CASE("RepeatTestCaseI0", "[ANNLayerTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Input will be 4 x 3.
   MatType input(4, 3, arma::fill::randn);
@@ -66,7 +66,7 @@ TEMPLATE_TEST_CASE("RepeatTestCaseI0", "[ANNLayerTest]", arma::mat, arma::fmat)
  */
 TEMPLATE_TEST_CASE("RepeatTestCaseI1", "[ANNLayerTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Input will be 4 x 3.
   MatType input(4, 3, arma::fill::randn);
@@ -108,7 +108,7 @@ TEMPLATE_TEST_CASE("RepeatTestCaseI1", "[ANNLayerTest]", arma::mat, arma::fmat)
  */
 TEMPLATE_TEST_CASE("RepeatTestCaseI2", "[ANNLayerTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Input will be 4 x 3.
   MatType input(4, 3, arma::fill::randn);
@@ -156,7 +156,7 @@ TEMPLATE_TEST_CASE("RepeatTestCaseI2", "[ANNLayerTest]", arma::mat, arma::fmat)
  */
 TEMPLATE_TEST_CASE("RepeatTestCaseB1", "[ANNLayerTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Input will be 4 x 3.
   MatType input(4, 3, arma::fill::randn);
@@ -195,7 +195,7 @@ TEMPLATE_TEST_CASE("RepeatTestCaseB1", "[ANNLayerTest]", arma::mat, arma::fmat)
  */
 TEMPLATE_TEST_CASE("RepeatTestCaseB2", "[ANNLayerTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Input will be 4 x 3.
   MatType input(4, 3, arma::fill::randn);
@@ -234,7 +234,7 @@ TEMPLATE_TEST_CASE("RepeatTestCaseB2", "[ANNLayerTest]", arma::mat, arma::fmat)
  */
 TEMPLATE_TEST_CASE("RepeatTestCaseB3", "[ANNLayerTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Input will be 4 x 3.
   MatType input(4, 3, arma::fill::randn);
@@ -288,7 +288,7 @@ template <> struct GradientBound<arma::fmat>
 TEMPLATE_TEST_CASE("GradientRepeatTest", "[ANNLayerTest]", arma::mat,
     arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
   struct GradientFunction
   {
     GradientFunction(std::vector<size_t> multiples, bool interleave) :

--- a/src/mlpack/tests/ann/recurrent_network_test.cpp
+++ b/src/mlpack/tests/ann/recurrent_network_test.cpp
@@ -34,7 +34,7 @@ void GenerateNoisySines(arma::cube& data,
                         const size_t sequences,
                         const double noise = 0.3)
 {
-  arma::colvec x =  arma::linspace<arma::colvec>(0, points - 1, points) /
+  arma::colvec x = arma::linspace<arma::colvec>(0, points - 1, points) /
       points * 20.0;
   arma::colvec y1 = arma::sin(x + randu() * 3.0);
   arma::colvec y2 = arma::sin(x / 2.0 + randu() * 3.0);

--- a/src/mlpack/tests/bayesian_linear_regression_test.cpp
+++ b/src/mlpack/tests/bayesian_linear_regression_test.cpp
@@ -211,7 +211,7 @@ TEST_CASE("EqualtoRidge", "[BayesianLinearRegressionTest]")
 TEMPLATE_TEST_CASE("BayesianLinearRegressionConstructorVariantTest",
     "[BayesianLinearRegressionTest]", arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   MatType matX;
   arma::Row<typename MatType::elem_type> y;
@@ -278,7 +278,7 @@ TEMPLATE_TEST_CASE("BayesianLinearRegressionConstructorVariantTest",
 TEMPLATE_TEST_CASE("BayesianLinearRegressionTrainVariantTest",
     "[BayesianLinearRegressionTest]", arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   MatType matX;
   arma::Row<typename MatType::elem_type> y;

--- a/src/mlpack/tests/cli_binding_test.cpp
+++ b/src/mlpack/tests/cli_binding_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("GetParamLoadedMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  typedef std::tuple<string, size_t, size_t> TupleType;
+  using TupleType = std::tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::mat, TupleType> tuple = make_tuple(m, testTuple);
   d.value = tuple;
@@ -137,7 +137,7 @@ TEST_CASE("GetParamUnloadedMatTest", "[CLIOptionTest]")
   arma::mat test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::mat m;
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::mat, TupleType> tuple = make_tuple(m, testTuple);
   d.value = tuple;
@@ -165,7 +165,7 @@ TEST_CASE("GetParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::Mat<size_t> m(5, 5, arma::fill::ones);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::Mat<size_t>, TupleType> tuple = make_tuple(m, testTuple);
   d.value = tuple;
@@ -192,7 +192,7 @@ TEST_CASE("GetParamUnloadedUmatTest", "[CLIOptionTest]")
   arma::Mat<size_t> test(5, 5, arma::fill::ones);
   data::Save("test.csv", test);
   arma::Mat<size_t> m;
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::Mat<size_t>, TupleType> tuple = make_tuple(m, testTuple);
   d.value = tuple;
@@ -236,7 +236,7 @@ TEST_CASE("GetParamDatasetInfoMatTest", "[CLIOptionTest]")
   data::DatasetInfo dd;
   arma::mat m;
 
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
   tuple<decltype(tuple1), TupleType> tuple2 = make_tuple(tuple1, testTuple);
@@ -313,7 +313,7 @@ TEST_CASE("RawParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::ones);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::mat, TupleType> tuple = make_tuple(m, testTuple);
   d.value = tuple;
@@ -363,7 +363,7 @@ TEST_CASE("GetRawParamDatasetInfoTest", "[CLIOptionTest]")
   // Create tuples.
   data::DatasetInfo dd(3);
   arma::mat m(3, 3, arma::fill::randu);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<data::DatasetInfo, arma::mat> tuple1 = make_tuple(dd, m);
   tuple<decltype(tuple1), TupleType> tuple2 = make_tuple(tuple1, testTuple);
@@ -392,7 +392,7 @@ TEST_CASE("OutputParamMatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::mat m(3, 3, arma::fill::randu);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::mat, TupleType> t = make_tuple(m, testTuple);
 
@@ -420,7 +420,7 @@ TEST_CASE("OutputParamUmatTest", "[CLIOptionTest]")
   // Create value.
   string filename = "test.csv";
   arma::Mat<size_t> m(3, 3, arma::fill::randu);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::Mat<size_t>, TupleType> t = make_tuple(m, testTuple);
 
@@ -513,7 +513,7 @@ TEST_CASE("SetParamMatrixTest", "[CLIOptionTest]")
   // Create initial value.
   string filename = "hello.csv";
   arma::mat m(5, 5, arma::fill::randu);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   d.value = make_tuple(m, testTuple);
 
@@ -565,7 +565,7 @@ TEST_CASE("SetParamDatasetInfoMatTest", "[CLIOptionTest]")
   string filename = "test.csv";
   arma::mat m(3, 3, arma::fill::randu);
   DatasetInfo di(3);
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<DatasetInfo, arma::mat> t1 = make_tuple(di, m);
   tuple<tuple<DatasetInfo, arma::mat>, TupleType> t2 = make_tuple(t1,
@@ -608,7 +608,7 @@ TEST_CASE("GetAllocatedMemoryNonModelTest", "[CLIOptionTest]")
   // Also test with a matrix type.
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::mat, TupleType> t = make_tuple(test, testTuple);
   d.value = t;
@@ -656,7 +656,7 @@ TEST_CASE("DeleteAllocatedMemoryNonModelTest", "[CLIOptionTest]")
 
   arma::mat test(10, 10, arma::fill::ones);
   string filename = "test.csv";
-  typedef tuple<string, size_t, size_t> TupleType;
+  using TupleType = tuple<string, size_t, size_t>;
   TupleType testTuple{filename, 0, 0};
   tuple<arma::mat, TupleType> t = make_tuple(test, testTuple);
   d.value = t;

--- a/src/mlpack/tests/decision_tree_regressor_test.cpp
+++ b/src/mlpack/tests/decision_tree_regressor_test.cpp
@@ -1194,7 +1194,7 @@ TEST_CASE("CategoricalMADGainWeightedBuildTest", "[DecisionTreeRegressorTest]")
 TEMPLATE_TEST_CASE("SimpleGeneralizationTest_",
     "[DecisionTreeRegressorTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Allow three trials.
   bool success = false;

--- a/src/mlpack/tests/det_test.cpp
+++ b/src/mlpack/tests/det_test.cpp
@@ -267,7 +267,7 @@ TEST_CASE("TestGrow", "[DETTest]")
   rootError = -log(4.0) - log(7.0) - log(7.0);
 
   lError = 2 * log(2.0 / 5.0) - (log(7.0) + log(4.0) + log(4.5));
-  rError =  2 * log(3.0 / 5.0) - (log(7.0) + log(4.0) + log(2.5));
+  rError = 2 * log(3.0 / 5.0) - (log(7.0) + log(4.0) + log(2.5));
 
   rlError = 2 * log(1.0 / 5.0) - (log(0.5) + log(4.0) + log(2.5));
   rrError = 2 * log(2.0 / 5.0) - (log(6.5) + log(4.0) + log(2.5));
@@ -396,7 +396,7 @@ TEST_CASE("TestVariableImportance", "[DETTest]")
   rootError = -1.0 * exp(-log(4.0) - log(7.0) - log(7.0));
 
   lError = -1.0 * exp(2 * log(2.0 / 5.0) - (log(7.0) + log(4.0) + log(4.5)));
-  rError =  -1.0 * exp(2 * log(3.0 / 5.0) - (log(7.0) + log(4.0) + log(2.5)));
+  rError = -1.0 * exp(2 * log(3.0 / 5.0) - (log(7.0) + log(4.0) + log(2.5)));
 
   rlError = -1.0 * exp(2 * log(1.0 / 5.0) - (log(0.5) + log(4.0) + log(2.5)));
   rrError = -1.0 * exp(2 * log(2.0 / 5.0) - (log(6.5) + log(4.0) + log(2.5)));

--- a/src/mlpack/tests/distance_test.cpp
+++ b/src/mlpack/tests/distance_test.cpp
@@ -108,7 +108,7 @@ TEST_CASE("LMetricZerosTest", "[DistanceTest]")
  */
 TEMPLATE_TEST_CASE("MDUnsetCovarianceTest", "[DistanceTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   MahalanobisDistance<false, arma::Mat<eT>> md;
   md.Q() = arma::eye<arma::Mat<eT>>(4, 4);
@@ -125,7 +125,7 @@ TEMPLATE_TEST_CASE("MDUnsetCovarianceTest", "[DistanceTest]", float, double)
  */
 TEMPLATE_TEST_CASE("MDRootUnsetCovarianceTest", "[DistanceTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   MahalanobisDistance<true, arma::Mat<eT>> md;
   md.Q() = arma::eye<arma::Mat<eT>>(4, 4);
@@ -142,7 +142,7 @@ TEMPLATE_TEST_CASE("MDRootUnsetCovarianceTest", "[DistanceTest]", float, double)
  */
 TEMPLATE_TEST_CASE("MDEyeCovarianceTest", "[DistanceTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   MahalanobisDistance<false, arma::Mat<eT>> md(4);
   arma::Col<eT> a = "1.0 2.0 2.0 3.0";
@@ -158,7 +158,7 @@ TEMPLATE_TEST_CASE("MDEyeCovarianceTest", "[DistanceTest]", float, double)
  */
 TEMPLATE_TEST_CASE("MDRootEyeCovarianceTest", "[DistanceTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   MahalanobisDistance<true, arma::Mat<eT>> md(4);
   arma::Col<eT> a = "1.0 2.0 2.5 5.0";
@@ -173,7 +173,7 @@ TEMPLATE_TEST_CASE("MDRootEyeCovarianceTest", "[DistanceTest]", float, double)
  */
 TEMPLATE_TEST_CASE("MDDiagonalCovarianceTest", "[DistanceTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   arma::Mat<eT> q = arma::eye<arma::Mat<eT>>(5, 5);
   q(0, 0) = 2.0;
@@ -195,7 +195,7 @@ TEMPLATE_TEST_CASE("MDDiagonalCovarianceTest", "[DistanceTest]", float, double)
  */
 TEMPLATE_TEST_CASE("MDFullCovarianceTest", "[DistanceTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   arma::Mat<eT> q = "1.0 2.0 3.0 4.0;"
                     "0.5 0.6 0.7 0.1;"

--- a/src/mlpack/tests/distribution_test.cpp
+++ b/src/mlpack/tests/distribution_test.cpp
@@ -36,10 +36,10 @@ TEMPLATE_TEST_CASE("DiscreteDistributionConstructorTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d(5);
 
@@ -61,10 +61,10 @@ TEMPLATE_TEST_CASE("DiscreteDistributionProbabilityTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d(5);
 
@@ -87,11 +87,11 @@ TEMPLATE_TEST_CASE("DiscreteDistributionRandomTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d(arma::Col<size_t>("3"));
 
@@ -123,10 +123,10 @@ TEMPLATE_TEST_CASE("DiscreteDistributionTrainTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d(4);
 
@@ -150,11 +150,11 @@ TEMPLATE_TEST_CASE("DiscreteDistributionTrainProbTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d(3);
 
@@ -179,10 +179,10 @@ TEMPLATE_TEST_CASE("MultiDiscreteDistributionTrainProbTest",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d("10 10 10");
 
@@ -208,10 +208,10 @@ TEMPLATE_TEST_CASE("MultiDiscreteDistributionConstructorTest",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d("4 4 4 4");
 
@@ -231,11 +231,11 @@ TEMPLATE_TEST_CASE("MultiDiscreteDistributionTrainTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   std::vector<VecType> pro;
   pro.push_back(VecType("0.1, 0.3, 0.6"));
@@ -261,11 +261,11 @@ TEMPLATE_TEST_CASE("MultiDiscreteDistributionTrainProTest",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   DiscreteDistribution<MatType, ObsMatType> d("5 5 5");
 
@@ -293,11 +293,11 @@ TEMPLATE_TEST_CASE("DiscreteLogProbabilityTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   // Same case as before.
   DiscreteDistribution<MatType, ObsMatType> d("5 5");
@@ -326,11 +326,11 @@ TEMPLATE_TEST_CASE("DiscreteProbabilityTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   // Same case as before.
   DiscreteDistribution<MatType, ObsMatType> d("5 5");
@@ -358,7 +358,7 @@ TEMPLATE_TEST_CASE("DiscreteProbabilityTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GaussianDistributionEmptyConstructor", "[DistributionTest]",
     float, double)
 {
-  typedef typename arma::Mat<TestType> MatType;
+  using MatType = arma::Mat<TestType>;
 
   GaussianDistribution<MatType> d;
 
@@ -373,7 +373,7 @@ TEMPLATE_TEST_CASE("GaussianDistributionEmptyConstructor", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GaussianDistributionDimensionalityConstructor",
                    "[DistributionTest]", float, double)
 {
-  typedef typename arma::Mat<TestType> MatType;
+  using MatType = arma::Mat<TestType>;
 
   GaussianDistribution<MatType> d(4);
 
@@ -389,9 +389,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionDimensionalityConstructor",
 TEMPLATE_TEST_CASE("GaussianDistributionDistributionConstructor",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean(3);
   MatType covariance(3, 3);
@@ -417,9 +417,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionDistributionConstructor",
 TEMPLATE_TEST_CASE("GaussianDistributionProbabilityTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean("5 6 3 3 2");
   MatType cov("6 1 1 1 2;"
@@ -450,9 +450,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionProbabilityTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GaussianUnivariateProbabilityTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
@@ -496,9 +496,9 @@ TEMPLATE_TEST_CASE("GaussianUnivariateProbabilityTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GaussianMultivariateProbabilityTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
@@ -569,9 +569,9 @@ TEMPLATE_TEST_CASE("GaussianMultivariateProbabilityTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GaussianMultipointMultivariateProbabilityTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   // Same case as before.
   VecType mean = "5 6 3 3 2";
@@ -607,9 +607,9 @@ TEMPLATE_TEST_CASE("GaussianMultipointMultivariateProbabilityTest",
 TEMPLATE_TEST_CASE("GaussianDistributionRandomTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.3 : 0.125;
 
@@ -644,9 +644,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionRandomTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GaussianDistributionTrainTest", "[DistributionTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-3 : 1e-5;
 
@@ -691,9 +691,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionTrainTest", "[DistributionTest]", float,
 TEMPLATE_TEST_CASE("GaussianDistributionTrainWithProbabilitiesTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.25 : 0.1;
 
@@ -735,9 +735,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionTrainWithProbabilitiesTest",
 TEMPLATE_TEST_CASE("GaussianDistributionWithProbabilties1Test",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol1 = (std::is_same_v<ElemType, float>) ? 1e-10 : 1e-17;
   const ElemType tol2 = (std::is_same_v<ElemType, float>) ? 1e-2 : 1e-4;
@@ -779,9 +779,9 @@ TEMPLATE_TEST_CASE("GaussianDistributionWithProbabilties1Test",
 TEMPLATE_TEST_CASE("GaussianDistributionTrainWithTwoDistProbabilitiesTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean1 = ("5.0");
   VecType cov1 = ("4.0");
@@ -836,8 +836,8 @@ TEMPLATE_TEST_CASE("GaussianDistributionTrainWithTwoDistProbabilitiesTest",
 TEMPLATE_TEST_CASE("GammaDistributionTrainTest", "[DistributionTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
 
   // Create a gamma distribution random generator.
   ElemType alphaReal = 5.3;
@@ -887,9 +887,9 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainTest", "[DistributionTest]", float,
 TEMPLATE_TEST_CASE("GammaDistributionTrainWithProbabilitiesTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.03 : 0.015;
 
@@ -938,9 +938,9 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainWithProbabilitiesTest",
 TEMPLATE_TEST_CASE("GammaDistributionTrainAllProbabilities1Test",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   ElemType alphaReal = 5.4;
   ElemType betaReal = 6.7;
@@ -982,9 +982,9 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainAllProbabilities1Test",
 TEMPLATE_TEST_CASE("GammaDistributionTrainTwoDistProbabilities1Test",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.25 : 0.075;
 
@@ -1042,8 +1042,8 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainTwoDistProbabilities1Test",
 TEMPLATE_TEST_CASE("GammaDistributionFittingTest", "[DistributionTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
 
   // Offset from the actual alpha/beta. 10% is quite a relaxed tolerance since
   // the random points we generate are few (for test speed) and might be fitted
@@ -1103,8 +1103,8 @@ TEMPLATE_TEST_CASE("GammaDistributionFittingTest", "[DistributionTest]", float,
 TEMPLATE_TEST_CASE("GammaDistributionTrainConstructorTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
 
   const MatType data = arma::randu<MatType>(10, 500);
 
@@ -1126,9 +1126,9 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainConstructorTest",
 TEMPLATE_TEST_CASE("GammaDistributionTrainStatisticsTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const MatType data = arma::randu<MatType>(1, 500);
 
@@ -1153,9 +1153,9 @@ TEMPLATE_TEST_CASE("GammaDistributionTrainStatisticsTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GammaDistributionRandomTest", "[DistributionTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const VecType a("2.0 2.5 3.0"), b("0.4 0.6 1.3");
   const size_t numPoints = 4000;
@@ -1179,9 +1179,9 @@ TEMPLATE_TEST_CASE("GammaDistributionRandomTest", "[DistributionTest]", float,
 TEMPLATE_TEST_CASE("GammaDistributionProbabilityTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   // Train two 1-dimensional distributions.
   const VecType a1("2.0"), b1("0.9"), a2("3.1"), b2("1.4");
@@ -1220,9 +1220,9 @@ TEMPLATE_TEST_CASE("GammaDistributionProbabilityTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("GammaDistributionLogProbabilityTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   // Train two 1-dimensional distributions.
   const VecType a1("2.0"), b1("0.9"), a2("3.1"), b2("1.4");
@@ -1268,12 +1268,12 @@ TEMPLATE_TEST_CASE("DiscreteDistributionTest", "[DistributionTest]",
     (std::pair<float, size_t>),
     (std::pair<float, unsigned short>))
 {
-  typedef typename TestType::first_type ElemType;
-  typedef typename TestType::second_type ObsElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Col<ObsElemType> ObsVecType;
-  typedef typename arma::Mat<ObsElemType> ObsMatType;
+  using ElemType = typename TestType::first_type;
+  using ObsElemType = typename TestType::second_type;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
+  using ObsVecType = arma::Col<ObsElemType>;
+  using ObsMatType = arma::Mat<ObsElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-8;
 
@@ -1373,9 +1373,9 @@ TEST_CASE("GaussianDistributionTest", "[DistributionTest]")
 TEMPLATE_TEST_CASE("LaplaceDistributionTest", "[DistributionTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef arma::Col<ElemType> VecType;
-  typedef arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean(20);
   mean.randu();
@@ -1398,9 +1398,9 @@ TEMPLATE_TEST_CASE("LaplaceDistributionTest", "[DistributionTest]", float,
 TEMPLATE_TEST_CASE("LaplaceDistributionProbabilityTest", "[DistributionTest]",
     float, double)
 {
-  typedef TestType ElemType;
-  typedef arma::Col<ElemType> VecType;
-  typedef arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   LaplaceDistribution<MatType> l(VecType("0.0"), 1.0);
 
@@ -1428,9 +1428,9 @@ TEMPLATE_TEST_CASE("LaplaceDistributionProbabilityTest", "[DistributionTest]",
 TEMPLATE_TEST_CASE("LaplaceDistributionLogProbabilityTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef arma::Col<ElemType> VecType;
-  typedef arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   LaplaceDistribution<MatType> l(VecType("0.0"), 1.0);
 
@@ -1513,7 +1513,7 @@ TEST_CASE("RegressionDistributionTest", "[DistributionTest]")
 TEMPLATE_TEST_CASE("DiagonalGaussianDistributionEmptyConstructor",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   DiagonalGaussianDistribution<arma::Mat<ElemType>> d;
 
@@ -1528,7 +1528,7 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionEmptyConstructor",
 TEMPLATE_TEST_CASE("DiagonalGaussianDistributionDimensionalityConstructor",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   DiagonalGaussianDistribution<arma::Mat<ElemType>> d(4);
 
@@ -1543,9 +1543,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionDimensionalityConstructor",
 TEMPLATE_TEST_CASE("DiagonalGaussianDistributionConstructor",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean = arma::randu<VecType>(3);
   VecType covariance = arma::randu<VecType>(3);
@@ -1567,9 +1567,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionConstructor",
 TEMPLATE_TEST_CASE("DiagonalGaussianDistributionProbabilityTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean("2 5 3 4 1");
   VecType cov("3 1 5 3 2");
@@ -1596,9 +1596,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionProbabilityTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianUnivariateProbabilityTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
@@ -1636,9 +1636,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianUnivariateProbabilityTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianMultivariateProbabilityTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
@@ -1671,9 +1671,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianMultivariateProbabilityTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianMultipointMultivariateProbabilityTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   VecType mean = "2 5 3 7 2";
   VecType cov("9 2 1 4 8");
@@ -1702,9 +1702,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianMultipointMultivariateProbabilityTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianDistributionRandomTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 0.2 : 0.1;
 
@@ -1735,9 +1735,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionRandomTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianDistributionTrainTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-3 : 1e-5;
 
@@ -1774,9 +1774,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianDistributionTrainTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianUnbiasedEstimatorTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 
@@ -1812,9 +1812,9 @@ TEMPLATE_TEST_CASE("DiagonalGaussianUnbiasedEstimatorTest",
 TEMPLATE_TEST_CASE("DiagonalGaussianWeightedParametersReductionTest",
     "[DistributionTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   const ElemType tol = (std::is_same_v<ElemType, float>) ? 1e-4 : 1e-7;
 

--- a/src/mlpack/tests/emst_test.cpp
+++ b/src/mlpack/tests/emst_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("EMSTExhaustiveSyntheticTest", "[EMSTTest]")
   arma::mat results;
 
   // Build the tree by hand to get a leaf size of 1.
-  typedef KDTree<EuclideanDistance, DTBStat, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, DTBStat, arma::mat>;
   std::vector<size_t> oldFromNew;
   std::vector<size_t> newFromOld;
   TreeType tree(data, oldFromNew, newFromOld, 1);

--- a/src/mlpack/tests/hoeffding_tree_test.cpp
+++ b/src/mlpack/tests/hoeffding_tree_test.cpp
@@ -548,8 +548,8 @@ TEST_CASE("HoeffdingTreeSimpleDatasetTest", "[HoeffdingTreeTest]")
 
   // Now train two streaming decision trees; one on the whole dataset, and one
   // on streaming data.
-  typedef HoeffdingTree<GiniImpurity, HoeffdingSizeTNumericSplit,
-      HoeffdingCategoricalSplit> TreeType;
+  using TreeType = HoeffdingTree<GiniImpurity, HoeffdingSizeTNumericSplit,
+      HoeffdingCategoricalSplit>;
   TreeType batchTree(dataset, info, labels, 3, false);
   TreeType streamTree(info, 3);
   for (size_t i = 0; i < 9000; ++i)
@@ -594,7 +594,7 @@ TEST_CASE("NumDescendantsTest1", "[HoeffdingTreeTest]")
   }
 
   // Now train streaming decision tree;
-  typedef HoeffdingTree<GiniImpurity, HoeffdingDoubleNumericSplit> TreeType;
+  using TreeType = HoeffdingTree<GiniImpurity, HoeffdingDoubleNumericSplit>;
   TreeType streamTree(info, 3);
   for (size_t i = 0; i < 500; ++i)
     streamTree.Train(dataset.col(i), labels[i]);
@@ -643,8 +643,8 @@ TEST_CASE("NumDescendantsTest2", "[HoeffdingTreeTest]")
 
   // Now train the streaming decision tree.  This should split because splitting
   // on dimension 2 gives a perfect split.
-  typedef HoeffdingTree<GiniImpurity, HoeffdingSizeTNumericSplit,
-      HoeffdingCategoricalSplit> TreeType;
+  using TreeType = HoeffdingTree<GiniImpurity, HoeffdingSizeTNumericSplit,
+      HoeffdingCategoricalSplit>;
   TreeType batchTree(dataset, info, labels, 3, false);
 
   REQUIRE(batchTree.NumDescendants() == 3);
@@ -836,7 +836,7 @@ TEST_CASE("NumericHoeffdingTreeTest", "[HoeffdingTreeTest]")
 
   // Now train two streaming decision trees; one on the whole dataset, and one
   // on streaming data.
-  typedef HoeffdingTree<GiniImpurity, HoeffdingDoubleNumericSplit> TreeType;
+  using TreeType = HoeffdingTree<GiniImpurity, HoeffdingDoubleNumericSplit>;
   TreeType batchTree(dataset, info, labels, 3, false);
   TreeType streamTree(info, 3);
   for (size_t i = 0; i < 9000; ++i)
@@ -905,7 +905,7 @@ TEST_CASE("BinaryNumericHoeffdingTreeTest", "[HoeffdingTreeTest]")
 
   // Now train two streaming decision trees; one on the whole dataset, and one
   // on streaming data.
-  typedef HoeffdingTree<GiniImpurity, BinaryDoubleNumericSplit> TreeType;
+  using TreeType = HoeffdingTree<GiniImpurity, BinaryDoubleNumericSplit>;
   TreeType batchTree(dataset, info, labels, 3, false);
   TreeType streamTree(info, 3);
   for (size_t i = 0; i < 9000; ++i)

--- a/src/mlpack/tests/io_test.cpp
+++ b/src/mlpack/tests/io_test.cpp
@@ -1084,7 +1084,7 @@ TEST_CASE("MatrixAndDatasetInfoTest", "[IOTest]")
   f.close();
 
   // Add options.
-  typedef tuple<DatasetInfo, arma::mat> TupleType;
+  using TupleType = tuple<DatasetInfo, arma::mat>;
   #define BINDING_NAME MatrixAndDatasetInfoTest
   PARAM_MATRIX_AND_INFO_IN("dataset", "Test dataset", "d");
   #undef BINDING_NAME

--- a/src/mlpack/tests/kde_test.cpp
+++ b/src/mlpack/tests/kde_test.cpp
@@ -100,7 +100,7 @@ TEST_CASE("KDETreeAsArguments", "[KDETest]")
                                 kernel);
 
   // Get dual-tree results.
-  typedef KDTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = KDTree<EuclideanDistance, KDEStat, arma::mat>;
   std::vector<size_t> oldFromNewQueries, oldFromNewReferences;
   Tree* queryTree = new Tree(query, oldFromNewQueries, 2);
   Tree* referenceTree = new Tree(reference, oldFromNewReferences, 2);
@@ -295,7 +295,7 @@ TEST_CASE("BallTreeGaussianKDETest", "[KDETest]")
                                 kernel);
 
   // BallTree KDE.
-  typedef BallTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = BallTree<EuclideanDistance, KDEStat, arma::mat>;
   std::vector<size_t> oldFromNewQueries, oldFromNewReferences;
   Tree* queryTree = new Tree(query, oldFromNewQueries, 2);
   Tree* referenceTree = new Tree(reference, oldFromNewReferences, 2);
@@ -467,7 +467,7 @@ TEST_CASE("DuplicatedReferenceSampleKDETest", "[KDETest]")
                                 kernel);
 
   // Dual-tree KDE.
-  typedef KDTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = KDTree<EuclideanDistance, KDEStat, arma::mat>;
   std::vector<size_t> oldFromNewQueries, oldFromNewReferences;
   Tree* queryTree = new Tree(query, oldFromNewQueries, 2);
   Tree* referenceTree = new Tree(reference, oldFromNewReferences, 2);
@@ -502,7 +502,7 @@ TEST_CASE("DuplicatedQuerySampleKDETest", "[KDETest]")
   query.col(2) = query.col(3);
 
   // Dual-tree KDE.
-  typedef KDTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = KDTree<EuclideanDistance, KDEStat, arma::mat>;
   std::vector<size_t> oldFromNewQueries, oldFromNewReferences;
   Tree* queryTree = new Tree(query, oldFromNewQueries, 2);
   Tree* referenceTree = new Tree(reference, oldFromNewReferences, 2);
@@ -611,7 +611,7 @@ TEST_CASE("EmptyReferenceTest", "[KDETest]")
 
   // When training using a tree.
   std::vector<size_t> oldFromNewReferences;
-  typedef KDTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = KDTree<EuclideanDistance, KDEStat, arma::mat>;
   Tree* referenceTree = new Tree(reference, oldFromNewReferences, 2);
   REQUIRE_THROWS_AS(
       kde.Train(referenceTree, &oldFromNewReferences), std::invalid_argument);
@@ -644,7 +644,7 @@ TEST_CASE("EvaluationMatchDimensionsTest", "[KDETest]")
                     std::invalid_argument);
 
   // When evaluating using a query tree.
-  typedef KDTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = KDTree<EuclideanDistance, KDEStat, arma::mat>;
   std::vector<size_t> oldFromNewQueries;
   Tree* queryTree = new Tree(query, oldFromNewQueries, 3);
   REQUIRE_THROWS_AS(kde.Evaluate(queryTree, oldFromNewQueries, estimations),
@@ -679,7 +679,7 @@ TEST_CASE("EmptyQuerySetTest", "[KDETest]")
   REQUIRE_NOTHROW(kde.Evaluate(query, estimations));
 
   // When evaluating using a query tree.
-  typedef KDTree<EuclideanDistance, KDEStat, arma::mat> Tree;
+  using Tree = KDTree<EuclideanDistance, KDEStat, arma::mat>;
   std::vector<size_t> oldFromNewQueries;
   Tree* queryTree = new Tree(query, oldFromNewQueries, 3);
   REQUIRE_NOTHROW(
@@ -718,7 +718,7 @@ TEST_CASE("KDESerializationTest", "[KDETest]")
   kde.Train(reference);
 
   // Get estimations to compare.
-  arma::mat query = arma::randu(4, 100);;
+  arma::mat query = arma::randu(4, 100);
   arma::vec estimations = arma::vec(query.n_cols);
   kde.Evaluate(query, estimations);
 
@@ -802,7 +802,7 @@ TEST_CASE("CopyConstructor", "[KDETest]")
   const double kernelBandwidth = 1.5;
   const double relError = 0.05;
 
-  typedef KDE<GaussianKernel, EuclideanDistance, arma::mat> KDEType;
+  using KDEType = KDE<GaussianKernel, EuclideanDistance, arma::mat>;
 
   // KDE.
   KDEType kde(relError, 0, GaussianKernel(kernelBandwidth));
@@ -838,8 +838,7 @@ TEST_CASE("MoveConstructor", "[KDETest]")
   const double kernelBandwidth = 1.2;
   const double relError = 0.05;
 
-  typedef KDE<EpanechnikovKernel, EuclideanDistance, arma::mat>
-      KDEType;
+  using KDEType = KDE<EpanechnikovKernel, EuclideanDistance, arma::mat>;
 
   // KDE.
   KDEType kde(relError, 0, EpanechnikovKernel(kernelBandwidth));

--- a/src/mlpack/tests/kfn_test.cpp
+++ b/src/mlpack/tests/kfn_test.cpp
@@ -39,8 +39,8 @@ TEST_CASE("KFNExhaustiveSyntheticTest", "[KFNTest]")
   data[9] = 0.90;
   data[10] = 1.00;
 
-  typedef BinarySpaceTree<EuclideanDistance,
-      NeighborSearchStat<FurthestNeighborSort>, arma::mat> TreeType;
+  using TreeType = BinarySpaceTree<EuclideanDistance,
+      NeighborSearchStat<FurthestNeighborSort>, arma::mat>;
 
   // We will loop through three times, one for each method of performing the
   // calculation.  We'll always use 10 neighbors, so set that parameter.
@@ -470,8 +470,8 @@ TEST_CASE("KFNDualCoverTreeTest", "[KFNTest]")
   arma::mat kdDistances;
   tree.Search(dataset, 5, kdNeighbors, kdDistances);
 
-  typedef CoverTree<LMetric<2, true>, NeighborSearchStat<FurthestNeighborSort>,
-      arma::mat, FirstPointIsRoot> TreeType;
+  using TreeType = CoverTree<LMetric<2, true>,
+      NeighborSearchStat<FurthestNeighborSort>, arma::mat, FirstPointIsRoot>;
 
   TreeType referenceTree(dataset);
 
@@ -500,8 +500,8 @@ TEST_CASE("KFNSingleBallTreeTest", "[KFNTest]")
   arma::mat data;
   data.randu(75, 1000); // 75 dimensional, 1000 points.
 
-  typedef BallTree<EuclideanDistance, NeighborSearchStat<FurthestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = BallTree<EuclideanDistance,
+      NeighborSearchStat<FurthestNeighborSort>, arma::mat>;
   TreeType tree(data);
 
   KFN naive(tree.Dataset(), NAIVE_MODE);

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -363,8 +363,8 @@ TEST_CASE("KNNExhaustiveSyntheticTest", "[KNNTest]")
   data[9] = 0.90;
   data[10] = 1.00;
 
-  typedef KDTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   // We will loop through three times, one for each method of performing the
   // calculation.
@@ -864,8 +864,8 @@ TEST_CASE("KNNSingleBallTreeTest", "[KNNTest]")
   arma::mat data;
   data.randu(50, 300); // 50 dimensional, 300 points.
 
-  typedef BallTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = BallTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType tree(data);
 
   KNN naive(tree.Dataset(), NAIVE_MODE);
@@ -1030,8 +1030,8 @@ TEST_CASE("SparseKNNKDTreeTest", "[KNNTest]")
   arma::mat denseQuery(queryDataset);
   arma::mat denseReference(referenceDataset);
 
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::sp_mat,
-      KDTree> SparseKNN;
+  using SparseKNN = NeighborSearch<NearestNeighborSort, EuclideanDistance,
+      arma::sp_mat, KDTree>;
 
   SparseKNN a(referenceDataset);
   KNN naive(denseReference, NAIVE_MODE);
@@ -1058,8 +1058,8 @@ TEST_CASE("SparseKNNKDTreeTest", "[KNNTest]")
 /*
 TEST_CASE("SparseKNNCoverTreeTest", "[KNNTest]")
 {
-  typedef CoverTree<LMetric<2, true>, FirstPointIsRoot,
-      NeighborSearchStat<NearestNeighborSort>, arma::sp_mat> SparseCoverTree;
+  using SparseCoverTree = CoverTree<LMetric<2, true>, FirstPointIsRoot,
+      NeighborSearchStat<NearestNeighborSort>, arma::sp_mat>;
 
   // The dimensionality of these datasets must be high so that the probability
   // of a completely empty point is very low.  In this case, with dimensionality
@@ -1072,8 +1072,8 @@ TEST_CASE("SparseKNNCoverTreeTest", "[KNNTest]")
   arma::mat denseQuery(queryDataset);
   arma::mat denseReference(referenceDataset);
 
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance,
-      SparseCoverTree> SparseKNN;
+  using SparseKNN = NeighborSearch<NearestNeighborSort, EuclideanDistance,
+      SparseCoverTree>;
 
   arma::mat sparseDistances;
   arma::Mat<size_t> sparseNeighbors;
@@ -1098,7 +1098,7 @@ TEST_CASE("KNNModelTest", "[KNNTest]")
 {
   // Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
   // results.
-  typedef NSModel<NearestNeighborSort> KNNModel;
+  using KNNModel = NSModel<NearestNeighborSort>;
   util::Timers timers;
 
   arma::mat queryData = arma::randu<arma::mat>(10, 50);
@@ -1190,7 +1190,7 @@ TEST_CASE("KNNModelMonochromaticTest", "[KNNTest]")
 {
   // Ensure that we can build an NSModel<NearestNeighborSearch> and get correct
   // results, in the case where the reference set is the same as the query set.
-  typedef NSModel<NearestNeighborSort> KNNModel;
+  using KNNModel = NSModel<NearestNeighborSort>;
   util::Timers timers;
 
   arma::mat referenceData = arma::randu<arma::mat>(10, 200);
@@ -1357,8 +1357,8 @@ TEST_CASE("KNNCopyConstructorAndOperatorTest", "[KNNTest]")
 TEST_CASE("KNNCopyConstructorAndOperatorRTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      RTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, RTree>;
   NeighborSearchType knn(std::move(dataset));
 
   // Copy constructor and operator.
@@ -1385,8 +1385,8 @@ TEST_CASE("KNNCopyConstructorAndOperatorRTreeTest", "[KNNTest]")
 TEST_CASE("KNNCopyConstructorAndOperatorCoverTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, StandardCoverTree>;
   NeighborSearchType knn(std::move(dataset));
 
   // Copy constructor and operator.
@@ -1413,8 +1413,8 @@ TEST_CASE("KNNCopyConstructorAndOperatorCoverTreeTest", "[KNNTest]")
 TEST_CASE("KNNCopyConstructorAndOperatorBinarySpaceTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      KDTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, KDTree>;
   NeighborSearchType knn(std::move(dataset));
 
   // Copy constructor and operator.
@@ -1441,8 +1441,8 @@ TEST_CASE("KNNCopyConstructorAndOperatorBinarySpaceTreeTest", "[KNNTest]")
 TEST_CASE("KNNCopyConstructorAndOperatorSpillTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      SPTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, SPTree>;
   NeighborSearchType knn(std::move(dataset));
 
   // Copy constructor and operator.
@@ -1469,8 +1469,8 @@ TEST_CASE("KNNCopyConstructorAndOperatorSpillTreeTest", "[KNNTest]")
 TEST_CASE("KNNCopyConstructorAndOperatorOctreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      Octree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, Octree>;
   NeighborSearchType knn(std::move(dataset));
 
   // Copy constructor and operator.
@@ -1522,8 +1522,8 @@ TEST_CASE("KNNMoveConstructorTest", "[KNNTest]")
 TEST_CASE("KNNMoveConstructorRTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      RTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, RTree>;
   NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
 
   // Get predictions.
@@ -1556,8 +1556,8 @@ TEST_CASE("KNNMoveConstructorRTreeTest", "[KNNTest]")
 TEST_CASE("KNNMoveConstructorBinarySpaceTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      KDTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, KDTree>;
   NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
 
   // Get predictions.
@@ -1589,8 +1589,8 @@ TEST_CASE("KNNMoveConstructorBinarySpaceTreeTest", "[KNNTest]")
 TEST_CASE("KNNMoveConstructorOctreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      Octree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, Octree>;
   NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
 
   // Get predictions.
@@ -1622,8 +1622,8 @@ TEST_CASE("KNNMoveConstructorOctreeTest", "[KNNTest]")
 TEST_CASE("KNNMoveConstructorCoverTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, StandardCoverTree>;
   NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
 
   // Get predictions.
@@ -1655,8 +1655,8 @@ TEST_CASE("KNNMoveConstructorCoverTreeTest", "[KNNTest]")
 TEST_CASE("KNNMoveConstructorSpillTreeTest", "[KNNTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(5, 500);
-  typedef NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      SPTree> NeighborSearchType;
+  using NeighborSearchType = NeighborSearch<NearestNeighborSort,
+      EuclideanDistance, arma::mat, SPTree>;
   NeighborSearchType* knn = new NeighborSearchType(std::move(dataset));
 
   // Get predictions.

--- a/src/mlpack/tests/krann_search_test.cpp
+++ b/src/mlpack/tests/krann_search_test.cpp
@@ -170,8 +170,8 @@ TEST_CASE("DualTreeSearch", "[KRANNTest]")
   size_t expectedRankErrorUB = 10;
 
   // Build query tree by hand.
-  typedef KDTree<EuclideanDistance, RAQueryStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, RAQueryStat<NearestNeighborSort>,
+      arma::mat>;
   std::vector<size_t> oldFromNewQueries;
   TreeType queryTree(queryData, oldFromNewQueries);
 
@@ -286,8 +286,8 @@ TEST_CASE("SingleCoverTreeTest", "[KRANNTest]")
   arma::Mat<size_t> neighbors;
   arma::mat distances;
 
-  typedef RASearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> RACoverTreeSearch;
+  using RACoverTreeSearch = RASearch<NearestNeighborSort, EuclideanDistance,
+       arma::mat, StandardCoverTree>;
 
   RACoverTreeSearch tssRann(refData, false, true, 1.0, 0.95, false, false, 5);
 
@@ -350,10 +350,10 @@ TEST_CASE("DualCoverTreeTest", "[KRANNTest]")
   arma::Mat<size_t> neighbors;
   arma::mat distances;
 
-  typedef StandardCoverTree<EuclideanDistance, RAQueryStat<NearestNeighborSort>,
-      arma::mat> TreeType;
-  typedef RASearch<NearestNeighborSort, EuclideanDistance, arma::mat,
-      StandardCoverTree> RACoverTreeSearch;
+  using TreeType = StandardCoverTree<EuclideanDistance,
+      RAQueryStat<NearestNeighborSort>, arma::mat>;
+  using RACoverTreeSearch = RASearch<NearestNeighborSort, EuclideanDistance,
+      arma::mat, StandardCoverTree>;
 
   TreeType refTree(refData);
   TreeType queryTree(queryData);
@@ -421,10 +421,10 @@ TEST_CASE("SingleBallTreeTest", "[KRANNTest]")
   arma::Mat<size_t> neighbors;
   arma::mat distances;
 
-  typedef BinarySpaceTree<BallBound<>, RAQueryStat<NearestNeighborSort> >
-      TreeType;
-  typedef RASearch<NearestNeighborSort, EuclideanDistance, TreeType>
-      RABallTreeSearch;
+  using TreeType = BinarySpaceTree<BallBound<>,
+      RAQueryStat<NearestNeighborSort>>;
+  using RABallTreeSearch = RASearch<NearestNeighborSort, EuclideanDistance,
+      TreeType>;
 
   RABallTreeSearch tssRann(refData, queryData, false, true);
 
@@ -484,10 +484,10 @@ TEST_CASE("DualBallTreeTest", "[KRANNTest]")
   arma::Mat<size_t> neighbors;
   arma::mat distances;
 
-  typedef BinarySpaceTree<BallBound<>, RAQueryStat<NearestNeighborSort> >
-    TreeType;
-  typedef RASearch<NearestNeighborSort, EuclideanDistance, TreeType>
-      RABallTreeSearch;
+  using TreeType = BinarySpaceTree<BallBound<>,
+      RAQueryStat<NearestNeighborSort>>;
+  using RABallTreeSearch = RASearch<NearestNeighborSort, EuclideanDistance,
+      TreeType>;
 
   TreeType refTree(refData);
   TreeType queryTree(queryData);

--- a/src/mlpack/tests/lars_test.cpp
+++ b/src/mlpack/tests/lars_test.cpp
@@ -62,7 +62,7 @@ template<typename MatType>
 void LassoTest(size_t nPoints, size_t nDims, bool elasticNet, bool useCholesky,
                bool fitIntercept, bool normalizeData)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   MatType X;
   arma::Row<ElemType> y;
@@ -610,8 +610,8 @@ TEST_CASE("LARSTrainReturnCorrelation", "[LARSTest]")
  */
 TEMPLATE_TEST_CASE("LARSTestComputeError", "[LARSTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type ElemType;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
 
   MatType X;
   MatType Y;
@@ -943,8 +943,8 @@ TEST_CASE("LARSTestKKT", "[LARSTest]")
 TEMPLATE_TEST_CASE("LARSConstructorVariantTest", "[LARSTest]", arma::fmat,
     arma::mat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type ElemType;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
 
   // The results of the training are not all that important here; the more
   // important thing is just that all the overloads compile properly.  We do
@@ -1090,8 +1090,8 @@ TEMPLATE_TEST_CASE("LARSConstructorVariantTest", "[LARSTest]", arma::fmat,
 // Check that all variants of Train() appear to work.
 TEMPLATE_TEST_CASE("LARSTrainVariantTest", "[LARSTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type ElemType;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
 
   // The results of the training are not all that important here; the more
   // important thing is just that all the overloads compile properly.  We do
@@ -1223,8 +1223,8 @@ TEMPLATE_TEST_CASE("LARSTrainVariantTest", "[LARSTest]", arma::fmat, arma::mat)
 // Ensure that SelectBeta() works correctly.
 TEMPLATE_TEST_CASE("LARSSelectBetaTest", "[LARSTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef typename MatType::elem_type ElemType;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
 
   const ElemType tol = (std::is_same_v<ElemType, double>) ? 1e-5 : 5e-3;
 
@@ -1299,7 +1299,7 @@ TEST_CASE("LARSSelectBetaInvalidLambda1Test", "[LARSTest]")
 // Test that we can train a sparse model on dense data.
 TEMPLATE_TEST_CASE("LARSSparseModelDenseData", "[LARSTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // 1k-dimensional data.
   arma::Mat<eT> data(1000, 500, arma::fill::randu);

--- a/src/mlpack/tests/linear_regression_test.cpp
+++ b/src/mlpack/tests/linear_regression_test.cpp
@@ -24,9 +24,9 @@ using namespace mlpack;
 TEMPLATE_TEST_CASE("LinearRegressionTestCase", "[LinearRegressionTest]",
     arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef arma::Row<typename MatType::elem_type> RowType;
-  typedef arma::Col<typename MatType::elem_type> ColType;
+  using MatType = TestType;
+  using RowType = arma::Row<typename MatType::elem_type>;
+  using ColType = arma::Col<typename MatType::elem_type>;
 
   // Predictors and points are 10x3 matrices.
   MatType predictors(3, 10);
@@ -77,8 +77,8 @@ TEMPLATE_TEST_CASE("LinearRegressionTestCase", "[LinearRegressionTest]",
 TEMPLATE_TEST_CASE("ComputeErrorTest", "[LinearRegressionTest]", arma::fmat,
     arma::mat)
 {
-  typedef TestType MatType;
-  typedef arma::Row<typename MatType::elem_type> RowType;
+  using MatType = TestType;
+  using RowType = arma::Row<typename MatType::elem_type>;
 
   MatType predictors;
   predictors = { {  0, 1, 2, 4, 8, 16 },
@@ -281,8 +281,8 @@ TEST_CASE("LinearRegressionTrainReturnObjective", "[LinearRegressionTest]")
 TEMPLATE_TEST_CASE("LinearRegressionAllTrainVersionsTest",
     "[LinearRegressionTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef arma::Row<typename MatType::elem_type> RowType;
+  using MatType = TestType;
+  using RowType = arma::Row<typename MatType::elem_type>;
 
   // The data doesn't really matter for this test; mostly we want to make sure
   // that all the Train() variants work properly.
@@ -341,8 +341,8 @@ TEMPLATE_TEST_CASE("LinearRegressionAllTrainVersionsTest",
 TEMPLATE_TEST_CASE("LinearRegressionSinglePointPredictTest",
     "[LinearRegressionTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef arma::Row<typename MatType::elem_type> RowType;
+  using MatType = TestType;
+  using RowType = arma::Row<typename MatType::elem_type>;
 
   MatType predictors;
   predictors = { {  0, 1, 2, 4, 8, 16 },

--- a/src/mlpack/tests/linear_svm_test.cpp
+++ b/src/mlpack/tests/linear_svm_test.cpp
@@ -575,7 +575,7 @@ TEST_CASE("LinearSVMLBFGSTwoClasses", "[LinearSVMTest]")
     for (size_t i = 0; i < points / 2; ++i)
     {
       data.col(i) = g1.Random();
-      labels(i) =  0;
+      labels(i) = 0;
     }
     for (size_t i = points / 2; i < points; ++i)
     {
@@ -844,7 +844,7 @@ TEST_CASE("LinearSVMParallelSGDTwoClasses", "[LinearSVMTest]")
     for (size_t i = 0; i < points / 2; ++i)
     {
       data.col(i) = g1.Random();
-      labels(i) =  0;
+      labels(i) = 0;
     }
     for (size_t i = points / 2; i < points; ++i)
     {

--- a/src/mlpack/tests/linear_svm_test.cpp
+++ b/src/mlpack/tests/linear_svm_test.cpp
@@ -875,9 +875,9 @@ TEST_CASE("LinearSVMParallelSGDTwoClasses", "[LinearSVMTest]")
  */
 TEMPLATE_TEST_CASE("LinearSVMSparseLBFGSTest", "[LinearSVMTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::SpMat<ElemType> SparseMatType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using SparseMatType = arma::SpMat<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   // Create a random dataset.
   SparseMatType dataset;
@@ -908,9 +908,9 @@ TEMPLATE_TEST_CASE("LinearSVMSparseLBFGSTest", "[LinearSVMTest]", float, double)
 TEMPLATE_TEST_CASE("LinearSVMLBFGSMultipleClasses", "[LinearSVMTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Col<ElemType> VecType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
+  using VecType = arma::Col<ElemType>;
 
   const size_t points = 1000;
   const size_t inputSize = 5;
@@ -1015,9 +1015,9 @@ TEMPLATE_TEST_CASE("LinearSVMLBFGSMultipleClasses", "[LinearSVMTest]", float,
 TEMPLATE_TEST_CASE("LinearSVMClassifySinglePointTest", "[LinearSVMTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
-  typedef typename arma::Col<ElemType> VecType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
+  using VecType = arma::Col<ElemType>;
 
   const size_t points = 500;
   const size_t inputSize = 5;
@@ -1229,7 +1229,7 @@ TEST_CASE("LinearSVMCallbackTest", "[LinearSVMTest]")
 TEMPLATE_TEST_CASE("LinearSVMConstructorVariantTest", "[LinearSVMTest]",
     arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create some random data.  The results here do not matter all that much;
   // this is more of a test that all constructor variants successfully compile
@@ -1327,7 +1327,7 @@ TEMPLATE_TEST_CASE("LinearSVMConstructorVariantTest", "[LinearSVMTest]",
 TEMPLATE_TEST_CASE("LinearSVMTrainVariantTest", "[LinearSVMTest]", arma::fmat,
     arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create some random data.  The results here do not matter all that much;
   // this is more of a test that all constructor variants successfully compile

--- a/src/mlpack/tests/lmnn_test.cpp
+++ b/src/mlpack/tests/lmnn_test.cpp
@@ -32,7 +32,7 @@ using namespace ens;
  */
 TEMPLATE_TEST_CASE("LMNNTargetNeighborsTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -67,7 +67,7 @@ TEMPLATE_TEST_CASE("LMNNTargetNeighborsTest", "[LMNNTest]", float, double)
  */
 TEMPLATE_TEST_CASE("LMNNImpostorsTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("LMNNImpostorsTest", "[LMNNTest]", float, double)
  */
 TEMPLATE_TEST_CASE("LMNNInitialPointTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Cheap fake dataset.
   arma::Mat<ElemType> dataset = arma::randu<arma::Mat<ElemType>>(5, 5);
@@ -136,7 +136,7 @@ TEMPLATE_TEST_CASE("LMNNInitialPointTest", "[LMNNTest]", float, double)
  */
 TEMPLATE_TEST_CASE("LMNNInitialEvaluationTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -157,7 +157,7 @@ TEMPLATE_TEST_CASE("LMNNInitialEvaluationTest", "[LMNNTest]", float, double)
  */
 TEMPLATE_TEST_CASE("LMNNInitialGradientTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -185,7 +185,7 @@ TEMPLATE_TEST_CASE("LMNNInitialGradientTest", "[LMNNTest]", float, double)
 TEMPLATE_TEST_CASE("LMNNInitialEvaluateWithGradientTest", "[LMNNTest]", float,
     double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -215,7 +215,7 @@ TEMPLATE_TEST_CASE("LMNNInitialEvaluateWithGradientTest", "[LMNNTest]", float,
  */
 TEMPLATE_TEST_CASE("LMNNSeparableObjectiveTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -240,7 +240,7 @@ TEMPLATE_TEST_CASE("LMNNSeparableObjectiveTest", "[LMNNTest]", float, double)
  */
 TEMPLATE_TEST_CASE("LMNNSeparableGradientTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -304,7 +304,7 @@ TEMPLATE_TEST_CASE("LMNNSeparableGradientTest", "[LMNNTest]", float, double)
 TEMPLATE_TEST_CASE("LMNNSeparableEvaluateWithGradientTest", "[LMNNTest]", float,
     double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -377,7 +377,7 @@ TEMPLATE_TEST_CASE("LMNNSeparableEvaluateWithGradientTest", "[LMNNTest]", float,
 // Check that final objective value using SGD optimizer is optimal.
 TEMPLATE_TEST_CASE("LMNNSGDSimpleDatasetTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -402,7 +402,7 @@ TEMPLATE_TEST_CASE("LMNNSGDSimpleDatasetTest", "[LMNNTest]", float, double)
 // Check that final objective value using L-BFGS optimizer is optimal.
 TEMPLATE_TEST_CASE("LMNNLBFGSSimpleDatasetTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -430,7 +430,7 @@ double KnnAccuracy(const MatType& dataset,
                    const LabelsType& labels,
                    const size_t k)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   LabelsType uniqueLabels = arma::unique(labels);
 
@@ -468,7 +468,7 @@ double KnnAccuracy(const MatType& dataset,
 // simple dataset.
 TEMPLATE_TEST_CASE("LMNNAccuracyTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -498,7 +498,7 @@ TEMPLATE_TEST_CASE("LMNNAccuracyTest", "[LMNNTest]", float, double)
 // three tries.
 TEMPLATE_TEST_CASE("LMNNLowRankAccuracyLBFGSTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   bool success = false;
   for (size_t trial = 0; trial < 3; ++trial)
@@ -558,7 +558,7 @@ TEMPLATE_TEST_CASE("LMNNLowRankAccuracyLBFGSTest", "[LMNNTest]", float, double)
 // three tries.
 TEMPLATE_TEST_CASE("LMNNLowRankAccuracyTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   bool success = false;
   for (size_t trial = 0; trial < 3; ++trial)
@@ -679,7 +679,7 @@ double CheckGradient(FunctionType& function,
                      MatType& coordinates,
                      const typename MatType::elem_type eps = 1e-7)
 {
-  typedef typename MatType::elem_type ElemType;
+  using ElemType = typename MatType::elem_type;
 
   // Get gradients for the current parameters.
   MatType orgGradient, gradient, estGradient;
@@ -714,7 +714,7 @@ double CheckGradient(FunctionType& function,
 
 TEMPLATE_TEST_CASE("LMNNFunctionGradientTest", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -733,7 +733,7 @@ TEMPLATE_TEST_CASE("LMNNFunctionGradientTest", "[LMNNTest]", float, double)
 
 TEMPLATE_TEST_CASE("LMNNFunctionGradientTest2", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<ElemType> dataset = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -752,7 +752,7 @@ TEMPLATE_TEST_CASE("LMNNFunctionGradientTest2", "[LMNNTest]", float, double)
 
 TEMPLATE_TEST_CASE("LMNNFunctionGradientTest3", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   arma::Mat<ElemType> dataset;
   arma::Row<size_t> labels;
@@ -774,7 +774,7 @@ TEMPLATE_TEST_CASE("LMNNFunctionGradientTest3", "[LMNNTest]", float, double)
 
 TEMPLATE_TEST_CASE("LMNNFunctionGradientTest4", "[LMNNTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   arma::Mat<ElemType> dataset;
   arma::Row<size_t> labels;

--- a/src/mlpack/tests/local_coordinate_coding_test.cpp
+++ b/src/mlpack/tests/local_coordinate_coding_test.cpp
@@ -49,8 +49,8 @@ void VerifyCorrectness(const MatType& beta,
 TEMPLATE_TEST_CASE("LocalCoordinateCodingTestCodingStep",
     "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
-  typedef arma::Col<typename MatType::elem_type> VecType;
+  using MatType = TestType;
+  using VecType = arma::Col<typename MatType::elem_type>;
 
   double lambda1 = 0.1;
   uword nAtoms = 10;
@@ -90,7 +90,7 @@ TEMPLATE_TEST_CASE("LocalCoordinateCodingTestCodingStep",
 TEMPLATE_TEST_CASE("LocalCoordinateCodingTestDictionaryStep",
     "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   const double tol = 0.1;
 
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE("LocalCoordinateCodingTestDictionaryStep",
 TEMPLATE_TEST_CASE("LocalCoordinateCodingSerializationTest",
     "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   MatType X = randu<MatType>(100, 100);
   size_t nAtoms = 10;
@@ -183,7 +183,7 @@ TEMPLATE_TEST_CASE("LocalCoordinateCodingSerializationTest",
 TEMPLATE_TEST_CASE("LocalCoordinateCodingTrainReturnObjective",
     "[LocalCoordinateCodingTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   double lambda1 = 0.1;
   uword nAtoms = 10;

--- a/src/mlpack/tests/logistic_regression_test.cpp
+++ b/src/mlpack/tests/logistic_regression_test.cpp
@@ -1107,7 +1107,7 @@ TEST_CASE("IncrementalTraining", "[LogisticRegressionTest]")
 TEMPLATE_TEST_CASE("LogisticRegressionAllConstructorsTest",
     "[LogisticRegressionTest]", arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create random data.
   MatType data(50, 1000, arma::fill::randu);
@@ -1170,7 +1170,7 @@ TEMPLATE_TEST_CASE("LogisticRegressionAllConstructorsTest",
 TEMPLATE_TEST_CASE("LogisticRegressionAllTrainTest", "[LogisticRegressionTest]",
     arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create random data.
   MatType data(50, 1000, arma::fill::randu);

--- a/src/mlpack/tests/main_tests/bayesian_linear_regression_test.cpp
+++ b/src/mlpack/tests/main_tests/bayesian_linear_regression_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE_METHOD(BRTestFixture,
   int n = 50, m = 4;
   arma::mat matX = arma::randu<arma::mat>(m, n);
   arma::rowvec omega = arma::randu<arma::rowvec>(m);
-  arma::rowvec y =  omega * matX;
+  arma::rowvec y = omega * matX;
 
   SetInputParam("input", std::move(matX));
   SetInputParam("responses", std::move(y));
@@ -59,7 +59,7 @@ TEST_CASE_METHOD(BRTestFixture,
   arma::mat matX = arma::randu<arma::mat>(m, n);
   arma::mat matXtest = arma::randu<arma::mat>(m, 2 * n);
   const arma::rowvec omega = arma::randu<arma::rowvec>(m);
-  arma::rowvec y =  omega * matX;
+  arma::rowvec y = omega * matX;
 
   BayesianLinearRegression<> model;
   model.Train(matX, y);
@@ -99,7 +99,7 @@ TEST_CASE_METHOD(BRTestFixture,
   arma::mat matX = arma::randu<arma::mat>(m, n);
   arma::mat matXtest = arma::randu<arma::mat>(m, 2 * n);
   const arma::rowvec omega = arma::randu<arma::rowvec>(m);
-  arma::rowvec y =  omega * matX;
+  arma::rowvec y = omega * matX;
 
   BayesianLinearRegression<> model;
   model.Train(matX, y);

--- a/src/mlpack/tests/main_tests/cf_test.cpp
+++ b/src/mlpack/tests/main_tests/cf_test.cpp
@@ -352,7 +352,7 @@ TEST_CASE_METHOD(CFTestFixture, "CFMaxIterationsTest",
   FixedRandomSeed();
   RUN_BINDING();
 
-  outputModel =  params.Get<CFModel*>("output_model");
+  outputModel = params.Get<CFModel*>("output_model");
   // By default, the main program use NMFPolicy.
   CFType<NMFPolicy, NoNormalization>& cf =
       dynamic_cast<CFWrapper<NMFPolicy,

--- a/src/mlpack/tests/main_tests/hmm_train_test.cpp
+++ b/src/mlpack/tests/main_tests/hmm_train_test.cpp
@@ -58,7 +58,7 @@ inline void ApproximatelyEqual(HMMModel& h1,
 {
   REQUIRE(h1.Type() == h2.Type());
   HMMType  hmmType = h1.Type();
-  if (hmmType ==  DiscreteHMM)
+  if (hmmType == DiscreteHMM)
   {
     CheckMatrices(
         h1.DiscreteHMM()->Transition()*100,

--- a/src/mlpack/tests/main_tests/preprocess_split_test.cpp
+++ b/src/mlpack/tests/main_tests/preprocess_split_test.cpp
@@ -310,9 +310,9 @@ TEST_CASE_METHOD(
  *
  * The vc2 dataset labels file contains 40 0s, 100 1s, and 67 2s.
  * Considering a test ratio of 0.3,
- * Number of 0s in the test set lables =  12 ( floor(40 * 0.3) = floor(12) ).
- * Number of 1s in the test set labels =  30 ( floor(100 * 0.3) = floor(30) ).
- * Number of 2s in the test set labels =  20 ( floor(67 * 0.3) = floor(20.1) ).
+ * Number of 0s in the test set lables = 12 ( floor(40 * 0.3) = floor(12) ).
+ * Number of 1s in the test set labels = 30 ( floor(100 * 0.3) = floor(30) ).
+ * Number of 2s in the test set labels = 20 ( floor(67 * 0.3) = floor(20.1) ).
  * Total points in the test set = 62 ( 12 + 30 + 20 ).
  */
 TEST_CASE_METHOD(

--- a/src/mlpack/tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/mean_shift_test.cpp
@@ -58,7 +58,7 @@ MatType GetMeanShiftData()
  */
 TEMPLATE_TEST_CASE("MeanShiftSimpleTest", "[MeanShiftTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   MeanShift<> meanShift;
 
@@ -95,7 +95,7 @@ TEMPLATE_TEST_CASE("MeanShiftSimpleTest", "[MeanShiftTest]", float, double)
 TEMPLATE_TEST_CASE("MeanShiftSimpleCentroidsOnlyTest", "[MeanShiftTest]", float,
     double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   MeanShift<> meanShift;
 
@@ -110,8 +110,8 @@ TEMPLATE_TEST_CASE("MeanShiftSimpleCentroidsOnlyTest", "[MeanShiftTest]", float,
 // recovers those four centers.
 TEMPLATE_TEST_CASE("GaussianClustering", "[MeanShiftTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
 
   GaussianDistribution<MatType> g1("0.0 0.0 0.0", arma::eye<MatType>(3, 3));
   GaussianDistribution<MatType> g2("5.0 5.0 5.0", 2 * arma::eye<MatType>(3, 3));
@@ -188,8 +188,8 @@ TEMPLATE_TEST_CASE("GaussianClustering", "[MeanShiftTest]", float, double)
 TEMPLATE_TEST_CASE("GaussianClusteringCentroidsOnly", "[MeanShiftTest]", float,
     double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using MatType = arma::Mat<ElemType>;
 
   GaussianDistribution<MatType> g1("0.0 0.0 0.0", arma::eye<MatType>(3, 3));
   GaussianDistribution<MatType> g2("5.0 5.0 5.0", 2 * arma::eye<MatType>(3, 3));

--- a/src/mlpack/tests/metric_test.cpp
+++ b/src/mlpack/tests/metric_test.cpp
@@ -224,7 +224,7 @@ TEST_CASE("NMSMetricTest", "[MetricTest]")
  */
 TEST_CASE("BLEUScoreTest", "[MetricTest]")
 {
-  typedef typename std::vector<std::string> WordVector;
+  using WordVector = std::vector<std::string>;
   std::vector<std::vector<WordVector>> referenceCorpus
       = {{{"this", "is", "my", "house"},
           {"this", "is", "my", "car"},

--- a/src/mlpack/tests/nbc_test.cpp
+++ b/src/mlpack/tests/nbc_test.cpp
@@ -443,7 +443,7 @@ TEST_CASE("NBCResetTest", "[NBCTest]")
  */
 TEMPLATE_TEST_CASE("NBCIncrementalTest", "[NBCTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   const char* trainFilename = "trainSet.csv";
 
@@ -478,7 +478,7 @@ TEMPLATE_TEST_CASE("NBCIncrementalTest", "[NBCTest]", arma::fmat, arma::mat)
  */
 TEMPLATE_TEST_CASE("NBCModelMatTypeTest", "[NBCTest]", float, double)
 {
-  typedef TestType ElemType;
+  using ElemType = TestType;
 
   NaiveBayesClassifier<arma::Mat<ElemType>> nbc;
 

--- a/src/mlpack/tests/nca_test.cpp
+++ b/src/mlpack/tests/nca_test.cpp
@@ -28,7 +28,7 @@ using namespace ens;
  */
 TEMPLATE_TEST_CASE("SoftmaxInitialPoint", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Cheap fake dataset.
   arma::Mat<eT> data;
@@ -61,7 +61,7 @@ TEMPLATE_TEST_CASE("SoftmaxInitialPoint", "[NCATest]", float, double)
  */
 TEMPLATE_TEST_CASE("SoftmaxInitialEvaluation", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<eT> data       = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -85,7 +85,7 @@ TEMPLATE_TEST_CASE("SoftmaxInitialEvaluation", "[NCATest]", float, double)
  */
 TEMPLATE_TEST_CASE("SoftmaxInitialGradient", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<eT> data       = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -117,7 +117,7 @@ TEMPLATE_TEST_CASE("SoftmaxInitialGradient", "[NCATest]", float, double)
  */
 TEMPLATE_TEST_CASE("SoftmaxOptimalEvaluation", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Simple optimal dataset.
   arma::Mat<eT> data       = " 500  500 -500 -500;"
@@ -140,7 +140,7 @@ TEMPLATE_TEST_CASE("SoftmaxOptimalEvaluation", "[NCATest]", float, double)
  */
 TEMPLATE_TEST_CASE("SoftmaxOptimalGradient", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Simple optimal dataset.
   arma::Mat<eT> data       = " 500  500 -500 -500;"
@@ -164,7 +164,7 @@ TEMPLATE_TEST_CASE("SoftmaxOptimalGradient", "[NCATest]", float, double)
  */
 TEMPLATE_TEST_CASE("SoftmaxSeparableObjective", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<eT> data       = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -192,7 +192,7 @@ TEMPLATE_TEST_CASE("SoftmaxSeparableObjective", "[NCATest]", float, double)
 TEMPLATE_TEST_CASE("OptimalSoftmaxSeparableObjective", "[NCATest]", float,
     double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Simple optimal dataset.
   arma::Mat<eT> data       = " 500  500 -500 -500;"
@@ -217,7 +217,7 @@ TEMPLATE_TEST_CASE("OptimalSoftmaxSeparableObjective", "[NCATest]", float,
  */
 TEMPLATE_TEST_CASE("SoftmaxSeparableGradient", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<eT> data       = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -283,7 +283,7 @@ TEMPLATE_TEST_CASE("SoftmaxSeparableGradient", "[NCATest]", float, double)
  */
 TEMPLATE_TEST_CASE("NCASGDSimpleDataset", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<eT> data       = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
@@ -321,7 +321,7 @@ TEMPLATE_TEST_CASE("NCASGDSimpleDataset", "[NCATest]", float, double)
 
 TEMPLATE_TEST_CASE("NCALBFGSSimpleDataset", "[NCATest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   // Useful but simple dataset with six points and two classes.
   arma::Mat<eT> data       = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"

--- a/src/mlpack/tests/nmf_test.cpp
+++ b/src/mlpack/tests/nmf_test.cpp
@@ -307,7 +307,7 @@ TEST_CASE("NonNegNMFALSTest", "[NMFTest]")
  */
 TEMPLATE_TEST_CASE("NoInitializationTest", "[NMFTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   arma::Mat<eT> W, H;
   W.randu(100, 5);

--- a/src/mlpack/tests/pca_test.cpp
+++ b/src/mlpack/tests/pca_test.cpp
@@ -337,7 +337,7 @@ TEST_CASE("PCAScalingTest", "[PCATest]")
 TEMPLATE_TEST_CASE("PCASubviewTest", "[PCATest]", ExactSVDPolicy,
     RandomizedSVDPCAPolicy, RandomizedBlockKrylovSVDPolicy, QUICSVDPolicy)
 {
-  typedef TestType DecompositionPolicy;
+  using DecompositionPolicy = TestType;
 
   // Generate an artifical dataset in 10 dimensions.
   arma::mat data(3, 5000);
@@ -384,7 +384,7 @@ TEMPLATE_TEST_CASE("PCASubviewTest", "[PCATest]", ExactSVDPolicy,
 TEMPLATE_TEST_CASE("PCAExpressionTest", "[PCATest]", ExactSVDPolicy,
     RandomizedSVDPCAPolicy, RandomizedBlockKrylovSVDPolicy, QUICSVDPolicy)
 {
-  typedef TestType DecompositionPolicy;
+  using DecompositionPolicy = TestType;
 
   // Generate an artifical dataset in 10 dimensions.
   arma::mat data(3, 5000);
@@ -431,7 +431,7 @@ TEMPLATE_TEST_CASE("PCAExpressionTest", "[PCATest]", ExactSVDPolicy,
 TEMPLATE_TEST_CASE("PCAFloatTest", "[PCATest]", ExactSVDPolicy,
     RandomizedSVDPCAPolicy, RandomizedBlockKrylovSVDPolicy, QUICSVDPolicy)
 {
-  typedef TestType DecompositionPolicy;
+  using DecompositionPolicy = TestType;
 
   // Generate an artifical dataset in 10 dimensions.
   arma::fmat data(3, 5000);
@@ -475,8 +475,8 @@ TEMPLATE_TEST_CASE("PCAFloatTest", "[PCATest]", ExactSVDPolicy,
  */
 TEMPLATE_TEST_CASE("PCASparseToDenseTest", "[PCATest]", float, double)
 {
-  typedef arma::Mat<TestType> MatType;
-  typedef arma::SpMat<TestType> SpMatType;
+  using MatType = arma::Mat<TestType>;
+  using SpMatType = arma::SpMat<TestType>;
 
   SpMatType dataset;
   dataset.sprandu(1000, 50000, 0.01);

--- a/src/mlpack/tests/perceptron_test.cpp
+++ b/src/mlpack/tests/perceptron_test.cpp
@@ -221,7 +221,7 @@ TEST_CASE("TwoPoints", "[PerceptronTest]")
 TEMPLATE_TEST_CASE("NonLinearlySeparableDataset", "[PerceptronTest]", float,
     double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   Mat<eT> trainData;
   trainData = { { 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8 },

--- a/src/mlpack/tests/radical_test.cpp
+++ b/src/mlpack/tests/radical_test.cpp
@@ -18,9 +18,9 @@ using namespace std;
 
 TEMPLATE_TEST_CASE("Radical_Test_Radical3D", "[RadicalTest]", float, double)
 {
-  typedef TestType ElemType;
-  typedef typename arma::Col<ElemType> VecType;
-  typedef typename arma::Mat<ElemType> MatType;
+  using ElemType = TestType;
+  using VecType = arma::Col<ElemType>;
+  using MatType = arma::Mat<ElemType>;
 
   MatType matX;
   if (!data::Load("data_3d_mixed.txt", matX))

--- a/src/mlpack/tests/random_test.cpp
+++ b/src/mlpack/tests/random_test.cpp
@@ -77,7 +77,7 @@ TEST_CASE("WeightedRandomTest", "[RandomTest]")
   for (std::vector<double> weightSet : weights)
   {
     DiscreteDistribution<> d(1);
-    d.Probabilities(0) =  arma::vec(weightSet);
+    d.Probabilities(0) = arma::vec(weightSet);
     std::vector<int> count(weightSet.size(), 0);
     for (size_t iter = 0; iter < iterations; ++iter)
     {

--- a/src/mlpack/tests/range_search_test.cpp
+++ b/src/mlpack/tests/range_search_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE("ExhaustiveSyntheticTest", "[RangeSearchTest]")
   data[9] = 0.90;
   data[10] = 1.00;
 
-  typedef KDTree<EuclideanDistance, RangeSearchStat, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, RangeSearchStat, arma::mat>;
 
   // We will loop through three times, one for each method of performing the
   // calculation.
@@ -1126,7 +1126,7 @@ TEST_CASE("RangeSearchTrainTest", "[RangeSearchTest]")
 TEST_CASE("TrainTreeTest", "[RangeSearchTest]")
 {
   // Avoid mappings by using the cover tree.
-  typedef RangeSearch<EuclideanDistance, arma::mat, StandardCoverTree> RSType;
+  using RSType = RangeSearch<EuclideanDistance, arma::mat, StandardCoverTree>;
   RSType empty;
 
   arma::mat dataset = arma::randu<arma::mat>(5, 100);

--- a/src/mlpack/tests/rectangle_tree_test.cpp
+++ b/src/mlpack/tests/rectangle_tree_test.cpp
@@ -42,8 +42,8 @@ TEST_CASE("RectangleTreeConstructionCountTest", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(3, 1000); // 1000 points in 3 dimensions.
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   TreeType tree(dataset, 20, 6, 5, 2, 0);
   TreeType tree2 = tree;
@@ -90,8 +90,8 @@ TEST_CASE("RectangleTreeConstructionRepeatTest", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   TreeType tree(dataset, 20, 6, 5, 2, 0);
 
@@ -218,8 +218,8 @@ TEST_CASE("RectangleTreeContainmentTest", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   TreeType tree(dataset, 20, 6, 5, 2, 0);
   CheckContainment(tree);
@@ -263,8 +263,8 @@ TEST_CASE("CheckMinAndMaxFills", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   TreeType tree(dataset, 20, 6, 5, 2, 0);
   CheckFills(tree);
@@ -353,8 +353,8 @@ TEST_CASE("TreeBalance", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   TreeType tree(dataset, 20, 6, 5, 2, 0);
 
@@ -376,8 +376,8 @@ TEST_CASE("PointDeletion", "[RectangleTreeTraitsTest]")
 
   const int numIter = 50;
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType tree(dataset, 20, 6, 5, 2, 0);
 
   for (int i = 0; i < numIter; ++i)
@@ -449,8 +449,8 @@ TEST_CASE("PointDynamicAdd", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType tree(dataset, 20, 6, 5, 2, 0);
 
   // Add numIter new points to the dataset.  The tree copies the dataset, so we
@@ -529,8 +529,8 @@ TEST_CASE("SingleTreeTraverserTest", "[RectangleTreeTraitsTest]")
   arma::Mat<size_t> neighbors2;
   arma::mat distances2;
 
-  typedef RStarTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RStarTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType rTree(dataset, 20, 6, 5, 2, 0);
 
   REQUIRE(rTree.NumDescendants() == 1000);
@@ -572,8 +572,8 @@ TEST_CASE("XTreeTraverserTest", "[RectangleTreeTraitsTest]")
   arma::Mat<size_t> neighbors2;
   arma::mat distances2;
 
-  typedef XTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = XTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType xTree(dataset, 20, 6, 5, 2, 0);
 
   REQUIRE(xTree.NumDescendants() == numP);
@@ -613,8 +613,8 @@ TEST_CASE("HilbertRTreeTraverserTest", "[RectangleTreeTraitsTest]")
   arma::Mat<size_t> neighbors2;
   arma::mat distances2;
 
-  typedef HilbertRTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = HilbertRTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType hilbertRTree(dataset, 20, 6, 5, 2, 0);
 
   REQUIRE(hilbertRTree.NumDescendants() == numP);
@@ -684,8 +684,8 @@ TEST_CASE("HilbertRTreeOrderingTest", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef HilbertRTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = HilbertRTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType hilbertRTree(dataset, 20, 6, 5, 2, 0);
 
   CheckHilbertOrdering(hilbertRTree);
@@ -694,9 +694,8 @@ TEST_CASE("HilbertRTreeOrderingTest", "[RectangleTreeTraitsTest]")
 template<typename TreeType>
 void CheckDiscreteHilbertValueSync(const TreeType& tree)
 {
-  typedef DiscreteHilbertValue<typename TreeType::ElemType>
-      HilbertValue;
-  typedef typename HilbertValue::HilbertElemType HilbertElemType;
+  using HilbertValue = DiscreteHilbertValue<typename TreeType::ElemType>;
+  using HilbertElemType = typename HilbertValue::HilbertElemType;
 
   if (tree.IsLeaf())
   {
@@ -725,8 +724,8 @@ TEST_CASE("DiscreteHilbertValueSyncTest", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef HilbertRTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = HilbertRTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType hilbertRTree(dataset, 20, 6, 5, 2, 0);
 
   CheckDiscreteHilbertValueSync(hilbertRTree);
@@ -856,8 +855,7 @@ TEST_CASE("DiscreteHilbertValueTest", "[RectangleTreeTraitsTest]")
 template<typename TreeType>
 void CheckHilbertValue(const TreeType& tree)
 {
-  typedef DiscreteHilbertValue<typename TreeType::ElemType>
-      HilbertValue;
+  using HilbertValue = DiscreteHilbertValue<typename TreeType::ElemType>;
 
   const HilbertValue& value = tree.AuxiliaryInfo().HilbertValue();
 
@@ -892,8 +890,8 @@ void CheckHilbertValue(const TreeType& tree)
 
 TEST_CASE("HilbertRTeeCopyConstructorTest", "[RectangleTreeTraitsTest]")
 {
-  typedef HilbertRTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = HilbertRTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
@@ -912,8 +910,8 @@ TEST_CASE("HilbertRTeeCopyConstructorTest", "[RectangleTreeTraitsTest]")
 
 TEST_CASE("HilbertRTeeMoveConstructorTest", "[RectangleTreeTraitsTest]")
 {
-  typedef HilbertRTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = HilbertRTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
@@ -965,8 +963,8 @@ TEST_CASE("RPlusTreeOverlapTest", "[RectangleTreeTraitsTest]")
   arma::mat dataset;
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
-  typedef RPlusTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = RPlusTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType rPlusTree(dataset, 20, 6, 5, 2, 0);
 
   CheckOverlap(rPlusTree);
@@ -993,8 +991,8 @@ TEST_CASE("RPlusTreeTraverserTest", "[RectangleTreeTraitsTest]")
   arma::Mat<size_t> neighbors2;
   arma::mat distances2;
 
-  typedef RPlusTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat > TreeType;
+  using TreeType = RPlusTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType rPlusTree(dataset, 20, 6, 5, 2, 0);
 
   REQUIRE(rPlusTree.NumDescendants() == numP);
@@ -1026,7 +1024,7 @@ TEST_CASE("RPlusTreeTraverserTest", "[RectangleTreeTraitsTest]")
 template<typename TreeType>
 void CheckRPlusPlusTreeBound(const TreeType& tree)
 {
-  typedef HRectBound<EuclideanDistance, typename TreeType::ElemType> Bound;
+  using Bound = HRectBound<EuclideanDistance, typename TreeType::ElemType>;
 
   bool success = true;
 
@@ -1082,8 +1080,8 @@ TEST_CASE("RPlusPlusTreeBoundTest", "[RectangleTreeTraitsTest]")
   dataset.randu(8, 1000); // 1000 points in 8 dimensions.
 
   // Check the MinimalCoverageSweep.
-  typedef RPlusPlusTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat> TreeType;
+  using TreeType = RPlusPlusTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType rPlusPlusTree(dataset, 20, 6, 5, 2, 0);
 
   CheckRPlusPlusTreeBound(rPlusPlusTree);
@@ -1096,11 +1094,10 @@ TEST_CASE("RPlusPlusTreeBoundTest", "[RectangleTreeTraitsTest]")
   REQUIRE((int) rPlusPlusTree.TreeDepth() == GetMinLevel(rPlusPlusTree));
 
   // Check the MinimalSplitsNumberSweep.
-  typedef RectangleTree<EuclideanDistance,
+  using RPlusPlusTreeMinimalSplits = RectangleTree<EuclideanDistance,
       NeighborSearchStat<NearestNeighborSort>, arma::mat,
       RPlusTreeSplit<RPlusPlusTreeSplitPolicy, MinimalCoverageSweep>,
-      RPlusPlusTreeDescentHeuristic, RPlusPlusTreeAuxiliaryInformation>
-          RPlusPlusTreeMinimalSplits;
+      RPlusPlusTreeDescentHeuristic, RPlusPlusTreeAuxiliaryInformation>;
 
   RPlusPlusTreeMinimalSplits rPlusPlusTree2(dataset, 20, 6, 5, 2, 0);
 
@@ -1122,8 +1119,8 @@ TEST_CASE("RPlusPlusTreeTraverserTest", "[RectangleTreeTraitsTest]")
   arma::Mat<size_t> neighbors2;
   arma::mat distances2;
 
-  typedef RPlusPlusTree<EuclideanDistance,
-      NeighborSearchStat<NearestNeighborSort>, arma::mat > TreeType;
+  using TreeType = RPlusPlusTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType rPlusPlusTree(dataset, 20, 6, 5, 2, 0);
 
   REQUIRE(rPlusPlusTree.NumDescendants() == numP);
@@ -1169,8 +1166,8 @@ TEST_CASE("RTreeSplitTest", "[RectangleTreeTraitsTest]")
                                          "0.1 0.5;"
                                          "0.3 0.7;"));
 
-  typedef RTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
   TreeType rTree(data, 5, 2, 2, 1, 0);
 
   // There's technically no reason they have to be in a certain order, so we
@@ -1264,8 +1261,8 @@ TEST_CASE("RStarTreeSplitTest", "[RectangleTreeTraitsTest]")
                                          "0.1 0.5;"
                                          "0.3 0.7;"));
 
-  typedef RStarTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-    arma::mat> TreeType;
+  using TreeType = RStarTree<EuclideanDistance,
+      NeighborSearchStat<NearestNeighborSort>, arma::mat>;
 
   TreeType rTree(data, 5, 2, 2, 1, 0);
 
@@ -1345,7 +1342,7 @@ TEST_CASE("RStarTreeSplitTest", "[RectangleTreeTraitsTest]")
 TEST_CASE("RectangleTreeMoveDatasetTest", "[RectangleTreeTraitsTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(3, 1000);
-  typedef RTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   TreeType tree(std::move(dataset));
 

--- a/src/mlpack/tests/serialization_test.cpp
+++ b/src/mlpack/tests/serialization_test.cpp
@@ -299,7 +299,7 @@ TEST_CASE("BinarySpaceTreeTest", "[SerializationTest]")
 {
   arma::mat data;
   data.randu(3, 100);
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(data);
 
   TreeType* xmlTree;
@@ -319,7 +319,7 @@ TEST_CASE("BinarySpaceTreeOverwriteTest", "[SerializationTest]")
 {
   arma::mat data;
   data.randu(3, 100);
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(data);
 
   arma::mat otherData;
@@ -337,8 +337,8 @@ TEST_CASE("CoverTreeTest", "[SerializationTest]")
 {
   arma::mat data;
   data.randu(3, 100);
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(data);
 
   TreeType* xmlTree;
@@ -392,8 +392,8 @@ TEST_CASE("CoverTreeOverwriteTest", "[SerializationTest]")
 {
   arma::mat data;
   data.randu(3, 100);
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(data);
 
   arma::mat otherData;
@@ -445,7 +445,7 @@ TEST_CASE("RectangleTreeTest", "[SerializationTest]")
 {
   arma::mat data;
   data.randu(3, 1000);
-  typedef RTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(data);
 
   TreeType* xmlTree;
@@ -500,7 +500,7 @@ TEST_CASE("RectangleTreeOverwriteTest", "[SerializationTest]")
 {
   arma::mat data;
   data.randu(3, 1000);
-  typedef RTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = RTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(data);
 
   arma::mat otherData;
@@ -648,7 +648,7 @@ TEST_CASE("SoftmaxRegressionTest", "[SerializationTest]")
 
 TEST_CASE("DETTest", "[SerializationTest]")
 {
-  typedef DTree<arma::mat> DTreeX;
+  using DTreeX = DTree<arma::mat>;
 
   // Create a density estimation tree on a random dataset.
   arma::mat dataset = arma::randu<arma::mat>(25, 5000);

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -207,7 +207,7 @@ TEST_CASE("SoftmaxRegressionTwoClasses", "[SoftmaxRegressionTest]")
   for (size_t i = 0; i < points / 2; ++i)
   {
     data.col(i) = g1.Random();
-    labels(i) =  0;
+    labels(i) = 0;
   }
   for (size_t i = points / 2; i < points; ++i)
   {

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -223,7 +223,7 @@ TEST_CASE("SoftmaxRegressionTwoClasses", "[SoftmaxRegressionTest]")
 TEMPLATE_TEST_CASE("SoftmaxRegressionFitIntercept", "[SoftmaxRegressionTest]",
     arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Generate a two-Gaussian dataset,
   // which can't be separated without adding the intercept term.
@@ -272,8 +272,8 @@ TEMPLATE_TEST_CASE("SoftmaxRegressionFitIntercept", "[SoftmaxRegressionTest]",
 TEMPLATE_TEST_CASE("SoftmaxRegressionMultipleClasses",
     "[SoftmaxRegressionTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
-  typedef typename GetColType<TestType>::type VecType;
+  using MatType = TestType;
+  using VecType = typename GetColType<TestType>::type;
 
   const size_t points = 5000;
   const size_t inputSize = 5;
@@ -729,7 +729,7 @@ TEST_CASE("SoftmaxImmediateTrainTest", "[SoftmaxRegressionTest]")
 TEMPLATE_TEST_CASE("SoftmaxRegressionConstructorVariantTest",
     "[SoftmaxRegressionTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create random data.
   MatType data(50, 1000, arma::fill::randu);
@@ -809,7 +809,7 @@ TEMPLATE_TEST_CASE("SoftmaxRegressionConstructorVariantTest",
 TEMPLATE_TEST_CASE("SoftmaxRegressionTrainVariantTest",
     "[SoftmaxRegressionTest]", arma::fmat, arma::mat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   // Create random data.
   MatType data(50, 1000, arma::fill::randu);

--- a/src/mlpack/tests/sort_policy_test.cpp
+++ b/src/mlpack/tests/sort_policy_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE("NnsNodeToNodeDistance", "[SortPolicyTest]")
   // Well, there's no easy way to make HRectBounds the way we want, so we have
   // to make them and then expand the region to include new points.
   arma::mat dataset("1");
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType nodeOne(dataset);
   arma::vec utility(1);
   utility[0] = 0;
@@ -118,7 +118,7 @@ TEST_CASE("NnsPointToNodeDistance", "[SortPolicyTest]")
   utility[0] = 0;
 
   arma::mat dataset("1");
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType node(dataset);
   node.Bound() = HRectBound<EuclideanDistance>(1);
   node.Bound() |= utility;
@@ -191,7 +191,7 @@ TEST_CASE("FnsNodeToNodeDistance", "[SortPolicyTest]")
   utility[0] = 0;
 
   arma::mat dataset("1");
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType nodeOne(dataset);
   nodeOne.Bound() = HRectBound<EuclideanDistance>(1);
   nodeOne.Bound() |= utility;
@@ -243,7 +243,7 @@ TEST_CASE("FnsPointToNodeDistance", "[SortPolicyTest]")
   utility[0] = 0;
 
   arma::mat dataset("1");
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType node(dataset);
   node.Bound() = HRectBound<EuclideanDistance>(1);
   node.Bound() |= utility;

--- a/src/mlpack/tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/sparse_coding_test.cpp
@@ -50,8 +50,8 @@ void SCVerifyCorrectness(const VecType& beta,
 TEMPLATE_TEST_CASE("SparseCodingTestCodingStepLasso", "[SparseCodingTest]",
     arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
-  typedef arma::Col<typename MatType::elem_type> VecType;
+  using MatType = TestType;
+  using VecType = arma::Col<typename MatType::elem_type>;
 
   double lambda1 = 0.1;
   uword nAtoms = 25;
@@ -84,8 +84,8 @@ TEMPLATE_TEST_CASE("SparseCodingTestCodingStepLasso", "[SparseCodingTest]",
 TEMPLATE_TEST_CASE("SparseCodingTestCodingStepElasticNet", "[SparseCodingTest]",
     arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
-  typedef arma::Col<typename MatType::elem_type> VecType;
+  using MatType = TestType;
+  using VecType = arma::Col<typename MatType::elem_type>;
 
   double lambda1 = 0.1;
   double lambda2 = 0.2;
@@ -120,7 +120,7 @@ TEMPLATE_TEST_CASE("SparseCodingTestCodingStepElasticNet", "[SparseCodingTest]",
 TEMPLATE_TEST_CASE("SparseCodingTestDictionaryStep", "[SparseCodingTest]",
     arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   const double tol = std::is_same_v<typename MatType::elem_type, float> ?
       0.01 : 1e-6;
@@ -153,7 +153,7 @@ TEMPLATE_TEST_CASE("SparseCodingTestDictionaryStep", "[SparseCodingTest]",
 TEMPLATE_TEST_CASE("SerializationTest", "[SparseCodingTest]", arma::mat,
     arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   MatType X = randu<MatType>(100, 100);
   size_t nAtoms = 25;
@@ -213,7 +213,7 @@ TEMPLATE_TEST_CASE("SerializationTest", "[SparseCodingTest]", arma::mat,
 TEMPLATE_TEST_CASE("SparseCodingTrainReturnObjective", "[SparseCodingTest]",
     arma::mat, arma::fmat)
 {
-  typedef TestType MatType;
+  using MatType = TestType;
 
   const double tol = std::is_same_v<typename MatType::elem_type, float> ?
       0.01 : 1e-6;

--- a/src/mlpack/tests/spill_tree_test.cpp
+++ b/src/mlpack/tests/spill_tree_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("SpillTreeConstructionCountTest", "[SpillTreeTest]")
   arma::mat dataset;
   dataset.randu(3, 1000); // 1000 points in 3 dimensions.
 
-  typedef SPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = SPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   // When overlapping buffer is 0, there shouldn't be repeated points.
   TreeType tree1(dataset, 0);
@@ -79,7 +79,7 @@ TEST_CASE("SpillTreeConstructionParentTest", "[SpillTreeTest]")
   arma::mat dataset;
   dataset.randu(3, 1000); // 1000 points in 3 dimensions.
 
-  typedef SPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = SPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   TreeType tree(dataset, 0.5);
 
@@ -204,11 +204,11 @@ void SpillTreeHyperplaneTestAux()
  */
 TEST_CASE("SpillTreeHyperplaneTest", "[SpillTreeTest]")
 {
-  typedef SPTree<EuclideanDistance, EmptyStatistic, arma::mat> SpillType1;
-  typedef NonOrtSPTree<EuclideanDistance, EmptyStatistic, arma::mat> SpillType2;
-  typedef MeanSPTree<EuclideanDistance, EmptyStatistic, arma::mat> SpillType3;
-  typedef NonOrtMeanSPTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      SpillType4;
+  using SpillType1 = SPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
+  using SpillType2 = NonOrtSPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
+  using SpillType3 = MeanSPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
+  using SpillType4 =
+      NonOrtMeanSPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   SpillTreeHyperplaneTestAux<SpillType1>();
   SpillTreeHyperplaneTestAux<SpillType2>();
@@ -222,7 +222,7 @@ TEST_CASE("SpillTreeHyperplaneTest", "[SpillTreeTest]")
 TEST_CASE("SpillTreeMoveConstructorTest", "[SpillTreeTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(3, 1000);
-  typedef SPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = SPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   TreeType tree(dataset);
 
@@ -257,7 +257,7 @@ TEST_CASE("SpillTreeMoveConstructorTest", "[SpillTreeTest]")
 TEST_CASE("SpillTreeCopyConstructorTest", "[SpillTreeTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(3, 1000);
-  typedef SPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = SPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   TreeType* tree = new TreeType(dataset);
 
@@ -293,7 +293,7 @@ TEST_CASE("SpillTreeCopyConstructorTest", "[SpillTreeTest]")
 TEST_CASE("SpillTreeMoveDatasetTest", "[SpillTreeTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(3, 1000);
-  typedef SPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = SPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   TreeType tree(std::move(dataset));
 

--- a/src/mlpack/tests/svd_batch_test.cpp
+++ b/src/mlpack/tests/svd_batch_test.cpp
@@ -24,7 +24,7 @@ using namespace arma;
 TEMPLATE_TEST_CASE("SVDBatchConvergenceElementTest", "[SVDBatchTest]", float,
     double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   SpMat<eT> data;
   data.sprandn(100, 100, 0.2);
@@ -67,7 +67,7 @@ class SpecificRandomInitialization
  */
 TEMPLATE_TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   Mat<eT> dataset;
   if (!data::Load("GroupLensSmall.csv", dataset))
@@ -121,7 +121,7 @@ TEMPLATE_TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]", float, double)
 TEMPLATE_TEST_CASE("SVDBatchRegularizationTest", "[SVDBatchTest]", float,
     double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   Mat<eT> dataset;
   if (!data::Load("GroupLensSmall.csv", dataset))

--- a/src/mlpack/tests/svd_incremental_test.cpp
+++ b/src/mlpack/tests/svd_incremental_test.cpp
@@ -25,7 +25,7 @@ using namespace arma;
 TEMPLATE_TEST_CASE("SVDIncompleteIncrementalConvergenceTest",
     "[SVDIncrementalTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   SpMat<eT> data;
   data.sprandn(100, 100, 0.2);
@@ -53,7 +53,7 @@ TEMPLATE_TEST_CASE("SVDIncompleteIncrementalConvergenceTest",
 TEMPLATE_TEST_CASE("SVDCompleteIncrementalConvergenceTest",
     "[SVDIncrementalTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   SpMat<eT> data;
   data.sprandn(100, 100, 0.2);
@@ -101,7 +101,7 @@ class SpecificRandomInitialization
 TEMPLATE_TEST_CASE("SVDIncompleteIncrementalRegularizationTest",
     "[SVDIncrementalTest]", float, double)
 {
-  typedef TestType eT;
+  using eT = TestType;
 
   Mat<eT> dataset;
   if (!data::Load("GroupLensSmall.csv", dataset))

--- a/src/mlpack/tests/tree_test.cpp
+++ b/src/mlpack/tests/tree_test.cpp
@@ -1130,7 +1130,7 @@ TEST_CASE("FurthestPointDistanceTest", "[TreeTest]")
   arma::mat dataset;
   dataset.randu(5, 100);
 
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(dataset);
 
   // Now, check each node.
@@ -1176,7 +1176,7 @@ TEST_CASE("ParentDistanceTest", "[TreeTest]")
   arma::mat dataset;
   dataset.randu(5, 500);
 
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(dataset);
 
   // The root's parent distance should be 0 (although maybe it doesn't actually
@@ -1222,7 +1222,7 @@ TEST_CASE("ParentDistanceTestWithMapping", "[TreeTest]")
   dataset.randu(5, 500);
   std::vector<size_t> oldFromNew;
 
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(dataset, oldFromNew);
 
   // The root's parent distance should be 0 (although maybe it doesn't actually
@@ -1286,7 +1286,7 @@ void GenerateVectorOfTree(TreeType* node,
  */
 TEST_CASE("KdTreeTest", "[TreeTest]")
 {
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   size_t maxRuns = 10; // Ten total tests.
   size_t pointIncrements = 1000; // Range is from 2000 points to 11000.
@@ -1355,7 +1355,7 @@ TEST_CASE("KdTreeTest", "[TreeTest]")
 
 TEST_CASE("MaxRPTreeTest", "[TreeTest]")
 {
-  typedef MaxRPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = MaxRPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   size_t maxRuns = 10; // Ten total tests.
   size_t pointIncrements = 1000; // Range is from 2000 points to 11000.
@@ -1398,7 +1398,7 @@ TEST_CASE("MaxRPTreeTest", "[TreeTest]")
 template<typename TreeType>
 bool CheckHyperplaneSplit(const TreeType& tree)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
 
   const typename TreeType::Mat& dataset = tree.Dataset();
   arma::Mat<typename TreeType::ElemType> mat(dataset.n_rows + 1,
@@ -1487,7 +1487,7 @@ void CheckMaxRPTreeSplit(const TreeType& tree)
 
 TEST_CASE("MaxRPTreeSplitTest", "[TreeTest]")
 {
-  typedef MaxRPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = MaxRPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   arma::mat dataset;
   dataset.randu(8, 1000);
   TreeType root(dataset);
@@ -1497,7 +1497,7 @@ TEST_CASE("MaxRPTreeSplitTest", "[TreeTest]")
 
 TEST_CASE("RPTreeTest", "[TreeTest]")
 {
-  typedef RPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = RPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   size_t maxRuns = 10; // Ten total tests.
   size_t pointIncrements = 1000; // Range is from 2000 points to 11000.
@@ -1540,7 +1540,7 @@ TEST_CASE("RPTreeTest", "[TreeTest]")
 template<typename TreeType, typename DistanceType>
 void CheckRPTreeSplit(const TreeType& tree)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   if (tree.IsLeaf())
     return;
 
@@ -1575,7 +1575,7 @@ void CheckRPTreeSplit(const TreeType& tree)
 
 TEST_CASE("RPTreeSplitTest", "[TreeTest]")
 {
-  typedef RPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = RPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   arma::mat dataset;
   dataset.randu(8, 1000);
   TreeType root(dataset);
@@ -1611,7 +1611,7 @@ bool CheckPointBounds(TreeType& node)
  */
 TEST_CASE("BallTreeTest", "[TreeTest]")
 {
-  typedef BallTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = BallTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   size_t maxRuns = 10; // Ten total tests.
   size_t pointIncrements = 1000; // Range is from 2000 points to 11000.
@@ -1690,8 +1690,8 @@ void GenerateVectorOfTree(TreeType* node,
  */
 TEST_CASE("ExhaustiveSparseKDTreeTest", "[TreeTest]")
 {
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::SpMat<double>>
-      TreeType;
+  using TreeType =
+      KDTree<EuclideanDistance, EmptyStatistic, arma::SpMat<double>>;
 
   size_t maxRuns = 2; // Two total tests.
   size_t pointIncrements = 200; // Range is from 200 points to 400.
@@ -1859,8 +1859,8 @@ TEST_CASE("SimpleCoverTreeConstructionTest", "[TreeTest]")
                                          "2.0 1.0;"));
 
   // The root point will be the first point, (0, 0).
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType = StandardCoverTree<EuclideanDistance, EmptyStatistic,
+      arma::mat>;
   TreeType tree(data); // Expansion constant of 2.0.
 
   // The furthest point from the root will be (-5, -5), with a distance of
@@ -1897,8 +1897,8 @@ TEST_CASE("CoverTreeConstructionTest", "[TreeTest]")
   // 50-dimensional, 1000 point.
   dataset.randu(50, 1000);
 
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(dataset);
 
   // Ensure each leaf is only created once.
@@ -1929,8 +1929,8 @@ TEST_CASE("SparseCoverTreeConstructionTest", "[TreeTest]")
   // 50-dimensional, 1000 point.
   dataset.sprandu(50, 1000, 0.3);
 
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::sp_mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::sp_mat>;
   TreeType tree(dataset);
 
   // Ensure each leaf is only created once.
@@ -1960,8 +1960,8 @@ TEST_CASE("CoverTreeManualConstructorTest", "[TreeTest]")
   arma::mat dataset;
   dataset.zeros(10, 10);
 
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType node(dataset, 1.3, 3, 2, NULL, 1.5, 2.75);
 
   REQUIRE(&node.Dataset() == &dataset);
@@ -1982,8 +1982,8 @@ TEST_CASE("CoverTreeAlternateMetricTest", "[TreeTest]")
   // 5-dimensional, 300-point dataset.
   dataset.randu(5, 300);
 
-  typedef StandardCoverTree<ManhattanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<ManhattanDistance, EmptyStatistic, arma::mat>;
   TreeType tree(dataset);
 
   // Ensure each leaf is only created once.
@@ -2012,8 +2012,8 @@ TEST_CASE("CoverTreeCopyConstructor", "[TreeTest]")
 {
   arma::mat dataset;
   dataset.randu(10, 10); // dataset is irrelevant.
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType c(dataset, 1.3, 0, 5, NULL, 1.45, 5.2); // Random parameters.
   c.Children().push_back(new TreeType(dataset, 1.3, 1, 4, &c, 1.3, 2.45));
   c.Children().push_back(new TreeType(dataset, 1.5, 2, 3, &c, 1.2, 5.67));
@@ -2070,8 +2070,8 @@ TEST_CASE("CoverTreeCopyConstructor", "[TreeTest]")
 TEST_CASE("CoverTreeMoveDatasetTest", "[TreeTest]")
 {
   arma::mat dataset = arma::randu<arma::mat>(3, 1000);
-  typedef StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>
-      TreeType;
+  using TreeType =
+      StandardCoverTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   TreeType t(std::move(dataset));
 
@@ -2094,7 +2094,7 @@ TEST_CASE("CoverTreeMoveDatasetTest", "[TreeTest]")
 TEST_CASE("BinarySpaceTreeCopyConstructor", "[TreeTest]")
 {
   arma::mat data("1");
-  typedef KDTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = KDTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   TreeType b(data);
   b.Begin() = 10;
   b.Count() = 50;

--- a/src/mlpack/tests/tree_traits_test.cpp
+++ b/src/mlpack/tests/tree_traits_test.cpp
@@ -44,7 +44,7 @@ TEST_CASE("DefaultsTraitsTest", "[TreeTraitsTest]")
 // Test the binary space tree traits.
 TEST_CASE("BinarySpaceTreeTraitsTest", "[TreeTraitsTest]")
 {
-  typedef BinarySpaceTree<LMetric<2, false>> TreeType;
+  using TreeType = BinarySpaceTree<LMetric<2, false>>;
 
   // Children are non-overlapping.
   bool b = TreeTraits<TreeType>::HasOverlappingChildren;

--- a/src/mlpack/tests/ub_tree_test.cpp
+++ b/src/mlpack/tests/ub_tree_test.cpp
@@ -18,10 +18,9 @@ using namespace mlpack;
 
 TEST_CASE("AddressTest", "[UBTreeTest]")
 {
-  typedef double ElemType;
-  typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
-                                    uint32_t,
-                                    uint64_t> AddressElemType;
+  using ElemType = double;
+  using AddressElemType = std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
+                                             uint32_t, uint64_t>;
   arma::Mat<ElemType> dataset(8, 1000);
 
   dataset.randu();
@@ -43,10 +42,9 @@ TEST_CASE("AddressTest", "[UBTreeTest]")
 template<typename TreeType>
 void CheckSplit(const TreeType& tree)
 {
-  typedef typename TreeType::ElemType ElemType;
-  typedef std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
-                                    uint32_t,
-                                    uint64_t> AddressElemType;
+  using ElemType = typename TreeType::ElemType;
+  using AddressElemType = std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
+                                             uint32_t, uint64_t>;
 
   if (tree.IsLeaf())
     return;
@@ -86,7 +84,7 @@ void CheckSplit(const TreeType& tree)
 
 TEST_CASE("UBTreeSplitTest", "[UBTreeTest]")
 {
-  typedef UBTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = UBTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   arma::mat dataset(8, 1000);
 
   dataset.randu();
@@ -98,7 +96,7 @@ TEST_CASE("UBTreeSplitTest", "[UBTreeTest]")
 template<typename TreeType>
 void CheckBound(const TreeType& tree)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   for (size_t i = 0; i < tree.NumDescendants(); ++i)
   {
     arma::Col<ElemType> point = tree.Dataset().col(tree.Descendant(i));
@@ -139,7 +137,7 @@ void CheckBound(const TreeType& tree)
 
 TEST_CASE("UBTreeBoundTest", "[UBTreeTest]")
 {
-  typedef UBTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = UBTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   arma::mat dataset(8, 1000);
 
   dataset.randu();
@@ -152,7 +150,7 @@ TEST_CASE("UBTreeBoundTest", "[UBTreeTest]")
 template<typename TreeType, typename DistanceType>
 void CheckDistance(TreeType& tree, TreeType* node = NULL)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   if (node == NULL)
   {
     node = &tree;
@@ -239,7 +237,7 @@ void CheckDistance(TreeType& tree, TreeType* node = NULL)
 
 TEST_CASE("UBTreeDistanceTest", "[UBTreeTest]")
 {
-  typedef UBTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = UBTree<EuclideanDistance, EmptyStatistic, arma::mat>;
   arma::mat dataset(8, 200);
 
   dataset.randu();
@@ -251,7 +249,7 @@ TEST_CASE("UBTreeDistanceTest", "[UBTreeTest]")
 
 TEST_CASE("UBTreeTest", "[UBTreeTest]")
 {
-  typedef UBTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = UBTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   size_t maxRuns = 10; // Ten total tests.
   size_t pointIncrements = 1000; // Range is from 2000 points to 11000.

--- a/src/mlpack/tests/vantage_point_tree_test.cpp
+++ b/src/mlpack/tests/vantage_point_tree_test.cpp
@@ -18,7 +18,7 @@ using namespace mlpack;
 
 TEST_CASE("VPTreeTraitsTest", "[VantagePointTreeTest]")
 {
-  typedef VPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = VPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   bool b = TreeTraits<TreeType>::HasOverlappingChildren;
   REQUIRE(b == true);
@@ -124,7 +124,7 @@ TEST_CASE("HollowBallBoundTest", "[VantagePointTreeTest]")
 template<typename TreeType>
 void CheckBound(TreeType& tree)
 {
-  typedef typename TreeType::ElemType ElemType;
+  using ElemType = typename TreeType::ElemType;
   if (tree.IsLeaf())
   {
     // Ensure that the bound contains all descendant points.
@@ -168,7 +168,7 @@ void CheckBound(TreeType& tree)
 
 TEST_CASE("VPTreeBoundTest", "[VantagePointTreeTest]")
 {
-  typedef VPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = VPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   arma::mat dataset(8, 1000);
   dataset.randu();
@@ -179,7 +179,7 @@ TEST_CASE("VPTreeBoundTest", "[VantagePointTreeTest]")
 
 TEST_CASE("VPTreeTest", "[VantagePointTreeTest]")
 {
-  typedef VPTree<EuclideanDistance, EmptyStatistic, arma::mat> TreeType;
+  using TreeType = VPTree<EuclideanDistance, EmptyStatistic, arma::mat>;
 
   size_t maxRuns = 10; // Ten total tests.
   size_t pointIncrements = 1000; // Range is from 2000 points to 11000.


### PR DESCRIPTION
The `using` keyword improves readability simply be letting people read from left to right.
Additionally some `typename` keywords have been removed, when they have not been required.