### PR TITLE
Update location of patched file for CRAN

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 _????-??-??_
 
+ * Update bundled STB to fix warnings in R bindings (#3940).
 
 ## mlpack 4.6.1
 

--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -471,7 +471,7 @@ macro (post_r_setup)
     )
   endforeach()
 
-  # Resolve gcc Warnings.
+  # Resolve gcc warnings.
   file(READ ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/cereal/external/base64.hpp CEREAL_BASE64)
   string(REGEX REPLACE
       "\n#ifdef __GNUC__\n#pragma GCC diagnostic push\n#pragma GCC diagnostic ignored \"-Wconversion\"\n#endif\n"
@@ -481,23 +481,12 @@ macro (post_r_setup)
       "" CEREAL_BASE64 "${CEREAL_BASE64}")
   file(WRITE ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/cereal/external/base64.hpp "${CEREAL_BASE64}")
 
-  # Copy STB headers for inclusion in the package, if STB is used.
   # NOTE: for CRAN, `sprintf` cannot be used; but it is used in
   # `stb_image_write.h`, so we replace it with `snprintf` below.
-  if (StbImage_FOUND)
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E
-        make_directory ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/stb
-    )
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${STB_IMAGE_INCLUDE_DIR}/stb_image.h
-            ${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/stb/stb_image.h)
-    file(READ "${STB_IMAGE_INCLUDE_DIR}/stb_image_write.h" STB_IMAGE_WRITE_H)
-    string(REGEX REPLACE "sprintf\\(buffer," "snprintf(buffer, 128,"
-        STB_IMAGE_WRITE_H_MOD "${STB_IMAGE_WRITE_H}")
-    file(WRITE "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/stb/stb_image_write.h" "${STB_IMAGE_WRITE_H_MOD}")
-  endif ()
+  file(READ "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack/core/stb/bundled/stb_image_write.h" STB_IMAGE_WRITE_H)
+  string(REGEX REPLACE "sprintf\\(buffer," "snprintf(buffer, 128,"
+      STB_IMAGE_WRITE_H_MOD "${STB_IMAGE_WRITE_H}")
+  file(WRITE "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack/core/stb/bundled/stb_image_write.h" "${STB_IMAGE_WRITE_H_MOD}")
 
   # Then configure 'mlpack.h.in' using ${R_SRC}.
   configure_file(


### PR DESCRIPTION
We have a manual patch for CRAN in `stb_image_write.h`, because CRAN complains about the use of `sprintf`.  The patch is simple---just modify and use `snprintf` instead.

However, I noticed that this patch is not being applied to the R sources anymore; this is because we are now bundling STB with mlpack instead of depending on it from external sources.

Therefore, now, we need to directly patch the bundled file (and we need to do it always).

There's no need for a new release specifically for CRAN after this PR---I just made the change manually to the 4.6.1 tarball.