### PR TITLE
Fix warnings due to signed unsigned comparison in `load_image_impl.hpp`.

### DIFF
--- a/src/mlpack/core/data/load_image_impl.hpp
+++ b/src/mlpack/core/data/load_image_impl.hpp
@@ -123,8 +123,9 @@ bool LoadImage(const std::vector<std::string>& files,
     dimension = opts.Width() * opts.Height() * opts.Channels();
     images.set_size(dimension, files.size());
 
-    if (tempWidth != opts.Width() || tempHeight != opts.Height()
-        || tempChannels != opts.Channels())
+    if ((size_t) tempWidth != opts.Width() ||
+        (size_t) tempHeight != opts.Height() ||
+        (size_t) tempChannels != opts.Channels())
     {
       std::stringstream oss;
       oss << "Load(): dimension mismatch: in the case of "


### PR DESCRIPTION
These were generating a lot of warnings during build, making it hard to spot other important messages.