### PR TITLE
Fix `-Wself-assign-field` in AdaBoost

### DIFF
--- a/src/mlpack/methods/adaboost/adaboost_impl.hpp
+++ b/src/mlpack/methods/adaboost/adaboost_impl.hpp
@@ -334,7 +334,6 @@ typename MatType::elem_type AdaBoost<WeakLearnerType, MatType>::TrainInternal(
   wl.clear();
   alpha.clear();
 
-  this->tolerance = tolerance;
   this->numClasses = numClasses;
 
   // crt is the cumulative rt value for terminating the optimization when rt is


### PR DESCRIPTION
This was reported by CRAN.  (I just fixed it manually in the tarball I uploaded, but wanted to get the fix into mlpack too, of course.)

```
../inst/include/mlpack/methods/adaboost/adaboost_impl.hpp:337:19: warning: assigning field to itself [-Wself-assign-field]    
```

Looks like some legacy code got left behind that is no longer needed.  `this->tolerance` is set by the `Train()` function, and doesn't need to be set in the `TrainInternal()` function.