### PR TITLE
Optimize convolution

### DIFF
--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -88,7 +88,8 @@ class NaiveConvolution
    * @param filter Filter used to perform the convolution.
    * @param inputPadded Input with padding applied.
    */
-  template<typename InMatType, typename FilMatType, typename Border = BorderMode>
+  template<typename InMatType, typename FilMatType,
+      typename Border = BorderMode>
   static std::enable_if_t<std::is_same_v<Border, ValidConvolution>, void>
   PadInput(const InMatType& input,
            const FilMatType& /* filter */,
@@ -107,7 +108,8 @@ class NaiveConvolution
    * @param filter Filter used to perform the convolution.
    * @param inputPadded Input with padding applied.
    */
-  template<typename InMatType, typename FilMatType, typename Border = BorderMode>
+  template<typename InMatType, typename FilMatType,
+      typename Border = BorderMode>
   static std::enable_if_t<std::is_same_v<Border, FullConvolution>, void>
   PadInput(const InMatType& input,
            const FilMatType& filter,
@@ -179,8 +181,9 @@ class NaiveConvolution
     // Pad filter and input to the working output shape.
     inputPadded = InCubeType(input.n_rows + 2 * paddingRows,
         input.n_cols + 2 * paddingCols, input.n_slices);
-    inputPadded.subcube(paddingRows, paddingCols, 0, paddingRows + input.n_rows - 1,
-        paddingCols + input.n_cols - 1, input.n_slices - 1) = input;
+    inputPadded.subcube(paddingRows, paddingCols, 0,
+        paddingRows + input.n_rows - 1, paddingCols + input.n_cols - 1,
+        input.n_slices - 1) = input;
   }
 
   /**
@@ -332,7 +335,7 @@ class NaiveConvolution
       const typename std::enable_if_t<IsCube<CubeType>::value>* = 0)
   {
     using MatType = typename GetDenseMatType<CubeType>::type;
-  
+
     CubeType inputPadded;
     PadInput(input, filter, inputPadded, dilationW, dilationH);
 

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -65,7 +65,7 @@ class NaiveConvolution
     //const size_t outputElems = outputRows * outputCols;
 
     // output = im2row * fil2col.
-    // im2row has `outputElems` rows and `filterElems` cols so that output has
+    // im2row has `outputElems` rows and `filterElems * inMaps` cols so that output has
     // `outputElems` rows and `outMaps` cols. Each output column is a slice of the
     // output cube.
 
@@ -291,14 +291,15 @@ class NaiveConvolution
           dW, dH, dilationW, dilationH);
     }
 
-    // Repeat filters so each input map is multiplied by the filter
-    MatType tempFilter;
-    MakeAlias(tempFilter, filter, filter.n_elem_slice, filter.n_slices);
-    MatType fil2col = repmat(tempFilter, input.n_slices, 1);
+    const size_t inMaps = input.n_slices;
+    const size_t outMaps = filter.n_slices / inMaps;
+
+    MatType fil2col;
+    MakeAlias(fil2col, filter, filter.n_elem_slice * inMaps, outMaps);
 
     // Alias so that we don't have to reshape output
     MatType tempOutput;
-    MakeAlias(tempOutput, output, output.n_elem_slice, filter.n_slices);
+    MakeAlias(tempOutput, output, output.n_elem_slice, outMaps);
 
     tempOutput += im2row * fil2col;
   }

--- a/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
+++ b/src/mlpack/methods/ann/convolution_rules/naive_convolution.hpp
@@ -73,12 +73,20 @@ class NaiveConvolution
       output.zeros(outputRows, outputCols);
     }
 
-    FilMatType dilatedFilter(filterRows, filterCols, arma::fill::zeros);
-    for (size_t i = 0; i < filter.n_rows; i++)
+    FilMatType dilatedFilter;
+    if (dilationW == 1 && dilationH == 1)
     {
-      for (size_t j = 0; j < filter.n_cols; j++)
+      MakeAlias(dilatedFilter, filter, filter.n_rows, filter.n_cols);
+    }
+    else
+    {
+      dilatedFilter = FilMatType(filterRows, filterCols, arma::fill::zeros);
+      for (size_t i = 0; i < filter.n_rows; i++)
       {
-        dilatedFilter(i * dilationH, j * dilationW) = filter(i, j);
+        for (size_t j = 0; j < filter.n_cols; j++)
+        {
+          dilatedFilter(i * dilationH, j * dilationW) = filter(i, j);
+        }
       }
     }
 

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -369,9 +369,6 @@ class ConvolutionType : public Layer<MatType>
   //! Locally-stored transformed error parameter.
   CubeType gTemp;
 
-  //! Locally-stored transformed gradient parameter.
-  CubeType gradientTemp;
-
   //! Locally-stored padding layer.
   PaddingType<MatType> padding;
 

--- a/src/mlpack/methods/ann/layer/convolution.hpp
+++ b/src/mlpack/methods/ann/layer/convolution.hpp
@@ -363,9 +363,6 @@ class ConvolutionType : public Layer<MatType>
   //! Locally-stored bias term object.
   MatType bias;
 
-  //! Locally-stored transformed output parameter.
-  CubeType outputTemp;
-
   //! Locally-stored transformed padded input parameter.
   MatType inputPadded;
 

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -503,6 +503,7 @@ void ConvolutionType<
   MatType tempSlice;
 
   // See Forward() for our iteration strategy.
+  #pragma omp parallel for schedule(dynamic)
   for (size_t offset = 0; offset < higherInDimensions * batchSize; ++offset)
   {
     const size_t fullInputOffset = offset * inMaps;

--- a/src/mlpack/methods/ann/layer/convolution_impl.hpp
+++ b/src/mlpack/methods/ann/layer/convolution_impl.hpp
@@ -339,7 +339,7 @@ void ConvolutionType<
       // Iterate over input maps (we will apply the filter and sum).
       for (size_t inMap = 0; inMap < inMaps; ++inMap)
       {
-        MakeAlias(inputSlice, (usingPadding ? inputPadded : input), 
+        MakeAlias(inputSlice, (usingPadding ? inputPadded : input),
             paddedRows, paddedCols, (inMap + fullInputOffset) *
             (paddedRows * paddedCols));
         ForwardConvolutionRule::Convolution(


### PR DESCRIPTION
This includes two improvements to convolution:

1. Removing some usage of temporary cubes in `convolution_impl.hpp` to avoid the overhead of creating cubes as suggested by @rcurtin 
2. Using the hadamard product to compute the naive convolution. This should also allow using bandicoot matrices

I tested the improvements with the `mnist_cnn` example by running it for 10 epochs and averaging the time from the progress bar.
Before: 5.772622 s/epoch
After decubifying: 5.575775 s/epoch
After decubifying + hadamard: 4.463865 s/epoch

In total, I got around 22.7% improvement on my setup.

Something I want to note: there are more optimal convolution techniques such as im2col. I didn't implement them because it would require a lot of major changes to the convolution rules api to implement them efficiently.