### PR TITLE
Update cache Github action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows' && runner.os != 'macOS'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-release-${{ hashFiles('depends.Rds') }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows' && runner.os != 'macOS'
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}


### PR DESCRIPTION
I got an email indicating that we were using old versions of the `cache` action.  Let's try updating them... as far as I can tell, they work the same as before.