### PR TITLE
docs: improve Q-Learning tutorial clarity and formatting

### DIFF
--- a/doc/tutorials/reinforcement_learning/q_learning.md
+++ b/doc/tutorials/reinforcement_learning/q_learning.md
@@ -1,8 +1,30 @@
 # Q-Learning in mlpack
 
-Here, we demonstrate Q-Learning in mlpack through the use of a simple example,
-the training of a Q-Learning agent on the `CartPole` environment. The code has
-been broken into chunks for easy understanding.
+This tutorial demonstrates how to use **Q-Learning** in mlpack by training an
+agent on the classic CartPole environment.
+
+The example is intentionally simple and broken into sections so each step is
+easy to follow.
+
+---
+
+## Prerequisites
+
+Before starting, you should:
+
+* know basic C++
+* have mlpack installed
+* be able to build programs using CMake
+
+Verify installation with:
+
+```bash
+mlpack_knn --help
+```
+
+---
+
+## Include headers and namespaces
 
 ```c++
 #include <mlpack.hpp>
@@ -12,8 +34,12 @@ using namespace ens;
 using namespace mlpack::rl;
 ```
 
-We include all the necessary components of our toy example and declare
-namespaces for convenience.
+We include the required components and bring a few namespaces into scope for
+convenience.
+
+---
+
+## Creating a Q-Learning network (SimpleDQN)
 
 ```c++
 int main()
@@ -22,80 +48,104 @@ int main()
   SimpleDQN<> model(4, 64, 32, 2);
 ```
 
-The first step in setting our Q-learning agent is to setup the network for it to
-use. `SimpleDQN` class creates a simple feed forward network with 2 hidden
-layers.  The network constructed here has an input shape of 4 and output shape
-of 2. This corresponds to the structure of the `CartPole` environment, where
-each state is represented as a column vector with 4 data members (position,
-velocity, angle, angular velocity). Similarly, the output shape is represented
-by the number of possible actions, which in this case, is only 2 (`foward` and
-`backward`).
+The first step is to **set up the neural network** that the Q-Learning agent
+will use to approximate the Q-function.
 
-We can also use mlpack's ann module to set up a custom `FFN` network. For
-example, here we use a single hidden layer. However, the Q-Learning agent
-expects the object to have a `ResetNoise` method which `SimpleDQN` has.  We
-can't pass mlpack's `FFN` network directly. Instead, we have to wrap it into
-`SimpleDQN` object.
+`SimpleDQN` creates a small feed-forward network with two hidden layers.
+
+* Input size: 4
+  (cart position, cart velocity, pole angle, angular velocity)
+* Output size: 2
+  (`forward`, `backward` actions)
+
+The output corresponds to the number of actions available in the environment.
+
+---
+
+## Using a custom FFN network (optional)
+
+You may want to design your own network with mlpack’s ANN module.
 
 ```c++
 int main()
 {
-  // Set up the network.
-  FFN<MeanSquaredError, GaussianInitialization> network(MeanSquaredError(),
-      GaussianInitialization(0, 0.001));
+  // Set up a custom network.
+  FFN<MeanSquaredError, GaussianInitialization> network(
+      MeanSquaredError(), GaussianInitialization(0, 0.001));
+
   network.Add<Linear>(128);
   network.Add<ReLU>();
   network.Add<Linear>(128);
   network.Add<ReLU>();
   network.Add<Linear>(2);
 
+  // Wrap the network so it provides the required interface.
   SimpleDQN<> model(network);
-
 ```
 
-The next step would be to setup the other components of the Q-learning agent,
-namely its policy, replay method and hyperparameters.
+### Why wrap the network?
+
+`FFN` does not implement some functions that Q-Learning requires,
+such as `ResetNoise()`.
+
+`SimpleDQN` provides this interface, so we wrap the model before using it.
+
+---
+
+## Configure policy, replay buffer, and hyperparameters
 
 ```c++
   // Set up the policy and replay method.
   GreedyPolicy<CartPole> policy(1.0, 1000, 0.1, 0.99);
   RandomReplay<CartPole> replayMethod(10, 10000);
 
+  // Training configuration.
   TrainingConfig config;
-  config.StepSize() = 0.01;
-  config.Discount() = 0.9;
+  config.StepSize() = 0.01;                // Learning rate
+  config.Discount() = 0.9;                 // Reward discount factor (gamma)
   config.TargetNetworkSyncInterval() = 100;
   config.ExplorationSteps() = 100;
   config.DoubleQLearning() = false;
   config.StepLimit() = 200;
 ```
 
-And now, we get to the heart of the program, declaring a Q-Learning agent.
+* The **policy** controls exploration and exploitation.
+* The **replay buffer** stores past transitions for training.
+* `TrainingConfig` defines core learning hyperparameters.
+
+---
+
+## Create the Q-Learning agent
 
 ```c++
   QLearning<CartPole, decltype(model), AdamUpdate, decltype(policy)>
       agent(config, model, policy, replayMethod);
 ```
 
-Here, we call the `QLearning` constructor, passing in the type of environment,
-network, updater, policy and replay. We use `decltype(var)` as a shorthand for
-the variable, saving us the trouble of copying the lengthy templated type.
+We pass:
 
-We pass references of the objects we created, as parameters to `QLearning`
-class.
+* the environment type
+* the neural network model
+* the optimizer
+* the policy
+* the replay buffer
 
-Now, we have our Q-Learning agent `agent` ready to be trained on the Cart Pole
-environment.
+`decltype(model)` simply avoids repeating a long templated type.
+
+---
+
+## Training loop and convergence
 
 ```c++
   arma::running_stat<double> averageReturn;
   size_t episodes = 0;
   bool converged = true;
+
   while (true)
   {
     double episodeReturn = agent.Episode();
     averageReturn(episodeReturn);
-    episodes += 1;
+    episodes++;
 
     if (episodes > 1000)
     {
@@ -104,27 +154,57 @@ environment.
       break;
     }
 
-    /**
-     * Reaching running average return 35 is enough to show it works.
-     */
+    // Reaching an average return of ~35 shows learning progress.
     std::cout << "Average return: " << averageReturn.mean()
-        << " Episode return: " << episodeReturn << std::endl;
+              << " Episode return: " << episodeReturn << std::endl;
+
     if (averageReturn.mean() > 35)
       break;
   }
+
   if (converged)
-    std::cout << "Hooray! Q-Learning agent successfully trained" << std::endl;
+    std::cout << "Q-Learning agent successfully trained." << std::endl;
 
   return 0;
 }
 ```
 
-We set up a loop to train the agent. The exit condition is determined by the
-average reward which can be computed with `arma::running_stat`. It is used for
-storing running statistics of scalars, which in this case is the reward signal.
-The agent can be said to have converged when the average return reaches a
-predetermined value (i.e. > 35).
+We train the agent one episode at a time and track the **running average
+return** using `arma::running_stat`.
 
-Conversely, if the average return does not go beyond that amount even after a
-thousand episodes, we can conclude that the agent will not converge and exit the
-training loop.
+In this example, we consider training successful when the running average reward
+exceeds **35**. This value is a heuristic chosen only for demonstration.
+
+If the agent does not reach this threshold after 1000 episodes, training stops.
+
+---
+
+## Build and run
+
+Save the file (for example as `q_learning.cpp`) and build it:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+./q_learning
+```
+
+---
+
+## Summary
+
+In this tutorial, you learned how to:
+
+* construct a neural network for Q-Learning
+* configure replay, policy, and training parameters
+* initialize a Q-Learning agent
+* train and evaluate convergence on CartPole
+
+You can extend this example by:
+
+* experimenting with different architectures
+* tuning hyperparameters
+* trying other environments
+* enabling Double Q-Learning


### PR DESCRIPTION
This PR improves the Q-Learning tutorial documentation.

Changes:
- clarified explanations of SimpleDQN and FFN
- fixed grammar and typos
- added build and run instructions
- improved section structure and headings
- added comments to code examples
- clarified convergence explanation

This PR makes the tutorial easier for beginners to follow.
No code behavior changes — documentation only.