### PR TITLE
Improve ELU implementation

### DIFF
--- a/src/mlpack/methods/ann/layer/elu.hpp
+++ b/src/mlpack/methods/ann/layer/elu.hpp
@@ -181,17 +181,14 @@ class ELUType : public Layer<MatType>
   void serialize(Archive& ar, const uint32_t /* version */);
 
  private:
-  //! Locally stored first derivative of the activation function.
-  MatType derivative;
-
-  //! ELU Hyperparameter (0 < alpha)
-  //! SELU parameter fixed to 1.6732632423543774 for normalized inputs.
+  // ELU Hyperparameter (0 < alpha)
+  // SELU parameter fixed to 1.6732632423543774 for normalized inputs.
   double alpha;
 
-  //! Lambda parameter used for multiplication of ELU function.
-  //! For ELU activation function, lambda = 1.
-  //! For SELU activation function, lambda = 1.0507009873554802 for normalized
-  //! inputs.
+  // Lambda parameter used for multiplication of ELU function.
+  // For ELU activation function, lambda = 1.
+  // For SELU activation function, lambda = 1.0507009873554802 for normalized
+  // inputs.
   double lambda;
 }; // class ELUType
 

--- a/src/mlpack/methods/ann/layer/elu_impl.hpp
+++ b/src/mlpack/methods/ann/layer/elu_impl.hpp
@@ -98,29 +98,22 @@ void ELUType<MatType>::Forward(
 {
   for (size_t i = 0; i < input.n_elem; ++i)
   {
-    if (input(i) < DBL_MAX)
-    {
-      output(i) = (input(i) > 0) ? lambda * input(i) : lambda * alpha *
-          (std::exp(input(i)) - 1);
-    }
-  }
-
-  if (this->training)
-  {
-    derivative.set_size(arma::size(input));
-    for (size_t i = 0; i < input.n_elem; ++i)
-      derivative(i) = (input(i) > 0) ? lambda : output(i) + lambda * alpha;
+    output(i) = (input(i) >= 0) ? lambda * input(i) : lambda * alpha *
+        (std::exp(input(i)) - 1);
   }
 }
 
 template<typename MatType>
 void ELUType<MatType>::Backward(
-    const MatType& /* input */,
-    const MatType& /* output */,
+    const MatType& input,
+    const MatType& output,
     const MatType& gy,
     MatType& g)
 {
-  g = gy % derivative;
+  for (size_t i = 0; i < input.n_elem; ++i)
+  {
+    g(i) = gy(i) * ((input(i) >= 0) ? lambda : output(i) + lambda * alpha);
+  }
 }
 
 template<typename MatType>

--- a/src/mlpack/tests/ann/layer/elu.cpp
+++ b/src/mlpack/tests/ann/layer/elu.cpp
@@ -1,0 +1,102 @@
+/**
+ * @file tests/ann/layer/elu.cpp
+ * @author Ryan Curtin
+ *
+ * Tests the ELU layer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/ann.hpp>
+
+#include "../../test_catch_tools.hpp"
+#include "../../catch.hpp"
+#include "../../serialization.hpp"
+#include "../ann_test_tools.hpp"
+
+using namespace mlpack;
+
+/**
+ * ELU layer numerical gradient test.
+ */
+TEST_CASE("GradientELUTest", "[ANNLayerTest]")
+{
+  // Softmax function gradient instantiation.
+  struct GradientFunction
+  {
+    GradientFunction() :
+        input(arma::randu(10, 1) - 0.5),
+        target(arma::mat("1; 0"))
+    {
+      model = new FFN<MeanSquaredError, RandomInitialization>;
+      model->ResetData(input, target);
+      model->Add<Linear>(10);
+      model->Add<ELU>(0.6);
+      model->Add<Linear>(2);
+      model->Add<Softmax>();
+    }
+
+    ~GradientFunction()
+    {
+      delete model;
+    }
+
+    double Gradient(arma::mat& gradient) const
+    {
+      double error = model->Evaluate(model->Parameters(), 0, 1);
+      model->Gradient(model->Parameters(), 0, gradient, 1);
+      return error;
+    }
+
+    arma::mat& Parameters() { return model->Parameters(); }
+
+    FFN<MeanSquaredError>* model;
+    arma::mat input, target;
+  } function;
+
+  REQUIRE(CheckGradient(function) <= 1e-4);
+}
+
+/**
+ * SELU layer numerical gradient test.
+ */
+TEST_CASE("GradientSELUTest", "[ANNLayerTest]")
+{
+  // Softmax function gradient instantiation.
+  struct GradientFunction
+  {
+    GradientFunction() :
+        input(arma::randu(10, 1) - 0.5),
+        target(arma::mat("1; 0"))
+    {
+      model = new FFN<MeanSquaredError, RandomInitialization>;
+      model->ResetData(input, target);
+      model->Add<Linear>(10);
+      model->Add<SELU>();
+      model->Add<Linear>(2);
+      model->Add<Softmax>();
+    }
+
+    ~GradientFunction()
+    {
+      delete model;
+    }
+
+    double Gradient(arma::mat& gradient) const
+    {
+      double error = model->Evaluate(model->Parameters(), 0, 1);
+      model->Gradient(model->Parameters(), 0, gradient, 1);
+      return error;
+    }
+
+    arma::mat& Parameters() { return model->Parameters(); }
+
+    FFN<MeanSquaredError>* model;
+    arma::mat input, target;
+  } function;
+
+  REQUIRE(CheckGradient(function) <= 1e-4);
+}

--- a/src/mlpack/tests/ann/layer_test.cpp
+++ b/src/mlpack/tests/ann/layer_test.cpp
@@ -30,6 +30,7 @@
 #include "layer/concatenate.cpp"
 #include "layer/c_relu.cpp"
 #include "layer/dropout.cpp"
+#include "layer/elu.cpp"
 #include "layer/flexible_relu.cpp"
 #include "layer/grouped_convolution.cpp"
 #include "layer/gru.cpp"


### PR DESCRIPTION
This is essentially identical to #3975.  I used basically the exact same strategy and added tests for both `ELU` and `SELU`.

Timing before:

```
Forward(): 0.0336677
Backward(): 0.00561942
```

Timing after:

```
Forward(): 0.0165522
Backward(): 0.0165066
```

The speed improvement is more modest here, but more importantly, the unnecessary `derivative` matrix is removed from the layer.