### PR TITLE
Reduce size of ccache for GHA jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.name }}
           variant: ccache
-          max-size: 5G # Large sizes needed for debug builds.
+          max-size: 1G # Github has a 10GB repo cache limit, so we use 1GB/job.
 
       - name: Configure ccache
         shell: bash
@@ -214,7 +214,7 @@ jobs:
         with:
           key: ${{ runner.os }}
           variant: ccache
-          max-size: 5G
+          max-size: 1G
 
       # Set up Visual Studio.
       - name: Set up Visual Studio


### PR DESCRIPTION
Github has a [limit on repository cache sizes of 10GB](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy).  We have 10 jobs, and the ccache limit is set for 5GB for each of them... so that is going to be too big.

So, unfortunately this will reduce how good of a job ccache can do, but I've reduced the GHA cache sizes to 1GB per job.  That will at least keep Github from evicting the entire ccache cache for a given job.