### PR TITLE
Fix cmake path variables for cpm installation

### DIFF
--- a/CMake/GeneratePkgConfig.cmake
+++ b/CMake/GeneratePkgConfig.cmake
@@ -24,5 +24,5 @@ set(MLPACK_VERSION_STRING
     "${MLPACK_VERSION_MAJOR}.${MLPACK_VERSION_MINOR}.${MLPACK_VERSION_PATCH}")
 
 configure_file(
-    ${CMAKE_BINARY_DIR}/CMake/mlpack.pc.in.partial
-    ${CMAKE_BINARY_DIR}/lib/pkgconfig/mlpack.pc @ONLY)
+    ${CMAKE_CURRENT_BINARY_DIR}/CMake/mlpack.pc.in.partial
+    ${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig/mlpack.pc @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,11 +448,11 @@ if (PKG_CONFIG_FOUND)
   set(MLPACK_VERSION_STRING "@MLPACK_VERSION_STRING@")
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/CMake/mlpack.pc.in
-    ${CMAKE_BINARY_DIR}/CMake/mlpack.pc.in.partial @ONLY)
+    ${CMAKE_CURRENT_BINARY_DIR}/CMake/mlpack.pc.in.partial @ONLY)
 
   add_custom_target(pkgconfig ALL
       ${CMAKE_COMMAND}
-          -D MLPACK_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+          -D MLPACK_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
           -P "${CMAKE_CURRENT_SOURCE_DIR}/CMake/GeneratePkgConfig.cmake"
       COMMENT "Generating mlpack.pc (pkg-config) file.")
 


### PR DESCRIPTION
## Problem description

We were trying to use mlpack in our project. It's added to the project using cmake's package manager, [cpm](https://github.com/cpm-cmake/CPM.cmake). The installation step ran into errors in `CMake/GeneratePkgConfig.cmake`:
- Cannot open src/mlpack/core/util/version.hpp
- mlpack.pc.in.partial does not exist

They can be fixed by changing the path variables in the cmake files.

## Reproduction

1. Download [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.2/CPM.cmake).
2. Create a simple project use [CMakeLists.txt](https://github.com/user-attachments/files/21263817/CMakeLists.txt), by putting the two files in a new folder.
3. Run: `cmake -B build && cmake --build build`.

For your convenience, the content of [CMakeLists.txt](https://github.com/user-attachments/files/21263817/CMakeLists.txt) is as follows:
```
cmake_minimum_required(VERSION 3.28)
project(TestProj LANGUAGES CXX)

set(CPM_SOURCE_CACHE
    "${CMAKE_SOURCE_DIR}/.cpmcache"
    CACHE STRING "Path to CPM source cache")

include(CPM.cmake)

CPMAddpackage(
    NAME mlpack
    GIT_REPOSITORY https://github.com/mlpack/mlpack.git
    GIT_TAG master
)
```

## Solution

`CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` are the top-level directories for the project, while `CMAKE_CURRENT_SOURCE_DIR` and `CMAKE_CURRENT_SOURCE_DIR` are the directories currently being processed by cmake. While using cpm, `CMAKE_CURRENT_SOURCE_DIR` is the directory inside cpm's cache, and `CMAKE_CURRENT_BINARY_DIR` is the build directory for mlpack, i.e., `${CMAKE_BINARY_DIR}/_deps/mlpack-build`.

The same errors might occur whenever mlpack is checked out into a different location other than the main project's source dir and built in a different location other than the main project's build dir. After applying the changes, the cmake build passed.

