### PR TITLE
Fixed GitHub Actions workflow bugs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issues-stale: 30
+          days-before-issue-stale: 30
           days-before-issue-close: 7
           stale-issue-label: "s: stale"
           stale-pr-label: "s: stale"
           stale-issue-message: "This issue has been automatically marked as stale because it has not had any recent activity.  It will be closed in 7 days if no further activity occurs.  Thank you for your contributions! :+1:"
-          days-before-pr-stale: 30,
+          days-before-pr-stale: 30
           days-before-pr-close: 14
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           exempt-issue-labels: "s: keep open"

--- a/.github/workflows/welcome-pr.yaml
+++ b/.github/workflows/welcome-pr.yaml
@@ -3,7 +3,7 @@
 name: 'Welcome message for new contributors'
 on:
   pull_request:
-    types: [open]
+    types: [opened]
 
 jobs:
   sticker_comment:


### PR DESCRIPTION
1. Changed **types: [open]** to **types: [opened]** in **welcome-pr.yaml** because the event type must be valid

The pull_request event does not have an "open" type.
Shifted to "opened" since that fits the actual type being used here.
Something was going wrong without anyone noticing.

2. Changed invalid parameter **days-before-issues-stale** to **days-before-issue-stale** in **stale.yml**

The stale@v9 action looks for 'days-before-issue-stale' just one word.
Nowhere does the plural version get attention.

3. Removed trailing comma in stale.yml line 20

**days-before-pr-stale: 30,**
