### PR TITLE
Fix path to mlpack-windows.msi.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,4 +393,4 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: mlpack-windows-installer
-          path: dist/win-installer/mlpack-win-installer/bin/Release/mlpack-windows.msi
+          path: dist/win-installer/mlpack-win-installer/bin/x64/Release/mlpack-windows.msi


### PR DESCRIPTION
I noticed that `mlpack-windows.msi` wasn't being properly published as an artifact in builds:

https://github.com/mlpack/mlpack/actions/runs/21554924554/job/62109526715

But the issue is just that the path is wrong.  It gets built:

```
   Windows Installer XML Toolset Linker version 3.14.1.8722
  Copyright (c) .NET Foundation and contributors. All rights reserved.
  mlpack-win-installer -> D:\a\mlpack\mlpack\dist\win-installer\mlpack-win-installer\bin\x64\Release\mlpack-windows.msi
```

but not published:

```
 Warning: No files were found with the provided path: dist/win-installer/mlpack-win-installer/bin/Release/mlpack-windows.msi. No artifacts will be uploaded.
```

Easy fix, just a missing `x64`...