### PR TITLE
Cross Entropy Loss

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/binary_cross_entropy_loss.hpp
@@ -91,14 +91,6 @@ class BCELossType
 // Default typedef for typical `arma::mat` usage.
 typedef BCELossType<arma::mat> BCELoss;
 
-/**
- * Alias of BCELossType.
- */
-typedef BCELossType<arma::mat> CrossEntropyError;
-
-template<typename MatType = arma::mat>
-using CrossEntropyErrorType = BCELossType<MatType>;
-
 } // namespace mlpack
 
 // Include implementation.

--- a/src/mlpack/methods/ann/loss_functions/cross_entropy_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cross_entropy_loss.hpp
@@ -1,37 +1,38 @@
+
 /**
- * @file methods/ann/loss_functions/cross_entropy_error.hpp
- * @author Konstantin Sidorov
+ * @file methods/ann/loss_functions/cross_entropy.hpp
+ * @author Antoine Dubois
  *
- * Definition of the binary-cross-entropy performance function.
- *
+ * Definition of the cross-entropy performance function between
+ * p and q. 
+ * !The target q must be passed as log-q to the Forward
+ * and backward methods.
+ * 
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTIONS_CROSS_ENTROPY_ERROR_HPP
-#define MLPACK_METHODS_ANN_LOSS_FUNCTIONS_CROSS_ENTROPY_ERROR_HPP
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTIONS_CROSS_ENTROPY_LOSS_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTIONS_CROSS_ENTROPY_LOSS_HPP
 
 #include <mlpack/prereqs.hpp>
 
 namespace mlpack {
 
 /**
- * The binary-cross-entropy performance function measures the Binary Cross
- * Entropy between the target and the output.
+ * The cross-entropy performance function measures the Cross
+ * Entropy between the target and the log-output.
  *
  * @tparam MatType Matrix representation to accept as input and use for
  *    computation.
  */
 template<typename MatType = arma::mat>
-class BCELossType
+class CrossEntropyLossType
 {
  public:
   /**
-   * Create the BinaryCrossEntropyLoss object.
-   *
-   * @param eps The minimum value used for computing logarithms
-   *            and denominators in a numerically stable way.
+   * Create the CrossEntropyLoss object.
    *
    * @param reduction Specifies the reduction to apply to the output. If false,
    *                  'mean' reduction is used, where sum of the output will be
@@ -39,34 +40,27 @@ class BCELossType
    *                  'sum' reduction is used and the output will be summed. It
    *                  is set to true by default.
    */
-  BCELossType(const double eps = 1e-10, const bool reduction = true);
+  CrossEntropyLossType(const bool reduction = true);
 
   /**
-   * Computes the cross-entropy function.
+   * Computes the cross-entropy function. sum (p log(q))
    *
-   * @param prediction Predictions used for evaluating the specified loss
-   *     function.
-   * @param target The target vector.
+   * @param logPrediction The logarithm of the predictions of the target
+   * @param target The target probability distribution: p
    */
-  typename MatType::elem_type Forward(const MatType& prediction,
+  typename MatType::elem_type Forward(const MatType& logPrediction,
                                       const MatType& target);
 
   /**
    * Ordinary feed backward pass of a neural network.
    *
-   * @param prediction Predictions used for evaluating the specified loss
-   *     function.
-   * @param target The target vector.
+   * @param logPrediction The logarithm of the predictions of the target
+   * @param target p the target distribution.
    * @param loss The calculated error.
    */
-  void Backward(const MatType& prediction,
+  void Backward(const MatType& logPrediction,
                 const MatType& target,
                 MatType& loss);
-
-  //! Get the epsilon.
-  double Eps() const { return eps; }
-  //! Modify the epsilon.
-  double& Eps() { return eps; }
 
   //! Get the reduction type, represented as boolean
   //! (false 'mean' reduction, true 'sum' reduction).
@@ -81,20 +75,17 @@ class BCELossType
   void serialize(Archive& ar, const uint32_t /* version */);
 
  private:
-  //! The minimum value used for computing logarithms and denominators
-  double eps;
-
   //! Boolean value that tells if reduction is 'sum' or 'mean'.
   bool reduction;
-}; // class BCELossType
+}; // class CrossEntropyLossType
 
 // Default typedef for typical `arma::mat` usage.
-typedef BCELossType<arma::mat> BCELoss;
+typedef CrossEntropyLossType<arma::mat> CrossEntropyLoss;
 
 } // namespace mlpack
 
 // Include implementation.
-#include "binary_cross_entropy_loss_impl.hpp"
+#include "cross_entropy_loss_impl.hpp"
 
 #endif
 

--- a/src/mlpack/methods/ann/loss_functions/cross_entropy_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cross_entropy_loss_impl.hpp
@@ -1,0 +1,65 @@
+/**
+ * @file methods/ann/loss_functions/cross_entropy_loss_impl.hpp
+ * @author Antoine Dubois
+ *
+ * Implementation of the cross-entropy performance function.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTIONS_CROSS_ENTROPY_LOSS_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTIONS_CROSS_ENTROPY_LOSS_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "cross_entropy_loss.hpp"
+
+namespace mlpack {
+
+template<typename MatType>
+CrossEntropyLossType<MatType>::CrossEntropyLossType(
+    const bool reduction) : reduction(reduction)
+{
+  // Nothing to do here.
+}
+
+template<typename MatType>
+typename MatType::elem_type CrossEntropyLossType<MatType>::Forward(
+    const MatType& logPrediction,
+    const MatType& target)
+{
+  typedef typename MatType::elem_type ElemType;
+
+  ElemType lossSum = -1.0 * arma::accu(target % logPrediction);
+
+  if (reduction)
+    return lossSum;
+
+  return lossSum / target.n_elem;
+}
+
+template<typename MatType>
+void CrossEntropyLossType<MatType>::Backward(
+    const MatType& ,
+    const MatType& target,
+    MatType& loss)
+{
+  loss = -target;
+  if (!reduction)
+    loss /= target.n_elem;
+}
+
+template<typename MatType>
+template<typename Archive>
+void CrossEntropyLossType<MatType>::serialize(
+    Archive& ar,
+    const uint32_t /* version */)
+{
+  ar(CEREAL_NVP(reduction));
+}
+
+} // namespace mlpack
+
+#endif
+

--- a/src/mlpack/methods/ann/loss_functions/loss_functions.hpp
+++ b/src/mlpack/methods/ann/loss_functions/loss_functions.hpp
@@ -15,6 +15,7 @@
 
 #include "binary_cross_entropy_loss.hpp"
 #include "cosine_embedding_loss.hpp"
+#include "cross_entropy_loss.hpp"
 #include "dice_loss.hpp"
 #include "earth_mover_distance.hpp"
 #include "empty_loss.hpp"

--- a/src/mlpack/tests/ann/loss_functions_test.cpp
+++ b/src/mlpack/tests/ann/loss_functions_test.cpp
@@ -1261,3 +1261,31 @@ TEST_CASE("JacobianNegativeLogLikelihoodLayerTest", "[LossFunctionsTest]")
     REQUIRE(error <= 1e-5);
   }
 }
+
+/**
+ * Cross Entropy loss test
+ */
+TEST_CASE("CrossEntropyLossTest", "[LossFunctionTest]")
+{
+  arma::mat prediction, target, output;
+  double loss, expectedLoss;
+  CrossEntropyLoss module;
+
+  // Test for sum reduction
+  prediction = arma::log(arma::mat("0.5 0.5 0.25 0.75 0.25 0.75"));
+  target = arma::mat("0.5 0.5 0.5 0.5 0.5 0.5");
+  expectedLoss = -1.0 * (
+    -0.6931471805599453
+    -0.8369882167858358
+    -0.8369882167858358);
+  prediction.reshape(2, 3);
+  target.reshape(2, 3);
+
+  loss = module.Forward(prediction, target);
+
+  REQUIRE(loss == Approx(expectedLoss).epsilon(1e-5));
+  arma::mat gradient;
+  module.Backward(prediction, target, gradient);
+  REQUIRE((gradient + target).max() <= 1e-5);
+}
+


### PR DESCRIPTION
This pull request introduces the Cross Entropy Loss function to mlpack, expanding it beyond the current binary categorical entropy. The Cross Entropy Loss function is widely used in deep reinforcement learning to train policy networks. This addition is a step toward implementing AlphaZero.

# Features
	1.	Implementation of the cross entropy loss function
	2.	Unit testing of the cross entropy loss function
	3.	Removal of the alias `CrossEntropyErrorType` and `CrossEntropyError ` of the binary cross entropy class `BCELossType`, which previously suggested that binary cross-entropy could support not categorical and multidimensional inputs.