### PR TITLE
Handle empty Armadillo objects in Python JSON conversion

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@ _????-??-??_
 
  * Bundle STB with mlpack and add `ResizeImages()` functionality (#3823).
 
+ * Fix conversion of empty Armadillo objects to numpy in Python bindings
+   (#3896).
+
 ## mlpack 4.5.1
 
 _2024-12-02_

--- a/src/mlpack/bindings/python/mlpack/preprocess_json_params.py
+++ b/src/mlpack/bindings/python/mlpack/preprocess_json_params.py
@@ -95,7 +95,7 @@ def np_to_arma(obj):
         n_rows, n_cols = obj[key].shape
 
         dic = OrderedDict()
-        
+
         dic["n_rows"] = str(n_cols) # implicit transpose
         dic["n_cols"] = str(n_rows) # implicit transpose
 
@@ -127,14 +127,18 @@ def arma_to_np(obj):
   if isinstance(obj, OrderedDict):
     for key in obj.keys():
       if isinstance(obj[key], OrderedDict):
-        # if "vec_state" is present in dictionary, then
-        # it must be armadillo vector. 
+        # if "vec_state" is present in dictionary, then it must be an Armadillo
+        # vector.
         if "vec_state" in obj[key].keys():
           n_rows = int(obj[key]["n_rows"])
           n_cols = int(obj[key]["n_cols"])
-          # implicit transpose
-          obj[key] = np.array(obj[key]["elem"])\
-              .reshape(n_cols, n_rows).astype(type(obj[key]["elem"][0]))
+
+          # Perform an implicit transpose, if there are any elements.
+          if n_rows > 0 and n_cols > 0:
+            obj[key] = np.array(obj[key]["elem"]).reshape(n_cols,
+                n_rows).astype(type(obj[key]["elem"][0]))
+          else:
+            obj[key] = np.zeros((n_rows, n_cols))
         else:
           arma_to_np(obj[key])
       else:


### PR DESCRIPTION
This fixes #3886.  Basically, the crash there happens like this:

 * When a user calls `.get_cpp_params()` on an mlpack object in Python, this uses cereal to serialize the C++ object to JSON.
 * We then load the JSON object into a Python dict with Python's `json.loads()`.
 * We detect any Armadillo objects in the dict and convert them to numpy objects.
 * During that conversion, we look for the `elem` key in the dictionary representation of the Armadillo object; but the code crashes, because for an empty Armadillo matrix (e.g. 0 rows or 0 columns), no `elem` key is serialized by cereal...

so, I addressed this by checking if the number of rows or columns is 0, and if so, returning an empty numpy object with the correct size.