### PR TITLE
Try to restrict link checking job to certain nodes

### DIFF
--- a/.jenkins/doc-link-check/Jenkinsfile
+++ b/.jenkins/doc-link-check/Jenkinsfile
@@ -11,6 +11,11 @@ pipeline
   // for this job.
   agent
   {
+    node
+    {
+      label 'doc-check'
+    }
+
     docker
     {
       image 'mlpack/jenkins-mlpack-docbuild:latest'


### PR DESCRIPTION
This PR only runs the documentation link checking job on hosts that don't seem to have problems with Cloudflare blocking (sigh... the modern internet).