### PR TITLE
Fix flaky LSTM test and a couple other little bits

### DIFF
--- a/src/mlpack/core/data/utilities.hpp
+++ b/src/mlpack/core/data/utilities.hpp
@@ -134,7 +134,11 @@ bool DetectFileType(const std::string& filename,
 template<typename MatType, typename DataOptionsType>
 bool SaveMatrix(const MatType& matrix,
                 const DataOptionsType& opts,
+#ifdef ARMA_USE_HDF5
                 const std::string& filename,
+#else
+                const std::string& /* filename */,
+#endif
                 std::fstream& stream)
 {
   bool success = false;

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -310,7 +310,7 @@ void FFN<
   // We must always store a copy of the forward pass in `networkOutputs` in case
   // we do a backward pass.
   networkOutput.set_size(network.OutputSize(), inputs.n_cols);
-  network.Forward(inputs, networkOutput, begin, end);
+  network.PartialForward(inputs, networkOutput, begin, end);
 
   // It's possible the user passed `networkOutput` as `results`; in this case,
   // we don't need to create an alias.

--- a/src/mlpack/methods/ann/layer/layer.hpp
+++ b/src/mlpack/methods/ann/layer/layer.hpp
@@ -30,8 +30,9 @@ namespace mlpack {
  *  - Forward(input, output): Performs the forward logic of applying the layer
  *    to the input object and storing the result in the output object.
  *
- *  - Backward(input, gy, g): Performs a backpropagation step through the layer,
- *    with respect to the given input.
+ *  - Backward(input, output, gy, g): Performs a backpropagation step through
+ *    the layer, with respect to the given input.  `output` is the result of
+ *    `Forward()`, which should have been previously called.
  *
  *  - Gradient(input, error, gradient): Computing the gradient of the layer with
  *    respect to its own input.
@@ -138,7 +139,7 @@ class Layer
    * Performs a backpropagation step through the layer, with respect to the
    * given input. In general this method makes the assumption Forward(input,
    * output) has been called before, with the same input. If you do not respect
-   * this rule, Backward(input, gy, g) might compute incorrect results.
+   * this rule, Backward(input, output, gy, g) might compute incorrect results.
    *
    * In general input and gy and g are matrices. However, some special
    * sub-classes like table layers might expect something else. Please, refer to

--- a/src/mlpack/methods/ann/layer/multi_layer.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer.hpp
@@ -78,10 +78,10 @@ class MultiLayer : public Layer<MatType>
    * @param start Index of first layer to pass data through.
    * @param end Index of last layer to pass data through.
    */
-  void Forward(const MatType& input,
-               MatType& output,
-               const size_t start,
-               const size_t end);
+  void PartialForward(const MatType& input,
+                      MatType& output,
+                      const size_t start,
+                      const size_t end);
 
   /**
    * Perform a backward pass with the given data.  `gy` is expected to be the

--- a/src/mlpack/methods/ann/layer/multi_layer_impl.hpp
+++ b/src/mlpack/methods/ann/layer/multi_layer_impl.hpp
@@ -138,11 +138,11 @@ template<typename MatType>
 void MultiLayer<MatType>::Forward(
     const MatType& input, MatType& output)
 {
-  Forward(input, output, 0, network.size() - 1);
+  PartialForward(input, output, 0, network.size() - 1);
 }
 
 template<typename MatType>
-void MultiLayer<MatType>::Forward(
+void MultiLayer<MatType>::PartialForward(
     const MatType& input,
     MatType& output,
     const size_t start,

--- a/src/mlpack/methods/ann/layer/nearest_interpolation.hpp
+++ b/src/mlpack/methods/ann/layer/nearest_interpolation.hpp
@@ -1,4 +1,3 @@
-//
 /**
  * @filer methods/ann/layer/nearest_interpolation.hpp
  * @author Andrew Furey
@@ -36,7 +35,8 @@ class NearestInterpolationType : public Layer<MatType>
   //! Create the NearestInterpolation object.
   NearestInterpolationType();
 
-  /**Create NearestInterpolation Object with the same scaleFactor along 
+  /**
+   * Create NearestInterpolation Object with the same scaleFactor along
    * each dimension.
    * NOTE: scaleFactors must be a two element vector, the first element
    * for scaling the first dimension and the second element for scaling
@@ -44,7 +44,7 @@ class NearestInterpolationType : public Layer<MatType>
    *
    * If the input dimensions are n x m x ..., then the output dimensions
    * will be (n x scaleFactors[0]) x (m x scaleFactors[1]) x ...
-   * 
+   *
    * @param scaleFactor Scale factors to scale each dimension by.
    */
   NearestInterpolationType(const std::vector<double> scaleFactors);
@@ -81,10 +81,12 @@ class NearestInterpolationType : public Layer<MatType>
    * the input size.
    *
    * @param * (input) The input matrix.
+   * @param * (output) The output matrix.
    * @param gradient The computed backward gradient.
    * @param output The resulting down-sampled output.
    */
-  void Backward(const MatType& /*input*/,
+  void Backward(const MatType& /* input */,
+                const MatType& /* output */,
                 const MatType& gradient,
                 MatType& output);
 

--- a/src/mlpack/methods/ann/layer/nearest_interpolation_impl.hpp
+++ b/src/mlpack/methods/ann/layer/nearest_interpolation_impl.hpp
@@ -20,7 +20,7 @@ namespace mlpack {
 
 template<typename MatType>
 NearestInterpolationType<MatType>::NearestInterpolationType():
-  Layer<MatType>()
+    Layer<MatType>()
 {
   // Nothing to do here.
 }
@@ -28,7 +28,7 @@ NearestInterpolationType<MatType>::NearestInterpolationType():
 template<typename MatType>
 NearestInterpolationType<MatType>::
 NearestInterpolationType(const std::vector<double> scaleFactors) :
-  Layer<MatType>()
+    Layer<MatType>()
 {
   if (scaleFactors.size() != 2) {
     throw std::runtime_error("Scale factors must have 2 dimensions");
@@ -39,8 +39,8 @@ NearestInterpolationType(const std::vector<double> scaleFactors) :
 template<typename MatType>
 NearestInterpolationType<MatType>::
 NearestInterpolationType(const NearestInterpolationType& other) :
-  Layer<MatType>(),
-  scaleFactors(other.scaleFactors)
+    Layer<MatType>(),
+    scaleFactors(other.scaleFactors)
 {
   // Nothing to do here.
 }
@@ -48,8 +48,8 @@ NearestInterpolationType(const NearestInterpolationType& other) :
 template<typename MatType>
 NearestInterpolationType<MatType>::
 NearestInterpolationType(NearestInterpolationType&& other) :
-  Layer<MatType>(std::move(other)),
-  scaleFactors(std::move(other.scaleFactors))
+    Layer<MatType>(std::move(other)),
+    scaleFactors(std::move(other.scaleFactors))
 {
   // Nothing to do here.
 }
@@ -82,7 +82,7 @@ operator=(NearestInterpolationType&& other)
 
 template<typename MatType>
 void NearestInterpolationType<MatType>::Forward(
-  const MatType& input, MatType& output)
+    const MatType& input, MatType& output)
 {
   const size_t channels = this->inputDimensions[2];
 
@@ -114,9 +114,10 @@ void NearestInterpolationType<MatType>::Forward(
 
 template<typename MatType>
 void NearestInterpolationType<MatType>::Backward(
-  const MatType& /*input*/,
-  const MatType& gradient,
-  MatType& output)
+    const MatType& /* input */,
+    const MatType& /* output */,
+    const MatType& gradient,
+    MatType& output)
 {
   const size_t channels = this->inputDimensions[2];
 
@@ -169,7 +170,7 @@ void NearestInterpolationType<MatType>::ComputeOutputDimensions()
 template<typename MatType>
 template<typename Archive>
 void NearestInterpolationType<MatType>::serialize(
-  Archive& ar, const uint32_t /* version */)
+    Archive& ar, const uint32_t /* version */)
 {
   ar(CEREAL_NVP(scaleFactors));
 }

--- a/src/mlpack/methods/reinforcement_learning/environment/acrobot.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/acrobot.hpp
@@ -121,7 +121,7 @@ class Acrobot
   Acrobot(const size_t maxSteps = 500,
           const double gravity = 9.81,
           const double linkLength1 = 1.0,
-          const double linkLength2 = 1.0,
+          const double /* linkLength2 */ = 1.0,
           const double linkMass1 = 1.0,
           const double linkMass2 = 1.0,
           const double linkCom1 = 0.5,
@@ -134,7 +134,7 @@ class Acrobot
       maxSteps(maxSteps),
       gravity(gravity),
       linkLength1(linkLength1),
-      linkLength2(linkLength2),
+      //linkLength2(linkLength2),
       linkMass1(linkMass1),
       linkMass2(linkMass2),
       linkCom1(linkCom1),
@@ -360,8 +360,8 @@ class Acrobot
   //! Locally-stored length of link 1.
   double linkLength1;
 
-  //! Locally-stored length of link 2.
-  double linkLength2;
+  //! Locally-stored length of link 2.  (NOTE: not currently used)
+  //double linkLength2;
 
   //! Locally-stored mass of link 1.
   double linkMass1;

--- a/src/mlpack/methods/reinforcement_learning/environment/cart_pole.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/cart_pole.hpp
@@ -125,7 +125,7 @@ class CartPole
            const double doneReward = 1.0) :
       maxSteps(maxSteps),
       gravity(gravity),
-      massCart(massCart),
+      //massCart(massCart),
       massPole(massPole),
       totalMass(massCart + massPole),
       length(length),
@@ -247,8 +247,8 @@ class CartPole
   //! Locally-stored gravity.
   double gravity;
 
-  //! Locally-stored mass of the cart.
-  double massCart;
+  //! Locally-stored mass of the cart.  NOTE: not currently used.
+  //double massCart;
 
   //! Locally-stored mass of the pole.
   double massPole;

--- a/src/mlpack/methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
@@ -104,7 +104,8 @@ class ContinuousDoublePoleCart
    * @param l2 The length of the second pole.
    * @param gravity The gravity constant.
    * @param massCart The mass of the cart.
-   * @param forceMag The magnitude of the applied force.
+   * @param forceMag The magnitude of the applied force.  NOTE: not currently
+   *      used.
    * @param tau The time interval.
    * @param thetaThresholdRadians The maximum angle.
    * @param xThreshold The maximum position.
@@ -118,7 +119,7 @@ class ContinuousDoublePoleCart
                            const double l2 = 0.05,
                            const double gravity = 9.8,
                            const double massCart = 1.0,
-                           const double forceMag = 10.0,
+                           const double /* forceMag */ = 10.0,
                            const double tau = 0.02,
                            const double thetaThresholdRadians = 36 * 2 *
                               3.1416 / 360,
@@ -131,7 +132,7 @@ class ContinuousDoublePoleCart
       l2(l2),
       gravity(gravity),
       massCart(massCart),
-      forceMag(forceMag),
+      //forceMag(forceMag),
       tau(tau),
       thetaThresholdRadians(thetaThresholdRadians),
       xThreshold(xThreshold),
@@ -340,8 +341,8 @@ class ContinuousDoublePoleCart
   //! Locally-stored mass of the cart.
   double massCart;
 
-  //! Locally-stored magnitude of the applied force.
-  double forceMag;
+  //! Locally-stored magnitude of the applied force.  NOTE: not currently used.
+  //double forceMag;
 
   //! Locally-stored time interval.
   double tau;

--- a/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
@@ -111,18 +111,19 @@ class Pendulum
    * @param maxAngularVelocity Maximum angular velocity.
    * @param maxTorque Maximum torque.
    * @param dt The differential value.
-   * @param doneReward The reward recieved by the agent on success.
+   * @param doneReward The reward recieved by the agent on success.  NOTE: not
+   *      currently used.
    */
   Pendulum(const size_t maxSteps = 200,
            const double maxAngularVelocity = 8,
            const double maxTorque = 2.0,
            const double dt = 0.05,
-           const double doneReward = 0.0) :
+           const double /* doneReward */ = 0.0) :
       maxSteps(maxSteps),
       maxAngularVelocity(maxAngularVelocity),
       maxTorque(maxTorque),
       dt(dt),
-      doneReward(doneReward),
+      //doneReward(doneReward),
       stepsPerformed(0)
   { /* Nothing to do here */ }
 
@@ -254,8 +255,8 @@ class Pendulum
   //! Locally-stored dt.
   double dt;
 
-  //! Locally-stored done reward.
-  double doneReward;
+  //! Locally-stored done reward.  NOTE: not currently used.
+  //double doneReward;
 
   //! Locally-stored number of steps performed.
   size_t stepsPerformed;

--- a/src/mlpack/tests/ann/layer/nearest_interpolation.cpp
+++ b/src/mlpack/tests/ann/layer/nearest_interpolation.cpp
@@ -1,8 +1,8 @@
 /**
- * @file tests/ann/layer/add.cpp
- * @author Ryan Curtin
+ * @file tests/ann/layer/nearest_interpolation.cpp
+ * @author Andrew Furey
  *
- * Tests the nearest interpolation layer
+ * Tests the nearest interpolation layer.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
@@ -60,7 +60,7 @@ TEST_CASE("NearestInterpolationLayerTest", "[ANNLayerTest]")
 
   expectedOutput = arma::mat{4.0, 8.0, 12.0, 16.0};
   expectedOutput.reshape(4, 1);
-  layer.Backward(output, output, unzoomedOutput);
+  layer.Backward(output, output, output, unzoomedOutput);
   CheckMatrices(unzoomedOutput - expectedOutput,
       arma::zeros(input.n_rows), 1e-4);
 
@@ -71,15 +71,15 @@ TEST_CASE("NearestInterpolationLayerTest", "[ANNLayerTest]")
   arma::mat input1 {{1.0, 2.0, 3.0},
                     {4.0, 5.0, 6.0}};
   input1.reshape(6, 1);
-  output1.zeros(17*23, 1);
+  output1.zeros(17 * 23, 1);
   unzoomedOutput1.zeros(6, 1);
-  mlpack::NearestInterpolation layer1({17/2.0f, 23/3.0f});
+  mlpack::NearestInterpolation layer1({17 / 2.0f, 23 / 3.0f});
 
   layer1.InputDimensions() = { 2, 3, channels };
   layer1.ComputeOutputDimensions();
 
   layer1.Forward(input1, output1);
-  layer1.Backward(output1, output1, unzoomedOutput1);
+  layer1.Backward(output1, output1, output1, unzoomedOutput1);
   REQUIRE(accu(output1) - 1317.00 == Approx(0.0).margin(1e-05));
   REQUIRE(accu(unzoomedOutput1) - 1317.00 ==
           Approx(0.0).margin(1e-05));

--- a/src/mlpack/tests/lmnn_test.cpp
+++ b/src/mlpack/tests/lmnn_test.cpp
@@ -453,7 +453,7 @@ double KnnAccuracy(const MatType& dataset,
     for (size_t j = 0; j < k; ++j)
       m(labels(neighbors(j, i))) += 1 / std::pow(distances(j, i) + 1, 2);
 
-    size_t index = ConvTo<size_t>::From(arma::find(m == arma::max(m)));
+    size_t index = arma::as_scalar(arma::find(m == arma::max(m)));
 
     // Increase count if labels match.
     if (index == labels(i))

--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -2651,7 +2651,6 @@ TEST_CASE("LoadCSVSemiColonMissingToNanHeader", "[LoadSaveTest]")
 
   data::Load("test.csv", dataset, opts);
 
-  dataset.print();
   arma::field<std::string> headers = opts.Headers();
 
   REQUIRE(dataset.n_rows == 2);

--- a/src/mlpack/tests/lsh_test.cpp
+++ b/src/mlpack/tests/lsh_test.cpp
@@ -37,16 +37,13 @@ void GetPointset(const size_t N, arma::mat& rdata)
   arma::mat c4(d, N / 4, arma::fill::randu);
 
   arma::colvec offset1;
-  offset1 = { { 0 },
-              { 3 } };
+  offset1 = { 0, 3 };
 
   arma::colvec offset2;
-  offset2 = { { 3 },
-              { 3 } };
+  offset2 = { 3, 3 };
 
   arma::colvec offset4;
-  offset4 = { { 3 },
-              { 0 } };
+  offset4 = { 3, 0 };
 
   // Spread points in plane.
   for (size_t p = 0; p < N / 4; ++p)


### PR DESCRIPTION
I noticed `LSTMDistractedSequenceRecallTest` failing on the cross-compilation jobs regularly.  When I ran locally with different random seeds, it failed twice every 100 trials or so.  So, I allowed retraining of the network---it can start in bad locations for the optimizer and fail to converge.  I'm still convinced that LSTMs are working correctly if it converges at all.

I also noticed that another RNN test didn't actually have a `REQUIRE()` in it!  So I fixed that.

Lastly I did a handful of warning cleanups, including renaming an overload of `MultiLayer::Forward()` to prevent this relatively new warning on GCC:

```
/home/ryan/src/mlpack/src/mlpack/methods/ann/layer/multi_layer.hpp:81:8: warning: 'mlpack::MultiLayer<arma::Mat<double>>::Forward' hides overloaded virtual function [-Woverloaded-virtual]
   81 |   void Forward(const MatType& input,
      |        ^
/home/ryan/src/mlpack/src/mlpack/methods/ann/ffn.hpp:514:23: note: in instantiation of template class 'mlpack::MultiLayer<arma::Mat<double>>' requested here
  514 |   MultiLayer<MatType> network;
      |                       ^
/home/ryan/src/mlpack/src/mlpack/tests/cv_test.cpp:276:46: note: in instantiation of template class 'mlpack::FFN<mlpack::MeanSquaredErrorType<>, mlpack::ConstInitialization>' requested here
  276 |   FFN<MeanSquaredError, ConstInitialization> ffn(MeanSquaredError(),
      |                                              ^
/home/ryan/src/mlpack/src/mlpack/methods/ann/layer/layer.hpp:133:16: note: hidden overloaded virtual function 'mlpack::Layer<>::Forward' declared here: different number of parameters (2 vs 4)
  133 |   virtual void Forward(const MatType& /* input */,

```

That's not a public-facing function so I don't mind renaming it.  @andrewfurey21 if you don't mind taking a look, that rename will probably affect the DAGNetwork implementation and #3943, hopefully not a big deal.  Let me know if otherwise.