### PR TITLE
Use `Shuffle()` in ensmallen `ParallelSGD` overloads

### DIFF
--- a/src/mlpack/methods/bias_svd/bias_svd_function_impl.hpp
+++ b/src/mlpack/methods/bias_svd/bias_svd_function_impl.hpp
@@ -313,7 +313,7 @@ inline double ParallelSGD<ExponentialBackoff>::Optimize(
     // Get the stepsize for this iteration
     double stepSize = decayPolicy.StepSize(i);
 
-    if (shuffle) // Determine order of visitation.
+    if (Shuffle()) // Determine order of visitation.
       std::shuffle(visitationOrder.begin(), visitationOrder.end(),
           mlpack::RandGen());
 

--- a/src/mlpack/methods/regularized_svd/regularized_svd_function_impl.hpp
+++ b/src/mlpack/methods/regularized_svd/regularized_svd_function_impl.hpp
@@ -269,7 +269,7 @@ inline double ParallelSGD<ExponentialBackoff>::Optimize(
     // Get the stepsize for this iteration
     double stepSize = decayPolicy.StepSize(i);
 
-    if (shuffle) // Determine order of visitation.
+    if (Shuffle()) // Determine order of visitation.
       std::shuffle(visitationOrder.begin(), visitationOrder.end(),
           mlpack::RandGen());
 

--- a/src/mlpack/methods/svdplusplus/svdplusplus_function_impl.hpp
+++ b/src/mlpack/methods/svdplusplus/svdplusplus_function_impl.hpp
@@ -451,7 +451,7 @@ inline double ParallelSGD<ExponentialBackoff>::Optimize(
     // Get the stepsize for this iteration
     double stepSize = decayPolicy.StepSize(i);
 
-    if (shuffle) // Determine order of visitation.
+    if (Shuffle()) // Determine order of visitation.
       std::shuffle(visitationOrder.begin(), visitationOrder.end(),
           mlpack::RandGen());
 


### PR DESCRIPTION
Upstream, as a part of ensmallen#425, the member `ParallelSGD::shuffle` will have to change to `ParallelSGD::shuffleFlag`.  As a result, downstream mlpack code---which contains a specialization of `ParallelSGD` for a couple of iterative SVD solvers---will break.  An easy solution that avoids the use of `#ifdef` is simply to access the member via `ParallelSGD::Shuffle()` instead: that function name will not change upstream.