### PR TITLE
Minor CI cleanups

### DIFF
--- a/.jenkins/cross-compilation/Jenkinsfile
+++ b/.jenkins/cross-compilation/Jenkinsfile
@@ -13,19 +13,26 @@ pipeline
   {
     // Only allow one build at a time of this job.
     disableConcurrentBuilds(abortPrevious: true)
+
+    // We will do checkout manually.
+    skipDefaultCheckout()
   }
 
   stages
   {
-    stage('Set build as pending')
+    stage('Set up workspace')
     {
       steps
       {
-        // Set the build status...
+        cleanWs(deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true)
+        checkout scm
+
         script
         {
           u = load '.jenkins/utils.groovy'
-          u.startBuild("Cross-compilation Tests");
+          u.startCheck('Cross-compilation checks', 'Setting up workspace...')
         }
 
         // Create a directory for our resulting reports.
@@ -79,6 +86,11 @@ pipeline
             }
             steps
             {
+              script
+              {
+                u.updateCheckStatus('Building mlpack for ' + env.target + '...')
+              }
+
               sh '''
                 rm -rf build/
                 mkdir build/
@@ -94,6 +106,11 @@ pipeline
                     ../
                 make mlpack_test;
               '''
+
+              script
+              {
+                u.updateCheckStatus('Testing mlpack on ' + env.target + '...')
+              }
 
               withCredentials([sshUserPrivateKey(
                   credentialsId: 'mlpack-jenkins-cross-compile-rsa-key',
@@ -138,24 +155,27 @@ pipeline
 
   post
   {
+    success
+    {
+      script { u.finishCheck('Cross-compilation checks passed.', true) }
+    }
+
+    failure
+    {
+      script { u.finishCheck('Cross-compilation checks failed.', false) }
+    }
+
     always
     {
-      junit '**/reports/mlpack_test.*.junit.xml'
+      junit(allowEmptyResults: true,
+            skipPublishingChecks: true,
+            testResults: '**/reports/mlpack_test.*.junit.xml')
 
       // Clean the workspace.
       cleanWs(cleanWhenNotBuilt: true,
               deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true)
-
-      script
-      {
-        u.setBuildStatus(result: currentBuild.currentResult,
-                         context: "Cross-compilation Tests",
-                         successMessage: "Cross-compilation succeeded with no errors.",
-                         unstableMessage: "Cross-compilation build unstable.",
-                         failureMessage: "Cross-compilation failed.");
-      }
     }
   }
 }

--- a/.jenkins/doc-link-check/Jenkinsfile
+++ b/.jenkins/doc-link-check/Jenkinsfile
@@ -99,12 +99,12 @@ pipeline
     {
       // Publish the generated HTML.
       publishHTML([
-        allowMissing: false,
-        alwaysLinkToLastBuild: false,
-        keepAll: true,
-        reportDir: 'doc/html/',
-        reportFiles: 'index.html',
-        reportName: 'Build documentation']);
+          allowMissing: false,
+          alwaysLinkToLastBuild: false,
+          keepAll: true,
+          reportDir: 'doc/html/',
+          reportFiles: 'index.html',
+          reportName: 'Build documentation']);
 
       // Clean the workspace.
       cleanWs(cleanWhenNotBuilt: true,

--- a/.jenkins/doc-link-check/Jenkinsfile
+++ b/.jenkins/doc-link-check/Jenkinsfile
@@ -33,17 +33,19 @@ pipeline
     // Check out the repository and start the check.
     stage('Set up workspace')
     {
-      cleanWs(deleteDirs: true,
-              disableDeferredWipeout: true,
-              notFailBuild: true)
-      checkout scm
-
       steps
       {
-        u = load '.jenkins/utils.groovy'
-        u.startCheck('Documentation link check', 'Setting up workspace...')
-      }
+        cleanWs(deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true)
+        checkout scm
 
+        script
+        {
+          u = load '.jenkins/utils.groovy'
+          u.startCheck('Documentation link check', 'Setting up workspace...')
+        }
+      }
     }
 
     // Actually run the check.

--- a/.jenkins/doc-link-check/Jenkinsfile
+++ b/.jenkins/doc-link-check/Jenkinsfile
@@ -23,21 +23,35 @@ pipeline
   {
     // Only allow one build at a time of this job.
     disableConcurrentBuilds(abortPrevious: true)
+
+    // We will do checkout manually.
+    skipDefaultCheckout()
   }
 
   stages
   {
-    // First we have to check out the jenkins-conf repository, which contains
-    // the scripts that we will use for checking the style.
+    // Check out the repository and start the check.
+    stage('Set up workspace')
+    {
+      cleanWs(deleteDirs: true,
+              disableDeferredWipeout: true,
+              notFailBuild: true)
+      checkout scm
+
+      steps
+      {
+        u = load '.jenkins/utils.groovy'
+        u.startCheck('Documentation link check', 'Setting up workspace...')
+      }
+
+    }
+
+    // Actually run the check.
     stage('Build documentation and check links')
     {
       steps
       {
-        script
-        {
-          u = load '.jenkins/utils.groovy'
-          u.startBuild("Documentation Link Check");
-        }
+        script { u.updateCheckStatus('Checking documentation links...') }
 
         sh '''
           # Set $HOME because the Docker container may be running with a
@@ -76,6 +90,9 @@ pipeline
 
   post
   {
+    success { script { u.finishCheck('No HTML issues found.', true) } }
+    failure { script { u.finishCheck('Problems found in HTML.', false) } }
+
     always
     {
       // Publish the generated HTML.
@@ -92,16 +109,6 @@ pipeline
               deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true);
-
-      // Set the build status.
-      script
-      {
-        u.setBuildStatus(result: currentBuild.currentResult,
-                         context: "Documentation Link Check",
-                         successMessage: "All HTML links checked.",
-                         unstableMessage: "Problem with HTML links.",
-                         failureMessage: "HTML link check failure or problem.");
-      }
     }
   }
 }

--- a/.jenkins/doc-snippet-build/Jenkinsfile
+++ b/.jenkins/doc-snippet-build/Jenkinsfile
@@ -18,19 +18,36 @@ pipeline
   {
     // Only allow one build at a time of this job.
     disableConcurrentBuilds(abortPrevious: true)
+
+    // We will do checkout manually.
+    skipDefaultCheckout()
   }
 
   stages
   {
+    stage('Set up workspace')
+    {
+      steps
+      {
+        // Clean the workspace.
+        cleanWs(deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true);
+        checkout scm
+
+        script
+        {
+          u = load '.jenkins/utils.groovy'
+          u.startCheck('Documentation snippet build', 'Setting up workspace...')
+        }
+      }
+    }
+
     stage('Extract and build documentation snippets')
     {
       steps
       {
-        script
-        {
-          u = load '.jenkins/utils.groovy'
-          u.startBuild("Documentation Snippet Build");
-        }
+        script { u.updateCheckStatus('Testing documentation snippets...') }
 
         sh'''
           export CCACHE_DIR=/opt/ccache/;
@@ -52,6 +69,22 @@ pipeline
 
   post
   {
+    success
+    {
+      script
+      {
+        u.finishCheck('All documentation snippets build and run.', true)
+      }
+    }
+
+    failure
+    {
+      script
+      {
+        u.finishCheck('Problems building documentation snippets.', false)
+      }
+    }
+
     always
     {
       // Clean the workspace.
@@ -59,16 +92,6 @@ pipeline
               deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true);
-
-      // Set the build status.
-      script
-      {
-        u.setBuildStatus(result: currentBuild.currentResult,
-                         context: "Documentation Snippet Build",
-                         successMessage: "All snippets built and run successfully.",
-                         unstableMessage: "Snippets build unstable..",
-                         failureMessage: "Snippet build or runtime failure.");
-      }
     }
   }
 }

--- a/.jenkins/memory-checks/Jenkinsfile
+++ b/.jenkins/memory-checks/Jenkinsfile
@@ -17,22 +17,32 @@ pipeline
   {
     // Only allow one build at a time of this job.
     disableConcurrentBuilds(abortPrevious: true)
+
+    // We will do checkout manually.
+    skipDefaultCheckout()
   }
 
   stages
   {
     // First we have to check out the jenkins-conf repository, which contains
     // the scripts that we will use for checking the style.
-    stage('Check out jenkins-conf repository')
+    stage('Set up workspace')
     {
       steps
       {
+        cleanWs(deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true)
+        checkout scm
+
         script
         {
           u = load '.jenkins/utils.groovy'
-          u.startBuild("Memory Checks");
+          u.startCheck('Memory checks', 'Setting up workspace...')
         }
 
+        // We also need the jenkins-conf repository for the memory checking
+        // scripts.
         sh '''
           git clone https://github.com/mlpack/jenkins-conf
         '''
@@ -44,6 +54,8 @@ pipeline
     {
       steps
       {
+        script { u.updateCheckStatus('Building mlpack...') }
+
         sh '''
           export CCACHE_DIR=/opt/ccache/;
           ccache --zero-stats
@@ -69,6 +81,8 @@ pipeline
         // what files have changed.
         script
         {
+          u.updateCheckStatus('Running memory checks...')
+
           if (env.BRANCH_NAME.startsWith('PR-'))
           {
             // Strip 'PR-' from the front.
@@ -112,9 +126,20 @@ pipeline
 
   post
   {
+    success
+    {
+      script { u.finishCheck('No memory errors found.', true) }
+    }
+
+    failure
+    {
+      script { u.finishCheck('Memory errors found.', false) }
+    }
+
     always
     {
       junit(allowEmptyResults: true,
+            skipPublishingChecks: true,
             testResults: '**/reports/tests/*.xml')
 
       // Clean the workspace.

--- a/.jenkins/memory-checks/Jenkinsfile
+++ b/.jenkins/memory-checks/Jenkinsfile
@@ -147,16 +147,6 @@ pipeline
               deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true)
-
-      // Set the build status.
-      script
-      {
-        u.setBuildStatus(result: currentBuild.currentResult,
-                         context: "Memory Checks",
-                         successMessage: "No memory errors.",
-                         unstableMessage: "Build unstable.",
-                         failureMessage: "Memory check failure with valgrind.");
-      }
     }
   }
 }

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline
                       status: 'IN_PROGRESS',
                       title: 'Style checks (title)',
                       text: 'Setting up workspace...',
-                      detailsURL: absoluteUrl)
+                      detailsURL: job.getAbsoluteUrl())
 
         cleanWs(deleteDirs: true,
                 disableDeferredWipeout: true,
@@ -74,7 +74,7 @@ pipeline
                       status: 'IN_PROGRESS',
                       title: 'Style checks (title)',
                       text: 'Checking code style...',
-                      detailsURL: absoluteUrl)
+                      detailsURL: job.getAbsoluteUrl())
 
         sh '''
           mkdir -p reports
@@ -108,7 +108,7 @@ pipeline
                     conclusion: 'FAILURE',
                     title: 'Style checks (title)',
                     text: 'Style checks failed.',
-                    detailsURL: absoluteUrl)
+                    detailsURL: job.getAbsoluteUrl())
     }
 
     success
@@ -118,7 +118,7 @@ pipeline
                     conclusion: 'SUCCESS',
                     title: 'Style checks (title)',
                     text: 'Style checks passed.',
-                    detailsURL: absoluteUrl)
+                    detailsURL: job.getAbsoluteUrl())
 
     }
 

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -101,6 +101,7 @@ pipeline
     {
       // Process the test results.
       junit(allowEmptyResults: true,
+            skipPublishingChecks: true,
             testResults: '**/reports/cpplint.junit.xml')
 
       // Clean the workspace after the build too.

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -28,10 +28,13 @@ pipeline
     {
       steps
       {
-        // Set the initial status.
-        u = load '.jenkins/utils.groovy'
-        u.startCheck(name: 'Style checks',
-                     status: 'Setting up workspace...')
+        script
+        {
+          // Set the initial status.
+          u = load '.jenkins/utils.groovy'
+          u.startCheck(name: 'Style checks',
+                       status: 'Setting up workspace...')
+        }
 
         cleanWs(deleteDirs: true,
                 disableDeferredWipeout: true,

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -28,6 +28,11 @@ pipeline
     {
       steps
       {
+        cleanWs(deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true)
+        checkout scm
+
         script
         {
           // Set the initial status.
@@ -35,11 +40,6 @@ pipeline
           u.startCheck(name: 'Style checks',
                        status: 'Setting up workspace...')
         }
-
-        cleanWs(deleteDirs: true,
-                disableDeferredWipeout: true,
-                notFailBuild: true)
-        checkout scm
 
         sh '''
           git clone https://github.com/mlpack/jenkins-conf

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline
         script
         {
           // Set the initial status.
-          def u = load '.jenkins/utils.groovy'
+          u = load '.jenkins/utils.groovy'
           u.startCheck('Style checks', 'Setting up workspace...')
         }
 

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -33,7 +33,13 @@ pipeline
                 notFailBuild: true)
         checkout scm
 
-        // We also need the jenkins-conf repository for the style check scripts.
+        script
+        {
+          // Set the initial status.
+          u = load '.jenkins/utils.groovy'
+          u.startCheck('Style checks', 'Setting up workspace...')
+        }
+
         sh '''
           git clone https://github.com/mlpack/jenkins-conf
         '''
@@ -45,6 +51,11 @@ pipeline
     {
       steps
       {
+        script
+        {
+          u.updateCheckStatus('Checking code style...')
+        }
+
         sh '''
           mkdir -p reports
           ./jenkins-conf/linter/lint.sh \
@@ -61,6 +72,31 @@ pipeline
 
   post
   {
+    // Mark unstable builds as failed.
+    unstable
+    {
+      script
+      {
+        u.finishCheck('Style checks failed.', false)
+      }
+    }
+
+    failure
+    {
+      script
+      {
+        u.finishCheck('Style checks failed.', false)
+      }
+    }
+
+    success
+    {
+      script
+      {
+        u.finishCheck('Style checks passed.', true)
+      }
+    }
+
     always
     {
       // Process the test results.

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline
                       status: 'IN_PROGRESS',
                       title: 'Style checks (title)',
                       text: 'Setting up workspace...',
-                      detailsURL: job.getAbsoluteUrl())
+                      detailsURL: currentBuild.absoluteUrl)
 
         cleanWs(deleteDirs: true,
                 disableDeferredWipeout: true,
@@ -74,7 +74,7 @@ pipeline
                       status: 'IN_PROGRESS',
                       title: 'Style checks (title)',
                       text: 'Checking code style...',
-                      detailsURL: job.getAbsoluteUrl())
+                      detailsURL: currentBuild.absoluteUrl)
 
         sh '''
           mkdir -p reports
@@ -108,7 +108,7 @@ pipeline
                     conclusion: 'FAILURE',
                     title: 'Style checks (title)',
                     text: 'Style checks failed.',
-                    detailsURL: job.getAbsoluteUrl())
+                    detailsURL: currentBuild.absoluteUrl)
     }
 
     success
@@ -118,7 +118,7 @@ pipeline
                     conclusion: 'SUCCESS',
                     title: 'Style checks (title)',
                     text: 'Style checks passed.',
-                    detailsURL: job.getAbsoluteUrl())
+                    detailsURL: currentBuild.absoluteUrl)
 
     }
 

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -33,13 +33,7 @@ pipeline
                 notFailBuild: true)
         checkout scm
 
-        script
-        {
-          // Set the initial status.
-          u = load '.jenkins/utils.groovy'
-          u.startCheck('Style checks', 'Setting up workspace...')
-        }
-
+        // We also need the jenkins-conf repository for the style check scripts.
         sh '''
           git clone https://github.com/mlpack/jenkins-conf
         '''
@@ -51,11 +45,6 @@ pipeline
     {
       steps
       {
-        script
-        {
-          u.updateCheckStatus('Checking code style...')
-        }
-
         sh '''
           mkdir -p reports
           ./jenkins-conf/linter/lint.sh \
@@ -72,31 +61,6 @@ pipeline
 
   post
   {
-    // Mark unstable builds as failed.
-    unstable
-    {
-      script
-      {
-        u.finishCheck('Style checks failed.', false)
-      }
-    }
-
-    failure
-    {
-      script
-      {
-        u.finishCheck('Style checks failed.', false)
-      }
-    }
-
-    success
-    {
-      script
-      {
-        u.finishCheck('Style checks passed.', true)
-      }
-    }
-
     always
     {
       // Process the test results.

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -37,8 +37,7 @@ pipeline
         {
           // Set the initial status.
           u = load '.jenkins/utils.groovy'
-          u.startCheck(name: 'Style checks',
-                       status: 'Setting up workspace...')
+          u.startCheck('Style checks', 'Setting up workspace...')
         }
 
         sh '''
@@ -52,11 +51,10 @@ pipeline
     {
       steps
       {
-        publishChecks(name: 'Style checks',
-                      status: 'IN_PROGRESS',
-                      title: 'Checking code style...',
-                      text: 'Checking code style...',
-                      detailsURL: currentBuild.absoluteUrl + 'console')
+        script
+        {
+          u.updateCheckStatus('Checking code style...')
+        }
 
         sh '''
           mkdir -p reports
@@ -77,33 +75,26 @@ pipeline
     // Mark unstable builds as failed.
     unstable
     {
-      publishChecks(name: 'Style checks',
-                    status: 'COMPLETED',
-                    conclusion: 'FAILURE',
-                    title: 'Style checks failed.',
-                    text: 'Style checks failed.',
-                    detailsURL: currentBuild.absoluteUrl + 'testReport/')
+      script
+      {
+        u.finishCheck('Style checks failed.', false)
+      }
     }
 
     failure
     {
-      publishChecks(name: 'Style checks',
-                    status: 'COMPLETED',
-                    conclusion: 'FAILURE',
-                    title: 'Style checks failed.',
-                    text: 'Style checks failed.',
-                    detailsURL: currentBuild.absoluteUrl + 'testReport/')
+      script
+      {
+        u.finishCheck('Style checks failed.', false)
+      }
     }
 
     success
     {
-      publishChecks(name: 'Style checks',
-                    status: 'COMPLETED',
-                    conclusion: 'SUCCESS',
-                    title: 'Style checks passed.',
-                    text: 'Style checks passed.',
-                    detailsURL: currentBuild.absoluteUrl + 'testReport/')
-
+      script
+      {
+        u.finishCheck('Style checks passed.', true)
+      }
     }
 
     always

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -29,11 +29,9 @@ pipeline
       steps
       {
         // Set the initial status.
-        publishChecks(name: 'Style checks',
-                      status: 'IN_PROGRESS',
-                      title: 'Setting up workspace...',
-                      text: 'Setting up workspace...',
-                      detailsURL: currentBuild.absoluteUrl + 'console')
+        u = load '.jenkins/utils.groovy'
+        u.startCheck(name: 'Style checks',
+                     status: 'Setting up workspace...')
 
         cleanWs(deleteDirs: true,
                 disableDeferredWipeout: true,

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -16,10 +16,25 @@ pipeline
   {
     // Only allow one build at a time of this job.
     disableConcurrentBuilds(abortPrevious: true)
+
+    // We will do checkout manually.
+    skipDefaultCheckout()
   }
 
   stages
   {
+    // Clean the workspace and check out the code.
+    stage('Clean workspace')
+    {
+      steps
+      {
+        cleanWs(deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true)
+        checkout scm
+      }
+    }
+
     // First we have to check out the jenkins-conf repository, which contains
     // the scripts that we will use for checking the style.
     stage('Check out jenkins-conf repository')
@@ -28,8 +43,11 @@ pipeline
       {
         script
         {
-          u = load '.jenkins/utils.groovy'
-          u.startBuild('Style Checks')
+          publishChecks(name: 'Style Checks',
+                        title: 'Style Checks (title)',
+                        summary: 'Style checks for mlpack code',
+                        text: 'checking out the repository',
+                        detailsURL: 'https://ci.mlpack.org/invalid/')
         }
 
         sh '''
@@ -74,20 +92,10 @@ pipeline
       junit(allowEmptyResults: true,
             testResults: '**/reports/cpplint.junit.xml')
 
-      // Clean the workspace.
-      cleanWs(cleanWhenNotBuilt: false,
-              deleteDirs: true,
+      // Clean the workspace after the build too.
+      cleanWs(deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true)
-
-      script
-      {
-        u.setBuildStatus(result: currentBuild.currentResult,
-                         context: "Style Checks",
-                         successMessage: "No style issues.",
-                         unstableMessage: "Style issues found.",
-                         failureMessage: "Style issues found.");
-      }
     }
   }
 }

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline
             testResults: '**/reports/cpplint.junit.xml')
 
       // Clean the workspace after the build too.
-      cleanWs(cleanWhenNotBuild: true,
+      cleanWs(cleanWhenNotBuilt: true,
               deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true)

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -31,9 +31,9 @@ pipeline
         // Set the initial status.
         publishChecks(name: 'Style checks',
                       status: 'IN_PROGRESS',
-                      title: 'Style checks (title)',
+                      title: 'Setting up workspace...',
                       text: 'Setting up workspace...',
-                      detailsURL: currentBuild.absoluteUrl)
+                      detailsURL: currentBuild.absoluteUrl + 'console')
 
         cleanWs(deleteDirs: true,
                 disableDeferredWipeout: true,
@@ -46,25 +46,6 @@ pipeline
       }
     }
 
-    // First we have to check out the jenkins-conf repository, which contains
-    // the scripts that we will use for checking the style.
-    stage('Check out jenkins-conf repository')
-    {
-      steps
-      {
-        script
-        {
-          publishChecks(name: 'Style Checks',
-                        title: 'Style Checks (title)',
-                        summary: 'Style checks for mlpack code',
-                        text: 'checking out the repository',
-                        detailsURL: 'https://ci.mlpack.org/invalid/')
-        }
-
-
-      }
-    }
-
     // Now we can run those scripts.
     stage('Check code style')
     {
@@ -72,9 +53,9 @@ pipeline
       {
         publishChecks(name: 'Style checks',
                       status: 'IN_PROGRESS',
-                      title: 'Style checks (title)',
+                      title: 'Checking code style...',
                       text: 'Checking code style...',
-                      detailsURL: currentBuild.absoluteUrl)
+                      detailsURL: currentBuild.absoluteUrl + 'console')
 
         sh '''
           mkdir -p reports
@@ -95,10 +76,12 @@ pipeline
     // Mark unstable builds as failed.
     unstable
     {
-      script
-      {
-        error "Style check failure."
-      }
+      publishChecks(name: 'Style checks',
+                    status: 'COMPLETED',
+                    conclusion: 'FAILURE',
+                    title: 'Style checks failed.',
+                    text: 'Style checks failed.',
+                    detailsURL: currentBuild.absoluteUrl + 'testReport/')
     }
 
     failure
@@ -106,9 +89,9 @@ pipeline
       publishChecks(name: 'Style checks',
                     status: 'COMPLETED',
                     conclusion: 'FAILURE',
-                    title: 'Style checks (title)',
+                    title: 'Style checks failed.',
                     text: 'Style checks failed.',
-                    detailsURL: currentBuild.absoluteUrl)
+                    detailsURL: currentBuild.absoluteUrl + 'testReport/')
     }
 
     success
@@ -116,9 +99,9 @@ pipeline
       publishChecks(name: 'Style checks',
                     status: 'COMPLETED',
                     conclusion: 'SUCCESS',
-                    title: 'Style checks (title)',
+                    title: 'Style checks passed.',
                     text: 'Style checks passed.',
-                    detailsURL: currentBuild.absoluteUrl)
+                    detailsURL: currentBuild.absoluteUrl + 'testReport/')
 
     }
 

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline
         script
         {
           // Set the initial status.
-          u = load '.jenkins/utils.groovy'
+          def u = load '.jenkins/utils.groovy'
           u.startCheck('Style checks', 'Setting up workspace...')
         }
 

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -51,10 +51,7 @@ pipeline
     {
       steps
       {
-        script
-        {
-          u.updateCheckStatus('Checking code style...')
-        }
+        script { u.updateCheckStatus('Checking code style...') }
 
         sh '''
           mkdir -p reports
@@ -73,29 +70,9 @@ pipeline
   post
   {
     // Mark unstable builds as failed.
-    unstable
-    {
-      script
-      {
-        u.finishCheck('Style checks failed.', false)
-      }
-    }
-
-    failure
-    {
-      script
-      {
-        u.finishCheck('Style checks failed.', false)
-      }
-    }
-
-    success
-    {
-      script
-      {
-        u.finishCheck('Style checks passed.', true)
-      }
-    }
+    unstable { script { u.finishCheck('Style checks failed.', false) } }
+    failure { script { u.finishCheck('Style checks failed.', false) } }
+    success { script { u.finishCheck('Style checks passed.', true) } }
 
     always
     {
@@ -105,7 +82,8 @@ pipeline
             testResults: '**/reports/cpplint.junit.xml')
 
       // Clean the workspace after the build too.
-      cleanWs(deleteDirs: true,
+      cleanWs(cleanWhenNotBuild: true,
+              deleteDirs: true,
               disableDeferredWipeout: true,
               notFailBuild: true)
     }

--- a/.jenkins/style-checks/Jenkinsfile
+++ b/.jenkins/style-checks/Jenkinsfile
@@ -24,14 +24,25 @@ pipeline
   stages
   {
     // Clean the workspace and check out the code.
-    stage('Clean workspace')
+    stage('Set up workspace')
     {
       steps
       {
+        // Set the initial status.
+        publishChecks(name: 'Style checks',
+                      status: 'IN_PROGRESS',
+                      title: 'Style checks (title)',
+                      text: 'Setting up workspace...',
+                      detailsURL: absoluteUrl)
+
         cleanWs(deleteDirs: true,
                 disableDeferredWipeout: true,
                 notFailBuild: true)
         checkout scm
+
+        sh '''
+          git clone https://github.com/mlpack/jenkins-conf
+        '''
       }
     }
 
@@ -50,9 +61,7 @@ pipeline
                         detailsURL: 'https://ci.mlpack.org/invalid/')
         }
 
-        sh '''
-          git clone https://github.com/mlpack/jenkins-conf
-        '''
+
       }
     }
 
@@ -61,6 +70,12 @@ pipeline
     {
       steps
       {
+        publishChecks(name: 'Style checks',
+                      status: 'IN_PROGRESS',
+                      title: 'Style checks (title)',
+                      text: 'Checking code style...',
+                      detailsURL: absoluteUrl)
+
         sh '''
           mkdir -p reports
           ./jenkins-conf/linter/lint.sh \
@@ -84,6 +99,27 @@ pipeline
       {
         error "Style check failure."
       }
+    }
+
+    failure
+    {
+      publishChecks(name: 'Style checks',
+                    status: 'COMPLETED',
+                    conclusion: 'FAILURE',
+                    title: 'Style checks (title)',
+                    text: 'Style checks failed.',
+                    detailsURL: absoluteUrl)
+    }
+
+    success
+    {
+      publishChecks(name: 'Style checks',
+                    status: 'COMPLETED',
+                    conclusion: 'SUCCESS',
+                    title: 'Style checks (title)',
+                    text: 'Style checks passed.',
+                    detailsURL: absoluteUrl)
+
     }
 
     always

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -63,4 +63,45 @@ def setBuildStatus(Map paramsMap)
   ]);
 }
 
+def startCheck(String name, String status)
+{
+  // Set module-level variables that we will retain as we build.
+  this.name = name
+  this.status = status
+  this.time = currentBuild.duration
+
+  publishChecks(name: name,
+                status: 'IN_PROGRESS',
+                title: status,
+                text: status,
+                detailsURL: currentBuild.absoluteUrl + 'console')
+}
+
+def updateCheckStatus(String status)
+{
+  def stepTime = (currentBuild.duration - this.time) / 1000.0
+  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
+  this.time = currentBuild.duration
+
+  publishChecks(name: this.name,
+                status: 'IN_PROGRESS',
+                title: status,
+                text: this.status,
+                detailsURL: currentBuild.absoluteUrl + 'console')
+}
+
+def finishCheck(String status, boolean success)
+{
+  def stepTime = (currentBuild.duration - this.time) / 1000.0
+  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
+  this.time = currentBuild.duration
+
+  publishChecks(name: this.name,
+                status: 'COMPLETED',
+                conclusion: success ? 'SUCCESS' : 'FAILURE',
+                title: status,
+                text: this.status,
+                detailsURL: currentBuild.absoluteUrl + 'testReport')
+}
+
 return this

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -1,67 +1,7 @@
-// A simple utility to mark the build as pending on Github.
-def startBuild(String context)
-{
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource",
-                    url: "https://github.com/mlpack/mlpack"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource",
-                      context: context ],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler",
-                       result: "UNSTABLE"]],
-      statusResultSource: [$class: "ConditionalStatusResultSource",
-                           results: [[$class: "AnyBuildResult",
-                                      message: "Building...",
-                                      state: "PENDING"]]]
-  ]);
-}
-
-// A simple utility to set the build status on Github for a commit.
-def setBuildStatus(Map paramsMap)
-{
-  // Extract arguments from the map.
-  def result = paramsMap.result;
-  def context = paramsMap.context;
-  def successMessage = paramsMap.successMessage;
-  def unstableMessage = paramsMap.unstableMessage;
-  def failureMessage = paramsMap.failureMessage;
-
-  def message = "(unknown Jenkins build result)";
-  def state = "FAILURE";
-  if (result == "FAILURE")
-  {
-    message = failureMessage;
-  }
-  else if (result == "UNSTABLE")
-  {
-    message = unstableMessage;
-    state = "UNSTABLE";
-  }
-  else if (result == "SUCCESS")
-  {
-    message = successMessage;
-    state = "SUCCESS";
-  }
-  else if (result == "ABORTED")
-  {
-    message = "Job aborted.";
-    state = "ERROR";
-  }
-
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource",
-                    url: "https://github.com/mlpack/mlpack"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource",
-                      context: context ],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler",
-                       result: "UNSTABLE"]],
-      statusResultSource: [$class: "ConditionalStatusResultSource",
-                           results: [[$class: "AnyBuildResult",
-                                      message: message,
-                                      state: state]]]
-  ]);
-}
+// These variables are set to hold state between status check updates.
+def name = ''
+def status = ''
+def time = 0
 
 def startCheck(String name, String status)
 {

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -80,7 +80,8 @@ def startCheck(String name, String status)
 def updateCheckStatus(String status)
 {
   def stepTime = (currentBuild.duration - this.time) / 1000.0
-  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
+  this.status += ' (' + stepTime.toString() + 's)\n'
+  this.status += status
   this.time = currentBuild.duration
 
   publishChecks(name: this.name,
@@ -93,8 +94,14 @@ def updateCheckStatus(String status)
 def finishCheck(String status, boolean success)
 {
   def stepTime = (currentBuild.duration - this.time) / 1000.0
-  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
-  this.time = currentBuild.duration
+  this.status += ' (' + stepTime.toString() + 's)\n'
+  this.status += status
+
+  if (!success)
+  {
+    this.status += '\n\n' +
+        '<b>Click \'view more details\' below to see failure details...</b>';
+  }
 
   publishChecks(name: this.name,
                 status: 'COMPLETED',

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -63,4 +63,17 @@ def setBuildStatus(Map paramsMap)
   ]);
 }
 
+def startCheck(Map paramsMap)
+{
+  // Extract arguments from the map.
+  def name = paramsMap.name;
+  def status = paramsMap.status;
+
+  publishChecks(name: name,
+                status: 'IN_PROGRESS',
+                title: status,
+                text: status,
+                detailsURL: currentBuild.absoluteUrl + 'console')
+}
+
 return this

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -68,7 +68,7 @@ def startCheck(String name, String status)
   // Set module-level variables that we will retain as we build.
   this.name = name
   this.status = status
-  this.time = currentBuild.timeInMillis
+  this.time = currentBuild.duration
 
   publishChecks(name: name,
                 status: 'IN_PROGRESS',
@@ -79,9 +79,9 @@ def startCheck(String name, String status)
 
 def updateCheckStatus(String status)
 {
-  def stepTime = (currentBuild.timeInMillis - this.time) / 1000.0
+  def stepTime = (currentBuild.duration - this.time) / 1000.0
   this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
-  this.time = currentBuild.timeInMillis
+  this.time = currentBuild.duration
 
   publishChecks(name: this.name,
                 status: 'IN_PROGRESS',
@@ -92,9 +92,9 @@ def updateCheckStatus(String status)
 
 def finishCheck(String status, boolean success)
 {
-  def stepTime = (currentBuild.timeInMillis - this.time) / 1000.0
+  def stepTime = (currentBuild.duration - this.time) / 1000.0
   this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
-  this.time = currentBuild.timeInMillis
+  this.time = currentBuild.duration
 
   publishChecks(name: this.name,
                 status: 'COMPLETED',

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -63,45 +63,4 @@ def setBuildStatus(Map paramsMap)
   ]);
 }
 
-def startCheck(String name, String status)
-{
-  // Set module-level variables that we will retain as we build.
-  this.name = name
-  this.status = status
-  this.time = currentBuild.duration
-
-  publishChecks(name: name,
-                status: 'IN_PROGRESS',
-                title: status,
-                text: status,
-                detailsURL: currentBuild.absoluteUrl + 'console')
-}
-
-def updateCheckStatus(String status)
-{
-  def stepTime = (currentBuild.duration - this.time) / 1000.0
-  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
-  this.time = currentBuild.duration
-
-  publishChecks(name: this.name,
-                status: 'IN_PROGRESS',
-                title: status,
-                text: this.status,
-                detailsURL: currentBuild.absoluteUrl + 'console')
-}
-
-def finishCheck(String status, boolean success)
-{
-  def stepTime = (currentBuild.duration - this.time) / 1000.0
-  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
-  this.time = currentBuild.duration
-
-  publishChecks(name: this.name,
-                status: 'COMPLETED',
-                conclusion: success ? 'SUCCESS' : 'FAILURE',
-                title: status,
-                text: this.status,
-                detailsURL: currentBuild.absoluteUrl + 'testReport')
-}
-
 return this

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -63,17 +63,40 @@ def setBuildStatus(Map paramsMap)
   ]);
 }
 
-def startCheck(Map paramsMap)
+def startCheck(String name, String status)
 {
-  // Extract arguments from the map.
-  def name = paramsMap.name;
-  def status = paramsMap.status;
+  // Set module-level variables that we will retain as we build.
+  this.name = name
+  this.status = status
 
   publishChecks(name: name,
                 status: 'IN_PROGRESS',
                 title: status,
                 text: status,
                 detailsURL: currentBuild.absoluteUrl + 'console')
+}
+
+def updateCheckStatus(String status)
+{
+  this.status += '\n' + status
+
+  publishChecks(name: this.name,
+                status: 'IN_PROGRESS',
+                title: status,
+                text: this.status,
+                detailsURL: currentBuild.absoluteUrl + 'console')
+}
+
+def finishCheck(String status, boolean success)
+{
+  this.status += '\n' + status
+
+  publishChecks(name: this.name,
+                status: 'COMPLETED',
+                conclusion: success ? 'SUCCESS' : 'FAILURE',
+                title: status,
+                text: this.status,
+                detailsURL: currentBuild.absoluteUrl + 'testReport')
 }
 
 return this

--- a/.jenkins/utils.groovy
+++ b/.jenkins/utils.groovy
@@ -68,6 +68,7 @@ def startCheck(String name, String status)
   // Set module-level variables that we will retain as we build.
   this.name = name
   this.status = status
+  this.time = currentBuild.timeInMillis
 
   publishChecks(name: name,
                 status: 'IN_PROGRESS',
@@ -78,7 +79,9 @@ def startCheck(String name, String status)
 
 def updateCheckStatus(String status)
 {
-  this.status += '\n' + status
+  def stepTime = (currentBuild.timeInMillis - this.time) / 1000.0
+  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
+  this.time = currentBuild.timeInMillis
 
   publishChecks(name: this.name,
                 status: 'IN_PROGRESS',
@@ -89,7 +92,9 @@ def updateCheckStatus(String status)
 
 def finishCheck(String status, boolean success)
 {
-  this.status += '\n' + status
+  def stepTime = (currentBuild.timeInMillis - this.time) / 1000.0
+  this.status += '\n' + status + ' (' + stepTime.toString() + 's)'
+  this.time = currentBuild.timeInMillis
 
   publishChecks(name: this.name,
                 status: 'COMPLETED',

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -2555,3 +2555,14 @@ TEST_CASE("LoadCSVHeaderTest", "[LoadSaveTest]")
   REQUIRE(dataset.n_rows == 4);
   REQUIRE(dataset.n_cols == 2);
 }
+
+TEST_CASE("will_fail_test")
+{
+  arma::mat x(10, 10, arma::fill::randu);
+  arma::mat y(20, 20, arma::fill::randu);
+
+  y += x;
+
+  REQUIRE( y.n_rows == 20 );
+  REQUIRE( y.n_cols == 20 );
+}

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -2555,15 +2555,3 @@ TEST_CASE("LoadCSVHeaderTest", "[LoadSaveTest]")
   REQUIRE(dataset.n_rows == 4);
   REQUIRE(dataset.n_cols == 2);
 }
-
-TEST_CASE("will_fail_test")
-{
-  arma::mat x(10, 10, arma::fill::randu);
-  arma::mat y(20, 20, arma::fill::randu);
-  //thislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolong
-
-  y += x;
-
-  REQUIRE( y.n_rows == 20 );
-  REQUIRE( y.n_cols == 20 );
-}

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -2560,6 +2560,7 @@ TEST_CASE("will_fail_test")
 {
   arma::mat x(10, 10, arma::fill::randu);
   arma::mat y(20, 20, arma::fill::randu);
+  //thislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolongthislineistoolong
 
   y += x;
 


### PR DESCRIPTION
I fixed a few issues with the Jenkins CI jobs in this PR:

 * Jenkins backref links are really bad---you click on a failed build and it brings you to some random pipeline page.  Now it takes you to the build page itself, or the test report page if any tests failed.
 * Jenkins statuses are strange, and sometimes don't work correctly.  Now we use the Github Checks plugin which seems to be more reliable.
 * Jenkins workspace cleanings sometimes fail, because Jenkinsfiles are surprisingly brittle and I have to do all the error checking myself, I guess.  So now I don't check the repo out from git automatically, and instead always clean the workspace before and after a build, and check out manually after that cleaning step is done.