### PR TITLE
Fix inconsistency in embedded tutorial

### DIFF
--- a/doc/embedded/crosscompile_armv7.md
+++ b/doc/embedded/crosscompile_armv7.md
@@ -113,7 +113,7 @@ cross-compilation toolchain.
 cmake \
     -DBUILD_TESTS=ON \
     -DBOARD_NAME="RPI2" \
-    -DCMAKE_CROSSCOMPILE=ON \
+    -DCMAKE_CROSSCOMPILING=ON \
     -DCMAKE_TOOLCHAIN_FILE=../board/crosscompile-toolchain.cmake \
     -DTOOLCHAIN_PREFIX=/path/to/bootlin/toolchain/armv7-eabihf--glibc--stable-2024.02-1/bin/arm-buildroot-linux-gnueabihf- \
     -DCMAKE_SYSROOT=/path/to/bootlin/toolchain/armv7-eabihf--glibc--stable-2024.02-1/arm-buildroot-linux-gnueabihf/sysroot \

--- a/doc/embedded/crosscompile_armv7.md
+++ b/doc/embedded/crosscompile_armv7.md
@@ -115,7 +115,7 @@ cmake \
     -DBOARD_NAME="RPI2" \
     -DCMAKE_CROSSCOMPILE=ON \
     -DCMAKE_TOOLCHAIN_FILE=../board/crosscompile-toolchain.cmake \
-    -DTOOLCHAIN_PREFIX=/path/to/bootlin/toolchain/armv7-eabihf--glibc--stable-2023.08-1/bin/arm-buildroot-linux-gnueabihf- \
+    -DTOOLCHAIN_PREFIX=/path/to/bootlin/toolchain/armv7-eabihf--glibc--stable-2024.02-1/bin/arm-buildroot-linux-gnueabihf- \
     -DCMAKE_SYSROOT=/path/to/bootlin/toolchain/armv7-eabihf--glibc--stable-2024.02-1/arm-buildroot-linux-gnueabihf/sysroot \
     ../
 ```


### PR DESCRIPTION
I was working through the embedded tutorial for an RPi3 today and I noticed that the CMake configuration command to build the tests uses two different buildroot directories.  This simple PR makes them the same.