### PR TITLE
Turn silent disabling of OpenMP into an actual compilation error

### DIFF
--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -93,15 +93,15 @@
   #pragma warning(disable : 4519)
 #endif
 
-// OpenMP usage must be version 3.0 or newer, if it is being used.
+// OpenMP usage must be version 3.1 or newer, if it is being used.
 #if (defined(_OPENMP) && (_OPENMP >= 201107))
   #undef MLPACK_USE_OPENMP
   #define MLPACK_USE_OPENMP
 #elif defined(_OPENMP)
   #ifdef _MSC_VER
-    #error "mlpack requires OpenMP 3.0+; compile without /OPENMP"
+    #error "mlpack requires OpenMP 3.1+; compile without /OPENMP"
   #else
-    #error "mlpack requires OpenMP 3.0+; disable OpenMP with your compiler"
+    #error "mlpack requires OpenMP 3.1+; disable OpenMP in your compiler"
   #endif
 #endif
 

--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -95,6 +95,9 @@
 
 // OpenMP usage must be version 3.0 or newer, if it is being used.
 #if (defined(_OPENMP) && (_OPENMP >= 201107))
+  #undef MLPACK_USE_OPENMP
+  #define MLPACK_USE_OPENMP
+#elif defined(_OPENMP)
   #ifdef _MSC_VER
     #error "mlpack requires OpenMP 3.0 or newer; compile without /OPENMP"
   #else

--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -99,9 +99,9 @@
   #define MLPACK_USE_OPENMP
 #elif defined(_OPENMP)
   #ifdef _MSC_VER
-    #error "mlpack requires OpenMP 3.0 or newer; compile without /OPENMP"
+    #error "mlpack requires OpenMP 3.0+; compile without /OPENMP"
   #else
-    #error "mlpack requires OpenMP 3.0 or newer; disable OpenMP with your compiler"
+    #error "mlpack requires OpenMP 3.0+; disable OpenMP with your compiler"
   #endif
 #endif
 

--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -93,11 +93,13 @@
   #pragma warning(disable : 4519)
 #endif
 
-// This can be removed when Visual Studio supports an OpenMP version with
-// unsigned loop variables.
+// OpenMP usage must be version 3.0 or newer, if it is being used.
 #if (defined(_OPENMP) && (_OPENMP >= 201107))
-  #undef  MLPACK_USE_OPENMP
-  #define MLPACK_USE_OPENMP
+  #ifdef _MSC_VER
+    #error "mlpack requires OpenMP 3.0 or newer; compile without /OPENMP on Visual Studio or switch to a compiler that supports OpenMP 3.0"
+  #else
+    #error "mlpack requires OpenMP 3.0 or newer; disable OpenMP with your compiler"
+  #endif
 #endif
 
 #endif

--- a/src/mlpack/base.hpp
+++ b/src/mlpack/base.hpp
@@ -96,7 +96,7 @@
 // OpenMP usage must be version 3.0 or newer, if it is being used.
 #if (defined(_OPENMP) && (_OPENMP >= 201107))
   #ifdef _MSC_VER
-    #error "mlpack requires OpenMP 3.0 or newer; compile without /OPENMP on Visual Studio or switch to a compiler that supports OpenMP 3.0"
+    #error "mlpack requires OpenMP 3.0 or newer; compile without /OPENMP"
   #else
     #error "mlpack requires OpenMP 3.0 or newer; disable OpenMP with your compiler"
   #endif


### PR DESCRIPTION
This is a follow-up for #3873.  mlpack's CMake configuration will refuse to enable OpenMP for Visual Studio, where the OpenMP version is very old, but that only helps a user if they are building mlpack directly.  If a user is building their own project, they may simply enable `/OPENMP` when using Visual Studio.  But this will then result in compilation errors, because the Visual Studio OpenMP support is too old. Even though `base.hpp` does disable `MLPACK_USE_OPENMP`, this does not help compilation because we use unguarded `#pragma omp`s throughout the codebase (and I'd prefer to keep it this way: less boilerplate, simpler to read, and if you are compiling without OpenMP the pragmas just get ignored).

I thought about it for a little while and I think the best solution is to issue a compiler error if the OpenMP version is too old.  I wrote an MSVC-specific error message and then also an error message for other compilers.

Unfortunately, I cannot test this because I don't have a compiler with OpenMP < 3 and I don't have a Windows system either.  But I have a pretty strong belief it will work...