### PR TITLE
Accelerate some tests that take a long time

### DIFF
--- a/src/mlpack/methods/cf/cf_model.hpp
+++ b/src/mlpack/methods/cf/cf_model.hpp
@@ -100,7 +100,7 @@ class CFWrapper : public CFWrapperBase
             const size_t numUsersForSimilarity,
             const size_t rank,
             const size_t maxIterations,
-            const size_t minResidue,
+            const double minResidue,
             const bool mit) :
       cf(data,
          decomposition,

--- a/src/mlpack/tests/main_tests/nca_test.cpp
+++ b/src/mlpack/tests/main_tests/nca_test.cpp
@@ -395,8 +395,8 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentNumBasisTest",
   {
     // Simple dataset.
     arma::mat x;
-    x.randu(8, 600);
-    arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(600,
+    x.randu(4, 100);
+    arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(100,
         DistrParam(0, 1));
 
     arma::mat y = x;
@@ -407,6 +407,7 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentNumBasisTest",
     SetInputParam("labels", std::move(labels));
     SetInputParam("optimizer",  std::string("lbfgs"));
     SetInputParam("num_basis", (int) 5);
+    SetInputParam("max_iterations", (int) 10);
 
     RUN_BINDING();
 
@@ -421,6 +422,7 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentNumBasisTest",
     SetInputParam("labels", std::move(labels2));
     SetInputParam("optimizer",  std::string("lbfgs"));
     SetInputParam("num_basis", (int) 1);
+    SetInputParam("max_iterations", (int) 10);
 
     RUN_BINDING();
 

--- a/src/mlpack/tests/sparse_coding_test.cpp
+++ b/src/mlpack/tests/sparse_coding_test.cpp
@@ -230,7 +230,8 @@ TEMPLATE_TEST_CASE("SparseCodingTrainReturnObjective", "[SparseCodingTest]",
   for (uword i = 0; i < nPoints; ++i)
     X.col(i) /= norm(X.col(i), 2);
 
-  SparseCoding<MatType> sc(nAtoms, lambda1, 0.0, 0, 0.01, tol);
+  // Use only 10 iterations to keep the test from taking too long.
+  SparseCoding<MatType> sc(nAtoms, lambda1, 0.0, 5, 0.01, tol);
   double objVal = sc.Train(X);
 
   REQUIRE(std::isfinite(objVal) == true);

--- a/src/mlpack/tests/svd_batch_test.cpp
+++ b/src/mlpack/tests/svd_batch_test.cpp
@@ -96,11 +96,13 @@ TEMPLATE_TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]", float, double)
   SpecificRandomInitialization<Mat<eT>> sri(cleanedData.n_rows, 2,
       cleanedData.n_cols);
 
-  ValidationRMSETermination<SpMat<eT>, Mat<eT>> vrt(cleanedData, 500);
+  // Use only 25 iterations---with momentum, we should be able to get a better
+  // result quickly.
+  ValidationRMSETermination<SpMat<eT>, Mat<eT>> vrt(cleanedData, 500, 1e-5, 25);
   AMF<ValidationRMSETermination<SpMat<eT>, Mat<eT>>,
       SpecificRandomInitialization<Mat<eT>>,
       SVDBatchLearning<Mat<eT>>> amf1(vrt, sri,
-      SVDBatchLearning<Mat<eT>>(0.0009, 0, 0, 0));
+      SVDBatchLearning<Mat<eT>>(0.001, 0, 0, 0));
 
   Mat<eT> m1, m2;
   const double regularRMSE = amf1.Apply(cleanedData, 2, m1, m2);
@@ -108,7 +110,7 @@ TEMPLATE_TEST_CASE("SVDBatchMomentumTest", "[SVDBatchTest]", float, double)
   AMF<ValidationRMSETermination<SpMat<eT>, Mat<eT>>,
       SpecificRandomInitialization<Mat<eT>>,
       SVDBatchLearning<Mat<eT>>> amf2(vrt, sri,
-      SVDBatchLearning<Mat<eT>>(0.0009, 0, 0, 0.8));
+      SVDBatchLearning<Mat<eT>>(0.001, 0, 0, 0.8));
 
   const double momentumRMSE = amf2.Apply(cleanedData, 2, m1, m2);
 


### PR DESCRIPTION
Using some spare time, I took a look at some of the tests that were taking a long time on the cross-compilation systems (specifically the RPi3):

```
307.288 s: NCADifferentNumBasisTest
132.809 s: CFMinResidueTest
61.782 s: SVDBatchMomentumTest - float
54.336 s: PendulumWithDDPG
51.422 s: SVDBatchMomentumTest - double
27.445 s: CartPoleWithDuelingDoubleNoisyDQN
22.917 s: SparseCodingTrainReturnObjective - arma::mat
16.773 s: SVDBatchRegularizationTest - float
15.068 s: SVDBatchRegularizationTest - double
14.605 s: CartPoleWithDuelingDQNPrioritizedReplay
...
```

I focused on those top three and reduced the test time by orders of magnitude.  I actually found that the `min_residue` parameter was not being passed correctly in the `CFModel` class.  Fixing that accelerated the test a lot (because it meant that 0.1 did not get truncated to the integer `0`... and it's a lot quicker to get to a residue of 0.1 than 0 :)).