### PR TITLE
Add links to cross-compilation pages

### DIFF
--- a/doc/sidebar.html
+++ b/doc/sidebar.html
@@ -506,8 +506,8 @@ when the sidebar is built for each page.
               </a>
             </li>
             <li>
-              <a href="LINKROOTembedded/crosscompile_armv7.html">
-                Cross-compile to RPi2
+              <a href="LINKROOTuser/deploy_docker.html">
+                Deploying with Docker
               </a>
             </li>
             <li>
@@ -516,8 +516,18 @@ when the sidebar is built for each page.
               </a>
             </li>
             <li>
-              <a href="LINKROOTuser/deploy_docker.html">
-                Deploying with Docker
+              <a href="LINKROOTembedded/supported_boards.html">
+                Setting up for cross-compilation
+              </a>
+            </li>
+            <li>
+              <a href="LINKROOTembedded/crosscompile_example.html">
+                Cross-compile to embedded systems
+              </a>
+            </li>
+            <li>
+              <a href="LINKROOTembedded/crosscompile_armv7.html">
+                Cross-compile bindings to RPi2
               </a>
             </li>
           </ul>


### PR DESCRIPTION
@shrit and I noticed that these two pages were missing from the cross-compilation documentation:

https://www.mlpack.org/doc/embedded/supported_boards.html
https://www.mlpack.org/doc/embedded/crosscompile_example.html

I added them to `sidebar.html` and reorganized things just a little bit.