### PR TITLE
Use internal metaprogramming utilities for `LogSoftmax`

### DIFF
--- a/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
+++ b/src/mlpack/methods/ann/layer/log_softmax_impl.hpp
@@ -65,7 +65,7 @@ LogSoftMax<MatType>::operator=(LogSoftMax&& other)
 template<typename MatType>
 void LogSoftMax<MatType>::Forward(const MatType& input, MatType& output)
 {
-  if constexpr (arma::is_arma_type<MatType>::value)
+  if constexpr (IsArma<MatType>::value)
   {
     MatType maxInput = repmat(max(input, 0), input.n_rows, 1);
     output = (maxInput - input);
@@ -114,8 +114,7 @@ void LogSoftMax<MatType>::Forward(const MatType& input, MatType& output)
     }
     output = input - maxInput;
   }
-#if defined(MLPACK_HAS_COOT)
-  else if constexpr (coot::is_coot_type<MatType>::value)
+  else if constexpr (IsCoot<MatType>::value)
   {
     MatType maxInput = repmat(max(input), input.n_rows, 1);
     output = (maxInput - input);
@@ -123,7 +122,6 @@ void LogSoftMax<MatType>::Forward(const MatType& input, MatType& output)
     maxInput.each_row() += log(sum(output));
     output = input - maxInput;
   }
-#endif
 }
 
 template<typename MatType>


### PR DESCRIPTION
I noticed that #4012 used the `arma::is_arma_type<>` and `coot::is_coot_type<>` types.  Specifically `coot::is_coot_type<>` requires an `#ifdef` guard to make sure we have Bandicoot, but, we could instead just use the mlpack-internal `IsArma` and `IsCoot` classes to simplify a little bit.