### PR TITLE
Release version 4.6.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@
 
 _????-??-??_
 
+
+## mlpack 4.6.0
+
+_2025-03-31_
+
  * Fix command-line duplicate output bug when loading matrices for some bindings
    (#3838).
  * Use `CMAKE_BUILD_TYPE` to specify build type instead of DEBUG and PROFILE options (#3865).

--- a/src/mlpack/core/util/version.hpp
+++ b/src/mlpack/core/util/version.hpp
@@ -17,8 +17,8 @@
 // The version of mlpack.  If this is a git repository, this will be a version
 // with higher number than the most recent release.
 #define MLPACK_VERSION_MAJOR 4
-#define MLPACK_VERSION_MINOR 5
-#define MLPACK_VERSION_PATCH 2
+#define MLPACK_VERSION_MINOR 6
+#define MLPACK_VERSION_PATCH 1
 
 // The name of the version (for use by --version).
 namespace mlpack {


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 4.6.0 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog



 * Fix command-line duplicate output bug when loading matrices for some bindings (#3838).
 * Use `CMAKE_BUILD_TYPE` to specify build type instead of DEBUG and PROFILE options (#3865).

 * Add `MLPACK_NO_STD_MUTEX` to allow disabling `std::mutex` (#3868).

 * Bundle STB with mlpack and add `ResizeImages()` functionality (#3823).

 * Add `mlpack.cmake` to facilitate finding mlpack and its dependencies (#3872).

 * Fix conversion of empty Armadillo objects to numpy in Python bindings (#3896).

 * Added bootstrap strategies for `RandomForest`: `IdentityBootstrap`, `DefaultBootstrap`, and `SequentialBootstrap` (#3829).

 * Add `ResizeCropImages()` for resize-and-crop image preprocessing functionality (#3903).

 * Fix `LSTM` input size calculation for multidimensional inputs (#3913).