### PR TITLE
Use catch `-o` option for junit output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,7 @@ jobs:
           # The use of only one thread is to prevent thrashing on older versions
           # of OpenBLAS (0.3.26 and older) where OpenMP and pthreads aren't
           # playing together well.
-          OMP_NUM_THREADS=1 bin/mlpack_test -r junit | tee /dev/stderr > mlpack_test.junit.xml
-          # Remove version numbers and other non-xml from the output.
-          cat mlpack_test.junit.xml | sed '/<?xml/,$!d' > mlpack_test.junit.xml.tmp
-          mv mlpack_test.junit.xml.tmp mlpack_test.junit.xml
+          OMP_NUM_THREADS=1 bin/mlpack_test -r junit -o mlpack_test.junit.xml
 
       # Run binding tests for each binding type.
       - name: Run binding tests

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -26,6 +26,10 @@ TEST_CASE("NoExtensionLoad", "[LoadSaveTest]")
 {
   arma::mat out;
   REQUIRE(data::Load("noextension", out) == false);
+
+  std::cerr << "This is some stderr output!\n";
+  std::cout << "This is some stdout output!\n";
+  REQUIRE(false);
 }
 
 /**

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -26,10 +26,6 @@ TEST_CASE("NoExtensionLoad", "[LoadSaveTest]")
 {
   arma::mat out;
   REQUIRE(data::Load("noextension", out) == false);
-
-  std::cerr << "This is some stderr output!\n";
-  std::cout << "This is some stdout output!\n";
-  REQUIRE(false);
 }
 
 /**


### PR DESCRIPTION
The current GHA pipelines code, when it runs the tests, redirects all output into a file which it then parses to remove unnecessary output.  But Catch2 offers a `-o` option which could mean we don't even need the redirect/postprocessing!

For testing, I have forced a test to fail and give stdout and stderr output, so that I can ensure this is still visible from the GHA test output.  If everything works, I'll remove that, and the only change will be `ci.yml`.