### PR TITLE
Use Github Actions to build MSI installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,3 +280,74 @@ jobs:
           show: "fail, skip"
           fail_job: true
           print_output: true
+
+      - name: Archive compiled programs
+        run: mkdir exe_archive && cp -r build/Release/*.exe exe_archive/
+
+      - name: Publish Windows no-libs archive
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: mlpack-windows-vs17-no-libs
+          path: exe_archive/
+
+      - name: Publish Windows libs archive
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: mlpack-windows-vs17
+          path: build/Release/
+
+      - name: Build MSI installer
+        shell: powershell
+        run: |
+          # Preparing installer staging.
+          mkdir dist\win-installer\mlpack-win-installer\Sources\lib
+          cp build\Release\*.lib dist\win-installer\mlpack-win-installer\Sources\lib\
+          cp build\Release\*.exp dist\win-installer\mlpack-win-installer\Sources\lib\
+          cp build\Release\*.dll dist\win-installer\mlpack-win-installer\Sources\
+          cp build\Release\*.exe dist\win-installer\mlpack-win-installer\Sources\
+          cp $(Agent.ToolsDirectory)\OpenBLAS.0.2.14.1\lib\native\bin\x64\*.dll dist\win-installer\mlpack-win-installer\Sources\
+          #
+          # Copy documentation.
+          mkdir dist\win-installer\mlpack-win-installer\Sources\doc
+          cp doc\html dist\win-installer\mlpack-win-installer\Sources\doc -recurse
+          #
+          # Copy sources.
+          mkdir dist\win-installer\mlpack-win-installer\Sources\include\mlpack
+          cp src\mlpack.hpp dist\win-installer\mlpack-win-installer\Sources\include
+          cp src\mlpack\*.hpp dist\win-installer\mlpack-win-installer\Sources\include\mlpack
+          cp src\mlpack\core dist\win-installer\mlpack-win-installer\Sources\include\mlpack -recurse
+          cp src\mlpack\methods dist\win-installer\mlpack-win-installer\Sources\include\mlpack -recurse
+          #
+          # Copy examples.
+          cp doc\examples dist\win-installer\mlpack-win-installer\Sources\ -recurse
+          cp src\mlpack\tests\data\german.csv dist\win-installer\mlpack-win-installer\Sources\examples\sample-ml-app\sample-ml-app\data\
+          #
+          # Check current git version or mlpack version.
+          $ver = (Get-Content "src\mlpack\core\util\version.hpp" | where {$_ -like "*MLPACK_VERSION*"});
+          $env:MLPACK_VERSION += $ver[0].substring($ver[0].length - 1, 1) + '.';
+          $env:MLPACK_VERSION += $ver[1].substring($ver[1].length - 1, 1) + '.';
+          $env:MLPACK_VERSION += $ver[2].substring($ver[2].length - 1, 1);
+          #
+          if (Test-Path "src/mlpack/core/util/gitversion.hpp")
+          {
+            $ver = (Get-Content "src/mlpack/core/util/gitversion.hpp");
+            $env:INSTALL_VERSION = $ver.Split('"')[1].Split(' ')[1];
+          }
+          else
+          {
+            $env:INSTALL_VERSION = $env:MLPACK_VERSION;
+          }
+          #
+          # Build the MSI installer.
+          cd dist\win-installer\mlpack-win-installer
+          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe' `
+              -t:rebuild `
+              -p:Configuration=Release `
+              -p:TreatWarningsAsErrors=True `
+              mlpack-win-installer.wixproj
+
+      - name: Publish MSI installer
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: mlpack-windows-installer
+          path: dist/win-installer/mlpack-win-installer/bin/Release/mlpack-windows.msi


### PR DESCRIPTION
I noticed that I forgot to move the Azure Pipelines configuration that built the mlpack Windows installer and archived the compiled command-line programs and libraries over to Github Actions.  This PR fixes that; it's a transliteration of this part of the older build scripts:

https://github.com/mlpack/mlpack/blob/4498706851a0f634da05d46d9ce6b2d5b8f1b7a9/.ci/windows-steps.yaml#L117

I'll mark it as ready for review once I confirm that all the artifacts are being built and uploaded correctly.