### PR TITLE
Fix incorrect documentation about image linearization

### DIFF
--- a/doc/user/load_save.md
+++ b/doc/user/load_save.md
@@ -963,7 +963,7 @@ will be populated with the metadata of the image.
 
 Images are flattened along rows, with channel values interleaved, starting from
 the top left.  Thus, the value of the pixel at position `(x, y)` in channel `c`
-will be contained in element/row `y * (width * channels) + x * (channels) + c`
+will be contained in element/row `y * (channels) + x * (width * channels) + c`
 of the flattened vector.
 
  * Supported image loading formats are JPEG, PNG, TGA, BMP, PSD, GIF, PIC, and


### PR DESCRIPTION
In the discussion of #4050 I realized that our documentation on how images are linearized is actually subtly incorrect.  The [STB documentation](https://github.com/nothings/stb/blob/f1c79c02822848a9bed4315b12c8c8f3761e1296/stb_image.h#L154) writes:

> The pixel data consists of *y scanlines of *x pixels, with each pixel consisting of N interleaved 8-bit components; the first pixel pointed to is top-left-most in the image.

which is actually backwards from how our documentation describes it!  Luckily, it is a simple fix.
