### PR TITLE
Fix decision tree load

### DIFF
--- a/src/mlpack/tests/decision_tree_test.cpp
+++ b/src/mlpack/tests/decision_tree_test.cpp
@@ -1972,7 +1972,7 @@ TEST_CASE("DifferentMaximumDepthTest", "[DecisionTreeTest]")
     FAIL("Cannot load test dataset vc2.csv!");
 
   // 3. Create options for the labels
-  // (We use a separate object just to be safe and explicit, matching the PR style)
+
   data::TextOptions labelOpts;
   labelOpts.HasHeaders() = false;
   labelOpts.Categorical() = false;


### PR DESCRIPTION
### Description
Updated `src/mlpack/tests/decision_tree_test.cpp` to use the new `data::Load` and `data::Save` interface with `data::TextOptions`, replacing the deprecated boolean overloads.

### Changes
* Replaced implicit `data::Load(file, matrix, true)` calls with explicit `data::TextOptions`.
* Verified that all tests in `DecisionTreeTest` pass locally.

### Related Issue
Fixes #4049