### PR TITLE
Fix RcppEnsmallen CI build by pre-installing LAPACK/BLAS headers

### DIFF
--- a/.github/actions/binding_setup/action.yml
+++ b/.github/actions/binding_setup/action.yml
@@ -102,12 +102,6 @@ runs:
           Rscript -e 'install.packages(c("remotes", "roxygen2", "pkgbuild"))'
           Rscript -e 'remotes::install_deps(".", dependencies=TRUE)'
 
-    - name: Test RcppEnsmallen source build
-      if: inputs.lang == 'R'
-      shell: bash
-      run: |
-          Rscript -e 'bspm::disable(); install.packages("RcppEnsmallen")'
-
     - name: Install cereal manually for R
       if: inputs.lang == 'R'
       shell: bash


### PR DESCRIPTION
I did this not by modifying the binding setup action, but instead by simply moving our install of `libopenblas-dev` to earlier in the CI process.

I also followed @eddelbuettel's suggestion to try compiling RcppEnsmallen manually.  Once that's shown to work correctly, I'll remove that bit and we can merge this PR.