### PR TITLE
Add Mode Imputation Class in imputation_methods

### DIFF
--- a/src/mlpack/core/data/imputation_methods/imputation_methods.hpp
+++ b/src/mlpack/core/data/imputation_methods/imputation_methods.hpp
@@ -14,6 +14,7 @@
 
 #include "mean_imputation.hpp"
 #include "median_imputation.hpp"
+#include "mode_imputation.hpp"
 #include "listwise_deletion.hpp"
 #include "custom_imputation.hpp"
 

--- a/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
+++ b/src/mlpack/core/data/imputation_methods/mode_imputation.hpp
@@ -1,0 +1,95 @@
+/*
+ * Definition and Implementation of ModeImputation class
+*/
+
+#ifndef MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MODE_IMPUTATION_HPP
+#define MLPACK_CORE_DATA_IMPUTE_STRATEGIES_MODE_IMPUTATION_HPP
+
+#include <mlpack/prereqs.hpp>
+#include <unordered_map>
+
+namespace mlpack {
+namespace data {
+
+/**
+ * This class implements mode imputation, replacing missing values with the 
+ * most frequent (mode) value in the given dimension.
+ *
+ * @tparam T Type of Armadillo matrix.
+ */
+template <typename T>
+class ModeImputation
+{
+ public:
+  /**
+   * Impute function searches for mappedValue and replaces it with the 
+   * mode of the given dimension. The result is overwritten in the input matrix.
+   *
+   * @param input Matrix that contains mappedValue.
+   * @param mappedValue Value that should be replaced.
+   * @param dimension Index of the dimension containing mappedValue.
+   * @param columnMajor Whether the input matrix is column-major or row-major.
+   */
+  void Impute(arma::Mat<T>& input,
+              const T& mappedValue,
+              const size_t dimension,
+              const bool columnMajor = true)
+  {
+    std::unordered_map<T, size_t> frequencyMap;
+    
+    if (columnMajor)
+    {
+      for (size_t i = 0; i < input.n_cols; ++i)
+      {
+        T value = input(dimension, i);
+        if (value != mappedValue && !std::isnan(value))
+          frequencyMap[value]++;
+      }
+    }
+    else
+    {
+      for (size_t i = 0; i < input.n_rows; ++i)
+      {
+        T value = input(i, dimension);
+        if (value != mappedValue && !std::isnan(value))
+          frequencyMap[value]++;
+      }
+    }
+
+    // Determine the mode (most frequent value)
+    T mode = 0.0; // Default to 0 if all values are missing.
+    size_t maxFrequency = 0;
+
+    for (const auto& it : frequencyMap)
+    {
+      if (it.second > maxFrequency)
+      {
+        maxFrequency = it.second;
+        mode = it.first;
+      }
+    }
+
+    // Replace missing values with the mode
+    if (columnMajor)
+    {
+      for (size_t i = 0; i < input.n_cols; ++i)
+      {
+        if (input(dimension, i) == mappedValue || std::isnan(input(dimension, i)))
+          input(dimension, i) = mode;
+      }
+    }
+    else
+    {
+      for (size_t i = 0; i < input.n_rows; ++i)
+      {
+        if (input(i, dimension) == mappedValue || std::isnan(input(i, dimension)))
+          input(i, dimension) = mode;
+      }
+    }
+  }
+};
+
+} // namespace data
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/tests/imputation_test.cpp
+++ b/src/mlpack/tests/imputation_test.cpp
@@ -221,6 +221,54 @@ TEST_CASE("MedianImputationTest", "[ImputationTest]")
 }
 
 /**
+ * Make sure ModeImputation method replaces data 0 to mode value of each
+ * dimensions.
+ */
+TEST_CASE("ModeImputationTest", "[ImputationTest]")
+{
+  arma::mat columnWiseInput("3.0 0.0 2.0 0.0;"
+		                        "5.0 6.0 0.0 5.0;"
+		                        "9.0 6.0 4.0 8.0;");
+  arma::mat rowWiseInput(columnWiseInput);
+  double mappedValue = 0.0;
+
+  ModeImputation<double> imputer;
+
+  // column wise
+  imputer.Impute(columnWiseInput, mappedValue, 1, true); 
+    
+  REQUIRE(columnWiseInput(0, 0) == Approx(3.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(0, 1) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(0, 2) == Approx(2.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(0, 3) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(1, 0) == Approx(5.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(1, 1) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(1, 2) == Approx(5.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(1, 3) == Approx(5.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(2, 0) == Approx(9.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(2, 1) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(2, 2) == Approx(4.0).epsilon(1e-7));
+  REQUIRE(columnWiseInput(2, 3) == Approx(8.0).epsilon(1e-7));
+
+  // row wise
+  imputer.Impute(rowWiseInput, mappedValue, 1, false);
+
+  REQUIRE(rowWiseInput(0, 0) == Approx(3.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(0, 1) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(0, 2) == Approx(2.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(0, 3) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(1, 0) == Approx(5.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(1, 1) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(1, 2) == Approx(0.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(1, 3) == Approx(5.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(2, 0) == Approx(9.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(2, 1) == Approx(6.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(2, 2) == Approx(4.0).epsilon(1e-7));
+  REQUIRE(rowWiseInput(2, 3) == Approx(8.0).epsilon(1e-7));
+     
+}
+
+/**
  * Make sure ListwiseDeletion method deletes the whole column (if column wise)
  * or the row (if row wise) containing value of 0.
  */


### PR DESCRIPTION
While exploring the library, I found it already had imputation techniques like mean, median and custom imputation, but it didn't had any mode imputation technique. I have
<ul>
<li> Implemented ModeImputaion class </li>
<li> Used Unordered Map data structure to store the count of each data point </li>
<li> Build and check test </li>
<li> Couldn't find the relevant documentation, thus didn't add docs </li>
<li> Tried to maintain same coding standard as followed in other imputation classes </li>
</ul>
