### PR TITLE
Fix Jenkins job definitions

### DIFF
--- a/.jenkins/doc-link-check/Jenkinsfile
+++ b/.jenkins/doc-link-check/Jenkinsfile
@@ -98,20 +98,23 @@ pipeline
 
     always
     {
-      // Publish the generated HTML.
-      publishHTML([
-          allowMissing: false,
-          alwaysLinkToLastBuild: false,
-          keepAll: true,
-          reportDir: 'doc/html/',
-          reportFiles: 'index.html',
-          reportName: 'Build documentation']);
+      script
+      {
+        // Publish the generated HTML.
+        publishHTML([
+            allowMissing: false,
+            alwaysLinkToLastBuild: false,
+            keepAll: true,
+            reportDir: 'doc/html/',
+            reportFiles: 'index.html',
+            reportName: 'Build documentation']);
 
-      // Clean the workspace.
-      cleanWs(cleanWhenNotBuilt: true,
-              deleteDirs: true,
-              disableDeferredWipeout: true,
-              notFailBuild: true);
+        // Clean the workspace.
+        cleanWs(cleanWhenNotBuilt: true,
+                deleteDirs: true,
+                disableDeferredWipeout: true,
+                notFailBuild: true);
+      }
     }
   }
 }


### PR DESCRIPTION
I noticed that on most PRs the Jenkins jobs aren't working anymore.  I think this may be due to a Jenkins upgrade, and now I am seeing failures like:

```
Error when executing always post condition:
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 246e30bc-e435-4edd-8562-add308a98284
org.jenkinsci.plugins.workflow.steps.MissingContextVariableException: Required context class hudson.FilePath is missing
Perhaps you forgot to surround the publishHTML step with a step that provides this, such as: node
```

http://ci.mlpack.org/job/mlpack%20documentation%20link%20check/view/change-requests/job/PR-4022/4/console

So, the troubleshooting begins...