### PR TITLE
Shuffle sequence lengths

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -162,6 +162,7 @@ Copyright:
   Copyright 2024, Felix Patschkowski <felix.patschkowski@gmail.com>
   Copyright 2025, Benjamin A. Beasley <code@musicinmybrain.net>
   Copyright 2025, Maksym Prots <imaxprots@gmail.com>
+  Copyright 2025, Zachary Ng <zachn716@gmail.com>
 
 License: BSD-3-clause
   All rights reserved.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 ## mlpack ?.?.?
 
 _????-??-??_
+ * Shuffle sequence lengths (#3926)
+
  * Add ability to compile OpenBLAS for windows (#3922)
 
  * Drop pytest-runner and "setup.py test" support (#3921).

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -191,8 +191,8 @@ void ShuffleData(const MatType& inputPoints,
         ordering[i]) = inputPoints.tube(0, i, inputPoints.n_rows - 1, i);
     outputLabelsPtr->tube(0, ordering[i], outputLabelsPtr->n_rows - 1,
         ordering[i]) = inputLabels.tube(0, i, inputLabels.n_rows - 1, i);
+    outputWeightsPtr->at(ordering[i]) = inputWeights[i];
   }
-  *outputWeightsPtr = outputWeightsPtr->cols(ordering);
 
   // Clean up memory if needed.
   if (&inputPoints == &outputPoints)

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -148,23 +148,22 @@ void ShuffleData(const MatType& inputPoints,
 
 /**
  * Shuffle a cube-shaped dataset and associated labels (or responses) which are
- * also cube-shaped.  Also shuffle its sequence lengths if they aren't empty.  
- * It is expected that inputPoints, inputLabels, and inputLengths (if it's not 
- * empty) have the same number of columns.
+ * also cube-shaped.  Also shuffle its weights.  It is expected that inputPoints, 
+ * inputLabels, and inputWeights have the same number of columns.
  *
- * Shuffled data will be output into outputPoints, outputLabels, and outputLengths.
+ * Shuffled data will be output into outputPoints, outputLabels, and outputWeights.
  */
-template<typename MatType, typename LabelsType, typename LengthsType>
+template<typename MatType, typename LabelsType, typename WeightsType>
 void ShuffleData(const MatType& inputPoints,
                  const LabelsType& inputLabels,
-                 const LengthsType& inputLengths,
+                 const WeightsType& inputWeights,
                  MatType& outputPoints,
                  LabelsType& outputLabels,
-                 LengthsType& outputLengths,
+                 WeightsType& outputWeights,
                  const std::enable_if_t<!arma::is_SpMat<MatType>::value>* = 0,
                  const std::enable_if_t<arma::is_Cube<MatType>::value>* = 0,
                  const std::enable_if_t<arma::is_Cube<LabelsType>::value>* = 0,
-                 const std::enable_if_t<arma::is_Row<LengthsType>::value>* = 0)
+                 const std::enable_if_t<arma::is_Row<WeightsType>::value>* = 0)
 {
   // Generate ordering.
   arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,
@@ -174,19 +173,19 @@ void ShuffleData(const MatType& inputPoints,
   // object.
   MatType* outputPointsPtr = &outputPoints;
   LabelsType* outputLabelsPtr = &outputLabels;
-  LengthsType* outputLengthsPtr = &outputLengths;
+  WeightsType* outputWeightsPtr = &outputWeights;
   if (&inputPoints == &outputPoints)
     outputPointsPtr = new MatType();
   if (&inputLabels == &outputLabels)
     outputLabelsPtr = new LabelsType();
-  if (&inputLengths == &outputLengths)
-    outputLengthsPtr = new LengthsType();
+  if (&inputWeights == &outputWeights)
+    outputWeightsPtr = new WeightsType();
 
   outputPointsPtr->set_size(inputPoints.n_rows, inputPoints.n_cols,
       inputPoints.n_slices);
   outputLabelsPtr->set_size(inputLabels.n_rows, inputLabels.n_cols,
       inputLabels.n_slices);
-  outputLengthsPtr->set_size(inputLengths.n_cols);
+  outputWeightsPtr->set_size(inputWeights.n_cols);
   for (size_t i = 0; i < ordering.n_elem; ++i)
   {
     outputPointsPtr->tube(0, ordering[i], outputPointsPtr->n_rows - 1,
@@ -194,9 +193,9 @@ void ShuffleData(const MatType& inputPoints,
     outputLabelsPtr->tube(0, ordering[i], outputLabelsPtr->n_rows - 1,
         ordering[i]) = inputLabels.tube(0, i, inputLabels.n_rows - 1, i);
   }
-  if (inputLengths.n_elem > 0)
+  if (inputWeights.n_elem > 0)
   {
-    *outputLengthsPtr = outputLengthsPtr->cols(ordering);
+    *outputWeightsPtr = outputWeightsPtr->cols(ordering);
   }
 
   // Clean up memory if needed.
@@ -212,10 +211,10 @@ void ShuffleData(const MatType& inputPoints,
     delete outputLabelsPtr;
   }
 
-  if (&inputLengths == &outputLengths)
+  if (&inputWeights == &outputWeights)
   {
-    outputLengths = std::move(*outputLengthsPtr);
-    delete outputLengthsPtr;
+    outputWeights = std::move(*outputWeightsPtr);
+    delete outputWeightsPtr;
   }
 }
 

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -162,8 +162,7 @@ void ShuffleData(const MatType& inputPoints,
                  WeightsType& outputWeights,
                  const std::enable_if_t<!arma::is_SpMat<MatType>::value>* = 0,
                  const std::enable_if_t<arma::is_Cube<MatType>::value>* = 0,
-                 const std::enable_if_t<arma::is_Cube<LabelsType>::value>* = 0,
-                 const std::enable_if_t<arma::is_Row<WeightsType>::value>* = 0)
+                 const std::enable_if_t<arma::is_Cube<LabelsType>::value>* = 0)
 {
   // Generate ordering.
   arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -164,7 +164,7 @@ void ShuffleData(const MatType& inputPoints,
                  const std::enable_if_t<!arma::is_SpMat<MatType>::value>* = 0,
                  const std::enable_if_t<arma::is_Cube<MatType>::value>* = 0,
                  const std::enable_if_t<arma::is_Cube<LabelsType>::value>* = 0,
-                 const std::enable_if_t<IsVector<LengthsType>::value>* = 0)
+                 const std::enable_if_t<arma::is_Row<LengthsType>::value>* = 0)
 {
   // Generate ordering.
   arma::uvec ordering = arma::shuffle(arma::linspace<arma::uvec>(0,

--- a/src/mlpack/core/math/shuffle_data.hpp
+++ b/src/mlpack/core/math/shuffle_data.hpp
@@ -193,10 +193,7 @@ void ShuffleData(const MatType& inputPoints,
     outputLabelsPtr->tube(0, ordering[i], outputLabelsPtr->n_rows - 1,
         ordering[i]) = inputLabels.tube(0, i, inputLabels.n_rows - 1, i);
   }
-  if (inputWeights.n_elem > 0)
-  {
-    *outputWeightsPtr = outputWeightsPtr->cols(ordering);
-  }
+  *outputWeightsPtr = outputWeightsPtr->cols(ordering);
 
   // Clean up memory if needed.
   if (&inputPoints == &outputPoints)

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -633,8 +633,15 @@ void RNN<
     MatType
 >::Shuffle()
 {
-  ShuffleData(predictors, responses, sequenceLengths,
-      predictors, responses, sequenceLengths);
+  if (sequenceLengths.n_elem > 0)
+  {
+    ShuffleData(predictors, responses, sequenceLengths,
+        predictors, responses, sequenceLengths);
+  }
+  else
+  {
+    ShuffleData(predictors, responses, predictors, responses);
+  }
 }
 
 template<

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -633,7 +633,8 @@ void RNN<
     MatType
 >::Shuffle()
 {
-  ShuffleData(predictors, responses, sequenceLengths, predictors, responses, sequenceLengths);
+  ShuffleData(predictors, responses, sequenceLengths,
+      predictors, responses, sequenceLengths);
 }
 
 template<

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -633,7 +633,7 @@ void RNN<
     MatType
 >::Shuffle()
 {
-  ShuffleData(predictors, responses, predictors, responses);
+  ShuffleData(predictors, responses, sequenceLengths, predictors, responses, sequenceLengths);
 }
 
 template<

--- a/src/mlpack/tests/math_test.cpp
+++ b/src/mlpack/tests/math_test.cpp
@@ -708,14 +708,14 @@ TEST_CASE("RaggedCubeShuffleTest", "[MathTest]")
   data.fill(-1);
   labels.fill(-1);
 
-  for (size_t i = 0; i < lengths.n_elem; ++i)
+  for (size_t c = 0; c < lengths.n_elem; ++c)
   {
-    lengths[i] = i;
-    for (size_t j = 0; j < lengths[i]; ++j)
+    lengths[c] = c;
+    for (size_t s = 0; s < lengths[c]; ++s)
     {
-      data(0, i, j) = j;
-      data(1, i, j) = i;
-      labels(0, i, j) = i + j;
+      data(0, c, s) = s;
+      data(1, c, s) = c;
+      labels(0, c, s) = c + s;
     }
   }
 
@@ -730,34 +730,39 @@ TEST_CASE("RaggedCubeShuffleTest", "[MathTest]")
   REQUIRE(outputLabels.n_rows == labels.n_rows);
   REQUIRE(outputLabels.n_cols == labels.n_cols);
   REQUIRE(outputLabels.n_slices == labels.n_slices);
+  REQUIRE(lengths.n_elem == outputLengths.n_elem);
 
   // Make sure each column has the right number of slices
-  arma::Row<size_t> sliceCount(lengths.n_elem);
+  arma::Row<size_t> sliceCount(5);
   for (size_t i = 0; i < outputLabels.n_cols; ++i)
   {
     for (size_t j = 0; j < outputLabels.n_slices; j++)
     {
       if (outputLabels(0, i, j) < 0) {
-        sliceCount = j;
+        sliceCount[i] = j;
         break;
       }
     }
   }
 
+  for (size_t i = 0; i < 5; ++i)
+    REQUIRE(sliceCount[i] == outputLengths[i]);
+  
   // Make sure we only have each point once.
   arma::Row<size_t> counts(5);
-  for (size_t i = 0; i < 5; ++i)
+  for (size_t c = 0; c < 5; ++c)
   {
-    for (size_t s = 0; s < lengths[i]; ++s)
+    for (size_t s = 0; s < outputLengths[c]; ++s)
     {
-      REQUIRE(data(0, i, s) + data(1, i, s) == labels(0, i, s));
-      REQUIRE(data(2, i, s) == Approx(-1.0).margin(1e-5));
-      counts[data(1, i, s)]++;
+      REQUIRE(outputData(0, c, s) + outputData(1, c, s)
+          == outputLabels(0, c, s));
+      REQUIRE(outputData(2, c, s) == Approx(-1.0).margin(1e-5));
+      counts[outputLengths[c]]++;
     }
   }
 
   for (size_t i = 0; i < 5; ++i)
-    REQUIRE(counts[i] == lengths[i]);
+    REQUIRE(counts[i] == i);
 }
 
 /**

--- a/src/mlpack/tests/math_test.cpp
+++ b/src/mlpack/tests/math_test.cpp
@@ -747,7 +747,7 @@ TEST_CASE("RaggedCubeShuffleTest", "[MathTest]")
 
   for (size_t i = 0; i < 5; ++i)
     REQUIRE(sliceCount[i] == outputLengths[i]);
-  
+
   // Make sure we only have each point once.
   arma::Row<size_t> counts(5);
   for (size_t c = 0; c < 5; ++c)

--- a/src/mlpack/tests/math_test.cpp
+++ b/src/mlpack/tests/math_test.cpp
@@ -761,53 +761,6 @@ TEST_CASE("RaggedCubeShuffleTest", "[MathTest]")
 }
 
 /**
- * Make sure shuffling cubes with empty sequence lengths works.
- * Just a copy of CubeShuffleTest but with an empty lengths argument
- */
-TEST_CASE("EmptyRaggedCubeShuffleTest", "[MathTest]")
-{
-  arma::cube data(3, 10, 5);
-  arma::cube labels(1, 10, 5);
-  arma::urowvec lengths;
-  for (size_t i = 0; i < labels.n_slices; ++i)
-  {
-    for (size_t j = 0; j < labels.n_cols; ++j)
-    {
-      data(0, j, i) = i;
-      data(1, j, i) = j;
-      labels(0, j, i) = j + i;
-    }
-  }
-
-  arma::cube outputData, outputLabels;
-  arma::urowvec outputLengths;
-
-  ShuffleData(data, labels, lengths, outputData, outputLabels, outputLengths);
-
-  REQUIRE(outputData.n_rows == data.n_rows);
-  REQUIRE(outputData.n_cols == data.n_cols);
-  REQUIRE(outputData.n_slices == data.n_slices);
-  REQUIRE(outputLabels.n_rows == labels.n_rows);
-  REQUIRE(outputLabels.n_cols == labels.n_cols);
-  REQUIRE(outputLabels.n_slices == labels.n_slices);
-
-  // Make sure we only have each point once.
-  arma::Row<size_t> counts(10);
-  for (size_t i = 0; i < 10; ++i)
-  {
-    for (size_t s = 0; s < data.n_slices; ++s)
-    {
-      REQUIRE(data(0, i, s) + data(1, i, s) == labels(0, i, s));
-      REQUIRE(data(2, i, s) == Approx(0.0).margin(1e-5));
-      counts[data(1, i, s)]++;
-    }
-  }
-
-  for (size_t i = 0; i < 10; ++i)
-    REQUIRE(counts[i] == data.n_slices);
-}
-
-/**
  * Make sure shuffling data with weights works.
  */
 TEST_CASE("ShuffleWeightsTest", "[MathTest]")


### PR DESCRIPTION
I noticed that rnns don't shuffle the sequence lengths with the data/labels

This pr should fix that