### PR TITLE
Quieten STB compilation with -Wno-missing-field-initializers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,8 @@ if (CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -ftemplate-depth=1000")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 
-  # To remove unused functions warnings.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function")
+  # To remove unused functions warnings as well as missing-field-inits (from STB)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -Wno-missing-field-initializers")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function")
 endif()
 


### PR DESCRIPTION
This is a very minor 'quality of life' improvement.  On systems such as mine, STB is found system-wide (no we cannot alter it) and under the current compiler flags nags for pages on end with

```
In file included from /home/edd/git/mlpack/src/mlpack/core/data/save_image.hpp:24,  
                 from /home/edd/git/mlpack/src/mlpack/core/data/save.hpp:24,        
                 from /home/edd/git/mlpack/src/mlpack/core/util/io.hpp:32,          
                 from /home/edd/git/mlpack/src/mlpack/core.hpp:44,                  
                 from /home/edd/git/mlpack/build/src/mlpack/bindings/R/build/generate_r_bayesian_linear_regression.cpp:24:                       
/usr/include/stb/stb_image_write.h: In function ‘int stbi_write_bmp_to_func(void (*)(void*, void*, int), void*, int, int, int, const void*)’:
/usr/include/stb/stb_image_write.h:514:32: warning: missing initializer for member ‘stbi__write_context::context’ [-Wmissing-field-initializers]
  514 |    stbi__write_context s = { 0 };    
      |                                ^     
```

We could of course vendor STB as proposed in #3823 but at least until add the switch makes some noise go away.