### PR TITLE
Fix compilation of `Save()` when HDF5 is enabled

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 _????-??-??_
 
+ * Fix compilation of `Save()` when HDF5 is enabled (#3942).
 
 ## mlpack 4.6.1
 

--- a/src/mlpack/core/data/save_impl.hpp
+++ b/src/mlpack/core/data/save_impl.hpp
@@ -135,21 +135,21 @@ bool Save(const std::string& filename,
     TextOptions txtOpts(std::move(opts));
     if constexpr (IsSparseMat<MatType>::value)
     {
-      success = SaveSparse(matrix, txtOpts, stream);
+      success = SaveSparse(matrix, txtOpts, filename, stream);
     }
     else if constexpr (IsCol<MatType>::value)
     {
       opts.NoTranspose() = true;
-      success = SaveDense(matrix, txtOpts, stream);
+      success = SaveDense(matrix, txtOpts, filename, stream);
     }
     else if constexpr (IsRow<MatType>::value)
     {
       opts.NoTranspose() = false;
-      success = SaveDense(matrix, txtOpts, stream);
+      success = SaveDense(matrix, txtOpts, filename, stream);
     }
     else if constexpr (IsDense<MatType>::value)
     {
-      success = SaveDense(matrix, txtOpts, stream);
+      success = SaveDense(matrix, txtOpts, filename, stream);
     }
     opts = std::move(txtOpts);
   }
@@ -183,6 +183,7 @@ bool Save(const std::string& filename,
 template<typename eT>
 bool SaveDense(const arma::Mat<eT>& matrix,
                TextOptions& opts,
+               const std::string& filename,
                std::fstream& stream)
 {
   bool success = false;
@@ -191,10 +192,10 @@ bool SaveDense(const arma::Mat<eT>& matrix,
   if (!opts.NoTranspose())
   {
     tmp = trans(matrix);
-    success = SaveMatrix(tmp, opts, stream);
+    success = SaveMatrix(tmp, opts, filename, stream);
   }
   else
-    success = SaveMatrix(matrix, opts, stream);
+    success = SaveMatrix(matrix, opts, filename, stream);
 
   return success;
 }
@@ -203,6 +204,7 @@ bool SaveDense(const arma::Mat<eT>& matrix,
 template<typename eT>
 bool SaveSparse(const arma::SpMat<eT>& matrix,
                 TextOptions& opts,
+                const std::string& filename,
                 std::fstream& stream)
 {
   bool success = false;
@@ -212,10 +214,10 @@ bool SaveSparse(const arma::SpMat<eT>& matrix,
   if (!opts.NoTranspose())
   {
     arma::SpMat<eT> tmp = trans(matrix);
-    success = SaveMatrix(tmp, opts, stream);
+    success = SaveMatrix(tmp, opts, filename, stream);
   }
   else
-    success = SaveMatrix(matrix, opts, stream);
+    success = SaveMatrix(matrix, opts, filename, stream);
 
   return success;
 }

--- a/src/mlpack/core/data/utilities.hpp
+++ b/src/mlpack/core/data/utilities.hpp
@@ -134,6 +134,7 @@ bool DetectFileType(const std::string& filename,
 template<typename MatType, typename DataOptionsType>
 bool SaveMatrix(const MatType& matrix,
                 const DataOptionsType& opts,
+                const std::string& filename,
                 std::fstream& stream)
 {
   bool success = false;

--- a/src/mlpack/core/data/utilities.hpp
+++ b/src/mlpack/core/data/utilities.hpp
@@ -142,7 +142,7 @@ bool SaveMatrix(const MatType& matrix,
   {
 #ifdef ARMA_USE_HDF5
     // We can't save with streams for HDF5.
-    success = matrix.save(filename, ToArmaFileType(opts.Format()))
+    success = matrix.save(filename, ToArmaFileType(opts.Format()));
 #endif
   }
   else


### PR DESCRIPTION
While compiling Python bindings on a system that had HDF5 enabled, I encountered a compilation failure:

http://ci.mlpack.org/job/mlpack-wheels/111/pipeline-console/?selected-node=67

Uh, it's really hard to find the failure in there, but basically in `SaveMatrix()`, when `ARMA_USE_HDF5` is set, then the `filename` parameter doesn't exist.  So I threaded the `filename` parameter through `SaveDense()` and `SaveSparse()` to fix the issue.

The reason that `filename` is needed is that Armadillo doesn't support saving HDF5 to streams---it only saves to filenames.

CC: @shrit because this is related to #3927.