### PR TITLE
Use r2u for Linux continuous integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,12 @@ jobs:
           echo "mlpack_r_package=$(echo mlpack_"$MLPACK_VERSION_VALUE".tar.gz)" >> $GITHUB_OUTPUT
 
       # Setup Pandoc
-      - uses: r-lib/actions/setup-pandoc@v2
+      - name: Setup pandoc
+        uses: r-lib/actions/setup-pandoc@v2
 
-      # Setup R actions
-      - uses: r-lib/actions/setup-r@v2
+      # Setup r2u (linux)
+      - name: Setup r2u
+        uses: eddelbuettel/github-actions/r2u-setup@master
 
       # Get and set up ccache
       - name: Get CCache
@@ -65,17 +67,10 @@ jobs:
       - name: Query dependencies
         run: |
           cp src/mlpack/bindings/R/mlpack/DESCRIPTION.in DESCRIPTION
-          Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps(dependencies = TRUE), 'depends.Rds')"
+          Rscript -e 'install.packages(c("remotes", "roxygen2", "pkgbuild"))'
+          Rscript -e 'remotes::install_deps(".", dependencies=TRUE)'
 
-      - name: Cache R packages
-        if: runner.os != 'Windows' && runner.os != 'macOS'
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-release-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-release-
-
-      - name: Install Build Dependencies
+      - name: Install Additional Build Dependencies
         run: |
           sudo apt-get update
           # We don't install cereal via apt, because the Debian packagers
@@ -94,21 +89,6 @@ jobs:
           # Fix cereal compilation on clang 19+; see
           # https://github.com/USCiLab/cereal/pull/835
           sed -i 's|::template apply|::apply|' cereal-1.3.2/include/cereal/types/tuple.hpp
-
-      - name: Install R-bindings dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran(c("roxygen2","pkgbuild"))
-        shell: Rscript {0}
-
-      # This appears to be needed to work around this issue:
-      # https://github.com/gagolews/stringi/issues/486
-      - name: "Work around stringi libicu issue"
-        if: inputs.lang == 'R' && runner.os == 'Linux'
-        shell: bash
-        run: |
-            wget http://mirrors.kernel.org/ubuntu/pool/main/i/icu/libicu70_70.1-2_amd64.deb
-            sudo dpkg -i libicu70_70.1-2_amd64.deb
 
       - name: CMake
         run: |
@@ -143,17 +123,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: windows-latest, r: "release", name: "Windows R" }
-          - { os: macOS-latest, r: "release", name: "macOS R" }
-          - {
-              os: ubuntu-latest,
-              r: "devel",
-              http-user-agent: "release",
-              name: "Linux R",
-            }
+          #- { os: windows-latest, r: "release", name: "Windows R" }
+          - { os: macOS-latest,   r: "release", name: "macOS R" }
+          - { os: ubuntu-latest,  r: "release", name: "Linux R" }
 
     env:
-      MAKEFLAGS: "-j 2"
+      MAKEFLAGS: "-j 4"
       R_BUILD_ARGS: "--no-build-vignettes"
       R_CHECK_ARGS: "--no-build-vignettes"
       _R_CHECK_FORCE_SUGGESTS: 0
@@ -166,42 +141,35 @@ jobs:
         with:
           name: mlpack_r_tarball
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - name: Setup pandoc
+        uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v2
+      - name: Setup p3m.dev (macos)
+        uses: r-lib/actions/setup-r@v2
+        if: runner.os == 'Windows' || runner.os == 'macOS'
         with:
           r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Query dependencies
-        run: Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps('${{ needs.jobR.outputs.r_bindings }}', dependencies = TRUE), 'depends.Rds')"
-
-      - name: Cache R packages
+      - name: Setup r2u (linux)
         if: runner.os != 'Windows' && runner.os != 'macOS'
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+        uses: eddelbuettel/github-actions/r2u-setup@master
 
-      - name: Install check dependencies
+      - name: Add system packages (linux)
         if: runner.os != 'Windows' && runner.os != 'macOS'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --allow-unauthenticated libcurl4-openssl-dev
+          sudo apt update -qq
+          sudo apt install -y --allow-unauthenticated libopenblas-dev liblapack-dev libensmallen-dev libarmadillo-dev
 
       - name: Install dependencies
         run: |
-          install.packages('remotes')
-          remotes::install_deps('${{ needs.jobR.outputs.r_bindings }}', dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-          remotes::install_cran("curl")
-        shell: Rscript {0}
+          Rscript -e "install.packages(c('remotes', 'rcmdcheck'))"
+          Rscript -e "remotes::install_deps('${{ needs.jobR.outputs.r_bindings }}', dependencies=TRUE)"
 
-      - name: Check
+      - name: Run the package check
         # TODO: revert to error_on = 'warning'
-        run: Rscript -e "rcmdcheck::rcmdcheck('${{ needs.jobR.outputs.r_bindings }}', args = c('--no-manual','--as-cran'), error_on = 'error', check_dir = 'check')"
+        run: |
+          Rscript -e "rcmdcheck::rcmdcheck('${{ needs.jobR.outputs.r_bindings }}', args = c('--no-manual','--as-cran'), error_on = 'error', check_dir = 'check')"
 
       - name: Upload check results
         if: failure()


### PR DESCRIPTION
This PR switches the Linux part of continuous integration to using [r2u](https://eddelbuettel.github.io/r2u) which yields faster installation as binaries are used (no need for a cache, simplifying the setup) and generally results in more robust behavior as the binaries have fully declared dependencies (as `.deb` binaries handled by `apt`) so no more surprises like `stringi` being compiled against the wrong `libicu*`.

It also reduces the scope away from windows, macos and linux to just the latter two as there is a pending PR dealing with windows.