### PR TITLE
Attempt to work around OpenBLAS thread thrashing issue

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -24,7 +24,7 @@ steps:
     git clone --depth 1 https://github.com/mlpack/jenkins-conf.git conf
 
     sudo apt-get install --yes --allow-unauthenticated \
-    	libopenblas-dev libstb-dev libcereal-dev xz-utils ccache
+        libopenblas-dev libstb-dev libcereal-dev xz-utils ccache
 
     if [ "$BINDING" = "python" ]; then
       python -m pip install --upgrade pip
@@ -68,7 +68,9 @@ steps:
   displayName: 'Build'
 
 # Run tests via ctest.
-- script: cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+# The OMP_NUM_THREADS is to prevent thrashing on older versions of OpenBLAS
+# (0.3.26 and older) where OpenMP and pthreads aren't playing together well.
+- script: cd build && OMP_NUM_THREADS=1 CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
   displayName: 'Run tests via ctest'
 
 # Ccache stats (two verbosity levels supported)

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -41,7 +41,7 @@ steps:
       ccache --set-config "hash_dir=false" 
       ccache --show-config
       ccache --zero-stats
-    fi  
+    fi
 
   displayName: 'Install Build Dependencies'
 
@@ -60,7 +60,9 @@ steps:
   displayName: 'Build'
 
 # Run tests via ctest.
-- script: cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+# The OMP_NUM_THREADS is to prevent thrashing on older versions of OpenBLAS
+# (0.3.26 and older) where OpenMP and pthreads aren't playing together well.
+- script: cd build && OMP_NUM_THREADS=1 CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
   displayName: 'Run tests via ctest'
 
 # Ccache stats (two verbosity levels supported

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -60,9 +60,7 @@ steps:
   displayName: 'Build'
 
 # Run tests via ctest.
-# The OMP_NUM_THREADS is to prevent thrashing on older versions of OpenBLAS
-# (0.3.26 and older) where OpenMP and pthreads aren't playing together well.
-- script: cd build && OMP_NUM_THREADS=1 CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+- script: cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
   displayName: 'Run tests via ctest'
 
 # Ccache stats (two verbosity levels supported

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           mkdir -p ~/.R
           cp -vax .github/etc/R_Makevars_${{ runner.os }} ~/.R/Makevars
-          
+
       - name: Configure Ccache for R
         run: |
           ccache --set-config "sloppiness=include_file_ctime"
@@ -113,7 +113,10 @@ jobs:
 
       - name: Run tests via ctest
         run: |
-          cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+          # The OMP_NUM_THREADS is to prevent thrashing on older versions of
+          # OpenBLAS (0.3.26 and older) where OpenMP and pthreads aren't playing
+          # together well.
+          cd build && OMP_NUM_THREADS=2 CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
 
       - name: Upload R packages
         uses: actions/upload-artifact@v4.4.0

--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ neural network, a compilation error will occur.
 
 ***Warning:*** older versions of OpenBLAS (0.3.26 and older) compiled to use
 pthreads may use too many threads for computation, causing significant slowdown.
-See the [test build guide](doc/user/install.md#build-tests) for more details and
-simple workarounds.
+OpenBLAS versions compiled with OpenMP do not suffer from this issue.  See the
+[test build guide](doc/user/install.md#build-tests) for more details and simple
+workarounds.
 
 See also:
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ add `#define MLPACK_ENABLE_ANN_SERIALIZATION` before including `<mlpack.hpp>`.
 If you don't define `MLPACK_ENABLE_ANN_SERIALIZATION` and your code serializes a
 neural network, a compilation error will occur.
 
-***Warning:*** older versions of OpenBLAS (0.3.26 and older) may use too many
-threads for computation, causing significant slowdown.  See the [test build
-guide](doc/user/install.md#build-tests) for more details and simple workarounds.
+***Warning:*** older versions of OpenBLAS (0.3.26 and older) compiled to use
+pthreads may use too many threads for computation, causing significant slowdown.
+See the [test build guide](doc/user/install.md#build-tests) for more details and
+simple workarounds.
 
 See also:
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ add `#define MLPACK_ENABLE_ANN_SERIALIZATION` before including `<mlpack.hpp>`.
 If you don't define `MLPACK_ENABLE_ANN_SERIALIZATION` and your code serializes a
 neural network, a compilation error will occur.
 
+***Warning:*** older versions of OpenBLAS (0.3.26 and older) may use too many
+threads for computation, causing significant slowdown.  See the [test build
+guide](doc/user/install.md#build-tests) for more details and simple workarounds.
+
 See also:
 
  * the [test program compilation section](doc/user/install.md#compiling-a-test-program)

--- a/doc/embedded/supported_boards.md
+++ b/doc/embedded/supported_boards.md
@@ -64,7 +64,7 @@ cmake \
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | CORTEXA76 | [Bootlin toolchain link](https://toolchains.bootlin.com/releases_aarch64.html)      | [Sysroot and toolchain prefix](#cortexa76) | [Cortex A76 on Wikipedia](https://en.wikipedia.org/wiki/ARM_Cortex-A76)  |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| C906      | [Bootlin toolchain link](https://toolchains.bootlin.com/releases_riscv64-lp64d.html)| [Sysroot and toolchain prefix](#c906) | [C906 on riscv](https://www.riscfive.com/2023/03/09/t-head-xuantie-c906-risc-v/) |
+| C906      | [Bootlin toolchain link](https://toolchains.bootlin.com/releases_riscv64-lp64d.html)| [Sysroot and toolchain prefix](#c906) | [C906 on riscv](https://www.riscvschool.com/2023/03/09/t-head-xuantie-c906-risc-v/) |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | x280      | [Bootlin toolchain link](https://toolchains.bootlin.com/releases_riscv64-lp64d.html)| [Sysroot and toolchain prefix](#x280) | [x280 on SiFive](https://www.sifive.cn/api/document-file?uid=x280-datasheet) |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -43,13 +43,13 @@ missing header files (e.g., `mlpack.hpp` missing in versions prior to 4.0).  To
 ensure compatibility with the latest mlpack features and examples, we recommend
 building mlpack from source, as explained in the [main README](../../README.md).
 
-***Warning:*** on Linux systems, older versions of OpenBLAS (0.3.26 and older)
-can over-use the number of cores on your system, causing slow execution of
-mlpack programs, especially mlpack's test suite.  To prevent this, set
-`OMP_NUM_THREADS` as detailed [in the test build
-guide](../user/install.md#build-tests), or install the `libopenblas-openmp`
-package on Ubuntu or Debian, or `openblas-openmp` package on Fedora.  Ubuntu
-24.04, Debian bookworm, and Fedora 41 and older are all affected by this issue.
+***Warning:*** on Ubuntu and Debian systems, older versions of OpenBLAS (0.3.26
+and older) can over-use the number of cores on your system, causing slow
+execution of mlpack programs, especially mlpack's test suite.  To prevent this,
+set `OMP_NUM_THREADS` as detailed [in the test build
+guide](../user/install.md#build-tests), or install the `libopenblas-openmp-dev`
+package on Ubuntu or Debian and remove `libopenblas-pthread-dev`.  Ubuntu 24.04,
+Debian bookworm, and older are all affected by this issue.
 
 ## Installing mlpack from vcpkg
 

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -37,12 +37,19 @@ docker run -it mlpack/mlpack /bin/bash
 If you prefer to build mlpack from scratch, see the
 [main README](../../README.md).
 
-**Note for Ubuntu LTS Users**: The libmlpack-dev version in the Ubuntu LTS 
+***Note for Ubuntu LTS Users***: The libmlpack-dev version in the Ubuntu LTS
 repositories may not always be the latest. This can lead to issues, such as
-missing header files (e.g., `mlpack.hpp` missing in versions prior to 4.0).
-To ensure compatibility with the latest mlpack features and examples,
-we recommend building mlpack from source, as explained in the
-[main README](../../README.md).
+missing header files (e.g., `mlpack.hpp` missing in versions prior to 4.0).  To
+ensure compatibility with the latest mlpack features and examples, we recommend
+building mlpack from source, as explained in the [main README](../../README.md).
+
+***Warning:*** on Linux systems, older versions of OpenBLAS (0.3.26 and older)
+can over-use the number of cores on your system, causing slow execution of
+mlpack programs, especially mlpack's test suite.  To prevent this, set
+`OMP_NUM_THREADS` as detailed [in the test build
+guide](../user/install.md#build-tests), or install the `libopenblas-openmp`
+package on Ubuntu or Debian, or `openblas-openmp` package on Fedora.  Ubuntu
+24.04, Debian bookworm, and Fedora 41 and older are all affected by this issue.
 
 ## Installing mlpack from vcpkg
 

--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -60,6 +60,14 @@ If you plan to write mlpack programs, make sure you have a C++ compiler that
 supports C++17 available (this may not be automatically installed by the package
 manager).
 
+***Warning:*** on Linux systems, older versions of OpenBLAS (0.3.26 and older)
+can over-use the number of cores on your system, causing slow execution of
+mlpack programs, especially mlpack's test suite.  To prevent this, set
+`OMP_NUM_THREADS` as detailed [below](#build-tests), or install the
+`libopenblas-openmp` package on Ubuntu or Debian, or `openblas-openmp` package
+on Fedora.  Ubuntu 24.04, Debian bookworm, and Fedora 41 and older are all
+affected by this issue.
+
 ## Install from source
 
 If you only intend to use mlpack in a C++ program, it is not necessary to
@@ -232,6 +240,24 @@ The `mlpack_test` program uses the [Catch2](https://github.com/catchorg/Catch2)
 library for unit testing; this supports many options---you can see them with
 `mlpack_test -h`.
 
+***Warning:*** on Linux systems, older versions of OpenBLAS (0.3.26 and older)
+can over-use the number of cores on your system, causing slow execution of
+mlpack programs, especially mlpack's test suite.  To prevent this, set
+`OMP_NUM_THREADS` to half the number of cores on your system; so, for a system
+with 8 cores, run
+
+```sh
+OMP_NUM_THREADS=4 bin/mlpack_test
+```
+
+This workaround should be applied to any mlpack program where:
+
+ * Compilation with OpenMP is enabled (e.g. `-fopenmp` is used),
+ * Armadillo is using OpenBLAS,
+ * OpenBLAS is version 0.3.26 or older, and
+ * OpenBLAS is compiled against pthreads (the default on Ubuntu, Debian, and
+   Fedora).
+
 ## Compiling a test program
 
 Once mlpack is installed and available on the system, it is easy to compile a
@@ -274,6 +300,9 @@ prefer different compilation options.
 ```sh
 g++ -O3 -std=c++17 -o my_program my_program.cpp -lopenblas -fopenmp
 ```
+
+ - See also the warning on OpenBLAS versions and too many threads in [the
+   previous section](#build-tests).
 
 See [the Armadillo documentation](https://arma.sourceforge.net/faq.html#linking)
 for more information on linking Armadillo programs.

--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -60,13 +60,13 @@ If you plan to write mlpack programs, make sure you have a C++ compiler that
 supports C++17 available (this may not be automatically installed by the package
 manager).
 
-***Warning:*** on Linux systems, older versions of OpenBLAS (0.3.26 and older)
-can over-use the number of cores on your system, causing slow execution of
-mlpack programs, especially mlpack's test suite.  To prevent this, set
-`OMP_NUM_THREADS` as detailed [below](#build-tests), or install the
-`libopenblas-openmp` package on Ubuntu or Debian, or `openblas-openmp` package
-on Fedora.  Ubuntu 24.04, Debian bookworm, and Fedora 41 and older are all
-affected by this issue.
+***Warning:*** on Ubuntu and Debian systems, older versions of OpenBLAS (0.3.26
+and older) can over-use the number of cores on your system, causing slow
+execution of mlpack programs, especially mlpack's test suite.  To prevent this,
+set `OMP_NUM_THREADS` as detailed [in the test build
+guide](../user/install.md#build-tests), or install the `libopenblas-openmp-dev`
+package on Ubuntu or Debian and remove `libopenblas-pthread-dev`.  Ubuntu 24.04,
+Debian bookworm, and older are all affected by this issue.
 
 ## Install from source
 
@@ -241,10 +241,11 @@ library for unit testing; this supports many options---you can see them with
 `mlpack_test -h`.
 
 ***Warning:*** on Linux systems, older versions of OpenBLAS (0.3.26 and older)
-can over-use the number of cores on your system, causing slow execution of
-mlpack programs, especially mlpack's test suite.  To prevent this, set
-`OMP_NUM_THREADS` to half the number of cores on your system; so, for a system
-with 8 cores, run
+compiled to use pthreads can over-use the number of cores on your system,
+causing slow execution of mlpack programs, especially mlpack's test suite.
+OpenBLAS versions compiled with OpenMP do not suffer from this issue.  To work
+around this problem, set `OMP_NUM_THREADS` to half the number of cores on your
+system; so, for a system with 8 cores, run
 
 ```sh
 OMP_NUM_THREADS=4 bin/mlpack_test


### PR DESCRIPTION
This is an attempt to fix #3852 by setting `OMP_NUM_THREADS` appropriately for CI jobs, and clarifying documentation throughout to point this issue out.

I wish that there was a better thing we could do to prevent this issue, but I think that we are stuck with it until Ubuntu 24.04 goes out of favor...