### PR TITLE
Make sure `GetPrintable` doesn't produce output during the call.

### DIFF
--- a/src/mlpack/methods/lsh/lsh_main.cpp
+++ b/src/mlpack/methods/lsh/lsh_main.cpp
@@ -182,6 +182,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   LSHSearch<>* allkann;
   if (params.Has("reference"))
   {
+    // Workaround: this avoids printing load information twice for the CLI
+    // bindings, where GetPrintable() will trigger a call to data::Load(),
+    // which prints loading information in the middle of the Log::Info
+    // message.
+    (void) params.Get<arma::mat>("reference");
+
     allkann = new LSHSearch<>();
     Log::Info << "Using reference data from "
         << params.GetPrintable<arma::mat>("reference") << "." << endl;
@@ -203,6 +209,9 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
         << endl;
     if (params.Has("query"))
     {
+      // Workaround: avoid printing load information twice for CLI bindings.
+      (void) params.Get<arma::mat>("query");
+
       Log::Info << "Loaded query data from "
           << params.GetPrintable<arma::mat>("query") << "." << endl;
       queryData = std::move(params.Get<arma::mat>("query"));

--- a/src/mlpack/methods/neighbor_search/kfn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/kfn_main.cpp
@@ -235,10 +235,10 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     kfn->RandomBasis() = randomBasis;
     kfn->LeafSize() = size_t(lsInt);
 
+    arma::mat& referenceSet = std::move(params.Get<arma::mat>("reference"));
+
     Log::Info << "Using reference data from "
         << params.GetPrintable<arma::mat>("reference") << "." << endl;
-
-    arma::mat referenceSet = std::move(params.Get<arma::mat>("reference"));
 
     kfn->BuildModel(timers, std::move(referenceSet), searchMode, epsilon);
   }
@@ -271,6 +271,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     arma::mat queryData;
     if (params.Has("query"))
     {
+      // Workaround: this avoids printing load information twice for the CLI
+      // bindings, where GetPrintable() will trigger a call to data::Load(),
+      // which prints loading information in the middle of the Log::Info
+      // message.
+      (void) params.Get<arma::mat>("query");
+
       Log::Info << "Using query data from "
           << params.GetPrintable<arma::mat>("query") << "." << endl;
       queryData = std::move(params.Get<arma::mat>("query"));

--- a/src/mlpack/methods/neighbor_search/knn_main.cpp
+++ b/src/mlpack/methods/neighbor_search/knn_main.cpp
@@ -248,10 +248,10 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     knn->Tau() = tau;
     knn->Rho() = rho;
 
+    arma::mat& referenceSet = params.Get<arma::mat>("reference");
+
     Log::Info << "Using reference data from "
         << params.GetPrintable<arma::mat>("reference") << "." << endl;
-
-    arma::mat referenceSet = std::move(params.Get<arma::mat>("reference"));
 
     knn->BuildModel(timers, std::move(referenceSet), searchMode, epsilon);
   }
@@ -284,6 +284,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     arma::mat queryData;
     if (params.Has("query"))
     {
+      // Workaround: this avoids printing load information twice for the CLI
+      // bindings, where GetPrintable() will trigger a call to data::Load(),
+      // which prints loading information in the middle of the Log::Info
+      // message.
+      (void) params.Get<arma::mat>("query");
+
       Log::Info << "Using query data from "
           << params.GetPrintable<arma::mat>("query") << "." << endl;
       queryData = std::move(params.Get<arma::mat>("query"));

--- a/src/mlpack/methods/perceptron/perceptron_main.cpp
+++ b/src/mlpack/methods/perceptron/perceptron_main.cpp
@@ -282,9 +282,9 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
   // Now, the training procedure is complete.  Do we have any test data?
   if (params.Has("test"))
   {
+    mat& testData = std::move(params.Get<arma::mat>("test"));
     Log::Info << "Classifying dataset '"
         << params.GetPrintable<arma::mat>("test") << "'." << endl;
-    mat testData = std::move(params.Get<arma::mat>("test"));
 
     if (testData.n_rows != p->P().Weights().n_rows)
     {

--- a/src/mlpack/methods/range_search/range_search_main.cpp
+++ b/src/mlpack/methods/range_search/range_search_main.cpp
@@ -206,10 +206,10 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     rs->TreeType() = tree;
     rs->RandomBasis() = randomBasis;
 
+    arma::mat& referenceSet = std::move(params.Get<arma::mat>("reference"));
+
     Log::Info << "Using reference data from "
         << params.GetPrintable<arma::mat>("reference") << "." << endl;
-
-    arma::mat referenceSet = std::move(params.Get<arma::mat>("reference"));
 
     const size_t leafSize = size_t(lsInt);
 
@@ -244,6 +244,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     arma::mat queryData;
     if (params.Has("query"))
     {
+      // Workaround: this avoids printing load information twice for the CLI
+      // bindings, where GetPrintable() will trigger a call to data::Load(),
+      // which prints loading information in the middle of the Log::Info
+      // message.
+      (void) params.Get<arma::mat>("query");
+
       Log::Info << "Using query data from "
           << params.GetPrintable<arma::mat>("query") << "." << endl;
       queryData = std::move(params.Get<arma::mat>("query"));

--- a/src/mlpack/methods/rann/krann_main.cpp
+++ b/src/mlpack/methods/rann/krann_main.cpp
@@ -205,9 +205,10 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     rann->TreeType() = tree;
     rann->RandomBasis() = randomBasis;
 
+    arma::mat& referenceSet = std::move(params.Get<arma::mat>("reference"));
+
     Log::Info << "Using reference data from "
         << params.GetPrintable<arma::mat>("reference") << "." << endl;
-    arma::mat referenceSet = std::move(params.Get<arma::mat>("reference"));
 
     rann->BuildModel(timers, std::move(referenceSet), size_t(lsInt), naive,
         singleMode);
@@ -246,6 +247,12 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& timers)
     arma::mat queryData;
     if (params.Has("query"))
     {
+      // Workaround: this avoids printing load information twice for the CLI
+      // bindings, where GetPrintable() will trigger a call to data::Load(),
+      // which prints loading information in the middle of the Log::Info
+      // message.
+      (void) params.Get<arma::mat>("query");
+
       queryData = std::move(params.Get<arma::mat>("query"));
       Log::Info << "Using query data from '"
           << params.GetPrintable<arma::mat>("query") << "' ("


### PR DESCRIPTION
@shrit noticed that the `mlpack_knn` binding would produce strange output when loading data:

```
$ ./bin/mlpack_knn -r ~/datasets/corel.csv -q ~/datasets/corel.csv -k 3 -v
[INFO ] Using reference data from Loading '/home/ryan/datasets/corel.csv' as CSV data.  Size is 32 x 37749.
[INFO ] '/home/ryan/datasets/corel.csv' (37749x32 matrix).
[INFO ] Building reference tree...
[INFO ] Tree built.
[INFO ] Using query data from Loading '/home/ryan/datasets/corel.csv' as CSV data.  Size is 32 x 37749.
[INFO ] '/home/ryan/datasets/corel.csv' (37749x32 matrix).
[INFO ] Searching for 3 neighbors with dual-tree kd-tree search...
```

You can see from the output that the first message is actually two messages being printed at the same time.

I dug into this and it is a strange artifact of how the command-line bindings work---the problem does not show up for other binding types.  The issue is this:

 * For command-line bindings, we call `data::Load()` the first time a parameter is accessed (e.g. `params.Get<arma::mat>("matrix")` or `params.GetPrintable<arma::mat>("matrix")`), and that call to `data::Load()` will produce output.
 * But in some bindings, the call to `GetPrintable<>` is used to print a status message.
 * If `GetPrintable<>` is called on a matrix parameter before the data has been loaded, then the `data::Load()` message will be printed while that `GetPrintable<>` call happens... leading to the duplicate message.

So, I found all bindings where this situation happens, and where possible I changed things around so that `GetPrintable<>` was not the first call that would trigger the load of a matrix.  So long as the first call is something like `params.Get<arma::mat>("matrix")`, then the load happens separately and there is no duplicate output.

After this PR the output of the program command above is:

```
[INFO ] Loading '/home/ryan/datasets/corel.csv' as CSV data.  Size is 32 x 37749.
[INFO ] Using reference data from '/home/ryan/datasets/corel.csv' (37749x32 matrix).
[INFO ] Building reference tree...
[INFO ] Tree built.
[INFO ] Loading '/home/ryan/datasets/corel.csv' as CSV data.  Size is 32 x 37749.
[INFO ] Using query data from '/home/ryan/datasets/corel.csv' (37749x32 matrix).
[INFO ] Searching for 3 neighbors with dual-tree kd-tree search...
```

which is what we would hope for.