### PR TITLE
Update tests to handle new step size batch size adjustments in ensmallen 3

### DIFF
--- a/src/mlpack/tests/ann/feedforward_network_test.cpp
+++ b/src/mlpack/tests/ann/feedforward_network_test.cpp
@@ -34,7 +34,12 @@ void TestNetwork(ModelType& model,
                  const size_t maxEpochs,
                  const double classificationErrorThreshold)
 {
+  #if ENS_VERSION_MAJOR >= 3
+  ens::RMSProp opt(0.32, 32, 0.88, 1e-8, trainData.n_cols * maxEpochs, -100);
+  #else
+  // Earlier ensmallen versions did not adjust the step size for the batch size.
   ens::RMSProp opt(0.01, 32, 0.88, 1e-8, trainData.n_cols * maxEpochs, -100);
+  #endif
   model.Train(trainData, trainLabels, opt);
 
   MatType predictionTemp;
@@ -59,7 +64,12 @@ void CheckCopyFunction(ModelType* network1,
                        MatType& trainData,
                        MatType& trainLabels)
 {
+  #if ENS_VERSION_MAJOR >= 3
+  ens::RMSProp opt(0.32, 32, 0.88, 1e-8, trainData.n_cols, -1);
+  #else
+  // Earlier ensmallen versions did not adjust the step size for the batch size.
   ens::RMSProp opt(0.01, 32, 0.88, 1e-8, trainData.n_cols, -1);
+  #endif
   network1->Train(trainData, trainLabels, opt);
 
   arma::mat predictions1;
@@ -82,7 +92,12 @@ void CheckMoveFunction(ModelType* network1,
                        MatType& trainData,
                        MatType& trainLabels)
 {
+  #if ENS_VERSION_MAJOR >= 3
+  ens::RMSProp opt(0.32, 32, 0.88, 1e-8, trainData.n_cols, -1);
+  #else
+  // Earlier ensmallen versions did not adjust the step size for the batch size.
   ens::RMSProp opt(0.01, 32, 0.88, 1e-8, trainData.n_cols, -1);
+  #endif
   network1->Train(trainData, trainLabels, opt);
 
   arma::mat predictions1;
@@ -447,7 +462,14 @@ TEST_CASE("ForwardBackwardTest", "[FeedForwardNetworkTest][long]")
   ens::VanillaUpdate::Policy<arma::mat, arma::mat> optPolicy(opt,
       model.Parameters().n_rows, model.Parameters().n_cols);
   #endif
+
+  #if ENS_VERSION_MAJOR >= 3
+  double stepSize = 0.1;
+  #else
+  // Older versions of ensmallen did not adjust the step size with the batch
+  // size.
   double stepSize = 0.01;
+  #endif
   size_t batchSize = 10;
 
   size_t iteration = 0;
@@ -702,7 +724,12 @@ TEST_CASE("FFSerializationTest", "[FeedForwardNetworkTest]")
   model.Add<Linear>(3);
   model.Add<LogSoftMax>();
 
+  #if ENS_VERSION_MAJOR >= 3
+  ens::RMSProp opt(0.32, 32, 0.88, 1e-8, trainData.n_cols /* 1 epoch */, -1);
+  #else
+  // Older versions of ensmallen did not adjust for the batch size.
   ens::RMSProp opt(0.01, 32, 0.88, 1e-8, trainData.n_cols /* 1 epoch */, -1);
+  #endif
 
   model.Train(trainData, trainLabels, opt);
 
@@ -803,7 +830,13 @@ TEST_CASE("FFNTrainReturnObjective", "[FeedForwardNetworkTest]")
   model.Add<Linear>(3);
   model.Add<LogSoftMax>();
 
+  #if ENS_VERSION_MAJOR >= 3
+  ens::RMSProp opt(0.32, 32, 0.88, 1e-8, trainData.n_cols /* 1 epoch */, -1);
+  #else
+  // Older versions of ensmallen did not adjust the step size for the batch
+  // size.
   ens::RMSProp opt(0.01, 32, 0.88, 1e-8, trainData.n_cols /* 1 epoch */, -1);
+  #endif
 
   double objVal = model.Train(trainData, trainLabels, opt);
 

--- a/src/mlpack/tests/ann/layer/parametric_relu.cpp
+++ b/src/mlpack/tests/ann/layer/parametric_relu.cpp
@@ -124,7 +124,13 @@ TEST_CASE("PReLUIntegrationTest", "[ANNLayerTest]")
     model.Add<Linear>(1);
 
     const size_t epochs = 500;
+    #if ENS_VERSION_MAJOR >= 3
+    ens::RMSProp optimizer(0.02, 8, 0.99, 1e-8, epochs * trainData.n_cols);
+    #else
+    // Older versions of ensmallen did not adjust the step size for the batch
+    // size.
     ens::RMSProp optimizer(0.0025, 8, 0.99, 1e-8, epochs * trainData.n_cols);
+    #endif
     model.Reset(data.n_rows);
     model.Train(trainData, trainLabels, optimizer);
 

--- a/src/mlpack/tests/ann/recurrent_network_test.cpp
+++ b/src/mlpack/tests/ann/recurrent_network_test.cpp
@@ -70,7 +70,13 @@ double ImpulseStepDataTest(const size_t dimensions, const size_t rho)
   net.Add<RecurrentLayerType>(dimensions);
 
   const size_t numEpochs = 50;
+  #if ENS_VERSION_MAJOR >= 3
+  RMSProp opt(0.096, 32, 0.9, 1e-08, 700 * numEpochs, 1e-5);
+  #else
+  // Older versions of ensmallen did not adjust the step size for the batch
+  // size.
   RMSProp opt(0.003, 32, 0.9, 1e-08, 700 * numEpochs, 1e-5);
+  #endif
 
   net.Train(trainData, trainResponses, opt);
 
@@ -271,7 +277,13 @@ void BatchSizeTest()
   {
     const size_t batchSize = std::pow((size_t) 2, bsPow);
 
+    #if ENS_VERSION_MAJOR >= 3
+    opt = StandardSGD(0.1, batchSize, batchSize);
+    #else
+    // Older versions of ensmallen did not adjust the step size for the batch
+    // size.
     opt = StandardSGD(0.1 / ((double) batchSize), batchSize, batchSize);
+    #endif
     opt.Shuffle() = false;
     model.Reset(1);
     model.Parameters() = initParams;
@@ -344,7 +356,13 @@ TEST_CASE("LargeRhoValueRnnTest", "[RecurrentNetworkTest]")
 
   // Train the model and ensure that it gives reasonable results.
   // Use a very small learning rate to prevent divergence on this problem.
+  #if ENS_VERSION_MAJOR >= 3
+  ens::StandardSGD opt(1.6e-14, 16, 1 * data.n_cols /* 1 epoch */);
+  #else
+  // Older versions of ensmallen did not adjust the step size for the batch
+  // size.
   ens::StandardSGD opt(1e-15, 16, 1 * data.n_cols /* 1 epoch */);
+  #endif
   model.Train(data, outputs, opt);
 
   // Ensure that none of the weights are NaNs or Inf.
@@ -376,7 +394,13 @@ TEST_CASE("RNNFFNTest", "[RecurrentNetworkTest]")
   arma::cube responses(1, 200, 1, arma::fill::randu);
 
   // Train the FFN.
+  #if ENS_VERSION_MAJOR >= 3
+  ens::StandardSGD optimizer(1e-3, 100, 200, 1e-8, false);
+  #else
+  // Older versions of ensmallen did not adjust the step size for the batch
+  // size.
   ens::StandardSGD optimizer(1e-5, 100, 200, 1e-8, false);
+  #endif
 
   ffn.Train(data.slice(0), responses.slice(0), optimizer);
   rnn.Train(data, responses, optimizer);

--- a/src/mlpack/tests/logistic_regression_test.cpp
+++ b/src/mlpack/tests/logistic_regression_test.cpp
@@ -720,7 +720,13 @@ TEST_CASE("LogisticRegressionInstantiatedOptimizer", "[LogisticRegressionTest]")
 
   // Now do the same with SGD.
   ens::StandardSGD sgdOpt;
+  #if ENS_VERSION_MAJOR >= 3
+  sgdOpt.StepSize() = 0.15 * sgdOpt.BatchSize();
+  #else
+  // Old versions of of ensmallen did not adjust the step size for the batch
+  // size.
   sgdOpt.StepSize() = 0.15;
+  #endif
   sgdOpt.Tolerance() = 1e-75;
   LogisticRegression<> lr2(data, responses, sgdOpt, 0.0005);
 


### PR DESCRIPTION
The PR ensmallen#431 will change how steps are taken in some SGD-like optimizers to adjust for the batch size. (Specifically, the step size is divided by the batch size.)  To keep tests converging, we will need to adjust the step sizes when ensmallen 3+ is used.

CI will not test ensmallen 3 (or rather the appropriate branch that has not yet been merged), but I ran these tests locally and they all passed.