### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
+++ b/src/mlpack/methods/amf/update_rules/svd_incomplete_incremental_learning.hpp
@@ -54,7 +54,7 @@ class SVDIncompleteIncrementalLearning
   SVDIncompleteIncrementalLearning(double u = 0.001,
                                    double kw = 0,
                                    double kh = 0)
-          : u(u), kw(kw), kh(kh), currentUserIndex(0)
+          : u(u), kw(kw), kh(kh), currentUserIndex(0), currentItemIndex(0)
   {
     // Nothing to do.
   }


### PR DESCRIPTION
The warning was detected during build of the tests on Linux with gcc 13.2.