### PR TITLE
Update deprecated .max(ind), .min(ind) to .index_max(), .index_min()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck('${{ needs.jobR.outputs.r_bindings }}', args = c('--no-manual','--as-cran'), error_on = 'warning', check_dir = 'check')"
+        run: Rscript -e "rcmdcheck::rcmdcheck('${{ needs.jobR.outputs.r_bindings }}', args = c('--no-manual','--as-cran'), error_on = 'error', check_dir = 'check')"
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck('${{ needs.jobR.outputs.r_bindings }}', args = c('--no-manual','--as-cran'), error_on = 'error', check_dir = 'check')"
+        run: Rscript -e "rcmdcheck::rcmdcheck('${{ needs.jobR.outputs.r_bindings }}', args = c('--no-manual','--as-cran'), error_on = 'warning', check_dir = 'check')"
 
       - name: Upload check results
         if: failure()

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -204,7 +204,7 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
   for (size_t i = 0; i < predictedLabels.n_cols; ++i)
   {
     probabilities.col(i) /= accu(probabilities.col(i));
-    probabilities.col(i).max(maxIndex);
+    maxIndex = probabilities.col(i).index_max();
     predictedLabels(i) = maxIndex;
   }
 }

--- a/src/mlpack/methods/approx_kfn/drusilla_select_impl.hpp
+++ b/src/mlpack/methods/approx_kfn/drusilla_select_impl.hpp
@@ -94,8 +94,7 @@ void DrusillaSelect<MatType>::Train(
   for (size_t i = 0; i < l; ++i)
   {
     // Pick best index.
-    arma::uword maxIndex = 0;
-    norms.max(maxIndex);
+    arma::uword maxIndex = norms.index_max();
 
     arma::vec line(refCopy.col(maxIndex) / norm(refCopy.col(maxIndex)));
 

--- a/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
+++ b/src/mlpack/methods/decision_tree/decision_tree_impl.hpp
@@ -1159,8 +1159,7 @@ void DecisionTree<FitnessFunction,
 
   // Now normalize into probabilities.
   classProbabilities /= UseWeights ? sumWeights : labels.n_elem;
-  arma::uword maxIndex = 0;
-  classProbabilities.max(maxIndex);
+  arma::uword maxIndex = classProbabilities.index_max();
   majorityClass = (size_t) maxIndex;
 }
 

--- a/src/mlpack/methods/hmm/hmm_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_impl.hpp
@@ -528,13 +528,14 @@ double HMM<Distribution>::Predict(const arma::mat& dataSeq,
     for (size_t j = 0; j < logTransition.n_rows; j++)
     {
       arma::vec prob = logStateProb.col(t - 1) + logTransition.row(j).t();
-      logStateProb(j, t) = prob.max(index) + logProbs(t, j);
+      index = prob.index_max();
+      logStateProb(j, t) = index + logProbs(t, j);
       stateSeqBack(j, t) = index;
     }
   }
 
   // Backtrack to find the most probable state sequence.
-  logStateProb.unsafe_col(dataSeq.n_cols - 1).max(index);
+  index = logStateProb.unsafe_col(dataSeq.n_cols - 1).index_max();
   stateSeq[dataSeq.n_cols - 1] = index;
   for (size_t t = 2; t <= dataSeq.n_cols; t++)
   {

--- a/src/mlpack/methods/hmm/hmm_impl.hpp
+++ b/src/mlpack/methods/hmm/hmm_impl.hpp
@@ -529,7 +529,7 @@ double HMM<Distribution>::Predict(const arma::mat& dataSeq,
     {
       arma::vec prob = logStateProb.col(t - 1) + logTransition.row(j).t();
       index = prob.index_max();
-      logStateProb(j, t) = index + logProbs(t, j);
+      logStateProb(j, t) = prob[index] + logProbs(t, j);
       stateSeqBack(j, t) = index;
     }
   }

--- a/src/mlpack/methods/hoeffding_trees/binary_numeric_split_impl.hpp
+++ b/src/mlpack/methods/hoeffding_trees/binary_numeric_split_impl.hpp
@@ -141,10 +141,9 @@ void BinaryNumericSplit<FitnessFunction, ObservationType>::Split(
   }
 
   // Calculate the majority classes of the children.
-  arma::uword maxIndex;
-  counts.unsafe_col(0).max(maxIndex);
+  arma::uword maxIndex = counts.unsafe_col(0).index_max();
   childMajorities[0] = size_t(maxIndex);
-  counts.unsafe_col(1).max(maxIndex);
+  maxIndex = counts.unsafe_col(1).index_max();
   childMajorities[1] = size_t(maxIndex);
 
   // Create the according SplitInfo object.
@@ -155,8 +154,7 @@ template<typename FitnessFunction, typename ObservationType>
 size_t BinaryNumericSplit<FitnessFunction, ObservationType>::MajorityClass()
     const
 {
-  arma::uword maxIndex;
-  classCounts.max(maxIndex);
+  arma::uword maxIndex = classCounts.index_max();
   return size_t(maxIndex);
 }
 

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_categorical_split_impl.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_categorical_split_impl.hpp
@@ -64,8 +64,7 @@ void HoeffdingCategoricalSplit<FitnessFunction>::Split(
   childMajorities.set_size(sufficientStatistics.n_cols);
   for (size_t i = 0; i < sufficientStatistics.n_cols; ++i)
   {
-    arma::uword maxIndex = 0;
-    sufficientStatistics.unsafe_col(i).max(maxIndex);
+    arma::uword maxIndex = sufficientStatistics.unsafe_col(i).index_max();
     childMajorities[i] = size_t(maxIndex);
   }
 
@@ -79,8 +78,7 @@ size_t HoeffdingCategoricalSplit<FitnessFunction>::MajorityClass() const
   // Calculate the class that we have seen the most of.
   arma::Col<size_t> classCounts = sum(sufficientStatistics, 1);
 
-  arma::uword maxIndex = 0;
-  classCounts.max(maxIndex);
+  arma::uword maxIndex = classCounts.index_max();
 
   return size_t(maxIndex);
 }

--- a/src/mlpack/methods/hoeffding_trees/hoeffding_numeric_split_impl.hpp
+++ b/src/mlpack/methods/hoeffding_trees/hoeffding_numeric_split_impl.hpp
@@ -122,8 +122,7 @@ void HoeffdingNumericSplit<FitnessFunction, ObservationType>::Split(
   childMajorities.set_size(sufficientStatistics.n_cols);
   for (size_t i = 0; i < sufficientStatistics.n_cols; ++i)
   {
-    arma::uword maxIndex = 0;
-    sufficientStatistics.unsafe_col(i).max(maxIndex);
+    arma::uword maxIndex = sufficientStatistics.unsafe_col(i).index_max();
     childMajorities[i] = size_t(maxIndex);
   }
 
@@ -144,8 +143,7 @@ size_t HoeffdingNumericSplit<FitnessFunction, ObservationType>::
     for (size_t i = 0; i < samplesSeen; ++i)
       classes[labels[i]]++;
 
-    arma::uword majorityClass;
-    classes.max(majorityClass);
+    arma::uword majorityClass = classes.index_max();
     return size_t(majorityClass);
   }
   else
@@ -154,8 +152,7 @@ size_t HoeffdingNumericSplit<FitnessFunction, ObservationType>::
     // statistics.
     arma::Col<size_t> classCounts = sum(sufficientStatistics, 1);
 
-    arma::uword maxIndex = 0;
-    classCounts.max(maxIndex);
+    arma::uword maxIndex = classCounts.index_max();
     return size_t(maxIndex);
   }
 }

--- a/src/mlpack/methods/kmeans/max_variance_new_cluster_impl.hpp
+++ b/src/mlpack/methods/kmeans/max_variance_new_cluster_impl.hpp
@@ -35,8 +35,7 @@ void MaxVarianceNewCluster::EmptyCluster(const MatType& data,
   this->iteration = iteration;
 
   // Now find the cluster with maximum variance.
-  arma::uword maxVarCluster = 0;
-  variances.max(maxVarCluster);
+  arma::uword maxVarCluster = variances.index_max();
 
   // If the cluster with maximum variance has variance of 0, then we can't
   // continue.  All the points are the same.

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -384,8 +384,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
   // Now calculate maximum probabilities for each point.
   for (size_t i = 0; i < data.n_cols; ++i)
   {
-    arma::uword maxIndex = 0;
-    logLikelihoods.unsafe_col(i).max(maxIndex);
+    arma::uword maxIndex = logLikelihoods.unsafe_col(i).index_max();
     predictions[i] = maxIndex;
   }
 }

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -258,8 +258,7 @@ size_t NaiveBayesClassifier<ModelMatType>::Classify(const VecType& point) const
   ModelMatType logLikelihoods;
   LogLikelihood(point, logLikelihoods);
 
-  arma::uword maxIndex = 0;
-  logLikelihoods.max(maxIndex);
+  arma::uword maxIndex = logLikelihoods.index_max();
   return maxIndex;
 }
 

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -243,8 +243,8 @@ void Perceptron<
       // Multiply for each variable and check whether the current weight vector
       // correctly classifies this.
       tempLabelMat = weights.t() * data.col(j) + biases;
-
-      tempLabelMat.max(maxIndexRow, maxIndexCol);
+      
+      maxIndexRow = arma::ind2sub(arma::size(tempLabelMat), tempLabelMat.index_max())(0);
 
       // Check whether prediction is correct.
       if (maxIndexRow != labels(0, j))
@@ -289,7 +289,7 @@ size_t Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   arma::uword maxIndex = 0;
 
   tempLabelVec = weights.t() * point + biases;
-  tempLabelVec.max(maxIndex);
+  maxIndex = tempLabelVec.index_max();
 
   return size_t(maxIndex);
 }
@@ -322,7 +322,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   for (size_t i = 0; i < test.n_cols; ++i)
   {
     tempLabelMat = weights.t() * test.col(i) + biases;
-    tempLabelMat.max(maxIndex);
+    maxIndex = tempLabelMat.index_max();
     predictedLabels(i) = maxIndex;
   }
 }

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -322,7 +322,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   for (size_t i = 0; i < test.n_cols; ++i)
   {
     tempLabelMat = weights.t() * test.col(i) + biases;
-    maxIndex = tempLabelMat.index_max();
+    tempLabelMat.max(maxIndex);
     predictedLabels(i) = maxIndex;
   }
 }

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -322,7 +322,7 @@ void Perceptron<LearnPolicy, WeightInitializationPolicy, MatType>::Classify(
   for (size_t i = 0; i < test.n_cols; ++i)
   {
     tempLabelMat = weights.t() * test.col(i) + biases;
-    tempLabelMat.max(maxIndex);
+    maxIndex = tempLabelMat.index_max();
     predictedLabels(i) = maxIndex;
   }
 }

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -243,8 +243,9 @@ void Perceptron<
       // Multiply for each variable and check whether the current weight vector
       // correctly classifies this.
       tempLabelMat = weights.t() * data.col(j) + biases;
-      
-      maxIndexRow = arma::ind2sub(arma::size(tempLabelMat), tempLabelMat.index_max())(0);
+
+      maxIndexRow = arma::ind2sub(arma::size(tempLabelMat),
+          tempLabelMat.index_max())(0);
 
       // Check whether prediction is correct.
       if (maxIndexRow != labels(0, j))

--- a/src/mlpack/methods/perceptron/perceptron_impl.hpp
+++ b/src/mlpack/methods/perceptron/perceptron_impl.hpp
@@ -225,7 +225,7 @@ void Perceptron<
   size_t j, i = 0;
   bool converged = false;
   size_t tempLabel;
-  arma::uword maxIndexRow = 0, maxIndexCol = 0;
+  arma::uword maxIndexRow = 0;
   arma::Mat<ElemType> tempLabelMat;
 
   LearnPolicy LP;

--- a/src/mlpack/methods/radical/radical_impl.hpp
+++ b/src/mlpack/methods/radical/radical_impl.hpp
@@ -103,8 +103,7 @@ inline typename MatType::elem_type Radical::Apply2D(const MatType& matX,
     values(i) = Vasicek(candidateY1, m) + Vasicek(candidateY2, m);
   }
 
-  arma::uword indOpt = 0;
-  values.min(indOpt); // we ignore the return value; we don't care about it
+  arma::uword indOpt = values.index_min();
   return (indOpt / (ElemType) angles) * M_PI / 2.0;
 }
 

--- a/src/mlpack/methods/random_forest/random_forest_impl.hpp
+++ b/src/mlpack/methods/random_forest/random_forest_impl.hpp
@@ -356,8 +356,7 @@ void RandomForest<
 
   // Find maximum element after renormalizing probabilities.
   probabilities /= trees.size();
-  arma::uword maxIndex = 0;
-  probabilities.max(maxIndex);
+  arma::uword maxIndex = probabilities.index_max();
 
   // Set prediction.
   prediction = (size_t) maxIndex;


### PR DESCRIPTION
This is a PR in response to an Armadillo 14.2.0 change that creates a fair amount of compilation noise for mlpack right now.  A corresponding (if smaller) PR for ensmallen [was made yesterday](https://github.com/mlpack/ensmallen/pull/409), tested fine, and is pending.

This PR driven primarily by the changes CRAN currently shows ([link here](https://cloud.r-project.org/web/checks/check_results_mlpack.html), screenshot of pertinent part below as the link will will change).

![image](https://github.com/user-attachments/assets/7ab9f6e0-463e-4e23-b23b-f4cf0f5cfed0)

(and similarly for the other OS/compiler combinations).

There is one warning I have addressed, namely
https://github.com/mlpack/mlpack/blob/4653e10b800f78b0cb1b5ef0a27a8af46b424bcb/src/mlpack/methods/perceptron/perceptron_impl.hpp#L247

This warns without a suggested alternate. If `std::max()` is to be used, then I may not understand the code -- `maxIndexCol` appears to be a constant zero here so is this meant to be `maxIndexRow = std::max(maxIndexRow, maxIndexCol);` where the latter is zero ... a null-op?  
