### PR TITLE
set networkDelta size before calling network.Backward

### DIFF
--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -336,6 +336,7 @@ typename MatType::elem_type FFN<
   outputLayer.Backward(networkOutput, targets, error);
 
   // Perform the backward pass.
+  networkDelta.set_size(inputs.n_rows, inputs.n_cols);
   network.Backward(inputs, networkOutput, error, networkDelta);
 
   // Now compute the gradients.


### PR DESCRIPTION
Set the `networkDelta` size when directly calling `Backward` in `FFN`. It's set correctly in `EvaluateWithGradient` but not in `Backward`.