### PR TITLE
rest of .max(index) to .index_max() changes

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -163,9 +163,8 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
     probabilities(prediction) += alpha[i];
   }
 
-  arma::uword maxIndex = 0;
   probabilities /= accu(probabilities);
-  maxIndex = probabilities.index_max();
+  arma::uword maxIndex = probabilities.index_max();
   prediction = (size_t) maxIndex;
 }
 

--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -165,7 +165,7 @@ void AdaBoost<WeakLearnerType, MatType>::Classify(
 
   arma::uword maxIndex = 0;
   probabilities /= accu(probabilities);
-  probabilities.max(maxIndex);
+  maxIndex = probabilities.index_max();
   prediction = (size_t) maxIndex;
 }
 

--- a/src/mlpack/methods/ann/loss_functions/vr_class_reward_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/vr_class_reward_impl.hpp
@@ -49,7 +49,7 @@ typename MatType::elem_type VRClassRewardType<MatType>::Forward(
 
   for (size_t i = 0; i < input.n_cols - 1; ++i)
   {
-    input.unsafe_col(i).max(index);
+    index = input.unsafe_col(i).index_max();
     reward = (index == target(i)) * scale;
   }
 

--- a/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
+++ b/src/mlpack/methods/naive_bayes/naive_bayes_classifier_impl.hpp
@@ -300,8 +300,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
       maxValue;
   probabilities = exp(logLikelihoods - logProbX); // log(exp(value)) == value.
 
-  arma::uword maxIndex = 0;
-  logLikelihoods.max(maxIndex);
+  arma::uword maxIndex = logLikelihoods.index_max();
   prediction = (size_t) maxIndex;
 }
 
@@ -331,8 +330,7 @@ void NaiveBayesClassifier<ModelMatType>::Classify(
 
   for (size_t i = 0; i < data.n_cols; ++i)
   {
-    arma::uword maxIndex = 0;
-    logLikelihoods.unsafe_col(i).max(maxIndex);
+    arma::uword maxIndex = logLikelihoods.unsafe_col(i).index_max();
     predictions[i] = maxIndex;
   }
 }

--- a/src/mlpack/tests/adaboost_test.cpp
+++ b/src/mlpack/tests/adaboost_test.cpp
@@ -644,7 +644,7 @@ TEMPLATE_TEST_CASE("ClassifyTest_VERTEBRALCOL", "[AdaBoostTest]", mat, fmat)
   for (size_t i = 0; i < predictedLabels1.n_cols; ++i)
   {
     pRow = probabilities.unsafe_col(i);
-    pRow.max(maxIndex);
+    maxIndex = pRow.index_max();
     REQUIRE(predictedLabels1(i) == maxIndex);
     REQUIRE(accu(probabilities.col(i)) == Approx(1));
   }
@@ -714,7 +714,7 @@ TEMPLATE_TEST_CASE("ClassifyTest_NONLINSEP", "[AdaBoostTest]", mat, fmat)
   for (size_t i = 0; i < predictedLabels1.n_cols; ++i)
   {
     pRow = probabilities.unsafe_col(i);
-    pRow.max(maxIndex);
+    maxIndex = pRow.index_max();
     REQUIRE(predictedLabels1(i) == maxIndex);
     REQUIRE(accu(probabilities.col(i)) == Approx(1).epsilon(1e-7));
   }
@@ -787,7 +787,7 @@ TEMPLATE_TEST_CASE("ClassifyTest_IRIS", "[AdaBoostTest]", mat, fmat)
   for (size_t i = 0; i < predictedLabels1.n_cols; ++i)
   {
     pRow = probabilities.unsafe_col(i);
-    pRow.max(maxIndex);
+    maxIndex = pRow.index_max();
     REQUIRE(predictedLabels1(i) == maxIndex);
     REQUIRE(accu(probabilities.col(i)) == Approx(1).epsilon(1e-7));
   }

--- a/src/mlpack/tests/mean_shift_test.cpp
+++ b/src/mlpack/tests/mean_shift_test.cpp
@@ -163,7 +163,8 @@ TEMPLATE_TEST_CASE("GaussianClustering", "[MeanShiftTest]", float, double)
           centroids.col(i));
 
       // Are we near a centroid of a Gaussian?
-      const ElemType minVal = centroidDistances.min(minIndices[i]);
+      minIndices[i] = centroidDistances.index_min();
+      const ElemType minVal = centroidDistances(minIndices[i]);
       success = (std::abs(minVal) <= 0.65);
       if (!success)
         break;
@@ -240,7 +241,8 @@ TEMPLATE_TEST_CASE("GaussianClusteringCentroidsOnly", "[MeanShiftTest]", float,
           centroids.col(i));
 
       // Are we near a centroid of a Gaussian?
-      const ElemType minVal = centroidDistances.min(minIndices[i]);
+      minIndices[i] = centroidDistances.index_min();
+      const ElemType minVal = centroidDistances(minIndices[i]);
       success = (std::abs(minVal) <= 0.65);
       if (!success)
         break;


### PR DESCRIPTION
@rcurtin followup to #3835, changing the remaining instances of deprecated`.max(index)` to `.index_max()` et al.

