### PR TITLE
Fix CMake configuration for older Armadillo versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,18 +114,18 @@ jobs:
           sudo apt-get install --yes --allow-unauthenticated \
               libopenblas-dev libstb-dev libcereal-dev xz-utils
           # Install the oldest Armadillo version that we support.
-          curl -k -L https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz | tar -xvJ && \
-              cd armadillo* && \
-              cmake . && \
-              make && \
-              sudo make install && \
-              cd ..
+          curl -k -L https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz | tar -xvJ
+          cd armadillo*
+          cmake .
+          make
+          sudo make install
+          cd ..
           # Install the latest ensmallen version.
           wget https://ensmallen.org/files/ensmallen-latest.tar.gz
-              tar -xvzpf ensmallen-latest.tar.gz # Unpack into ensmallen-*/.
-              cd ensmallen-*/ && \
-              sudo cp -vr include/* /usr/include/ && \
-              cd ..
+          tar -xvzpf ensmallen-latest.tar.gz # Unpack into ensmallen-*/.
+          cd ensmallen-*/
+          sudo cp -vr include/* /usr/include/
+          cd ..
 
       - name: Install build dependencies (macOS)
         if: matrix.config.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,12 @@ jobs:
           # Install the oldest Armadillo version that we support.
           curl -k -L https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz | tar -xvJ
           cd armadillo*
-          cmake .
+          # Armadillo 10.8.2 requests CMake 2.8.12+ compatibility, but that has
+          # been dropped from newer CMake versions.  However, with Armadillo's
+          # CMake configuration, it works just fine to specify
+          # CMAKE_POLICY_VERSION_MINIMUM to ignore the missing reverse
+          # compatibility.
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
           make
           sudo make install
           cd ..
@@ -214,6 +219,7 @@ jobs:
           tar -xf armadillo-10.8.2.tar.xz
           cd armadillo-10.8.2/
           cmake -G "Visual Studio 17 2022" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DBLAS_LIBRARY:FILEPATH=${{ github.workspace }}/deps/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a \
             -DLAPACK_LIBRARY:FILEPATH=${{ github.workspace }}/deps/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a \
             -DBUILD_SHARED_LIBS=OFF .


### PR DESCRIPTION
Two problems to be fixed here:

 * The build of Armadillo is not failing when CMake configuration fails.  (It fails at a later step.  It should fail earlier.)
 * CMake is refusing to configure the older Armadillo 10.8.2, which requests CMake 2.8.12+ compatibility.  New CMake dropped reverse compatibility for anything older than 3.5, so probably this just needs a workaround option.