### PR TITLE
Try using only one core for OS X.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,14 @@ jobs:
             os: 'macOS',
             name: 'CLI',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=ON',
-            cores: 3
+            cores: 2
           },
           {
             runner: macOS-latest,
             os: 'macOS',
             name: 'Python',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_PYTHON_BINDINGS=ON -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++',
-            cores: 3
+            cores: 2
           }
         ]
 
@@ -103,7 +103,6 @@ jobs:
       # Set up ccache.
       - name: Get ccache
         uses: hendrikmuhs/ccache-action@v1.2
-        if: matrix.config.os != 'macOS'
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.name }}
           append-timestamp: false
@@ -112,7 +111,6 @@ jobs:
 
       - name: Configure ccache
         shell: bash
-        if: matrix.config.os != 'macOS'
         run: |
           ccache --set-config "sloppiness=include_file_ctime"
           ccache --set-config "hash_dir=false"
@@ -160,7 +158,7 @@ jobs:
         if: matrix.config.os == 'macOS'
         run: |
           sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
-          brew install libomp openblas armadillo cereal ensmallen
+          brew install libomp openblas armadillo cereal ensmallen ccache
 
       # Because mlpack's precompiled headers basically include everything
       # (mlpack.hpp, core.hpp, etc.), changes to a single file will invalidate


### PR DESCRIPTION
Let's see what this does to the macOS build time.  (Note to self: when looking at the logs, make sure ccache missed entirely!  If ccache applies this won't tell us anything.)
