### PR TITLE
R bindings refinement for default parameter values

### DIFF
--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -47,17 +47,14 @@ void PrintInputParam(util::ParamData& d,
     if (std::is_same_v<T, std::string>)
     {
       MLPACK_COUT_STREAM << " = \"" << std::any_cast<std::string>(d.value) << "\"";
-      d.wasPassed = true;
     }
     else if (std::is_same_v<T, double>)
     {
       MLPACK_COUT_STREAM << " = " << std::any_cast<double>(d.value);
-      d.wasPassed = true;
     }
     else if (std::is_same_v<T, int>)
     {
       MLPACK_COUT_STREAM << " = " << std::any_cast<int>(d.value);
-      d.wasPassed = true;
     }
     else
     {

--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -49,9 +49,14 @@ void PrintInputParam(util::ParamData& d,
       MLPACK_COUT_STREAM << " = \"" << std::any_cast<std::string>(d.value) << "\"";
       d.wasPassed = true;
     }
-    else if (std::is_same_v<T, double> || std::is_same_v<T, int>)
+    else if (std::is_same_v<T, double>)
     {
-      MLPACK_COUT_STREAM << " = " << std::any_cast<T>(d.value);
+      MLPACK_COUT_STREAM << " = " << std::any_cast<double>(d.value);
+      d.wasPassed = true;
+    }
+    else if (std::is_same_v<T, int>)
+    {
+      MLPACK_COUT_STREAM << " = " << std::any_cast<int>(d.value);
       d.wasPassed = true;
     }
     else

--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -44,8 +44,20 @@ void PrintInputParam(util::ParamData& d,
   }
   else if (!d.required)
   {
-    MLPACK_COUT_STREAM << " = " << std::any_cast<T>(d.value);
-    d.wasPassed = true;
+    if (std::is_same_v<T, std::string>)
+    {
+      MLPACK_COUT_STREAM << " = \"" << std::any_cast<std::string>(d.value) << "\"";
+      d.wasPassed = true;
+    }
+    else if (std::is_same_v<T, double> || std::is_same_v<T, int>)
+    {
+      MLPACK_COUT_STREAM << " = " << std::any_cast<T>(d.value);
+      d.wasPassed = true;
+    }
+    else
+    {
+      MLPACK_COUT_STREAM << " = NA";
+    }
   }
 }
 

--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -44,7 +44,8 @@ void PrintInputParam(util::ParamData& d,
   }
   else if (!d.required)
   {
-    MLPACK_COUT_STREAM << "=NA";
+    MLPACK_COUT_STREAM << " = " << std::any_cast<T>(d.value);
+    d.wasPassed = true;
   }
 }
 

--- a/src/mlpack/bindings/R/print_input_param.hpp
+++ b/src/mlpack/bindings/R/print_input_param.hpp
@@ -35,18 +35,19 @@ void PrintInputParam(util::ParamData& d,
     {
       // Make sure that we use the global verbose option for the mlpack package
       // as the default.
-      MLPACK_COUT_STREAM << "=getOption(\"mlpack.verbose\", FALSE)";
+      MLPACK_COUT_STREAM << " = getOption(\"mlpack.verbose\", FALSE)";
     }
     else
     {
-      MLPACK_COUT_STREAM << "=FALSE";
+      MLPACK_COUT_STREAM << " = FALSE";
     }
   }
   else if (!d.required)
   {
     if (std::is_same_v<T, std::string>)
     {
-      MLPACK_COUT_STREAM << " = \"" << std::any_cast<std::string>(d.value) << "\"";
+      MLPACK_COUT_STREAM << " = \"" << std::any_cast<std::string>(d.value)
+                         << "\"";
     }
     else if (std::is_same_v<T, double>)
     {

--- a/src/mlpack/bindings/R/print_input_processing.hpp
+++ b/src/mlpack/bindings/R/print_input_processing.hpp
@@ -31,9 +31,12 @@ void PrintInputProcessing(
     const std::enable_if_t<!std::is_same_v<T,
         std::tuple<DatasetInfo, arma::mat>>>* = 0)
 {
-  if (!d.required)
+  if (!d.required &&
+      !(std::is_same_v<T, std::string> ||
+        std::is_same_v<T, bool> ||
+        std::is_same_v<T, double> ||
+        std::is_same_v<T, int>))
   {
-    if (d.wasPassed) return;
     /**
      * This gives us code like:
      *

--- a/src/mlpack/bindings/R/print_input_processing.hpp
+++ b/src/mlpack/bindings/R/print_input_processing.hpp
@@ -33,6 +33,7 @@ void PrintInputProcessing(
 {
   if (!d.required)
   {
+    if (d.wasPassed) return;
     /**
      * This gives us code like:
      *

--- a/src/mlpack/core/util/params_impl.hpp
+++ b/src/mlpack/core/util/params_impl.hpp
@@ -67,7 +67,11 @@ inline bool Params::Has(const std::string& key) const
   }
   const std::string& checkKey = usedKey;
 
-  return (parameters.at(checkKey).wasPassed > 0);
+  // For boolean parameters, return the actual value of the parameter.
+  if (parameters.at(checkKey).cppType == "bool")
+    return *std::any_cast<bool>(&parameters.at(checkKey).value);
+  else
+    return (parameters.at(checkKey).wasPassed > 0);
 }
 
 /**

--- a/src/mlpack/tests/main_tests/nca_test.cpp
+++ b/src/mlpack/tests/main_tests/nca_test.cpp
@@ -330,11 +330,11 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest",
                               " 1.0  0.0 -1.0  1.0  0.0 -1.0 ";
   arma::Row<size_t> labels2 = " 0    0    0    1    1    1   ";
 
-  // Set parameters using the same input but set linear_scan flag to false.
+  // Set parameters using the same input but rely on linear_scan flag
+  // default value false.
   SetInputParam("input", std::move(y));
   SetInputParam("labels", labels2);
   SetInputParam("optimizer", std::string("sgd"));
-  SetInputParam("linear_scan", false);
 
   RUN_BINDING();
 

--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -438,8 +438,9 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMaxDepthTest",
 }
 
 /**
- * Make sure that training and input_model are both passed when warm_start is
- * false.
+ * Make sure that training and labels are both passed when warm_start is
+ * false (the default value). If warm_start is passed (as true) and but
+ * a model is not passed, error.
  */
 TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestTrainingModelWarmStart",
                  "[RandomForestMainTest][BindingTests]")
@@ -453,14 +454,14 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestTrainingModelWarmStart",
     FAIL("Cannot load labels for vc2_labels.txt");
 
   // Input training data.
-  SetInputParam("training", std::move(inputData));
-  SetInputParam("labels", std::move(labels));
-
+  SetInputParam("training", inputData);
+  SetInputParam("labels", labels);
   RUN_BINDING();
 
-  // Setting warm_start flag.
-  SetInputParam("warm_start", false);
-
+  // Testing a warm_start
+  SetInputParam("training", std::move(inputData));
+  SetInputParam("labels", std::move(labels));
+  SetInputParam("warm_start", true);
   REQUIRE_THROWS_AS(RUN_BINDING(), std::runtime_error);
 }
 


### PR DESCRIPTION
This shorter PR follows up on #4138 and covers another smaller aspect:  default values for non-required parameters are now shown (where possible) in the R function signature; consequently the function body does a little bit of lifting in setting these.  This covers the common key cases if sclalar 'basic' types `std::string`, `double`, `int` and `bool`; more complex arguments are still handled inside the function as before.