### PR TITLE
Add entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ Testing/
 *.swp
 *.swo
 *~
+local/
+local-*
+.editorconfig
+# three files from GNU global
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
This is a minor 'quality of life' pull request suggestion adding a few files to `~/.gitignore` reflecting things I had here for years but that do clutter up `git status`.  I would be happy discuss each and every one of them, and of course remove as needed if there is opposition.

In short these are
- `.editorconfig` which I find convenient for consistent editor defaults
- `local/` as a catch-all directory for notes and things I keep around but do not want to commit
- `local-*` similar for help scripts, currently a cmake / build script for my current default settings and a way to alter them
- `GTAGS`, `GRTAGS`, `GPATH` are three index files for [GNU global](https://www.gnu.org/software/global/) used by an older, simple yet efficient tag lookup I use in Emacs (i.e. for quick jump to definition etc)

These should not have side effects.