### PR TITLE
Add the missing `Begin()` and `Count()` in `Octree`

### DIFF
--- a/src/mlpack/core/tree/octree/octree.hpp
+++ b/src/mlpack/core/tree/octree/octree.hpp
@@ -402,6 +402,16 @@ class Octree
       const VecType& point,
       typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
+  //! Return the index of the beginning point of this subset.
+  size_t Begin() const { return begin; }
+  //! Modify the index of the beginning point of this subset.
+  size_t& Begin() { return begin; }
+
+  //! Return the number of points in this subset.
+  size_t Count() const { return count; }
+  //! Modify the number of points in this subset.
+  size_t& Count() { return count; }
+
   //! Store the center of the bounding region in the given vector.
   template<typename VecType>
   void Center(VecType& center) const { bound.Center(center); }


### PR DESCRIPTION
Added the public `Begin()` and `Count()` methods to the Octree class. These methods were referenced in the [documentation](https://www.mlpack.org/doc/user/core/trees/octree.html) but were missing from the implementation.