### PR TITLE
Respect MLPACK_DISABLE_OPENMP for calls to `fetch_mlpack()`

### DIFF
--- a/CMake/mlpack.cmake
+++ b/CMake/mlpack.cmake
@@ -750,7 +750,9 @@ macro(fetch_mlpack COMPILE_OPENBLAS)
     endif()
   endif()
 
-  find_openmp()
+  if (NOT MLPACK_DISABLE_OPENMP)
+    find_openmp()
+  endif ()
 
 endmacro()
 


### PR DESCRIPTION
@eddelbuettel found while using `mlpack.cmake` that when `fetch_mlpack()` is called with `MLPACK_DISABLE_OPENMP` set, OpenMP still gets found anyway.  I dug into it a little bit and found there's just a missing check on the condition.  `find_mlpack()` already has the check so no need to add it there.