### PR TITLE
Fix minor issues in main tests for OpenMP and RNGs

### DIFF
--- a/src/mlpack/tests/main_tests/det_test.cpp
+++ b/src/mlpack/tests/main_tests/det_test.cpp
@@ -186,6 +186,11 @@ TEST_CASE_METHOD(DETTestFixture, "DETModelValidityTest",
 TEST_CASE_METHOD(DETTestFixture, "DETDiffMinLeafTest",
                 "[DETMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat trainingData;
   if (!Load("iris.csv", trainingData))
     FAIL("Unable to load dataset iris.csv!");
@@ -223,6 +228,10 @@ TEST_CASE_METHOD(DETTestFixture, "DETDiffMinLeafTest",
   REQUIRE(accu(testSetEstimates ==
       params.Get<arma::mat>("test_set_estimates")) <
       testSetEstimates.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -231,6 +240,11 @@ TEST_CASE_METHOD(DETTestFixture, "DETDiffMinLeafTest",
 TEST_CASE_METHOD(DETTestFixture, "DETDiffMaxLeafTest",
                 "[DETMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat trainingData;
   if (!Load("iris.csv", trainingData))
     FAIL("Unable to load dataset iris.csv!");
@@ -268,6 +282,10 @@ TEST_CASE_METHOD(DETTestFixture, "DETDiffMaxLeafTest",
   REQUIRE(accu(testSetEstimates ==
       params.Get<arma::mat>("test_set_estimates")) <
       testSetEstimates.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -276,6 +294,11 @@ TEST_CASE_METHOD(DETTestFixture, "DETDiffMaxLeafTest",
 TEST_CASE_METHOD(DETTestFixture, "DETDiffFoldsTest",
                 "[DETMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat trainingData;
   if (!Load("iris.csv", trainingData))
     FAIL("Unable to load dataset iris.csv!");
@@ -313,6 +336,10 @@ TEST_CASE_METHOD(DETTestFixture, "DETDiffFoldsTest",
   REQUIRE(accu(testSetEstimates ==
       params.Get<arma::mat>("test_set_estimates")) <
       testSetEstimates.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -321,6 +348,11 @@ TEST_CASE_METHOD(DETTestFixture, "DETDiffFoldsTest",
 TEST_CASE_METHOD(DETTestFixture, "DETSkipPruningTest",
                 "[DETMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat trainingData;
   if (!Load("iris.csv", trainingData))
     FAIL("Unable to load dataset iris.csv!");
@@ -358,4 +390,8 @@ TEST_CASE_METHOD(DETTestFixture, "DETSkipPruningTest",
   REQUIRE(accu(testSetEstimates ==
       params.Get<arma::mat>("test_set_estimates")) <
       testSetEstimates.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }

--- a/src/mlpack/tests/main_tests/kmeans_test.cpp
+++ b/src/mlpack/tests/main_tests/kmeans_test.cpp
@@ -153,7 +153,8 @@ TEST_CASE_METHOD(KmTestFixture, "KmClusteringSizeCheckLabelOnly",
 
 
 /**
- * Checking that predictions are not same when --allow_empty_clusters or kill_empty_clusters are specified
+ * Checking that predictions are not same when --allow_empty_clusters or
+ * kill_empty_clusters are specified
  */
 TEST_CASE_METHOD(KmTestFixture, "KmClusteringEmptyClustersCheck",
                  "[KmeansMainTest][BindingTests][long]")

--- a/src/mlpack/tests/main_tests/lmnn_test.cpp
+++ b/src/mlpack/tests/main_tests/lmnn_test.cpp
@@ -293,6 +293,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNNumTargetsTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNormalizationTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -306,6 +311,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNormalizationTest",
   SetInputParam("labels", labels);
   SetInputParam("linear_scan", true);
   SetInputParam("tolerance", 0.01);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -321,6 +327,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNormalizationTest",
   SetInputParam("normalize", true);
   SetInputParam("linear_scan", true);
   SetInputParam("tolerance", 0.01);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -328,6 +335,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNormalizationTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -336,6 +347,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNormalizationTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffStepSizeTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -349,6 +365,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffStepSizeTest",
   SetInputParam("labels", labels);
   SetInputParam("step_size", (double) 0.01);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -363,6 +380,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffStepSizeTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("step_size", (double) 20.5);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
@@ -371,6 +389,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffStepSizeTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -379,6 +401,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffStepSizeTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffToleranceTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -391,6 +418,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffToleranceTest",
   SetInputParam("input", inputData);
   SetInputParam("tolerance", (double) 1e-6);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -404,6 +432,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffToleranceTest",
   SetInputParam("input", std::move(inputData));
   SetInputParam("tolerance", (double) 0.3);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -411,6 +440,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffToleranceTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -419,6 +452,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffToleranceTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffBatchSizeTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -432,6 +470,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffBatchSizeTest",
   SetInputParam("labels", labels);
   SetInputParam("batch_size", (int) 20);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -446,6 +485,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffBatchSizeTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("batch_size", (int) 30);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -453,6 +493,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffBatchSizeTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -462,6 +506,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffBatchSizeTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNumTargetsTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -475,6 +524,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNumTargetsTest",
   SetInputParam("labels", labels);
   SetInputParam("k", 1);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -489,6 +539,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNumTargetsTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("k", 5);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -496,6 +547,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNumTargetsTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -505,6 +560,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffNumTargetsTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRegularizationTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -518,6 +578,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRegularizationTest",
   SetInputParam("labels", labels);
   SetInputParam("linear_scan",  (bool) true);
   SetInputParam("regularization", 1.0);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -532,6 +593,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRegularizationTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("linear_scan",  (bool) true);
   SetInputParam("regularization", 0.1);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -539,6 +601,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRegularizationTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -548,6 +614,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRegularizationTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRangeTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -560,6 +631,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRangeTest",
   SetInputParam("input", inputData);
   SetInputParam("labels", labels);
   SetInputParam("linear_scan",  (bool) true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -574,6 +646,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRangeTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("linear_scan",  (bool) true);
   SetInputParam("update_interval", 100);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -581,6 +654,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRangeTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -590,6 +667,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffRangeTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffMaxIterationTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -605,6 +687,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffMaxIterationTest",
   SetInputParam("optimizer",  std::string("lbfgs"));
   SetInputParam("k", 5);
   SetInputParam("max_iterations", (int) 2);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -621,6 +704,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffMaxIterationTest",
   SetInputParam("optimizer",  std::string("lbfgs"));
   SetInputParam("k", 5);
   SetInputParam("max_iterations", (int) 500);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -628,6 +712,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffMaxIterationTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -637,6 +725,11 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffMaxIterationTest",
 TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffPassesTest",
                 "[LMNNMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("iris.csv", inputData))
     FAIL("Cannot load iris.csv!");
@@ -650,6 +743,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffPassesTest",
   SetInputParam("labels", labels);
   SetInputParam("linear_scan",  (bool) true);
   SetInputParam("passes", (int) 2);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -664,6 +758,7 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffPassesTest",
   SetInputParam("labels", labels);
   SetInputParam("linear_scan",  (bool) true);
   SetInputParam("passes", (int) 6);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -671,6 +766,10 @@ TEST_CASE_METHOD(LMNNTestFixture, "LMNNDiffPassesTest",
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
   REQUIRE(accu(params.Get<arma::mat>("transformed_data") !=
       transformedData) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**

--- a/src/mlpack/tests/main_tests/lsh_test.cpp
+++ b/src/mlpack/tests/main_tests/lsh_test.cpp
@@ -109,6 +109,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHModelValidityTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHDiffTablesTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
 
   SetInputParam("reference", reference);
@@ -138,6 +143,10 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffTablesTest",
       params.Get<arma::Mat<size_t>>("neighbors")) < neighbors.n_elem);
   REQUIRE(accu(distances ==
       params.Get<arma::mat>("distances")) < distances.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -146,6 +155,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffTablesTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHDiffProjectionsTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
 
   SetInputParam("reference", reference);
@@ -175,6 +189,10 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffProjectionsTest",
       params.Get<arma::Mat<size_t>>("neighbors")) < neighbors.n_elem);
   REQUIRE(accu(distances ==
       params.Get<arma::mat>("distances")) < distances.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -183,6 +201,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffProjectionsTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHDiffHashWidthTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
 
   SetInputParam("reference", reference);
@@ -212,6 +235,10 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffHashWidthTest",
       params.Get<arma::Mat<size_t>>("neighbors")) < neighbors.n_elem);
   REQUIRE(accu(distances ==
       params.Get<arma::mat>("distances")) < distances.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -220,6 +247,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffHashWidthTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHDiffNumProbesTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
   arma::mat query = arma::randu<arma::mat>(5, 40);
 
@@ -227,6 +259,7 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffNumProbesTest",
   SetInputParam("query", query);
   SetInputParam("k", (int) 6);
 
+  FixedRandomSeed();
   RUN_BINDING();
 
   arma::Mat<size_t> neighbors = params.Get<arma::Mat<size_t>>("neighbors");
@@ -244,6 +277,7 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffNumProbesTest",
   SetInputParam("num_probes", (int) 5);
   SetInputParam("k", (int) 6);
 
+  FixedRandomSeed();
   RUN_BINDING();
 
   // Check that initial outputs and final outputs using two models are
@@ -252,6 +286,10 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffNumProbesTest",
       params.Get<arma::Mat<size_t>>("neighbors")) < neighbors.n_elem);
   REQUIRE(accu(distances ==
       params.Get<arma::mat>("distances")) < distances.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -260,6 +298,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffNumProbesTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHDiffSecondHashSizeTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
 
   SetInputParam("reference", reference);
@@ -289,6 +332,10 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffSecondHashSizeTest",
       params.Get<arma::Mat<size_t>>("neighbors")) < neighbors.n_elem);
   REQUIRE(accu(distances ==
       params.Get<arma::mat>("distances")) < distances.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -297,6 +344,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffSecondHashSizeTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHDiffBucketSizeTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
 
   SetInputParam("reference", reference);
@@ -326,6 +378,10 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffBucketSizeTest",
       params.Get<arma::Mat<size_t>>("neighbors")) < neighbors.n_elem);
   REQUIRE(accu(distances ==
       params.Get<arma::mat>("distances")) < distances.n_elem);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -334,6 +390,11 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHDiffBucketSizeTest",
 TEST_CASE_METHOD(LSHTestFixture, "LSHModelReuseTest",
                  "[LSHMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat reference = arma::randu<arma::mat>(5, 100);
   arma::mat query = arma::randu<arma::mat>(5, 40);
 
@@ -341,6 +402,7 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHModelReuseTest",
   SetInputParam("query", query);
   SetInputParam("k", (int) 6);
 
+  FixedRandomSeed();
   RUN_BINDING();
 
   arma::Mat<size_t> neighbors = params.Get<arma::Mat<size_t>>("neighbors");
@@ -356,12 +418,17 @@ TEST_CASE_METHOD(LSHTestFixture, "LSHModelReuseTest",
   SetInputParam("query", std::move(query));
   SetInputParam("k", (int) 6);
 
+  FixedRandomSeed();
   RUN_BINDING();
 
   // Check that initial query outputs and final outputs using saved model are
   // same.
   CheckMatrices(neighbors, params.Get<arma::Mat<size_t>>("neighbors"));
   CheckMatrices(distances, params.Get<arma::mat>("distances"));
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**

--- a/src/mlpack/tests/main_tests/nca_test.cpp
+++ b/src/mlpack/tests/main_tests/nca_test.cpp
@@ -38,6 +38,7 @@ TEST_CASE_METHOD(NCATestFixture, "NCAExplicitImplicitLabelsTest",
   x.randu(3, 6);
 
   SetInputParam("input", std::move(x));
+  SetInputParam("max_iterations", 100);
 
   RUN_BINDING();
 
@@ -58,6 +59,7 @@ TEST_CASE_METHOD(NCATestFixture, "NCAExplicitImplicitLabelsTest",
 
   SetInputParam("input", std::move(y));
   SetInputParam("labels", std::move(labels));
+  SetInputParam("max_iterations", 100);
 
   RUN_BINDING();
 
@@ -116,6 +118,11 @@ TEST_CASE_METHOD(NCATestFixture, "NCALabelSizeTest",
 TEST_CASE_METHOD(NCATestFixture, "NCANormalizationTest",
                 "[NCAMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   arma::mat inputData;
   if (!Load("vc2.csv", inputData))
     FAIL("Cannot load vc2.csv!");
@@ -129,6 +136,7 @@ TEST_CASE_METHOD(NCATestFixture, "NCANormalizationTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("linear_scan", true);
   SetInputParam("tolerance", 0.01);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -152,11 +160,16 @@ TEST_CASE_METHOD(NCATestFixture, "NCANormalizationTest",
   SetInputParam("normalize", true);
   SetInputParam("linear_scan", true);
   SetInputParam("tolerance", 0.01);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
   // Check that the output matrices are different.
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -165,6 +178,11 @@ TEST_CASE_METHOD(NCATestFixture, "NCANormalizationTest",
 TEST_CASE_METHOD(NCATestFixture, "NCADifferentStepSizeTest",
                 "[NCAMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Simple dataset with 6 points and two classes.
   arma::mat x              = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
                              " 1.0  0.0 -1.0  1.0  0.0 -1.0 ";
@@ -175,6 +193,7 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentStepSizeTest",
   SetInputParam("labels", std::move(labels));
   SetInputParam("step_size", (double) 1.2);
   SetInputParam("linear_scan", true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -194,11 +213,16 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentStepSizeTest",
   SetInputParam("labels", std::move(labels2));
   SetInputParam("step_size", (double) 20.5);
   SetInputParam("linear_scan", true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
   // Check that the output matrices are different.
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -207,54 +231,52 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentStepSizeTest",
 TEST_CASE_METHOD(NCATestFixture, "NCADifferentToleranceTest",
                 "[NCAMainTest][BindingTests][long]")
 {
-  // We aren't guaranteed that the test will be successful, so we run it
-  // multiple times.
-  bool success = false;
-  size_t trial = 0;
-  while (trial < 5)
-  {
-    // Random dataset.
-    arma::mat x;
-    x.randu(3, 600);
-    arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(600,
-        DistrParam(0, 1));
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
 
-    arma::mat y = x;
-    arma::Row<size_t> labels2 = labels;
+  // Random dataset.
+  arma::mat x;
+  x.randu(3, 600);
+  arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(600,
+      DistrParam(0, 1));
 
-    // Set parameters with a small tolerance.
-    SetInputParam("input", std::move(x));
-    SetInputParam("labels", std::move(labels));
-    SetInputParam("optimizer", std::string("lbfgs"));
-    SetInputParam("max_iterations", (int) 0);
-    SetInputParam("tolerance", (double) 1e-8);
+  arma::mat y = x;
+  arma::Row<size_t> labels2 = labels;
 
-    RUN_BINDING();
+  // Set parameters with a small tolerance.
+  SetInputParam("input", std::move(x));
+  SetInputParam("labels", std::move(labels));
+  SetInputParam("optimizer", std::string("lbfgs"));
+  SetInputParam("max_iterations", (int) 0);
+  SetInputParam("tolerance", (double) 0.1);
+  FixedRandomSeed();
 
-    arma::mat output = params.Get<arma::mat>("output");
+  RUN_BINDING();
 
-    // Reset settings.
-    CleanMemory();
-    ResetSettings();
+  arma::mat output = params.Get<arma::mat>("output");
 
-    // Set parameters using the same input but with a larger tolerance.
-    SetInputParam("input", std::move(y));
-    SetInputParam("labels", std::move(labels2));
-    SetInputParam("optimizer", std::string("lbfgs"));
-    SetInputParam("max_iterations", (int) 0);
-    SetInputParam("tolerance", (double) 100.0);
+  // Reset settings.
+  CleanMemory();
+  ResetSettings();
 
-    RUN_BINDING();
+  // Set parameters using the same input but with a larger tolerance.
+  SetInputParam("input", std::move(y));
+  SetInputParam("labels", std::move(labels2));
+  SetInputParam("optimizer", std::string("lbfgs"));
+  SetInputParam("max_iterations", (int) 0);
+  SetInputParam("tolerance", (double) 100.0);
+  FixedRandomSeed();
 
-    // Check that the output matrices are different.
-    success = (accu(params.Get<arma::mat>("output") != output) > 0);
-    if (success)
-      break;
+  RUN_BINDING();
 
-    ++trial;
-  }
+  // Check that the output matrices are different.
+  REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
 
-  REQUIRE(success == true);
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -263,6 +285,11 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentToleranceTest",
 TEST_CASE_METHOD(NCATestFixture, "NCADifferentBatchSizeTest",
                 "[NCAMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Simple dataset with 6 points and two classes.
   arma::mat x              = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
                              " 1.0  0.0 -1.0  1.0  0.0 -1.0 ";
@@ -274,6 +301,8 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentBatchSizeTest",
   SetInputParam("optimizer", std::string("sgd"));
   SetInputParam("batch_size", (int) 2);
   SetInputParam("linear_scan", true);
+  SetInputParam("max_iterations", 1000);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -294,19 +323,30 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentBatchSizeTest",
   SetInputParam("optimizer", std::string("sgd"));
   SetInputParam("batch_size", (int) 3);
   SetInputParam("linear_scan", true);
+  SetInputParam("max_iterations", 1000);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
   // Check that the output matrices are different.
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
- * Ensure that output is different when setting linear_scan to false.
+ * Ensure that output is different when setting linear_scan to true.
  */
 TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest",
                 "[NCAMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Simple dataset with 6 points and two classes.
   arma::mat x               = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
                               " 1.0  0.0 -1.0  1.0  0.0 -1.0 ";
@@ -316,6 +356,8 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest",
   SetInputParam("input", std::move(x));
   SetInputParam("labels", labels);
   SetInputParam("optimizer", std::string("sgd"));
+  SetInputParam("max_iterations", 100);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -334,12 +376,18 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest",
   SetInputParam("input", std::move(y));
   SetInputParam("labels", labels2);
   SetInputParam("optimizer", std::string("sgd"));
-  SetInputParam("linear_scan", false);
+  SetInputParam("max_iterations", 100);
+  SetInputParam("linear_scan", true);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
   // Check that the output matrices are different.
   REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -348,6 +396,11 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest",
 TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest2",
                 "[NCAMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Simple dataset with 6 points and two classes.
   arma::mat x               = "-0.1 -0.1 -0.1  0.1  0.1  0.1;"
                               " 1.0  0.0 -1.0  1.0  0.0 -1.0 ";
@@ -357,6 +410,8 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest2",
   SetInputParam("input", std::move(x));
   SetInputParam("labels", labels);
   SetInputParam("linear_scan", true);
+  SetInputParam("max_iterations", 1000);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -374,10 +429,17 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest2",
   SetInputParam("input", std::move(y));
   SetInputParam("labels", labels2);
   SetInputParam("linear_scan", true);
+  SetInputParam("max_iterations", 1000);
+  FixedRandomSeed();
+
   RUN_BINDING();
 
   // Check that the output matrices are equal.
   CheckMatrices(output, params.Get<arma::mat>("output"));
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -387,54 +449,52 @@ TEST_CASE_METHOD(NCATestFixture, "NCALinearScanTest2",
 TEST_CASE_METHOD(NCATestFixture, "NCADifferentNumBasisTest",
                 "[NCAMainTest][BindingTests]")
 {
-  // This test can randomly fail and it can be okay, so we run multiple times if
-  // necessary.
-  bool success = false;
-  size_t trial = 0;
-  while (trial < 5)
-  {
-    // Simple dataset.
-    arma::mat x;
-    x.randu(4, 100);
-    arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(100,
-        DistrParam(0, 1));
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
 
-    arma::mat y = x;
-    arma::Row<size_t> labels2 = labels;
+  // Simple dataset.
+  arma::mat x;
+  x.randu(4, 100);
+  arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(100,
+      DistrParam(0, 1));
 
-    // Set parameters and use a larger num_basis.
-    SetInputParam("input", std::move(x));
-    SetInputParam("labels", std::move(labels));
-    SetInputParam("optimizer",  std::string("lbfgs"));
-    SetInputParam("num_basis", (int) 5);
-    SetInputParam("max_iterations", (int) 10);
+  arma::mat y = x;
+  arma::Row<size_t> labels2 = labels;
 
-    RUN_BINDING();
+  // Set parameters and use a larger num_basis.
+  SetInputParam("input", std::move(x));
+  SetInputParam("labels", std::move(labels));
+  SetInputParam("optimizer",  std::string("lbfgs"));
+  SetInputParam("num_basis", (int) 5);
+  SetInputParam("max_iterations", (int) 10);
+  FixedRandomSeed();
 
-    arma::mat output = params.Get<arma::mat>("output");
+  RUN_BINDING();
 
-    // Reset Settings.
-    CleanMemory();
-    ResetSettings();
+  arma::mat output = params.Get<arma::mat>("output");
 
-    // Set parameters with a smaller num_basis.
-    SetInputParam("input", std::move(y));
-    SetInputParam("labels", std::move(labels2));
-    SetInputParam("optimizer",  std::string("lbfgs"));
-    SetInputParam("num_basis", (int) 1);
-    SetInputParam("max_iterations", (int) 10);
+  // Reset Settings.
+  CleanMemory();
+  ResetSettings();
 
-    RUN_BINDING();
+  // Set parameters with a smaller num_basis.
+  SetInputParam("input", std::move(y));
+  SetInputParam("labels", std::move(labels2));
+  SetInputParam("optimizer",  std::string("lbfgs"));
+  SetInputParam("num_basis", (int) 1);
+  SetInputParam("max_iterations", (int) 10);
+  FixedRandomSeed();
 
-    // Check that the output matrices are different.
-    success = (accu(params.Get<arma::mat>("output") != output) > 0);
-    if (success)
-      break;
+  RUN_BINDING();
 
-    ++trial;
-  }
+  // Check that the output matrices are different.
+  REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
 
-  REQUIRE(success == true);
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -444,50 +504,48 @@ TEST_CASE_METHOD(NCATestFixture, "NCADifferentNumBasisTest",
 TEST_CASE_METHOD(NCATestFixture, "NCADifferentMaxIterationTest",
                 "[NCAMainTest][BindingTests][long]")
 {
-  // This test can randomly fail and it can be okay, so we run multiple times if
-  // necessary.
-  bool success = false;
-  size_t trial = 0;
-  while (trial < 5)
-  {
-    // Random dataset.
-    arma::mat x;
-    x.randu(3, 600);
-    arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(600,
-        DistrParam(0, 1));
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
 
-    arma::mat y = x;
-    arma::Row<size_t> labels2 = labels;
+  // Random dataset.
+  arma::mat x;
+  x.randu(3, 600);
+  arma::Row<size_t> labels = arma::randi<arma::Row<size_t>>(600,
+      DistrParam(0, 1));
 
-    // Set parameters with a small max_iterations.
-    SetInputParam("input", std::move(x));
-    SetInputParam("labels", std::move(labels));
-    SetInputParam("optimizer",  std::string("lbfgs"));
-    SetInputParam("max_iterations", (int) 3);
+  arma::mat y = x;
+  arma::Row<size_t> labels2 = labels;
 
-    RUN_BINDING();
+  // Set parameters with a small max_iterations.
+  SetInputParam("input", std::move(x));
+  SetInputParam("labels", std::move(labels));
+  SetInputParam("optimizer",  std::string("lbfgs"));
+  SetInputParam("max_iterations", (int) 3);
+  FixedRandomSeed();
 
-    arma::mat output = params.Get<arma::mat>("output");
+  RUN_BINDING();
 
-    // Reset settings.
-    CleanMemory();
-    ResetSettings();
+  arma::mat output = params.Get<arma::mat>("output");
 
-    // Set parameters using the same input but with a larger max_iterations.
-    SetInputParam("input", std::move(y));
-    SetInputParam("labels", std::move(labels2));
-    SetInputParam("optimizer",  std::string("lbfgs"));
-    SetInputParam("max_iterations", (int) 500);
+  // Reset settings.
+  CleanMemory();
+  ResetSettings();
 
-    RUN_BINDING();
+  // Set parameters using the same input but with a larger max_iterations.
+  SetInputParam("input", std::move(y));
+  SetInputParam("labels", std::move(labels2));
+  SetInputParam("optimizer",  std::string("lbfgs"));
+  SetInputParam("max_iterations", (int) 20);
+  FixedRandomSeed();
 
-    // Check that the output matrices are different.
-    success = (accu(params.Get<arma::mat>("output") != output) > 0);
-    if (success)
-      break;
+  RUN_BINDING();
 
-    ++trial;
-  }
+  // Check that the output matrices are different.
+  REQUIRE(accu(params.Get<arma::mat>("output") != output) > 0);
 
-  REQUIRE(success == true);
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }

--- a/src/mlpack/tests/main_tests/random_forest_test.cpp
+++ b/src/mlpack/tests/main_tests/random_forest_test.cpp
@@ -232,6 +232,11 @@ inline bool CheckDifferentTrees(const TreeType& nodeA, const TreeType& nodeB)
 TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMinLeafSizeTest",
                  "[RandomForestMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Train for minimum leaf size 20.
   arma::mat inputData;
   if (!Load("vc2.csv", inputData))
@@ -245,6 +250,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMinLeafSizeTest",
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
   SetInputParam("minimum_leaf_size", (int) 20);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -262,6 +268,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMinLeafSizeTest",
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
   SetInputParam("minimum_leaf_size", (int) 10);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -278,6 +285,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMinLeafSizeTest",
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
   SetInputParam("minimum_leaf_size", (int) 1);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -295,6 +303,10 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMinLeafSizeTest",
   delete rf1;
   delete rf2;
   delete rf3;
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -304,6 +316,11 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMinLeafSizeTest",
 TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffNumTreeTest",
                  "[RandomForestMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Train for num_trees 1.
   arma::mat inputData;
   if (!Load("vc2.csv", inputData))
@@ -342,6 +359,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffNumTreeTest",
   SetInputParam("labels", labels);
   SetInputParam("num_trees", (int) 5);
   SetInputParam("minimum_leaf_size", (int) 1);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -358,6 +376,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffNumTreeTest",
   SetInputParam("labels", labels);
   SetInputParam("num_trees", (int) 10);
   SetInputParam("minimum_leaf_size", (int) 1);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -366,6 +385,10 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffNumTreeTest",
 
   REQUIRE(numTrees1 != numTrees2);
   REQUIRE(numTrees2 != numTrees3);
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**
@@ -374,6 +397,11 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffNumTreeTest",
 TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMaxDepthTest",
                  "[RandomForestMainTest][BindingTests]")
 {
+  #if defined(MLPACK_USE_OPENMP)
+  const size_t oldThreads = omp_get_num_threads();
+  omp_set_num_threads(1);
+  #endif
+
   // Train for minimum leaf size 20.
   arma::mat inputData;
   if (!Load("vc2.csv", inputData))
@@ -402,6 +430,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMaxDepthTest",
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
   SetInputParam("maximum_depth", (int) 2);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -418,6 +447,7 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMaxDepthTest",
   SetInputParam("training", inputData);
   SetInputParam("labels", labels);
   SetInputParam("maximum_depth", (int) 3);
+  FixedRandomSeed();
 
   RUN_BINDING();
 
@@ -435,6 +465,10 @@ TEST_CASE_METHOD(RandomForestTestFixture, "RandomForestDiffMaxDepthTest",
   delete rf1;
   delete rf2;
   delete rf3;
+
+  #if defined(MLPACK_USE_OPENMP)
+  omp_set_num_threads(oldThreads);
+  #endif
 }
 
 /**


### PR DESCRIPTION
A number of the tests in `main_tests/` concern bindings that use either OpenMP or random seeds, and run a binding twice to ensure that the results of a run are different when the input parameters are modified.  But:

* If the binding uses randomness---we need to set the same random seed for each run if we really want to check that we get different results.  In these cases I added `FixedRandomSeed()` calls before we run the binding, to set the random seed to a specific predefined value that will be the same across both tests.

 * If the binding uses OpenMP internally, which doesn't make any guarantees on thread assignment or ordering, we can't just set the OpenMP "random seed".  In these cases I added some code that sets OpenMP to only use one thread (if it's enabled).
