### PR TITLE
fix Trim() and TrimIf()

### DIFF
--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -27,11 +27,11 @@ namespace data {
  */
 inline void TrimIf(std::string &str, std::function<bool(char)> func)
 {
-  const auto leftmostCharToKeep =
+  const std::string::iterator leftmostCharToKeep =
       std::find_if_not(str.begin(), str.end(), func);
   str.erase(str.begin(), leftmostCharToKeep);
 
-  const auto leftmostTrailingCharToRemove =
+  const std::string::iterator leftmostTrailingCharToRemove =
       std::find_if_not(str.rbegin(), str.rend(), func).base();
   str.erase(leftmostTrailingCharToRemove, str.end());
 }

--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -17,45 +17,6 @@ namespace mlpack {
 namespace data {
 
 /**
- * A simple trim function to strip off whitespaces 
- * from both the sides of a string. If input is a string
- * with all spaces then str will be empty string.
- *
- * @param str the string to be trimmed.
- */
-inline void Trim(std::string& str)
-{
-  if (str.find_first_not_of(' ') == std::string::npos)
-  {
-    str = "";
-    return;
-  }
-
-  size_t startIndex = 0;
-
-  while (std::isspace(str[startIndex]))
-    startIndex++;
-
-  size_t endIndex = str.size() - 1;
-
-  while (std::isspace(str[endIndex]))
-    endIndex--;
-
-  std::string trimmedStr;
-
-  // Using ternary operator is not recommended here.
-  // Ternary operator is only useful for simple expressions
-  // that don't involve varrying types.
-  // https://en.cppreference.com/w/cpp/language/operator_other
-  if (endIndex - startIndex == str.size())
-    trimmedStr = std::move(str);
-  else
-    trimmedStr = str.substr(startIndex, endIndex - startIndex + 1);
-
-  str = trimmedStr;
-}
-
-/**
  * Trim off characters from start and end of
  * of the string. The supplied function is
  * used to determine which characters will
@@ -64,49 +25,20 @@ inline void Trim(std::string& str)
  * @param str the string to be trimmed.
  * @param func function to determine the characters which should be trimmed.
  */
-inline void TrimIf(std::string &str, std::function<bool(char)> func)
-{
-  if (str.find_first_not_of(' ') == std::string::npos)
-  {
-    str = "";
-    return;
-  }
+template <typename Func> void TrimIf(std::string &str, Func &&func) {
+  str.erase(str.begin(), std::find_if_not(str.begin(), str.end(), func));
+  str.erase(std::find_if_not(str.rbegin(), str.rend(), func).base(), str.end());
+}
 
-  size_t startIndex = 0;
-
-  for (size_t i = 0; i < str.size(); i++)
-  {
-    bool match = func(str[i]);
-
-    if (match)
-      startIndex++;
-    else
-      break;
-  }
-
-  size_t endIndex = str.size() - 1;
-
-  for (int i = str.size() - 1; i >= 0; i--)
-  {
-    bool match = func(str[i]);
-    if (match)
-      endIndex--;
-    else
-      break;
-  }
-
-  std::string trimmedStr;
-
-  // Using ternary operator is not recommended here.
-  // Ternary operator is only useful for simple expressions
-  // that don't involve varrying types.
-  // https://en.cppreference.com/w/cpp/language/operator_other
-  if (endIndex - startIndex == str.size())
-    trimmedStr = std::move(str);
-  else
-    trimmedStr = str.substr(startIndex, endIndex - startIndex + 1);
-
-  str = trimmedStr;
+/**
+ * A simple trim function to strip off whitespaces
+ * from both the sides of a string. If input is a string
+ * with all spaces then str will be empty string.
+ *
+ * @param str the string to be trimmed.
+ */
+inline void Trim(std::string &str) {
+  TrimIf(str, [](char c) { return std::isspace(c); });
 }
 
 /**

--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -25,7 +25,8 @@ namespace data {
  * @param str the string to be trimmed.
  * @param func function to determine the characters which should be trimmed.
  */
-inline void TrimIf(std::string &str, std::function<bool(char)> func) {
+inline void TrimIf(std::string &str, std::function<bool(char)> func)
+{
   const auto leftmostCharToKeep =
       std::find_if_not(str.begin(), str.end(), func);
   str.erase(str.begin(), leftmostCharToKeep);
@@ -42,7 +43,8 @@ inline void TrimIf(std::string &str, std::function<bool(char)> func) {
  *
  * @param str the string to be trimmed.
  */
-inline void Trim(std::string &str) {
+inline void Trim(std::string &str)
+{
   TrimIf(str, [](char c) { return std::isspace(c); });
 }
 

--- a/src/mlpack/core/data/string_algorithms.hpp
+++ b/src/mlpack/core/data/string_algorithms.hpp
@@ -25,9 +25,14 @@ namespace data {
  * @param str the string to be trimmed.
  * @param func function to determine the characters which should be trimmed.
  */
-template <typename Func> void TrimIf(std::string &str, Func &&func) {
-  str.erase(str.begin(), std::find_if_not(str.begin(), str.end(), func));
-  str.erase(std::find_if_not(str.rbegin(), str.rend(), func).base(), str.end());
+inline void TrimIf(std::string &str, std::function<bool(char)> func) {
+  const auto leftmostCharToKeep =
+      std::find_if_not(str.begin(), str.end(), func);
+  str.erase(str.begin(), leftmostCharToKeep);
+
+  const auto leftmostTrailingCharToRemove =
+      std::find_if_not(str.rbegin(), str.rend(), func).base();
+  str.erase(leftmostTrailingCharToRemove, str.end());
 }
 
 /**


### PR DESCRIPTION
The old implementations of `Trim()` and `TimIf()` had some problems:
- For inputs that consist only whitespace but do not contain a normal space (e.g. the string "\t"), `Trim()` accesses the input string at an invalid index. `endIndex` is decremented when it is already zero and the result is passed to the `[]` operator of the string.
- `TrimIf()` checks for the presence of spaces in the input string, regardless of the function that is passed. E.g. `std::string s = " "; TrimIf(s, [](char c){ return c == 'a';});` results in an emptry string instead of leaving the string untouched.