### PR TITLE
Fix `LSTM` input size calculation

### DIFF
--- a/.jenkins/cross-compilation/Jenkinsfile
+++ b/.jenkins/cross-compilation/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline
                   ssh jenkins@${hostname} -t mkdir -p test_${BRANCH_NAME}_${BUILD_ID}/
                   scp build/bin/mlpack_test jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
                   scp -r src/mlpack/tests/data/* jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
-                  #scp -r doc/img/cat.jpg jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
+                  scp -r doc/img/cat.jpg jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
                   # Unpack all compressed test data.
                   ssh jenkins@${hostname} -t "
                       cd test_${BRANCH_NAME}_${BUILD_ID};

--- a/.jenkins/cross-compilation/Jenkinsfile
+++ b/.jenkins/cross-compilation/Jenkinsfile
@@ -130,6 +130,7 @@ pipeline
                   ssh jenkins@${hostname} -t mkdir -p test_${BRANCH_NAME}_${BUILD_ID}/
                   scp build/bin/mlpack_test jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
                   scp -r src/mlpack/tests/data/* jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
+                  #scp -r doc/img/cat.jpg jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/
                   # Unpack all compressed test data.
                   ssh jenkins@${hostname} -t "
                       cd test_${BRANCH_NAME}_${BUILD_ID};
@@ -139,7 +140,8 @@ pipeline
                   ssh jenkins@${hostname} -t "
                       cd test_${BRANCH_NAME}_${BUILD_ID};
                       mkdir -p reports;
-                      ./mlpack_test -r junit -o reports/mlpack_test.junit.xml"
+                      ./mlpack_test -r junit -o reports/mlpack_test.junit.xml" \
+                      || echo "Test failure or other problem.";
 
                   # Clean up afterwards.
                   scp jenkins@${hostname}:test_${BRANCH_NAME}_${BUILD_ID}/reports/mlpack_test.junit.xml reports/mlpack_test.${hostname}.junit.xml;

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,8 @@ _????-??-??_
  * Add `ResizeCropImages()` for resize-and-crop image preprocessing
    functionality (#3903).
 
+ * Fix `LSTM` input size calculation for multidimensional inputs (#3913).
+
 ## mlpack 4.5.1
 
 _2024-12-02_

--- a/src/mlpack/methods/ann/layer/lstm.hpp
+++ b/src/mlpack/methods/ann/layer/lstm.hpp
@@ -207,8 +207,9 @@ class LSTMType : public RecurrentLayer<MatType>
   // Given a properly set InputDimensions(), compute the output dimensions.
   void ComputeOutputDimensions()
   {
-    inSize = std::accumulate(this->inputDimensions.begin(),
-        this->inputDimensions.end(), 0);
+    inSize = this->inputDimensions[0];
+    for (size_t i = 1; i < this->inputDimensions.size(); ++i)
+      inSize *= this->inputDimensions[i];
     this->outputDimensions = std::vector<size_t>(this->inputDimensions.size(),
         1);
 

--- a/src/mlpack/tests/ann/layer/lstm.cpp
+++ b/src/mlpack/tests/ann/layer/lstm.cpp
@@ -2132,3 +2132,21 @@ TEST_CASE("LSTMGradientPeepholeWeightsTest", "[ANNLayerTest]")
   REQUIRE(approx_equal(forgetGateBiasGrad, sum(df, 1), "both", 1e-5, 1e-5));
   REQUIRE(approx_equal(outputGateBiasGrad, sum(dout, 1), "both", 1e-5, 1e-5));
 }
+
+// Make sure that the output dimensions are computed correctly when the input is
+// multi-dimensional.
+TEST_CASE("LSTMMultidimensionalInputSizeTest", "[ANNLayerTest]")
+{
+  LSTM l(15);
+  l.InputDimensions() = std::vector<size_t>{ 10, 20, 30 };
+  l.ComputeOutputDimensions();
+
+  arma::mat weights(l.WeightSize(), 1);
+  l.CurrentStep(0);
+  l.SetWeights(weights);
+  l.ClearRecurrentState(1, 1);
+
+  // If the number of weight elements is correct, then we computed the input
+  // size correctly.
+  REQUIRE(l.InputGateWeight().n_elem == (10 * 20 * 30) * 15);
+}


### PR DESCRIPTION
As @nzachary pointed out in #3912, currently, the `LSTM` layer computes the size of its input by accumulating the input dimensions.  But this is not correct: it should be the product instead.

This simple PR fixes that and adds a test case.