### PR TITLE
Add missing backtick in `HoeffdingTree` documentation

### DIFF
--- a/doc/user/methods/hoeffding_tree.md
+++ b/doc/user/methods/hoeffding_tree.md
@@ -86,7 +86,7 @@ std::cout << arma::accu(predictions == 2) << " test points classified as class "
 
 ---
 
- * `tree = HoeffdingTree(data, datasetInfo, labels, numClasses)
+ * `tree = HoeffdingTree(data, datasetInfo, labels, numClasses)`
  * `tree = HoeffdingTree(data, datasetInfo, labels, numClasses, batchTraining=true, successProbability=0.95, maxSamples=0, checkInterval=100, minSamples=100)`
    - Train non-incrementally on mixed categorical data.
    - The tree will be reset if `numClasses` or `datasetInfo` does not match the


### PR DESCRIPTION
This is a really simple fix for a small typographical error found here:
https://www.mlpack.org/doc/user/methods/hoeffding_tree.html#constructors

It's just a missing backtick, so, easy fix.