### PR TITLE
Use a looser check for non-printable ASCII characters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@ _????-??-??_
 
  * Fix warning on CRAN for bundled STB (#3950).
 
+ * Use a looser check for auto-detection of categorical file types (#3961).
+
 ## mlpack 4.6.2
 
 _2025-05-22_

--- a/src/mlpack/core/data/detect_file_type_impl.hpp
+++ b/src/mlpack/core/data/detect_file_type_impl.hpp
@@ -126,7 +126,7 @@ inline FileType GuessFileType(std::istream& f)
   for (arma::uword i = 0; i < nUse; ++i)
   {
     const unsigned char val = dataMem[i];
-    if ((val <= 8) || (val >= 123))
+    if (val <= 8)
     {
       hasBinary = true;
       break;
@@ -394,10 +394,14 @@ bool DetectFileType(const std::string& filename,
     if (opts.Format() == FileType::AutoDetect)
     {
       if (isLoading)
+      {
         // Attempt to auto-detect the type from the given file.
         opts.Format() = AutoDetectFile(*stream, filename);
+      }
       else
+      {
         DetectFromExtension<ObjectType>(filename, opts);
+      }
       // Provide error if we don't know the type.
       if (opts.Format() == FileType::FileTypeUnknown)
       {


### PR DESCRIPTION
(CC @shrit)

This should fix #3960.  In essence the problem seen there is that a categorical CSV is not correctly detected based on its extension.  This problem surfaced in mlpack 4.6.2 due to the refactoring that is in progress to replace the existing `Load()` interface with a much nicer `DataOptions` class.

Prior to #3927, the code path taken for `Load()` on categorical matrices was separate, and file formats were inferred based on the extension alone.  But after #3927, this now uses the function `AutoDetectFile()` and the rest of the machinery that is used for regular matrices.  (That is a good thing!)

However, one line of code in there, which was meant to check whether or not a character was a numeric or possibly-numeric ASCII character, happens to fail specifically with the `movies.csv` file from the C++ quickstart, whose file contents are:

```
$ head movies.csv 
,movieId,title,genres
0,0,Toy Story (1995),Adventure|Animation|Children|Comedy|Fantasy
1,1,Jumanji (1995),Adventure|Children|Fantasy
2,2,Grumpier Old Men (1995),Comedy|Romance
3,3,Waiting to Exhale (1995),Comedy|Drama|Romance
4,4,Father of the Bride Part II (1995),Comedy
5,5,Heat (1995),Action|Crime|Thriller
6,6,Sabrina (1995),Comedy|Romance
7,7,Tom and Huck (1995),Adventure|Children
8,8,Sudden Death (1995),Action
```

The `|` character is actually outside the accepted bounds, so the file gets detected as `RawBinary` and then loading fails!

The easiest solution here is simply to relax the check a little bit, and only classify something as `RawBinary` if it really has some weird non-printable characters (e.g. those that are less than or equal to 0x08).

Thanks for the report @ranjodhsingh1729!