### PR TITLE
Accelerate `CELU` and add tests

### DIFF
--- a/src/mlpack/methods/ann/layer/celu.hpp
+++ b/src/mlpack/methods/ann/layer/celu.hpp
@@ -121,10 +121,7 @@ class CELUType : public Layer<MatType>
   void serialize(Archive& ar, const uint32_t /* version */);
 
  private:
-  //! Locally stored first derivative of the activation function.
-  MatType derivative;
-
-  //! CELU Hyperparameter (alpha > 0).
+  // CELU Hyperparameter (alpha > 0).
   double alpha;
 }; // class CELUType
 

--- a/src/mlpack/tests/ann/layer/celu.cpp
+++ b/src/mlpack/tests/ann/layer/celu.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file tests/ann/layer/celu.cpp
+ * @author Ryan Curtin
+ *
+ * Tests the CELU layer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/ann.hpp>
+
+#include "../../test_catch_tools.hpp"
+#include "../../catch.hpp"
+#include "../../serialization.hpp"
+#include "../ann_test_tools.hpp"
+
+using namespace mlpack;
+
+/**
+ * CELU layer numerical gradient test.
+ */
+TEST_CASE("GradientCELUTest", "[ANNLayerTest]")
+{
+  // Softmax function gradient instantiation.
+  struct GradientFunction
+  {
+    GradientFunction() :
+        input(arma::randu(10, 1) - 0.5),
+        target(arma::mat("1; 0"))
+    {
+      model = new FFN<MeanSquaredError, RandomInitialization>;
+      model->ResetData(input, target);
+      model->Add<Linear>(10);
+      model->Add<CELU>();
+      model->Add<Linear>(2);
+      model->Add<Softmax>();
+    }
+
+    ~GradientFunction()
+    {
+      delete model;
+    }
+
+    double Gradient(arma::mat& gradient) const
+    {
+      double error = model->Evaluate(model->Parameters(), 0, 1);
+      model->Gradient(model->Parameters(), 0, gradient, 1);
+      return error;
+    }
+
+    arma::mat& Parameters() { return model->Parameters(); }
+
+    FFN<MeanSquaredError>* model;
+    arma::mat input, target;
+  } function;
+
+  REQUIRE(CheckGradient(function) <= 1e-4);
+}


### PR DESCRIPTION
I noticed that the `CELU` layer held a matrix of derivatives between `Forward()` and `Backward()`.  But this is really not a great implementation as the output of the layer is available when `Backward()` is called.  So, I removed the member and simplified the layer.  On a simple timing test for `Forward()` and `Backward()` with 1M random elements between -0.5 and 0.5:

before:

```
Forward(): 0.0339329s
Backward(): 0.0239357s
```

after:

```
Forward(): 0.0176554s
Backward(): 0.0161865s
```

and memory usage will be smaller too.  Maybe it is possible to do better, I didn't put too much effort into it.