### PR TITLE
Residual connections for `DAGNetwork`

### DIFF
--- a/src/mlpack/methods/ann/dag_network.hpp
+++ b/src/mlpack/methods/ann/dag_network.hpp
@@ -703,7 +703,7 @@ class DAGNetwork
 
   // Connection type for some node that should have multiple parent nodes.
   // If this exists for a layer with <= 1 parent, it gets ignored.
-  std::unordered_map<size_t, ConnectionTypes> layerConnection;
+  std::unordered_map<size_t, ConnectionTypes> layerConnections;
 };
 
 } // namespace mlpack

--- a/src/mlpack/methods/ann/dag_network.hpp
+++ b/src/mlpack/methods/ann/dag_network.hpp
@@ -38,15 +38,15 @@ namespace mlpack {
  *
  * A node with multiple parents will either concatenate the output of its
  * parents along a specified axis, or accumulate using element-wise addition.
- * You can specify the axis of concatenation with `SetAxis`. If the axis is not specifed, the default
- * axis will be used, which is 0. 
-
- * TODO: by default concat along last axis (e.g. channels if using convs).
+ * You can specify the type of connection using `SetConnection`. If your
+ * connection is a concatenation, you can specify the axis with `SetAxis`.
+ *
+ * If no connection type or axis is set, by default the connection will be
+ * concatenation over the last axis of that layer.
  *
  * A DAGNetwork cannot have any cycles. Creating a network with a cycle will
- * result in an error.
- *
- * A DAGNetwork can only have one input layer and one output layer.
+ * result in an error. A DAGNetwork can only have one input layer and one 
+ * output layer.
  *
  * Although the actual types passed as input will be matrix objects with one
  * data point per column, each data point can be a tensor of arbitrary shape.
@@ -147,15 +147,20 @@ class DAGNetwork
     return id;
   }
 
-  // TODO: doc
+  /**
+   * Set the connection type for a layer that expects multiple parents.
+   *
+   * @param layerId The layer to be added to the model.
+   * @param connection The connection type.
+   */
   void SetConnection(size_t layerId, ConnectionTypes connection);
 
   /**
-   * Set the axis to concatenate along for a layer that expects multiple
-   * parent node. Can only be set once per layer.
+   * Set the axis to concatenate along for some layer that expects multiple
+   * parent.
    *
-   * @param concatAxis The axis to concatenate parent node outputs along.
    * @param layerId The layer to be added to the model.
+   * @param concatAxis The axis to concatenate parent node outputs along.
    */
   void SetAxis(size_t layerId, size_t concatAxis);
 
@@ -512,14 +517,24 @@ class DAGNetwork
    * This computes the dimensions of each layer held by the network, and the
    * output dimensions are set to the output dimensions of the last layer.
    *
-   * Layers with multiple inputs need an axis to concatenate their output
-   * along, specifed in Add(). Every dimension not along that axis in each
-   * input tensor must be the same, while the dimension along that axis can
-   * vary.
+   * Input dimensions of nodes that have multiple parents are also 
+   * calculated here, based on their connection type.
    */
   void ComputeOutputDimensions();
 
+  /**
+   * Compute the input dimensions of a concatenation layer with multiple
+   * parents.
+   *
+   * @param layerId The layer that has multiple parent layers.
+   */
   void ComputeConcatDimensions(size_t layerId);
+
+  /**
+   * Compute the input dimensions of an addition layer with multiple parents.
+   *
+   * @param layerId The layer that has multiple parent layers.
+   */
   void ComputeAdditionDimensions(size_t layerId);
 
   /**

--- a/src/mlpack/methods/ann/dag_network.hpp
+++ b/src/mlpack/methods/ann/dag_network.hpp
@@ -655,8 +655,10 @@ class DAGNetwork
   // called.  See `InitializeForwardPassMemory()`.
   MatType layerOutputMatrix;
   // These are aliases of `layerOutputMatrix` for the input of each layer
+  // Ordered in the same way as `sortedNetwork`.
   std::vector<MatType> layerInputs;
   // These are aliases of `layerOutputMatrix` for the output of each layer.
+  // Ordered in the same way as `sortedNetwork`.
   std::vector<MatType> layerOutputs;
 
   // Memory for the backward pass.

--- a/src/mlpack/methods/ann/dag_network_impl.hpp
+++ b/src/mlpack/methods/ann/dag_network_impl.hpp
@@ -49,6 +49,7 @@ DAGNetwork<
     childrenList(other.childrenList),
     parentsList(other.parentsList),
     layerAxes(other.layerAxes),
+    layerConnections(other.layerConnections),
 
     parameters(other.parameters),
     inputDimensions(other.inputDimensions),
@@ -83,6 +84,7 @@ DAGNetwork<
 
     network(std::move(other.network)),
     layerAxes(std::move(other.layerAxes)),
+    layerConnections(std::move(other.layerConnections)),
 
     parameters(std::move(other.parameters)),
     inputDimensions(std::move(other.inputDimensions)),
@@ -124,6 +126,7 @@ DAGNetwork<
     parentsList = other.parentsList;
     childrenList = other.childrenList;
     layerAxes = other.layerAxes;
+    layerConnections = other.layerConnections;
 
     parameters = other.parameters;
     inputDimensions = other.inputDimensions;
@@ -168,6 +171,7 @@ DAGNetwork<OutputLayerType,
     parentsList = std::move(other.parentsList);
     childrenList = std::move(other.childrenList);
     layerAxes = std::move(other.layerAxes);
+    layerConnections = std::move(other.layerConnections);
 
     parameters = std::move(other.parameters);
     inputDimensions = std::move(other.inputDimensions);
@@ -231,7 +235,7 @@ void DAGNetwork<
     throw std::logic_error(errMessage.str());
   }
 
-  layerConnection[layerId] = connection;
+  layerConnections[layerId] = connection;
 
   validOutputDimensions = false;
   graphIsSet = false;
@@ -577,12 +581,12 @@ void DAGNetwork<
         std::vector<size_t>(numOutputDimensions, 0);
 
       // By default concatenate when a node has multiple children.
-      if (layerConnection.count(currentLayer) == 0)
-        layerConnection.insert({ currentLayer, CONCATENATE });
+      if (layerConnections.count(currentLayer) == 0)
+        layerConnections.insert({ currentLayer, CONCATENATE });
 
       // numParents guaranteed to be > 1.
-      ConnectionTypes connectionType = layerConnection.at(currentLayer);
-      switch (layerConnection.at(currentLayer))
+      ConnectionTypes connectionType = layerConnections.at(currentLayer);
+      switch (layerConnections.at(currentLayer))
       {
         case CONCATENATE:
           ComputeConcatDimensions(currentLayer);
@@ -1097,7 +1101,7 @@ void DAGNetwork<
       // Concatenation
       if (parents.size() > 1)
       {
-        if (layerConnection.at(currentLayer) == CONCATENATE)
+        if (layerConnections.at(currentLayer) == CONCATENATE)
         {
           const size_t axis = layerAxes[currentLayer];
 
@@ -1196,7 +1200,7 @@ void DAGNetwork<
       const size_t numParents = parentsList[currentLayer].size();
       if (numParents > 1)
       {
-        if (layerConnection.at(currentLayer) == CONCATENATE)
+        if (layerConnections.at(currentLayer) == CONCATENATE)
         {
           // Calculating deltas for concatenation.
           const size_t axis = layerAxes[currentLayer];

--- a/src/mlpack/tests/ann/dag_network_test.cpp
+++ b/src/mlpack/tests/ann/dag_network_test.cpp
@@ -136,6 +136,88 @@ TEST_CASE("CheckMoveVanillaDAGNetworkTest", "[DAGNetworkTest]")
   CheckMove(model, trainData, trainLabels);
 }
 
+/**
+ * Check whether copying on DAG network is working or not.
+ * Uses element-wise addition and concatenation skip connection layers.
+ */
+TEST_CASE("CheckCopyDAGNetworkTest", "[DAGNetworkTest]")
+{
+  arma::mat trainData;
+  if (!data::Load("thyroid_train.csv", trainData))
+    FAIL("Cannot open thyroid_train.csv");
+
+  arma::mat trainLabels = trainData.row(trainData.n_rows - 1) - 1;
+  trainData.shed_row(trainData.n_rows - 1);
+
+  DAGNetwork<> *model = new DAGNetwork<>();
+  size_t layer0 = model->Add<Linear>(10);
+  size_t layer1 = model->Add<Sigmoid>();
+  size_t layer2 = model->Add<Sigmoid>();
+  size_t layer3 = model->Add<Linear>(20);
+  size_t layer4 = model->Add<Identity>();
+
+  size_t layer5 = model->Add<Linear>(3);
+  size_t layer6 = model->Add<LogSoftMax>();
+
+  model->Connect(layer0, layer1);
+  model->Connect(layer0, layer2);
+  model->Connect(layer0, layer3);
+
+  model->Connect(layer1, layer4);
+  model->Connect(layer2, layer4);
+  model->SetConnection(layer4, CONCATENATE);
+  model->SetAxis(layer4, 0);
+
+  model->Connect(layer3, layer5);
+  model->Connect(layer4, layer5);
+  model->SetConnection(layer5, ADDITION);
+
+  model->Connect(layer5, layer6);
+
+  CheckCopy(model, trainData, trainLabels);
+}
+
+/**
+ * Check whether moving on DAG network is working or not.
+ * Uses element-wise addition and concatenation skip connection layers.
+ */
+TEST_CASE("CheckMoveDAGNetworkTest", "[DAGNetworkTest]")
+{
+  arma::mat trainData;
+  if (!data::Load("thyroid_train.csv", trainData))
+    FAIL("Cannot open thyroid_train.csv");
+
+  arma::mat trainLabels = trainData.row(trainData.n_rows - 1) - 1;
+  trainData.shed_row(trainData.n_rows - 1);
+
+  DAGNetwork<> *model = new DAGNetwork<>();
+  size_t layer0 = model->Add<Linear>(10);
+  size_t layer1 = model->Add<Sigmoid>();
+  size_t layer2 = model->Add<Sigmoid>();
+  size_t layer3 = model->Add<Linear>(20);
+  size_t layer4 = model->Add<Identity>();
+
+  size_t layer5 = model->Add<Linear>(3);
+  size_t layer6 = model->Add<LogSoftMax>();
+
+  model->Connect(layer0, layer1);
+  model->Connect(layer0, layer2);
+  model->Connect(layer0, layer3);
+
+  model->Connect(layer1, layer4);
+  model->Connect(layer2, layer4);
+  model->SetConnection(layer4, CONCATENATE);
+  model->SetAxis(layer4, 0);
+
+  model->Connect(layer3, layer5);
+  model->Connect(layer4, layer5);
+  model->SetConnection(layer5, ADDITION);
+
+  model->Connect(layer5, layer6);
+
+  CheckMove(model, trainData, trainLabels);
+}
+
 TEST_CASE("DAGNetworkSetAxisOnNonExistentLayer", "[DAGNetworkTest]")
 {
   DAGNetwork model;
@@ -211,6 +293,32 @@ void CheckConcatenation(arma::mat& input,
 
   model.Predict(input, testOutput);
   CheckMatrices(testOutput, expectedOutput);
+}
+
+TEST_CASE("DAGNetworkTestElementWiseAddition", "[DAGNetworkTest]")
+{
+  DAGNetwork<MeanSquaredError, ConstInitialization> model =
+    DAGNetwork(MeanSquaredError(), ConstInitialization(1.0f));
+
+  size_t a = model.Add<Identity>();
+  size_t b = model.Add<Identity>();
+  size_t c = model.Add<Identity>();
+  size_t d = model.Add<Identity>();
+
+  model.Connect(a, b);
+  model.Connect(a, c);
+  model.Connect(b, d);
+  model.Connect(c, d);
+  model.SetConnection(d, ADDITION);
+
+  arma::mat input = arma::ones(10);
+  arma::mat expectedOutput = input * 2;
+  arma::mat output;
+
+  std::vector<size_t> inputDimensions = { 10 };
+
+  model.Forward(input, output);
+  CheckMatrices(output, expectedOutput);
 }
 
 TEST_CASE("DAGNetworkTestConcatAxis0", "[DAGNetworkTest]")
@@ -427,7 +535,7 @@ TEST_CASE("DAGNetworkConcatenationAxisOutOfBounds", "[DAGNetworkTest]")
   REQUIRE_THROWS_AS(model.Predict(testInput, testOutput), std::logic_error);
 }
 
-TEST_CASE("DAGNetworkComputeOutputDimensions", "[DAGNetworkTest]")
+TEST_CASE("DAGNetworkComputeConcatDimensions", "[DAGNetworkTest]")
 {
   DAGNetwork model;
   model.InputDimensions() = { 7, 7, 3 };
@@ -441,12 +549,63 @@ TEST_CASE("DAGNetworkComputeOutputDimensions", "[DAGNetworkTest]")
   model.Connect(layer0, layer2);
   model.Connect(layer2, layer3);
   model.Connect(layer1, layer3);
+
+  model.SetConnection(layer3, CONCATENATE);
   model.SetAxis(layer3, 2);
 
   arma::mat testInput = arma::ones(6);
   arma::mat testOutput;
 
   std::vector<size_t> expectedOutputDimensions = { 1, 1, 1 };
+  REQUIRE(model.OutputDimensions() == expectedOutputDimensions);
+}
+
+/*
+ * Test default skip connection is concatenation along last axis.
+ */
+TEST_CASE("DAGNetworkComputeOutputDimensionsImplicit", "[DAGNetworkTest]")
+{
+  DAGNetwork model;
+  model.InputDimensions() = { 7, 7, 3 };
+
+  size_t layer0 = model.Add<Convolution>(1, 3, 3);
+  size_t layer1 = model.Add<Convolution>(3, 3, 3, 1, 1, 1, 1);
+  size_t layer2 = model.Add<Convolution>(1, 3, 3, 1, 1, 1, 1);
+  size_t layer3 = model.Add<Convolution>(1, 5, 5);
+
+  model.Connect(layer0, layer1);
+  model.Connect(layer0, layer2);
+  model.Connect(layer2, layer3);
+  model.Connect(layer1, layer3);
+
+  arma::mat testInput = arma::ones(6);
+  arma::mat testOutput;
+
+  std::vector<size_t> expectedOutputDimensions = { 1, 1, 1 };
+  REQUIRE(model.OutputDimensions() == expectedOutputDimensions);
+}
+
+TEST_CASE("DAGNetworkComputeAdditionDimensions", "[DAGNetworkTest]")
+{
+  DAGNetwork model;
+  model.InputDimensions() = { 7, 7, 3 };
+
+  size_t layer0 = model.Add<Convolution>(1, 3, 3);
+  size_t layer1 = model.Add<Convolution>(3, 3, 3, 1, 1, 1, 1);
+  size_t layer2 = model.Add<Convolution>(3, 3, 3, 1, 1, 1, 1);
+  size_t layer3 = model.Add<Identity>();
+
+  model.Connect(layer0, layer1);
+  model.Connect(layer0, layer2);
+  model.Connect(layer2, layer3);
+  model.Connect(layer1, layer3);
+
+  model.SetConnection(layer3, ADDITION);
+
+  arma::mat testInput = arma::ones(6);
+  arma::mat testOutput;
+
+  std::vector<size_t> expectedOutputDimensions = { 5, 5, 3 };
   REQUIRE(model.OutputDimensions() == expectedOutputDimensions);
 }
 
@@ -477,9 +636,34 @@ TEST_CASE("DAGNetworkWrongDimensionsForConcat", "[DAGNetworkTest]")
   model.Connect(layer0, layer2);
   model.Connect(layer2, layer3);
   model.Connect(layer1, layer3);
+
+  model.SetConnection(layer3, CONCATENATE);
   model.SetAxis(layer3, 1);
 
   arma::mat testInput = arma::ones(13 * 13 * 3);
+  arma::mat testOutput;
+
+  REQUIRE_THROWS_AS(model.Predict(testInput, testOutput), std::logic_error);
+}
+
+TEST_CASE("DAGNetworkWrongDimensionsForAddition", "[DAGNetworkTest]")
+{
+  DAGNetwork model;
+  model.InputDimensions() = { 20 };
+
+  size_t layer0 = model.Add<Identity>();
+  size_t layer1 = model.Add<Linear>(10);
+  size_t layer2 = model.Add<Linear>(15);
+  size_t layer3 = model.Add<Identity>();
+
+  model.Connect(layer0, layer1);
+  model.Connect(layer0, layer2);
+  model.Connect(layer2, layer3);
+  model.Connect(layer1, layer3);
+
+  model.SetConnection(layer3, ADDITION);
+
+  arma::mat testInput = arma::ones(20);
   arma::mat testOutput;
 
   REQUIRE_THROWS_AS(model.Predict(testInput, testOutput), std::logic_error);
@@ -550,6 +734,9 @@ TEST_CASE("DAGNetworkForestTest", "[DAGNetworkTest]")
   REQUIRE_THROWS_AS(model.Predict(testInput, testOutput), std::logic_error);
 }
 
+/*
+ * Test case that uses the output of a layer multiple times.
+ */
 TEST_CASE("DAGNetworkDiamondTest", "[DAGNetworkTest]")
 {
    /*
@@ -574,10 +761,12 @@ TEST_CASE("DAGNetworkDiamondTest", "[DAGNetworkTest]")
   dagnet.Connect(layerA, layerC);
   dagnet.Connect(layerA, layerB);
   dagnet.Connect(layerB, layerC);
+  dagnet.SetConnection(layerC, CONCATENATE);
   dagnet.SetAxis(layerC, 0);
 
   dagnet.Connect(layerB, layerD);
   dagnet.Connect(layerC, layerD);
+  dagnet.SetConnection(layerD, CONCATENATE);
   dagnet.SetAxis(layerD, 0);
 
 
@@ -619,9 +808,12 @@ TEST_CASE("DAGNetworkAddMultiLayer", "[DAGNetworkTest]")
   REQUIRE_NOTHROW(model.Evaluate(input, actual));
 }
 
-TEST_CASE("DAGNetworkGradientAccumulatesAndResetsToZero", "[DAGNetworkTest]")
-{
-  DAGNetwork<MeanSquaredError, ConstInitialization> model =
+/*
+ * Accumulate gradient and reset to zero properly with concatenation
+ * skip connection layer.
+ */
+TEST_CASE("DAGNetworkGradientAccumulatesAndResetsToZeroUsingConcatenation",
+          "[DAGNetworkTest]") { DAGNetwork<MeanSquaredError, ConstInitialization> model =
     DAGNetwork(MeanSquaredError(), ConstInitialization(1.0f));
 
   size_t a = model.Add<Add>();
@@ -640,6 +832,45 @@ TEST_CASE("DAGNetworkGradientAccumulatesAndResetsToZero", "[DAGNetworkTest]")
   arma::mat deltaLoss = arma::ones(4);
   arma::mat gradients;
   arma::mat expectedGradients = arma::mat({2, 2, 1, 1, 1, 1, 1, 1}).t();
+  MeanSquaredError lossFunction;
+
+  model.Forward(input, output);
+  model.Backward(input, output, deltaLoss, gradients);
+
+  CheckMatrices(gradients, expectedGradients);
+
+  // Gradients at layer a should have been set to zero.
+  model.Forward(input, output);
+  model.Backward(input, output, deltaLoss, gradients);
+  CheckMatrices(gradients, expectedGradients);
+}
+
+/*
+ * Accumulate gradient and reset to zero properly with residual
+ * (element-wise addition) skip connection layer.
+ */
+TEST_CASE("DAGNetworkGradientAccumulatesAndResetsToZeroAddition",
+          "[DAGNetworkTest]")
+{
+  DAGNetwork<MeanSquaredError, ConstInitialization> model =
+    DAGNetwork(MeanSquaredError(), ConstInitialization(1.0f));
+
+  size_t a = model.Add<Add>();
+  size_t b = model.Add<Add>();
+  size_t c = model.Add<Add>();
+
+  model.Connect(a, b);
+  model.Connect(a, c);
+  model.Connect(b, c);
+  model.SetConnection(c, ADDITION);
+
+  arma::mat input  = arma::ones(2);
+  arma::mat actual = arma::ones(2);
+  arma::mat output;
+
+  arma::mat deltaLoss = arma::ones(2);
+  arma::mat gradients;
+  arma::mat expectedGradients = arma::mat({2, 2, 1, 1, 1, 1}).t();
   MeanSquaredError lossFunction;
 
   model.Forward(input, output);


### PR DESCRIPTION
This adds in residual connections for `DAGNetwork`. This should allow people to implement models like ResNet, ResNext, yolov3 etc.