### PR TITLE
Fix style issues that cpplint 2 found

### DIFF
--- a/doc/developer/ci.md
+++ b/doc/developer/ci.md
@@ -106,8 +106,8 @@ The [style checker job](http://ci.mlpack.org/job/pull-requests%20mlpack%20style%
 
  * The [`lint.sh` script](https://github.com/mlpack/jenkins-conf/blob/master/linter/lint.sh) to check for C++ style issues.
 
- * If your job failed this check, look at the "Style-Check Warnings" tab in the
-   Jenkins job.
+ * If your job failed this check, look at the "Test Result" tab in the Jenkins
+   job.  Style issues for each file will be displayed in an expandable block.
 
  * See also the
    [style guidelines for mlpack](https://github.com/mlpack/mlpack/wiki/DesignGuidelines).

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -88,7 +88,9 @@ inline void RandomSeed(const size_t seed)
 #if (BINDING_TYPE == BINDING_TYPE_TEST)
 inline void FixedRandomSeed()
 {
-  static const size_t seed = rand_r();
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist;
+  const size_t seed = dist(rng);
   RandGen().seed((uint32_t) seed + RandGenSeedOffset());
   srand((unsigned int) seed);
   arma::arma_rng::set_seed(seed + RandGenSeedOffset());

--- a/src/mlpack/core/math/random.hpp
+++ b/src/mlpack/core/math/random.hpp
@@ -88,7 +88,7 @@ inline void RandomSeed(const size_t seed)
 #if (BINDING_TYPE == BINDING_TYPE_TEST)
 inline void FixedRandomSeed()
 {
-  static const size_t seed = rand();
+  static const size_t seed = rand_r();
   RandGen().seed((uint32_t) seed + RandGenSeedOffset());
   srand((unsigned int) seed);
   arma::arma_rng::set_seed(seed + RandGenSeedOffset());

--- a/src/mlpack/core/tree/address.hpp
+++ b/src/mlpack/core/tree/address.hpp
@@ -56,9 +56,8 @@ void PointToAddress(AddressType& address, const VecType& point)
 {
   using VecElemType = typename VecType::elem_type;
   // Check that the arguments are compatible.
-  using AddressElemType =
-      std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
-                         uint32_t, uint64_t>;
+  using AddressElemType = std::conditional_t<
+      (sizeof(VecElemType) * CHAR_BIT <= 32), uint32_t, uint64_t>;
 
   static_assert(std::is_same_v<typename AddressType::elem_type,
       AddressElemType> == true, "The vector element type does not "
@@ -152,9 +151,8 @@ void AddressToPoint(VecType& point, const AddressType& address)
 {
   using VecElemType = typename VecType::elem_type;
   // Check that the arguments are compatible.
-  using AddressElemType =
-      std::conditional_t<sizeof(VecElemType) * CHAR_BIT <= 32,
-                         uint32_t, uint64_t>;
+  using AddressElemType = std::conditional_t<
+      (sizeof(VecElemType) * CHAR_BIT <= 32), uint32_t, uint64_t>;
 
   static_assert(std::is_same_v<typename AddressType::elem_type,
       AddressElemType> == true, "The vector element type does not "

--- a/src/mlpack/core/tree/cellbound.hpp
+++ b/src/mlpack/core/tree/cellbound.hpp
@@ -76,8 +76,8 @@ class CellBound
  public:
   //! Depending on the precision of the tree element type, we may need to use
   //! uint32_t or uint64_t.
-  using AddressElemType = std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
-                                             uint32_t, uint64_t>;
+  using AddressElemType = std::conditional_t<
+      (sizeof(ElemType) * CHAR_BIT <= 32), uint32_t, uint64_t>;
 
   /**
    * Empty constructor; creates a bound of dimensionality 0.

--- a/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
+++ b/src/mlpack/core/tree/rectangle_tree/discrete_hilbert_value.hpp
@@ -30,9 +30,8 @@ class DiscreteHilbertValue
  public:
   //! Depending on the precision of the tree element type, we may need to use
   //! uint32_t or uint64_t.
-  using HilbertElemType =
-      std::conditional_t<sizeof(TreeElemType) * CHAR_BIT <= 32,
-                         uint32_t, uint64_t>;
+  using HilbertElemType = std::conditional_t<
+      (sizeof(TreeElemType) * CHAR_BIT <= 32), uint32_t, uint64_t>;
 
   //! Default constructor.
   DiscreteHilbertValue();

--- a/src/mlpack/tests/hmm_test.cpp
+++ b/src/mlpack/tests/hmm_test.cpp
@@ -1050,7 +1050,7 @@ TEST_CASE("GaussianHMMPredictTest", "[HMMTest]")
   {
     double loglikelihood;
     arma::vec forwardLogProb;
-    for (size_t t = 0; t<obs.n_cols; ++t)
+    for (size_t t = 0; t < obs.n_cols; ++t)
     {
       loglikelihood = hmm.LogLikelihood(obs.col(t), loglikelihood,
                                         forwardLogProb);
@@ -1065,7 +1065,7 @@ TEST_CASE("GaussianHMMPredictTest", "[HMMTest]")
   {
     double loglikelihood = 0;
     arma::vec forwardLogProb;
-    for (size_t t = 0; t<obs.n_cols; ++t)
+    for (size_t t = 0; t < obs.n_cols; ++t)
     {
       double logScale = hmm.LogScaleFactor(obs.col(t), forwardLogProb);
       loglikelihood += logScale;

--- a/src/mlpack/tests/main_tests/hmm_train_test.cpp
+++ b/src/mlpack/tests/main_tests/hmm_train_test.cpp
@@ -126,7 +126,7 @@ inline void ApproximatelyEqual(HMMModel& h1,
     {
       REQUIRE(d1[i].Gaussians() == d2[i].Gaussians());
       size_t gaussians = d1[i].Gaussians();
-      for (size_t j=0; j<gaussians; ++j)
+      for (size_t j = 0; j < gaussians; ++j)
       {
         CheckMatrices(d1[i].Component(j).Mean()*100,
             d2[i].Component(j).Mean()*100,

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -891,9 +891,6 @@ TEST_CASE("SplitMatDataShuffleWithLabelsAndWeights", "[SplitDataTest]")
     REQUIRE(found[c]);
 
   // Make sure we can find each column of the labels.
-  labels.print("labels");
-  trainLabels.print("trainLabels");
-  testLabels.print("testLabels");
   found.flip();
   for (size_t i = 0; i < trainLabels.n_elem; ++i)
   {

--- a/src/mlpack/tests/split_data_test.cpp
+++ b/src/mlpack/tests/split_data_test.cpp
@@ -891,6 +891,9 @@ TEST_CASE("SplitMatDataShuffleWithLabelsAndWeights", "[SplitDataTest]")
     REQUIRE(found[c]);
 
   // Make sure we can find each column of the labels.
+  labels.print("labels");
+  trainLabels.print("trainLabels");
+  testLabels.print("testLabels");
   found.flip();
   for (size_t i = 0; i < trainLabels.n_elem; ++i)
   {

--- a/src/mlpack/tests/ub_tree_test.cpp
+++ b/src/mlpack/tests/ub_tree_test.cpp
@@ -19,8 +19,8 @@ using namespace mlpack;
 TEST_CASE("AddressTest", "[UBTreeTest]")
 {
   using ElemType = double;
-  using AddressElemType = std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
-                                             uint32_t, uint64_t>;
+  using AddressElemType = std::conditional_t<
+      (sizeof(ElemType) * CHAR_BIT <= 32), uint32_t, uint64_t>;
   arma::Mat<ElemType> dataset(8, 1000);
 
   dataset.randu();
@@ -43,8 +43,8 @@ template<typename TreeType>
 void CheckSplit(const TreeType& tree)
 {
   using ElemType = typename TreeType::ElemType;
-  using AddressElemType = std::conditional_t<sizeof(ElemType) * CHAR_BIT <= 32,
-                                             uint32_t, uint64_t>;
+  using AddressElemType = std::conditional_t<
+      (sizeof(ElemType) * CHAR_BIT <= 32), uint32_t, uint64_t>;
 
   if (tree.IsLeaf())
     return;


### PR DESCRIPTION
While cleaning up Jenkins jobs, I updated the version of [`cpplint`](https://github.com/cpplint/cpplint) we use to version 2.  This is controlled in [`lint.sh`](https://github.com/mlpack/jenkins-conf/blob/master/linter/lint.sh) in the jenkins-conf repository.

The update was made as part of a larger Jenkins cleanup---I removed the `cppcheck` plugin from Jenkins because it was outdated and deprecated, and then I modified the lint scripts to output to JUnit XML directly, which can then be parsed with another (newer) plugin.

As part of this, there were a couple small style issues that cpplint asked to be handled and I obliged.