### PR TITLE
Add testing step for Markdown bindings

### DIFF
--- a/.github/actions/binding_run_tests/action.yml
+++ b/.github/actions/binding_run_tests/action.yml
@@ -98,3 +98,14 @@ runs:
           cd build/src/mlpack/bindings/go/src/mlpack.org/v1/mlpack/
           CGO_LDFLAGS="-Wl,-no_warn_duplicate_libraries" go test -v $ROOTDIR/src/mlpack/bindings/go/tests/go_binding_test.go 2>&1 |\
               $HOME/go/bin/go-junit-report | tee $ROOTDIR/build/go_bindings.junit.xml;
+
+    #
+    # Markdown bindings.
+    #
+    - name: "Run Markdown binding tests"
+      if: inputs.lang == 'Markdown'
+      shell: bash
+      run: |
+          # Make sure that the generated Markdown bindings match the ones in the
+          # repository.
+          ./scripts/check-markdown-docs.sh build/

--- a/doc/user/bindings/cli.md
+++ b/doc/user/bindings/cli.md
@@ -1,5 +1,5 @@
 # mlpack CLI binding documentation
-
+test message to make markdown build fail
 ## mlpack overview
 
 mlpack is an intuitive, fast, and flexible header-only C++ machine learning library with bindings to other languages.  It aims to provide fast, lightweight implementations of both common and cutting-edge machine learning algorithms.


### PR DESCRIPTION
The `scripts/check-markdown-docs.sh` script is a utility script that makes sure that the bindings generated with `make markdown` match the Markdown documentation in `doc/user/bindings/`.  It's just something that diffs the files and exits with an error if they are different.  I originally wrote this script so that if someone modified, e.g., a URL in a binding `_main.cpp` file but forgot to rebuild the Markdown bindings and update `doc/user/bindings/`, they could be reminded that they needed to do that.

But it seems like I just forgot to add the step to CI to actually do that.

(This will be a draft until I first get it to trigger a failed build, and then fix it.)