### PR TITLE
use non-deprecated form of is_finite()

### DIFF
--- a/src/mlpack/methods/lmnn/lmnn_impl.hpp
+++ b/src/mlpack/methods/lmnn/lmnn_impl.hpp
@@ -103,7 +103,7 @@ void LMNN<DistanceType, DeprecatedOptimizerType>::LearnDistance(
   // having r x d dimensionality.
   if ((outputMatrix.n_cols != dataset.n_rows) ||
       (outputMatrix.n_rows > dataset.n_rows) ||
-      !(arma::is_finite(outputMatrix)))
+      !(outputMatrix.is_finite()))
   {
     outputMatrix.eye(dataset.n_rows, dataset.n_rows);
   }


### PR DESCRIPTION
Replace `arma::is_finite(X)` with `X.is_finite()`.

The function `arma::is_finite()` has long been silently deprecated in Armadillo (ie. undocumented).  It has now been explicitly marked as deprecated upstream, which will produce a compile time warning when compiling mlpack.

The replacement in this PR is to avoid various forms of "feedback" from CRAN.
