### PR TITLE
Clarify Python logistic_regression keyword usage and required parameters.

### DIFF
--- a/doc/developer/bindings.md
+++ b/doc/developer/bindings.md
@@ -1163,6 +1163,36 @@ are used to parse the command line input properly.
 
 ## Python bindings
 
+> **Note on Python Usage**
+>
+> When using `mlpack.logistic_regression` from Python, it is recommended to use **keyword arguments only**.
+> Positional arguments (for example, `logistic_regression(X, y)`) may lead to confusing runtime errors due to parameter misinterpretation.
+>
+> In particular:
+> - The `batch_size` parameter must be explicitly provided as an integer.
+> - Training data should be passed using the `training` keyword.
+> - Labels should be passed using the `labels` keyword.
+> - The trained model is returned under the key `output_model`.
+>
+> Example:
+>
+> ```python
+> from mlpack import logistic_regression
+> import numpy as np
+>
+> X = np.array([[1, 2], [2, 3], [3, 4], [4, 5]], dtype=float)
+> y = np.array([0, 0, 1, 1], dtype=int)
+>
+> out = logistic_regression(
+>     training=X,
+>     labels=y,
+>     batch_size=4
+> )
+>
+> model = out["output_model"]
+> ```
+
+
 This section describes the internal functionality of the mlpack Python binding
 generator.  If you are only interested in writing new bindings or building the
 bindings, this section is probably not worth reading.  But if you are interested


### PR DESCRIPTION
This PR adds a clarification note to the Python bindings documentation explaining the recommended use of keyword arguments for `mlpack.logistic_regression`.

It documents the requirement to explicitly provide `batch_size`, the use of the `training` and `labels` keywords, and the fact that the trained model is returned under the `output_model` key. This helps prevent confusing runtime errors for new Python users.

Related issue: #4074 

