### PR TITLE
Define ARMA_USE_CURRENT so Armadillo 15.0.1 used via RcppArmadillo

### DIFF
--- a/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
+++ b/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
@@ -10,10 +10,15 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_BINDINGS_R_RCPP_MLPACK_H
-#define MLPACK_BINDINGS_R_RCPP_MLPACK_H
+#ifndef MLPACK_BINDINGS_R_MLPACK_H
+#define MLPACK_BINDINGS_R_MLPACK_H
 
-// Also includes Rcpp headers along with RcppArmadillo
+// With RcppArmadillo 15.0.1-1 or later, prefer current Armadillo
+#if !defined(ARMA_USE_CURRENT)
+  #define ARMA_USE_CURRENT
+#endif
+
+// This also includes the Rcpp headers along with RcppArmadillo
 #include <RcppArmadillo.h>
 
 // Rcpp has its own stream object which cooperates more nicely with R's i/o

--- a/src/mlpack/bindings/R/mlpack/src/rcpp_mlpack.h
+++ b/src/mlpack/bindings/R/mlpack/src/rcpp_mlpack.h
@@ -13,6 +13,12 @@
 #ifndef MLPACK_BINDINGS_R_RCPP_MLPACK_H
 #define MLPACK_BINDINGS_R_RCPP_MLPACK_H
 
+// With RcppArmadillo 15.0.1-1 or later, prefer current Armadillo
+#if !defined(ARMA_USE_CURRENT)
+  #define ARMA_USE_CURRENT
+#endif
+
+// This also includes Rcpp headers along with RcppArmadillo
 #include <RcppArmadillo.h>
 
 // Rcpp has its own stream object which cooperates more nicely with R's i/o


### PR DESCRIPTION
The recent Armadillo releases switch to C++14 as a minimum, and 'suppress the deprecation suppressor' a number of packages relied upon.  As around 200+ CRAN packages using RcppArmadillo either (still) depend on / force C++11, and/or have deprecated code (which CRAN would nag them about), the RcppArmadillo package is now (most likely, upload pending) going "hybrid" including Armadillo 14.6.3 as fallback to permit all 1200+ RcppArmadillo-using packages at CRAN to continue to function.    For now, this means 14.6.3 is used, and a message is printed to consider selecting into 15.0.1 or newer.  This PR makes this selection for mlpack.

It also corrects one header which we had left at a previous filename.   Along with #3990 (which is needed now as well as it _inter alia_ also sets Armadillo up for header-only 'no wrapper' mode, else the build fails as R packages generally do not link to `libarmadillo.so`) this makes are quick update release 4.6.3 of mlpack at CRAN while we continue to progress towards 5.0.0.