### PR TITLE
Remove unused layerOutput and layerDelta

### DIFF
--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -169,8 +169,8 @@ class MultiLayer : public Layer<MatType>
     network.push_back(new LayerType(args...));
     if (network.size() > 1) {
       layerOutputs.push_back(MatType());
+      layerDeltas.push_back(MatType());
     }
-    layerDeltas.push_back(MatType());
     layerGradients.push_back(MatType());
   }
 
@@ -184,8 +184,8 @@ class MultiLayer : public Layer<MatType>
     network.push_back(layer);
     if (network.size() > 1) {
       layerOutputs.push_back(MatType());
+      layerDeltas.push_back(MatType());
     }
-    layerDeltas.push_back(MatType());
     layerGradients.push_back(MatType());
   }
 

--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -167,7 +167,9 @@ class MultiLayer : public Layer<MatType>
   void Add(Args... args)
   {
     network.push_back(new LayerType(args...));
-    layerOutputs.push_back(MatType());
+    if (network.size() > 1) {
+      layerOutputs.push_back(MatType());
+    }
     layerDeltas.push_back(MatType());
     layerGradients.push_back(MatType());
   }
@@ -180,7 +182,9 @@ class MultiLayer : public Layer<MatType>
   void Add(Layer<MatType>* layer)
   {
     network.push_back(layer);
-    layerOutputs.push_back(MatType());
+    if (network.size() > 1) {
+      layerOutputs.push_back(MatType());
+    }
     layerDeltas.push_back(MatType());
     layerGradients.push_back(MatType());
   }

--- a/src/mlpack/methods/ann/layer/multi_layer_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer_impl.hpp
@@ -333,7 +333,6 @@ void MultiLayer<MatType>::ComputeOutputDimensions()
   for (size_t i = 1; i < network.back()->OutputDimensions().size(); ++i)
     lastLayerSize *= network.back()->OutputDimensions()[i];
 
-  totalOutputSize += lastLayerSize;
   this->outputDimensions = network.back()->OutputDimensions();
 }
 


### PR DESCRIPTION
`layerOutput[network.size()-1]` and `layerDelta[0]` inside `MultiLayer` are unused. This PR removes them.

Should I rename `totalInputSize` and `totalOutputSize` since they don't mean with this PR?