### PR TITLE
Fix another CRAN warning for the definition of `STBIRDEF`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 _????-??-??_
 
+ * Fix warning on CRAN for bundled STB (#3950).
 
 ## mlpack 4.6.2
 

--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -488,6 +488,16 @@ macro (post_r_setup)
       STB_IMAGE_WRITE_H_MOD "${STB_IMAGE_WRITE_H}")
   file(WRITE "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack/core/stb/bundled/stb_image_write.h" "${STB_IMAGE_WRITE_H_MOD}")
 
+  # NOTE: also for CRAN, the `static` definition of STBIRDEF causes a warning
+  # indicating that it should instead be `static inline`, so we make that
+  # replacement below.
+  file(READ "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack/core/stb/bundled/stb_image_resize2.h" STB_IMAGE_RESIZE2_H)
+  string(REGEX REPLACE "#define STBIRDEF static"
+      "#define STBIRDEF static inline" STB_IMAGE_RESIZE2_H_MOD
+      "${STB_IMAGE_RESIZE2_H}")
+  file(WRITE "${CMAKE_BINARY_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack/core/stb/bundled/stb_image_resize2.h"
+      "${STB_IMAGE_RESIZE2_H_MOD}")
+
   # Then configure 'mlpack.h.in' using ${R_SRC}.
   configure_file(
       ${CMAKE_SOURCE_DIR}/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in


### PR DESCRIPTION
The fact that `STBIRDEF` in `stb_image_resize2.h` is a macro defined as `static` causes a warning on CRAN:

```
  ../inst/include/mlpack/core/stb/bundled/stb_image_resize2.h:7983:26: warning: 'static' function 'stbir_resize_uint8_linear' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
```

CRAN calls this a `significant warning`.  I don't.  But in any case, just like the other patch we apply to STB sources, I did this one in the same way.  I don't have a particularly strong justification for doing it here instead of updating our bundled version, I'm just sticking with the technique we're already doing (just above my patch).