### PR TITLE
Disable concurrent builds for GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ permissions:
   contents: read
 name: mlpack.mlpack
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ###
   ### Linux and macOS test matrix for all binding types.


### PR DESCRIPTION
This change should make it so that when a new commit is pushed to a branch, Github Actions jobs for previous commits will be canceled.

I looked into doing this for Jenkins, too, but the situation is... more complex, and I don't want to take the time to look into it right now.  This is at least a small improvement that is quick.