### PR TITLE
Roll the GitHub checkout action to the current v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       # Set up ccache.
       - name: Get ccache
@@ -206,7 +206,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       # Set up ccache.
       - name: Get ccache

--- a/.github/workflows/update-catch.yaml
+++ b/.github/workflows/update-catch.yaml
@@ -19,7 +19,7 @@ jobs:
     #    if: ${{ github.repository == 'mlpack/mlpack' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get Latest Catch Tagged Release
         id: catch-header
         run: |

--- a/.github/workflows/update-cli11.yaml
+++ b/.github/workflows/update-cli11.yaml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository == 'mlpack/mlpack' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Get Latest CLI11 Tagged Release
         id: cli11-header
         run: |


### PR DESCRIPTION
Closes #4051 

This updates the checkout action to the current v6.