### PR TITLE
Switch remaining upload-artifact to v4*

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: |


### PR DESCRIPTION
This addresses a concern by GitHub expressed in mass-mail to repo owners (so I got it for other repos) and updates one remaining artifact action from the soon-to-be inactive @v3 to one of the @v4* values we already use in the same file in another spot.