### PR TITLE
Fix documentation link that's failing

### DIFF
--- a/doc/developer/community.md
+++ b/doc/developer/community.md
@@ -12,9 +12,9 @@ information, see [this page](gsoc.md).
 
 All mlpack development is done on [GitHub](https://github.com/mlpack/mlpack).
 Commits and issue comments can be tracked via the
-[mlpack-git](https://freelists.org/list/mlpack-git) list (graciously hosted by
-[FreeLists](https://freelists.org).  Communication is generally either via
-issues on GitHub, or via chat:
+[mlpack-git](https://www.freelists.org/list/mlpack-git) list (graciously hosted
+by [FreeLists](https://www.freelists.org).  Communication is generally either
+via issues on GitHub, or via chat:
 
 ## Real-time chat
 

--- a/doc/developer/gsoc.md
+++ b/doc/developer/gsoc.md
@@ -51,7 +51,7 @@ project. A student should ideally be familiar with
    mlpack are SFINAE ([example in mlpack, see std::enable_if usages](https://github.com/mlpack/mlpack/blob/565cfd3aad22deec0656b86e801052593a937723/src/mlpack/methods/mean_shift/mean_shift.hpp)),
    [policy-based design](https://www.drdobbs.com/policy-based-design-in-the-real-world/184401861),
    and [compile-time class traits](https://accu.org/index.php/journals/442).
-   Here are some [other useful resources](https://www.codeproject.com/Articles/3743/A-gentle-introduction-to-Template-Metaprogramming)
+   Here are some [other useful resources](https://en.wikipedia.org/wiki/Template_metaprogramming)
    for learning template metaprogramming, and some useful
    [reference books](https://www.aristeia.com/books.html).
    If some of this sounds new to you, don’t feel overwhelmed; it’s not a


### PR DESCRIPTION
Seems like codeproject.com is down and has been for a few days... I switched it out with Wikipedia.  The idea was just for that page to link to some resources that describe template metaprogramming, and I think Wikipedia will work fine.