### PR TITLE
Add scripts/lint: lightweight tokenizer-aware C++ style linter

### DIFF
--- a/.github/workflows/style-lint.yml
+++ b/.github/workflows/style-lint.yml
@@ -1,0 +1,36 @@
+name: style-lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  style-lint:
+    name: style-lint (report mode)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run the linter's own test suite
+        run: python3 -m unittest discover -s scripts/lint -t scripts/lint
+
+      - name: Run the linter in check mode on the full tree
+        # --check fails only on auto-fixable issues. Baseline long-line
+        # diagnostics (which require human judgment) are printed for
+        # visibility but do not fail CI.
+        run: python3 scripts/lint/style_lint.py --check .

--- a/.github/workflows/style-lint.yml
+++ b/.github/workflows/style-lint.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   style-lint:
-    name: style-lint (report mode)
+    name: style-lint (check mode)
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/lint/README.md
+++ b/scripts/lint/README.md
@@ -1,0 +1,212 @@
+# `scripts/lint/`: mlpack style linter
+
+A lightweight, tokenizer aware C++ style linter. It exists because
+`clang-format` does not deal well with mlpack's heavy template code.
+`clang-format` wants to reformat the entire file, and its idea of how to
+wrap template argument lists disagrees with the maintainers'. This
+linter takes a narrower contract: **fix the mechanical stuff, leave the
+rest to humans.**
+
+## What it does
+
+Mechanical auto-fixes (safe to apply without review):
+
+| Code | What | Example |
+|---|---|---|
+| `encoding` | UTF-16 or UTF-8 with BOM rewritten as UTF-8 | Visual Studio sample sources |
+| `crlf` | CRLF line endings rewritten as LF | Files committed from Windows |
+| `tab` | tabs in code rewritten as 2 spaces | (string literals left alone) |
+| `trailing-ws` | trailing whitespace on code lines | (raw-string content left alone) |
+| `eof-newline` | missing final newline | |
+| `kw-paren` | `if(`, `for(`, `while(`, `switch(`, `catch(` rewritten as `if (` etc. | |
+| `brace-same-line` | `if (x) {` split into `if (x)` then `{` on the next line | Allman style |
+| `brace-else` | `} else {` split into `}`, `else`, `{` on three lines | |
+| `blank-run` | 3+ consecutive blank lines collapsed to 2 | |
+
+Report only (flagged for human judgment):
+
+| Code | What |
+|---|---|
+| `long-line` | lines > 80 cols, **suppressed inside template context** |
+
+Long lines are deliberately not auto-wrapped. That is where
+`clang-format` gets it wrong on template code, and mlpack would rather
+have the maintainer pick the wrap point.
+
+## Running it
+
+```bash
+# Report mode. Prints every diagnostic and exits non-zero if anything
+# was found, fixable or not.
+python3 scripts/lint/style_lint.py src/
+
+# Check mode. What CI uses. Prints every diagnostic, but exits
+# non-zero *only* if something auto-fixable exists. Baseline long-line
+# warnings do not trip it.
+python3 scripts/lint/style_lint.py --check src/
+
+# Fix mode. Applies safe rewrites atomically (via tempfile plus
+# os.replace) and reports whatever non-fixable remains for human review.
+python3 scripts/lint/style_lint.py --fix src/
+
+# Whole repo:
+python3 scripts/lint/style_lint.py --check .
+```
+
+The three modes are mutually exclusive. The common workflow is:
+`--check` locally before pushing, `--fix` when you want the rewrites
+applied, and plain report when you want to see everything including
+non-fixable diagnostics.
+
+Runtime on the full mlpack tree (~1550 C++ files) is around 2 seconds.
+Fix mode is essentially the same speed, because the rewrite path is
+only hit for the handful of files that actually need changes.
+
+## Safety: the tokenizer
+
+The linter contains a single-pass C++ tokenizer (`classify()`) that
+produces a mask over every byte of the file:
+
+* `c` for code
+* `s` for string or char literal (including delimiters)
+* `/` for comment (including delimiters)
+* `\n` preserved so per-line splits line up with the text
+
+Every auto-fix checks the mask before rewriting. The consequence is
+that things like
+
+```cpp
+const char* msg = "if(x) failed";
+const char* raw = R"(if(x) { while(true); })";
+// uses for(int i=0; i<n; ++i) internally
+/* if(y) {} */
+```
+
+pass through `--fix` completely untouched, while the same constructs
+outside strings and comments get rewritten. The tokenizer understands
+line comments, block comments (including across newlines), char
+literals, strings with backslash escapes, and raw string literals with
+prefixes (`u8R`, `uR`, `UR`, `LR`) and custom delimiters up to 16
+characters.
+
+## Exclusions
+
+Directories never walked:
+
+```
+.git/  build/  _build/  third_party/  _deps/  CMakeFiles/  bundled/  cereal/
+```
+
+Files excluded by name:
+
+```
+catch.hpp
+```
+
+Rationale: `bundled/`, `cereal/`, and `catch.hpp` are vendored
+third-party sources. We do not want to retrofit their upstream style,
+and drive-by rewrites make future upstream syncs painful.
+
+## Template aware long-line suppression
+
+The long-line check tracks angle-bracket depth across lines, in code
+regions only. When the depth is > 0, or the line contains the word
+`template`, long-line warnings are suppressed. The depth is clamped
+back to 0 at every line that does not end in `,` or `\`, so that a
+`for (int i = 0; i < n; ++i)` comparison operator does not poison the
+rest of the file.
+
+This heuristic is imperfect by design. The alternative (a full C++
+parser) is miles away from the effort we want to spend here. If it
+occasionally under-reports a long line inside complex template code,
+that is fine. Complex template code is where `clang-format` was wrong
+anyway.
+
+## Extending the linter
+
+### Adding a new auto-fix
+
+1. **Write the test first.** Use `scripts/lint/test_style_lint.py` as a
+   template. Include at least: a happy path fix case, a case that must
+   be skipped inside a string literal, and a case that must be skipped
+   inside a comment. Run the tests and watch them fail.
+2. **Add the rule to `lint_text()`**, not outside it. Rules are applied
+   in line order so they can see each other's output via `line_mask`.
+3. **Use the mask.** For regex-based rewrites, wrap every match in a
+   `_is_code_span(line_mask, start, end)` check before applying it.
+   For character-level rewrites (like tab expansion), check
+   `line_mask[k] == "c"` per character.
+4. **Emit a `Diag`** with `fixable=True` whenever you would rewrite.
+   The Diag itself is reported unconditionally; the `fixable` flag
+   tells `main` whether to suppress it after a successful `--fix`.
+5. **Atomic write is handled for you** via `atomic_write()` in
+   `process_file()`. You do not need to touch file I/O.
+
+### Adding a new report-only rule
+
+Same as above, but create the Diag with `fixable=False`. The rule can
+live in `lint_text()` next to the auto-fix rules; the only difference
+is that no rewrite happens.
+
+### Adding an exclusion
+
+Add the directory name to `EXCLUDE_DIRS` or the file basename to
+`EXCLUDE_FILES`. These are matched against the bare directory or file
+name during `os.walk`, not against full paths. If you need a
+path-prefix exclusion, extend `iter_sources()`.
+
+### Things to be careful about
+
+* **Do not rewrite inside `s` or `/` mask regions.** That is the whole
+  point of the tokenizer. A rewrite that corrupts a string literal is
+  much worse than any style nit it could fix.
+* **Assume the line may change under your feet.** Rules run in a fixed
+  order inside `lint_text()`. If a rule rewrites the line, subsequent
+  rules see the new content, and `line_mask` is kept in sync by each
+  fixing rule. If you add a rule that changes line length, update
+  `line_mask` the same way.
+* **Brace fix style rules may emit multiple output lines** for one
+  input line. Follow the pattern in `lint_text()`: produce a
+  `fixed_lines: list[str] | None` and let the trailing emission loop
+  do the work.
+* **Do not touch the long-line heuristic lightly.** The template depth
+  tracking looks trivial but has sharp edges around `<<`, `>>`, `<=`,
+  `>=`, and comparison operators. There are regression tests for all
+  of these; make sure they still pass.
+* **Never bypass `atomic_write()` for in-place edits.** An interrupted
+  rewrite of a header file in the middle of a large run is worse than
+  any bug the linter could catch.
+
+## Tests
+
+Pure stdlib unittest. No pytest, no third-party dependencies.
+
+```bash
+python3 scripts/lint/test_style_lint.py
+```
+
+67 tests covering the tokenizer (string, comment, and raw-string edge
+cases), every auto-fix rule, template-context long-line suppression,
+comparison operator non-poisoning, exclusion rules, encoding
+detection, atomic writes, and the `--check` exit code contract. Runs
+in under 100 ms.
+
+Required: every new rule ships with tests. The review rule is simple.
+If you did not watch a failing test for your rule, it did not exist
+first, and you cannot prove the rule actually tests anything.
+
+## CI
+
+See `.github/workflows/style-lint.yml`. The workflow runs
+`scripts/lint/test_style_lint.py` to sanity check the linter itself,
+then runs `scripts/lint/style_lint.py --check .` on the full tree.
+Both must exit zero for the job to pass.
+
+`--check` rather than plain report mode is intentional. Baseline
+long-line warnings in the existing tree would break CI on every PR
+otherwise. `--check` surfaces them in the log so contributors can
+still see them, but it only fails the job if something auto-fixable
+exists.
+
+Auto-fix is **not** run in CI. Rewriting files during CI is something
+you do locally, review in a PR, and commit deliberately.

--- a/scripts/lint/README.md
+++ b/scripts/lint/README.md
@@ -185,11 +185,11 @@ Pure stdlib unittest. No pytest, no third-party dependencies.
 python3 scripts/lint/test_style_lint.py
 ```
 
-67 tests covering the tokenizer (string, comment, and raw-string edge
-cases), every auto-fix rule, template-context long-line suppression,
-comparison operator non-poisoning, exclusion rules, encoding
-detection, atomic writes, and the `--check` exit code contract. Runs
-in under 100 ms.
+The test suite covers the tokenizer (string, comment, and raw-string
+edge cases), every auto-fix rule, template-context long-line
+suppression, comparison operator non-poisoning, exclusion rules,
+encoding detection, atomic writes, and the `--check` exit code
+contract. The full suite runs in under 100 ms.
 
 Required: every new rule ships with tests. The review rule is simple.
 If you did not watch a failing test for your rule, it did not exist

--- a/scripts/lint/style_lint.py
+++ b/scripts/lint/style_lint.py
@@ -64,9 +64,21 @@ TRAILING_BRACE = re.compile(
 BRACE_ELSE_SAMELINE = re.compile(r"^\s*\}\s*else\b")
 
 
-def _is_template_context_line(line: str) -> bool:
-    """Used to veto brace-placement fixes in template heavy lines."""
-    return bool(_TEMPLATE_WORD.search(line)) or (">::" in line)
+def _is_template_context_line(line: str, line_mask: str) -> bool:
+    """Used to veto brace-placement fixes in template heavy lines.
+
+    Only matches when `template` or `>::` occurs in code spans; mentions in
+    trailing comments or string literals do not suppress brace fixes.
+    """
+    m = _TEMPLATE_WORD.search(line)
+    if m and _is_code_span(line_mask, m.start(), m.end()):
+        return True
+    idx = line.find(">::")
+    while idx != -1:
+        if _is_code_span(line_mask, idx, idx + 3):
+            return True
+        idx = line.find(">::", idx + 3)
+    return False
 
 
 @dataclass
@@ -305,26 +317,29 @@ def lint_text(text: str, fix: bool) -> "tuple[str, list[Diag]]":
         start_template_depth = template_depth
 
         if "\t" in line:
-            col = line.find("\t")
-            if col < len(line_mask) and line_mask[col] == "c":
+            code_tab_cols = [
+                k for k, ch in enumerate(line)
+                if ch == "\t" and k < len(line_mask) and line_mask[k] == "c"
+            ]
+            for col in code_tab_cols:
                 diags.append(Diag(i, col + 1, "tab", "tab character", True))
-                if fix:
-                    new_chars: list[str] = []
-                    new_mask_chars: list[str] = []
-                    visual = 0
-                    for k, ch in enumerate(line):
-                        mch = line_mask[k] if k < len(line_mask) else "c"
-                        if ch == "\t" and mch == "c":
-                            pad = 2 - (visual % 2)
-                            new_chars.append(" " * pad)
-                            new_mask_chars.append("c" * pad)
-                            visual += pad
-                        else:
-                            new_chars.append(ch)
-                            new_mask_chars.append(mch)
-                            visual += 1
-                    line = "".join(new_chars)
-                    line_mask = "".join(new_mask_chars)
+            if fix and code_tab_cols:
+                new_chars: list[str] = []
+                new_mask_chars: list[str] = []
+                visual = 0
+                for k, ch in enumerate(line):
+                    mch = line_mask[k] if k < len(line_mask) else "c"
+                    if ch == "\t" and mch == "c":
+                        pad = 2 - (visual % 2)
+                        new_chars.append(" " * pad)
+                        new_mask_chars.append("c" * pad)
+                        visual += pad
+                    else:
+                        new_chars.append(ch)
+                        new_mask_chars.append(mch)
+                        visual += 1
+                line = "".join(new_chars)
+                line_mask = "".join(new_mask_chars)
 
         stripped = line.rstrip(" \t")
         if stripped != line:
@@ -449,7 +464,7 @@ def lint_text(text: str, fix: bool) -> "tuple[str, list[Diag]]":
                 )
 
         fixed_lines: "list[str] | None" = None
-        if not _is_template_context_line(line):
+        if not _is_template_context_line(line, line_mask):
             for rgx, code, msg, split in _BRACE_FIX_RULES:
                 match = rgx.match(line)
                 if match:
@@ -550,13 +565,18 @@ def read_source(path: str) -> "tuple[str, str]":
     return raw.decode("utf-8"), "utf-8"
 
 
-def process_file(path: str, fix: bool) -> "list[Diag]":
-    """Read, lint, and (in fix mode) rewrite a single file."""
+def process_file(path: str, fix: bool) -> "list[Diag] | None":
+    """Read, lint, and (in fix mode) rewrite a single file.
+
+    Returns None if the file could not be read/decoded; callers must treat
+    that as a hard error (counted separately from lint diagnostics so it
+    surfaces in every mode's exit code).
+    """
     try:
         text, encoding = read_source(path)
     except (OSError, UnicodeDecodeError) as e:
         print(f"{path}: skipped ({e})", file=sys.stderr)
-        return []
+        return None
 
     diags: list[Diag] = []
     if encoding != "utf-8":
@@ -612,8 +632,12 @@ def main() -> int:
 
     fixable_total = 0
     other_total = 0
+    read_errors = 0
     for path in iter_sources(args.paths):
         diags = process_file(path, fix=args.fix)
+        if diags is None:
+            read_errors += 1
+            continue
         for d in diags:
             if args.fix and d.fixable:
                 continue
@@ -622,10 +646,10 @@ def main() -> int:
         other_total += sum(1 for d in diags if not d.fixable)
 
     if args.fix:
-        return 1 if other_total else 0
+        return 1 if (other_total or read_errors) else 0
     if args.check:
-        return 1 if fixable_total else 0
-    return 1 if (fixable_total + other_total) else 0
+        return 1 if (fixable_total or read_errors) else 0
+    return 1 if (fixable_total + other_total + read_errors) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/lint/style_lint.py
+++ b/scripts/lint/style_lint.py
@@ -12,7 +12,7 @@ Auto-fixes only touch code regions. Strings, character literals, raw
 strings, and comments are excluded via a single-pass C++ tokenizer.
 
 Usage:
-    scripts/style_lint.py [--fix | --check] PATH [PATH ...]
+    scripts/lint/style_lint.py [--fix | --check] PATH [PATH ...]
 """
 
 from __future__ import annotations
@@ -355,15 +355,25 @@ def lint_text(text: str, fix: bool) -> "tuple[str, list[Diag]]":
                 )
             )
         if fix and kw_hits:
+            # Rebuild `line` AND `line_mask` together so subsequent rules
+            # (template depth, long-line, brace fix) still see an aligned
+            # mask. Without this, positional mask lookups after the rewrite
+            # point drift by the number of inserted spaces.
             pieces: list[str] = []
+            mask_pieces: list[str] = []
             last = 0
             for m_kw in kw_hits:
                 s, e = m_kw.start(), m_kw.end()
+                replacement = m_kw.group(1) + " ("
                 pieces.append(line[last:s])
-                pieces.append(m_kw.group(1) + " (")
+                mask_pieces.append(line_mask[last:s])
+                pieces.append(replacement)
+                mask_pieces.append("c" * len(replacement))
                 last = e
             pieces.append(line[last:])
+            mask_pieces.append(line_mask[last:])
             line = "".join(pieces)
+            line_mask = "".join(mask_pieces)
 
         max_depth_during = template_depth
         if "<" in line or ">" in line:
@@ -407,10 +417,19 @@ def lint_text(text: str, fix: bool) -> "tuple[str, list[Diag]]":
         # Only treat max_depth_during as evidence of template context when
         # the line looks like an opener of a multi-line parameter list,
         # i.e. it ends in a continuation token.
+        template_word_match = _TEMPLATE_WORD.search(line)
+        template_word_in_code = (
+            template_word_match is not None
+            and _is_code_span(
+                line_mask,
+                template_word_match.start(),
+                template_word_match.end(),
+            )
+        )
         in_template_context = (
             start_template_depth > 0
             or (max_depth_during > 0 and ends_with_continuation)
-            or _TEMPLATE_WORD.search(line) is not None
+            or template_word_in_code
         )
         if stripped_end and not ends_with_continuation:
             template_depth = 0
@@ -561,7 +580,10 @@ def process_file(path: str, fix: bool) -> "list[Diag]":
 def iter_sources(paths: Iterable[str]) -> Iterable[str]:
     for p in paths:
         if os.path.isfile(p):
-            yield p
+            if os.path.basename(p) in EXCLUDE_FILES:
+                continue
+            if p.endswith(SOURCE_EXTS):
+                yield p
         elif os.path.isdir(p):
             for root, dirs, files in os.walk(p):
                 dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]

--- a/scripts/lint/style_lint.py
+++ b/scripts/lint/style_lint.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""
+Lightweight style linter for mlpack C++ sources.
+
+Deliberately narrow in scope. The linter fixes only mechanical,
+unambiguous things (trailing whitespace, tabs, `if(` spacing, missing
+EOF newline, CRLF) and reports the judgment calls (long lines, brace
+placement) so the maintainer stays in control of template heavy code
+that clang-format butchers.
+
+Auto-fixes only touch code regions. Strings, character literals, raw
+strings, and comments are excluded via a single-pass C++ tokenizer.
+
+Usage:
+    scripts/style_lint.py [--fix | --check] PATH [PATH ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import codecs
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+SOURCE_EXTS = (".hpp", ".cpp", ".h", ".cc", ".cxx")
+MAX_LINE = 80
+EXCLUDE_DIRS = {
+    ".git",
+    "build",
+    "_build",
+    "third_party",
+    "_deps",
+    "CMakeFiles",
+    "bundled",
+    "cereal",
+}
+EXCLUDE_FILES = {"catch.hpp"}
+
+_CODE = ord("c")
+_STR = ord("s")
+_COMMENT = ord("/")
+_NL = ord("\n")
+
+KEYWORD_PAREN = re.compile(r"\b(if|for|while|switch|catch)\(")
+_TEMPLATE_WORD = re.compile(r"\btemplate\b")
+
+FIX_IF_GLUED = re.compile(
+    r"^(\s*)((?:if|while|for|switch|catch)\s*\(.*\))\s*\{\s*$"
+)
+FIX_DO_TRY_GLUED = re.compile(r"^(\s*)(do|try)\s*\{\s*$")
+FIX_ELSE_IF_GLUED = re.compile(r"^(\s*)\}\s*(else\s+if\s*\(.*\))\s*\{\s*$")
+FIX_ELSE_GLUED = re.compile(r"^(\s*)\}\s*else\s*\{\s*$")
+FIX_ELSE_UNBRACED = re.compile(r"^(\s*)\}\s*else\s*$")
+
+TRAILING_BRACE = re.compile(
+    r"^\s*(?:\}\s*)?(?:if|else|for|while|switch|catch)\b.*\)\s*\{\s*$"
+    r"|^\s*\}\s*else\b.*\{\s*$"
+    r"|^\s*(?:do|try)\s*\{\s*$"
+)
+BRACE_ELSE_SAMELINE = re.compile(r"^\s*\}\s*else\b")
+
+
+def _is_template_context_line(line: str) -> bool:
+    """Used to veto brace-placement fixes in template heavy lines."""
+    return bool(_TEMPLATE_WORD.search(line)) or (">::" in line)
+
+
+@dataclass
+class Diag:
+    line: int
+    col: int
+    code: str
+    msg: str
+    fixable: bool
+
+
+# ===========================================================================
+# Tokenizer
+# ===========================================================================
+
+def _scan_quoted(
+    text: str, out: bytearray, i: int, n: int, quote: str
+) -> int:
+    """Mask a char or string literal starting at `i` (positioned on the
+    opening quote). Returns the index just past the closing quote, or past
+    the terminating newline for an unterminated literal."""
+    out[i] = _STR
+    j = i + 1
+    while j < n:
+        ch = text[j]
+        if ch == "\\" and j + 1 < n:
+            out[j] = _STR
+            out[j + 1] = _NL if text[j + 1] == "\n" else _STR
+            j += 2
+            continue
+        if ch == quote:
+            out[j] = _STR
+            j += 1
+            break
+        if ch == "\n":
+            out[j] = _NL
+            j += 1
+            break
+        out[j] = _STR
+        j += 1
+    return j
+
+
+def _is_numeric_separator(text: str, i: int) -> bool:
+    """True when `text[i]` is a C++14 digit separator inside a numeric
+    pp-token rather than a char-literal opener.
+
+    A pp-number starts with a digit; the separator `'` appears between
+    alphanumeric run elements of that token. We walk backwards over the
+    alnum/underscore run ending at `i` and check whether it begins with a
+    digit. The walk is bounded by the length of a numeric literal, which
+    is tiny in practice.
+    """
+    if i == 0:
+        return False
+    t = i
+    while t > 0 and (text[t - 1].isalnum() or text[t - 1] in ("_", "'")):
+        t -= 1
+    return t < i and text[t].isdigit()
+
+
+def classify(text: str) -> str:
+    """Return a mask the same length as `text`.
+
+    Each position is one of:
+      'c'   code
+      's'   string or char literal (including delimiters)
+      '/'   comment (including delimiters)
+      '\\n' literal newline (preserved so per-line splits align with text)
+
+    Handles line comments, block comments, char literals, string
+    literals with backslash escapes, raw string literals (with prefixes
+    like u8R/uR/UR/LR), and C++14 digit separators inside numeric
+    literals.
+    """
+    n = len(text)
+    out = bytearray([_CODE]) * n
+    i = 0
+
+    while i < n:
+        c = text[i]
+
+        if c == "\n":
+            out[i] = _NL
+            i += 1
+            continue
+
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = i
+            while j < n and text[j] != "\n":
+                out[j] = _COMMENT
+                j += 1
+            i = j
+            continue
+
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            out[i] = _COMMENT
+            out[i + 1] = _COMMENT
+            j = i + 2
+            while j < n:
+                if j + 1 < n and text[j] == "*" and text[j + 1] == "/":
+                    out[j] = _COMMENT
+                    out[j + 1] = _COMMENT
+                    j += 2
+                    break
+                out[j] = _NL if text[j] == "\n" else _COMMENT
+                j += 1
+            i = j
+            continue
+
+        if c == "R" and i + 1 < n and text[i + 1] == '"':
+            delim_start = i + 2
+            delim_end = delim_start
+            while (
+                delim_end < n
+                and text[delim_end] != "("
+                and text[delim_end] != "\n"
+                and delim_end - delim_start < 16
+            ):
+                delim_end += 1
+            if delim_end < n and text[delim_end] == "(":
+                delim = text[delim_start:delim_end]
+                terminator = ")" + delim + '"'
+                tlen = len(terminator)
+                for k in range(i, delim_end + 1):
+                    out[k] = _NL if text[k] == "\n" else _STR
+                j = delim_end + 1
+                while j < n:
+                    if text[j : j + tlen] == terminator:
+                        for k in range(j, j + tlen):
+                            out[k] = _STR
+                        j += tlen
+                        break
+                    out[j] = _NL if text[j] == "\n" else _STR
+                    j += 1
+                i = j
+                continue
+
+        if c == "'":
+            if _is_numeric_separator(text, i):
+                i += 1
+                continue
+            i = _scan_quoted(text, out, i, n, "'")
+            continue
+
+        if c == '"':
+            i = _scan_quoted(text, out, i, n, '"')
+            continue
+
+        i += 1
+
+    return out.decode("latin-1")
+
+
+# ===========================================================================
+# Linter
+# ===========================================================================
+
+def _is_code_span(mask_line: str, start: int, end: int) -> bool:
+    return mask_line.count("c", start, end) == end - start
+
+
+# Table of brace-fix rules. Each entry supplies a pattern, the diagnostic
+# code and message, and a function that turns a regex Match into the list
+# of replacement lines to emit in place of the original.
+_BraceSplit = Callable[["re.Match[str]"], "list[str]"]
+_BRACE_FIX_RULES: "list[tuple[re.Pattern[str], str, str, _BraceSplit]]" = [
+    (
+        FIX_IF_GLUED,
+        "brace-same-line",
+        "opening brace should be on its own line",
+        lambda m: [m.group(1) + m.group(2), m.group(1) + "{"],
+    ),
+    (
+        FIX_DO_TRY_GLUED,
+        "brace-same-line",
+        "opening brace should be on its own line",
+        lambda m: [m.group(1) + m.group(2), m.group(1) + "{"],
+    ),
+    (
+        FIX_ELSE_IF_GLUED,
+        "brace-else",
+        "`} else if` should be split across lines",
+        lambda m: [m.group(1) + "}", m.group(1) + m.group(2), m.group(1) + "{"],
+    ),
+    (
+        FIX_ELSE_GLUED,
+        "brace-else",
+        "`} else {` should be split across lines",
+        lambda m: [m.group(1) + "}", m.group(1) + "else", m.group(1) + "{"],
+    ),
+    (
+        FIX_ELSE_UNBRACED,
+        "brace-else",
+        "`} else` should be split across lines",
+        lambda m: [m.group(1) + "}", m.group(1) + "else"],
+    ),
+]
+
+
+def lint_text(text: str, fix: bool) -> "tuple[str, list[Diag]]":
+    """Return (new_text, diagnostics). new_text == text unless fix=True."""
+    diags: list[Diag] = []
+
+    if "\r\n" in text:
+        if fix:
+            text = text.replace("\r\n", "\n")
+        diags.append(Diag(1, 1, "crlf", "file has CRLF line endings", True))
+
+    mask = classify(text)
+    text_lines = text.split("\n")
+    mask_lines = mask.split("\n")
+
+    trailing_newline = len(text_lines) > 0 and text_lines[-1] == ""
+    if trailing_newline:
+        text_lines = text_lines[:-1]
+        mask_lines = mask_lines[:-1]
+    else:
+        diags.append(
+            Diag(
+                max(1, len(text_lines)),
+                1,
+                "eof-newline",
+                "missing newline at end of file",
+                True,
+            )
+        )
+
+    new_body: list[str] = []
+    blank_run = 0
+    template_depth = 0
+
+    for i, (raw, m) in enumerate(zip(text_lines, mask_lines), start=1):
+        line = raw
+        line_mask = m
+        start_template_depth = template_depth
+
+        if "\t" in line:
+            col = line.find("\t")
+            if col < len(line_mask) and line_mask[col] == "c":
+                diags.append(Diag(i, col + 1, "tab", "tab character", True))
+                if fix:
+                    new_chars: list[str] = []
+                    new_mask_chars: list[str] = []
+                    visual = 0
+                    for k, ch in enumerate(line):
+                        mch = line_mask[k] if k < len(line_mask) else "c"
+                        if ch == "\t" and mch == "c":
+                            pad = 2 - (visual % 2)
+                            new_chars.append(" " * pad)
+                            new_mask_chars.append("c" * pad)
+                            visual += pad
+                        else:
+                            new_chars.append(ch)
+                            new_mask_chars.append(mch)
+                            visual += 1
+                    line = "".join(new_chars)
+                    line_mask = "".join(new_mask_chars)
+
+        stripped = line.rstrip(" \t")
+        if stripped != line:
+            trim_start = len(stripped)
+            if _is_code_span(line_mask, trim_start, len(line)):
+                diags.append(
+                    Diag(i, trim_start + 1, "trailing-ws", "trailing whitespace", True)
+                )
+                if fix:
+                    line = stripped
+                    line_mask = line_mask[:trim_start]
+
+        if "(" in line:
+            kw_hits = [
+                m_kw for m_kw in KEYWORD_PAREN.finditer(line)
+                if _is_code_span(line_mask, m_kw.start(), m_kw.end())
+            ]
+        else:
+            kw_hits = []
+        for m_kw in kw_hits:
+            diags.append(
+                Diag(
+                    i,
+                    m_kw.start() + 1,
+                    "kw-paren",
+                    f"missing space after `{m_kw.group(1)}`",
+                    True,
+                )
+            )
+        if fix and kw_hits:
+            pieces: list[str] = []
+            last = 0
+            for m_kw in kw_hits:
+                s, e = m_kw.start(), m_kw.end()
+                pieces.append(line[last:s])
+                pieces.append(m_kw.group(1) + " (")
+                last = e
+            pieces.append(line[last:])
+            line = "".join(pieces)
+
+        max_depth_during = template_depth
+        if "<" in line or ">" in line:
+            k = 0
+            L = len(line)
+            while k < L:
+                ch = line[k]
+                if k < len(line_mask) and line_mask[k] != "c":
+                    k += 1
+                    continue
+                if ch == "<":
+                    if k + 1 < L and line[k + 1] in "<=":
+                        k += 2
+                        continue
+                    template_depth += 1
+                    if template_depth > max_depth_during:
+                        max_depth_during = template_depth
+                    k += 1
+                    continue
+                if ch == ">":
+                    if k + 1 < L and line[k + 1] == "=":
+                        k += 2
+                        continue
+                    if k + 1 < L and line[k + 1] == ">":
+                        if template_depth >= 2:
+                            template_depth -= 2
+                        k += 2
+                        continue
+                    if template_depth > 0:
+                        template_depth -= 1
+                    k += 1
+                    continue
+                k += 1
+
+        stripped_end = line.rstrip()
+        ends_with_continuation = bool(stripped_end) and stripped_end.endswith(
+            (",", "\\")
+        )
+        # A single-line `<` (comparison operator) that leaves
+        # max_depth_during > 0 must NOT suppress long-line on its own line.
+        # Only treat max_depth_during as evidence of template context when
+        # the line looks like an opener of a multi-line parameter list,
+        # i.e. it ends in a continuation token.
+        in_template_context = (
+            start_template_depth > 0
+            or (max_depth_during > 0 and ends_with_continuation)
+            or _TEMPLATE_WORD.search(line) is not None
+        )
+        if stripped_end and not ends_with_continuation:
+            template_depth = 0
+
+        visual_len = len(line.expandtabs(2))
+        if visual_len > MAX_LINE and not in_template_context:
+            ls = line.lstrip()
+            if not (ls.startswith("#include") or "://" in line):
+                diags.append(
+                    Diag(
+                        i,
+                        MAX_LINE + 1,
+                        "long-line",
+                        f"line is {visual_len} > {MAX_LINE} cols",
+                        False,
+                    )
+                )
+
+        fixed_lines: "list[str] | None" = None
+        if not _is_template_context_line(line):
+            for rgx, code, msg, split in _BRACE_FIX_RULES:
+                match = rgx.match(line)
+                if match:
+                    diags.append(Diag(i, 1, code, msg, True))
+                    if fix:
+                        fixed_lines = split(match)
+                    break
+        else:
+            if TRAILING_BRACE.match(line):
+                diags.append(
+                    Diag(i, 1, "brace-same-line", "opening brace should be on its own line", False)
+                )
+            elif BRACE_ELSE_SAMELINE.match(line):
+                diags.append(
+                    Diag(i, 1, "brace-else", "`} else` should be split across lines", False)
+                )
+
+        emit_lines = fixed_lines if fixed_lines is not None else [line]
+
+        for el in emit_lines:
+            if not el or el.isspace():
+                blank_run += 1
+                if blank_run == 3:
+                    diags.append(
+                        Diag(i, 1, "blank-run", "3+ consecutive blank lines", True)
+                    )
+                if fix and blank_run >= 3:
+                    continue
+            else:
+                blank_run = 0
+            new_body.append(el)
+
+    new_text = "\n".join(new_body)
+    if new_body and (trailing_newline or fix):
+        new_text += "\n"
+
+    return (new_text if fix else text), diags
+
+
+# ===========================================================================
+# Atomic file writes
+# ===========================================================================
+
+def atomic_write(path: str, content: str) -> None:
+    """Write `content` to `path` atomically via tempfile + os.replace.
+
+    Preserves the target file's mode bits on POSIX. Cleans up the temp
+    file on any exception, including KeyboardInterrupt, which is why the
+    `except` catches BaseException.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    try:
+        original_mode = os.stat(path).st_mode & 0o7777
+    except FileNotFoundError:
+        original_mode = None
+
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".style_lint.", suffix=".tmp", dir=directory
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+        if original_mode is not None:
+            try:
+                os.chmod(tmp_path, original_mode)
+            except OSError:
+                pass
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ===========================================================================
+# File I/O: encoding detection and full file processing
+# ===========================================================================
+
+def read_source(path: str) -> "tuple[str, str]":
+    """Decode `path` and return (text, encoding_name).
+
+    Returned encoding is one of 'utf-16', 'utf-8-sig', 'utf-8'. Raises
+    UnicodeDecodeError on unsupported encodings.
+    """
+    with open(path, "rb") as f:
+        raw = f.read()
+    if raw.startswith(codecs.BOM_UTF16_LE) or raw.startswith(codecs.BOM_UTF16_BE):
+        return raw.decode("utf-16"), "utf-16"
+    if raw.startswith(codecs.BOM_UTF8):
+        return raw.decode("utf-8-sig"), "utf-8-sig"
+    return raw.decode("utf-8"), "utf-8"
+
+
+def process_file(path: str, fix: bool) -> "list[Diag]":
+    """Read, lint, and (in fix mode) rewrite a single file."""
+    try:
+        text, encoding = read_source(path)
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped ({e})", file=sys.stderr)
+        return []
+
+    diags: list[Diag] = []
+    if encoding != "utf-8":
+        diags.append(
+            Diag(1, 1, "encoding", f"file is {encoding}, expected utf-8", True)
+        )
+
+    new_text, lint_diags = lint_text(text, fix)
+    diags.extend(lint_diags)
+
+    if fix and (new_text != text or encoding != "utf-8"):
+        atomic_write(path, new_text)
+
+    return diags
+
+
+# ===========================================================================
+# File discovery + CLI
+# ===========================================================================
+
+def iter_sources(paths: Iterable[str]) -> Iterable[str]:
+    for p in paths:
+        if os.path.isfile(p):
+            yield p
+        elif os.path.isdir(p):
+            for root, dirs, files in os.walk(p):
+                dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+                for f in files:
+                    if f in EXCLUDE_FILES:
+                        continue
+                    if f.endswith(SOURCE_EXTS):
+                        yield os.path.join(root, f)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Lightweight style linter for mlpack C++ sources."
+    )
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--fix", action="store_true", help="apply safe rewrites in place"
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="report-only; exit 1 only if a fixable issue exists (CI mode)",
+    )
+    ap.add_argument("paths", nargs="+")
+    args = ap.parse_args()
+
+    fixable_total = 0
+    other_total = 0
+    for path in iter_sources(args.paths):
+        diags = process_file(path, fix=args.fix)
+        for d in diags:
+            if args.fix and d.fixable:
+                continue
+            print(f"{path}:{d.line}:{d.col}: {d.code}: {d.msg}")
+        fixable_total += sum(1 for d in diags if d.fixable)
+        other_total += sum(1 for d in diags if not d.fixable)
+
+    if args.fix:
+        return 1 if other_total else 0
+    if args.check:
+        return 1 if fixable_total else 0
+    return 1 if (fixable_total + other_total) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint/test_style_lint.py
+++ b/scripts/lint/test_style_lint.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/style_lint.py.
+"""Tests for scripts/lint/style_lint.py.
 
 `classify(text)` should return a mask string the same length as `text`:
   'c' = code, 's' = string or char literal, '/' = comment.
@@ -566,6 +566,32 @@ class TestEdgeCases(unittest.TestCase):
             msg=f"long line with `<` was incorrectly suppressed; diags={diags}",
         )
 
+    def test_long_line_not_suppressed_by_template_in_comment(self):
+        # A comment containing the word `template` must not suppress
+        # long-line on its own line. The word must be in code to count.
+        long_line = "// template " + ("x" * 90)
+        self.assertGreater(len(long_line), 80)
+        _, diags = sl.lint_text(long_line + "\n", fix=False)
+        self.assertTrue(
+            any(d.code == "long-line" for d in diags),
+            msg="comment with 'template' wrongly suppressed long-line",
+        )
+
+    def test_kw_paren_fix_keeps_mask_aligned_for_later_rules(self):
+        # Rewriting `if(` to `if (` lengthens the line by one character.
+        # Subsequent rules (template-depth scan, long-line check, brace
+        # placement) must still see a line_mask that matches the rewritten
+        # line. This exercises the parallel `mask_pieces` path in the
+        # kw-paren fix. If the mask drifts, the `<` inside the string below
+        # would be counted as a template open, potentially suppressing the
+        # long-line diagnostic on this same line.
+        long_suffix = " + " + "very_long_name_abcdefgh" * 4
+        text = 'if(x) "<<<<<" a' + long_suffix + ";\n"
+        new_text, diags = sl.lint_text(text, fix=True)
+        self.assertIn("if (", new_text)
+        self.assertTrue(any(d.code == "long-line" for d in diags))
+
+
     def test_template_identifier_not_false_positive(self):
         # `myTemplateCount` is an identifier that contains the substring
         # 'template'. The old substring check would skip the brace fix on
@@ -584,6 +610,29 @@ class TestEdgeCases(unittest.TestCase):
         new_text, diags = sl.lint_text(text, fix=True)
         self.assertIn("if (myTemplateCount < 10)\n{", new_text)
         self.assertTrue(any(d.code == "brace-same-line" for d in diags))
+
+
+class TestIterSourcesFiltersExplicitFiles(unittest.TestCase):
+    def test_explicit_excluded_file_is_filtered(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "catch.hpp")
+            with open(p, "w") as f:
+                f.write("int x;\n")
+            self.assertEqual(list(sl.iter_sources([p])), [])
+
+    def test_explicit_non_source_extension_is_filtered(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "note.txt")
+            with open(p, "w") as f:
+                f.write("not C++\n")
+            self.assertEqual(list(sl.iter_sources([p])), [])
+
+    def test_explicit_source_file_is_yielded(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "foo.hpp")
+            with open(p, "w") as f:
+                f.write("int x;\n")
+            self.assertEqual(list(sl.iter_sources([p])), [p])
 
 
 if __name__ == "__main__":

--- a/scripts/lint/test_style_lint.py
+++ b/scripts/lint/test_style_lint.py
@@ -596,15 +596,15 @@ class TestEdgeCases(unittest.TestCase):
         # `myTemplateCount` is an identifier that contains the substring
         # 'template'. The old substring check would skip the brace fix on
         # this line; the word-boundary regex must let it through.
-        self.assertFalse(
-            sl._is_template_context_line("int myTemplateCount = 0;")
-        )
-        self.assertFalse(
-            sl._is_template_context_line("void templateRegistration();")
-        )
-        self.assertTrue(
-            sl._is_template_context_line("template<typename T> void foo();")
-        )
+        def ctx(line: str) -> bool:
+            return sl._is_template_context_line(line, sl.classify(line))
+
+        self.assertFalse(ctx("int myTemplateCount = 0;"))
+        self.assertFalse(ctx("void templateRegistration();"))
+        self.assertTrue(ctx("template<typename T> void foo();"))
+        # `template` appearing only inside a trailing comment must not
+        # suppress brace fixes.
+        self.assertFalse(ctx("if (x) { // template specialization"))
 
         text = "if (myTemplateCount < 10) {\n  y;\n}\n"
         new_text, diags = sl.lint_text(text, fix=True)

--- a/scripts/lint/test_style_lint.py
+++ b/scripts/lint/test_style_lint.py
@@ -1,0 +1,590 @@
+"""Tests for scripts/style_lint.py.
+
+`classify(text)` should return a mask string the same length as `text`:
+  'c' = code, 's' = string or char literal, '/' = comment.
+
+`lint_text(text, fix=True)` must only auto-fix inside code regions.
+
+`atomic_write(path, content)` writes via a temp file + os.replace.
+"""
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import style_lint as sl  # noqa: E402
+
+
+class TestClassify(unittest.TestCase):
+    def assertMask(self, text, expected):
+        got = sl.classify(text)
+        self.assertEqual(
+            got, expected, f"\ntext:     {text!r}\ngot:      {got}\nexpected: {expected}"
+        )
+
+    def test_plain_code(self):
+        self.assertMask("if (x)", "cccccc")
+
+    def test_simple_string(self):
+        self.assertMask('"abc"', "sssss")
+
+    def test_code_and_string(self):
+        self.assertMask('x="ab"', "ccssss")
+
+    def test_line_comment(self):
+        self.assertMask("x//y", "c///")
+
+    def test_line_comment_ends_at_newline(self):
+        self.assertMask("x//y\nz", "c///\nc")
+
+    def test_block_comment_single_line(self):
+        self.assertMask("/*x*/y", "/////c")
+
+    def test_block_comment_multiline(self):
+        self.assertMask("a/*\nx\n*/b", "c//\n/\n//c")
+
+    def test_char_literal(self):
+        self.assertMask("'a'", "sss")
+
+    def test_escaped_quote_in_string(self):
+        # "a\"b" -> 6 chars, all string
+        self.assertMask('"a\\"b"', "ssssss")
+
+    def test_slashslash_inside_string_is_not_comment(self):
+        self.assertMask('"//"', "ssss")
+
+    def test_star_slash_inside_string_does_not_end_block_comment(self):
+        # Start outside; string contains "*/" which must not be seen as end.
+        self.assertMask('x="*/";', "ccssssc")
+
+    def test_raw_string_simple(self):
+        # R"(ab)"
+        self.assertMask('R"(ab)"', "sssssss")
+
+    def test_raw_string_multiline(self):
+        # R"(a\nb)". The newline inside the raw string stays as a newline in
+        # the mask so per-line splits line up; surrounding chars are string.
+        self.assertMask('R"(a\nb)"', "ssss\nsss")
+
+    def test_raw_string_with_delimiter(self):
+        # R"xx(a)"b)xx"
+        text = 'R"xx(a)"b)xx"'
+        self.assertMask(text, "s" * len(text))
+
+    def test_raw_string_slash_slash_inside(self):
+        # `//` inside raw string is content, not comment.
+        self.assertMask('R"(//)"', "sssssss")
+
+    def test_u8_raw_string(self):
+        # u8R"(a)". The u8 prefix is classified as code, which is safe
+        # because nothing we rewrite matches it. The raw-string body is 's'.
+        self.assertMask('u8R"(a)"', "ccssssss")
+
+    def test_block_comment_with_slash_slash_inside(self):
+        self.assertMask("/*//*/", "//////")
+
+
+class TestLintFixesSkipNonCode(unittest.TestCase):
+    def test_fix_rewrites_if_paren_in_code(self):
+        text = "if(x)\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "if (x)\n")
+
+    def test_fix_does_not_rewrite_if_paren_in_string(self):
+        text = 'const char* msg = "if(x) failed";\n'
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_fix_does_not_rewrite_if_paren_in_line_comment(self):
+        text = "int a = 0; // uses if(x) internally\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_fix_does_not_rewrite_if_paren_in_block_comment(self):
+        text = "/* if(x) */ int a = 0;\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_fix_does_not_rewrite_if_paren_in_raw_string(self):
+        text = 'auto s = R"(if(x))";\n'
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_fix_preserves_tabs_inside_string(self):
+        text = 'auto s = "a\tb";\n'
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_fix_converts_tab_in_code(self):
+        # Tab at column 3 expands to the next multiple of 2 (column 4) = 1 space.
+        text = "int\ta = 0;\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "int a = 0;\n")
+
+    def test_fix_skips_trailing_ws_inside_raw_string(self):
+        # Trailing whitespace on a line whose tail is inside a raw string
+        # must not be stripped; it is real string content.
+        text = 'auto s = R"(a   \nb)";\n'
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_fix_strips_trailing_ws_on_code_line(self):
+        text = "int a = 0;   \n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "int a = 0;\n")
+
+    def test_fix_adds_eof_newline(self):
+        text = "int a = 0;"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "int a = 0;\n")
+
+    def test_fix_normalises_crlf(self):
+        text = "int a = 0;\r\nint b = 1;\r\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "int a = 0;\nint b = 1;\n")
+
+    def test_report_mode_does_not_mutate(self):
+        text = "if(x)\n"
+        new_text, diags = sl.lint_text(text, fix=False)
+        self.assertEqual(new_text, text)
+        self.assertTrue(any(d.code == "kw-paren" for d in diags))
+
+
+class TestBraceFix(unittest.TestCase):
+    def test_fix_if_glued_brace(self):
+        text = "  if (x) {\n    y;\n  }\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "  if (x)\n  {\n    y;\n  }\n")
+
+    def test_fix_for_glued_brace(self):
+        text = "  for (int i = 0; i < n; ++i) {\n    y;\n  }\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "  for (int i = 0; i < n; ++i)\n  {\n    y;\n  }\n")
+
+    def test_fix_while_glued_brace(self):
+        text = "while (x) {\n}\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "while (x)\n{\n}\n")
+
+    def test_fix_do_glued_brace(self):
+        text = "  do {\n    y;\n  } while (x);\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "  do\n  {\n    y;\n  } while (x);\n")
+
+    def test_fix_try_glued_brace(self):
+        text = "try {\n}\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "try\n{\n}\n")
+
+    def test_fix_else_glued_brace(self):
+        text = "  } else {\n    y;\n  }\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "  }\n  else\n  {\n    y;\n  }\n")
+
+    def test_fix_else_if_glued_brace(self):
+        text = "  } else if (x) {\n    y;\n  }\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "  }\n  else if (x)\n  {\n    y;\n  }\n")
+
+    def test_fix_else_without_brace(self):
+        # `} else` on its own, followed by a block below, should split `}` off.
+        text = "  } else\n  {\n    y;\n  }\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "  }\n  else\n  {\n    y;\n  }\n")
+
+    def test_skip_brace_fix_in_template_context(self):
+        # Line contains `template<`: do not touch, reserved for human.
+        text = "template<typename T> void Foo() {\n}\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_skip_brace_fix_with_template_arg(self):
+        # `if (std::is_same<A, B>::value) {` has template args in the
+        # condition, so leave it alone.
+        text = "if (std::is_same<A, B>::value) {\n}\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_brace_fix_does_not_touch_lambda(self):
+        # Lambda `[](int x) { return x; }` is not control flow, so no fix.
+        text = "auto f = [](int x) { return x; };\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+    def test_brace_fix_ignores_glued_brace_in_string(self):
+        text = 'const char* s = "if (x) {";\n'
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+
+class TestBlankRunFix(unittest.TestCase):
+    def test_collapses_four_blanks_to_two(self):
+        text = "a;\n\n\n\n\nb;\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, "a;\n\n\nb;\n")
+
+    def test_two_blanks_untouched(self):
+        text = "a;\n\n\nb;\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertEqual(new_text, text)
+
+
+class TestLongLineTemplateSuppression(unittest.TestCase):
+    def _mk_long(self, prefix: str) -> str:
+        # Build a line of >80 cols by padding with identifiers/commas.
+        line = prefix
+        while len(line) <= 80:
+            line += "LongNameX, "
+        return line.rstrip(", ")
+
+    def test_long_line_flagged_in_plain_code(self):
+        line = "int foo = " + "a + " * 25 + "0;"
+        text = line + "\n"
+        _, diags = sl.lint_text(text, fix=False)
+        self.assertTrue(any(d.code == "long-line" for d in diags))
+
+    def test_long_line_suppressed_on_template_keyword_line(self):
+        line = "template<typename " + "LongName, typename " * 5 + "Last>"
+        self.assertGreater(len(line), 80)
+        _, diags = sl.lint_text(line + "\n", fix=False)
+        self.assertFalse(any(d.code == "long-line" for d in diags))
+
+    def test_long_line_suppressed_on_template_continuation(self):
+        # First line opens template<...> without closing on same line; second
+        # line is inside the template parameter list and too long.
+        text = (
+            "template<typename A,\n"
+            "         typename " + "LongName" * 10 + ">\n"
+            "void foo();\n"
+        )
+        _, diags = sl.lint_text(text, fix=False)
+        long_diags = [d for d in diags if d.code == "long-line"]
+        self.assertEqual(long_diags, [])
+
+    def test_comparison_op_does_not_poison_subsequent_lines(self):
+        # `<` as a less-than operator must not leave template_depth high
+        # for the rest of the file. Subsequent plain long lines must still
+        # be reported.
+        long_line = "int foo = " + "a + " * 25 + "0;"
+        text = "if (x < y) { f(); }\n" + long_line + "\n"
+        _, diags = sl.lint_text(text, fix=False)
+        self.assertTrue(
+            any(d.code == "long-line" for d in diags),
+            "long line after an `<` comparison should still be flagged",
+        )
+
+    def test_for_loop_comparison_does_not_poison_subsequent_lines(self):
+        long_line = "int foo = " + "a + " * 25 + "0;"
+        text = "for (int i = 0; i < n; ++i) {}\n" + long_line + "\n"
+        _, diags = sl.lint_text(text, fix=False)
+        self.assertTrue(any(d.code == "long-line" for d in diags))
+
+    def test_long_line_suppressed_on_template_qualified_name(self):
+        # `NeighborSearch<A, B, C,\n` opens angle brackets, so it stays
+        # in template territory on the following line.
+        text = (
+            "NeighborSearch<SortPolicy, DistanceType, MatType, TreeType,\n"
+            "    DualTreeTraversalType>::NeighborSearch(int a, int b, int c, int d, int e);\n"
+        )
+        _, diags = sl.lint_text(text, fix=False)
+        long_diags = [d for d in diags if d.code == "long-line"]
+        self.assertEqual(long_diags, [])
+
+
+class TestExclusions(unittest.TestCase):
+    def test_bundled_dir_excluded(self):
+        with tempfile.TemporaryDirectory() as td:
+            os.makedirs(os.path.join(td, "a", "bundled"))
+            os.makedirs(os.path.join(td, "a", "real"))
+            p1 = os.path.join(td, "a", "bundled", "x.hpp")
+            p2 = os.path.join(td, "a", "real", "y.hpp")
+            for p in (p1, p2):
+                with open(p, "w") as f:
+                    f.write("int x;\n")
+            found = set(sl.iter_sources([td]))
+            self.assertIn(p2, found)
+            self.assertNotIn(p1, found)
+
+    def test_vendored_files_excluded_by_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            catch = os.path.join(td, "catch.hpp")
+            normal = os.path.join(td, "normal.hpp")
+            for p in (catch, normal):
+                with open(p, "w") as f:
+                    f.write("int x;\n")
+            # When passed a directory, catch.hpp should be skipped.
+            found = set(sl.iter_sources([td]))
+            self.assertIn(normal, found)
+            self.assertNotIn(catch, found)
+
+    def test_cereal_dir_excluded(self):
+        with tempfile.TemporaryDirectory() as td:
+            os.makedirs(os.path.join(td, "core", "cereal"))
+            p = os.path.join(td, "core", "cereal", "x.hpp")
+            with open(p, "w") as f:
+                f.write("int x;\n")
+            found = set(sl.iter_sources([td]))
+            self.assertNotIn(p, found)
+
+
+class TestReadSource(unittest.TestCase):
+    def _write(self, td, name, raw):
+        p = os.path.join(td, name)
+        with open(p, "wb") as f:
+            f.write(raw)
+        return p
+
+    def test_plain_utf8(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, "f.hpp", b"int x = 0;\n")
+            text, enc = sl.read_source(p)
+            self.assertEqual(text, "int x = 0;\n")
+            self.assertEqual(enc, "utf-8")
+
+    def test_utf8_with_bom(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, "f.hpp", b"\xef\xbb\xbfint x = 0;\n")
+            text, enc = sl.read_source(p)
+            self.assertEqual(text, "int x = 0;\n")  # BOM stripped
+            self.assertEqual(enc, "utf-8-sig")
+
+    def test_utf16_le_bom(self):
+        with tempfile.TemporaryDirectory() as td:
+            raw = b"\xff\xfe" + "int x = 0;\n".encode("utf-16-le")
+            p = self._write(td, "f.hpp", raw)
+            text, enc = sl.read_source(p)
+            self.assertEqual(text, "int x = 0;\n")
+            self.assertEqual(enc, "utf-16")
+
+    def test_utf16_be_bom(self):
+        with tempfile.TemporaryDirectory() as td:
+            raw = b"\xfe\xff" + "int x = 0;\n".encode("utf-16-be")
+            p = self._write(td, "f.hpp", raw)
+            text, enc = sl.read_source(p)
+            self.assertEqual(text, "int x = 0;\n")
+            self.assertEqual(enc, "utf-16")
+
+    def test_binary_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, "f.hpp", b"\x80\x81\x82\x83 invalid utf-8")
+            with self.assertRaises(UnicodeDecodeError):
+                sl.read_source(p)
+
+
+class TestProcessFile(unittest.TestCase):
+    def test_fix_rewrites_utf16_as_utf8(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            content = "int x = 0;\n"
+            with open(p, "wb") as f:
+                f.write(b"\xff\xfe" + content.encode("utf-16-le"))
+            diags = sl.process_file(p, fix=True)
+            with open(p, "rb") as f:
+                raw = f.read()
+            self.assertEqual(raw, content.encode("utf-8"))
+            self.assertTrue(any(d.code == "encoding" for d in diags))
+
+    def test_fix_strips_utf8_bom(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            with open(p, "wb") as f:
+                f.write(b"\xef\xbb\xbfint x = 0;\n")
+            sl.process_file(p, fix=True)
+            with open(p, "rb") as f:
+                self.assertEqual(f.read(), b"int x = 0;\n")
+
+    def test_report_mode_does_not_rewrite(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            original = b"\xff\xfe" + "int x = 0;\n".encode("utf-16-le")
+            with open(p, "wb") as f:
+                f.write(original)
+            diags = sl.process_file(p, fix=False)
+            with open(p, "rb") as f:
+                self.assertEqual(f.read(), original)
+            self.assertTrue(any(d.code == "encoding" for d in diags))
+
+    def test_utf8_file_untouched_when_no_lint_changes(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            with open(p, "wb") as f:
+                f.write(b"int x = 0;\n")
+            sl.process_file(p, fix=True)
+            # Clean utf-8 file with no diagnostics should NOT be rewritten.
+            # (Checking via content is sufficient; mtime is racy.)
+            with open(p, "rb") as f:
+                self.assertEqual(f.read(), b"int x = 0;\n")
+
+
+class TestCheckMode(unittest.TestCase):
+    """--check is the CI-facing variant: no rewrites, exit 1 only if
+    something fixable exists. Baseline long-line warnings must not trip it.
+    """
+
+    def test_fixable_diagnostic_is_reported_but_file_untouched(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            with open(p, "wb") as f:
+                f.write(b"if(x) { y; }\n")
+            diags = sl.process_file(p, fix=False)
+            self.assertTrue(any(d.fixable for d in diags))
+            with open(p, "rb") as f:
+                self.assertEqual(f.read(), b"if(x) { y; }\n")
+
+    def test_long_line_only_file_has_no_fixable(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            with open(p, "w") as f:
+                f.write("// " + ("x" * 90) + "\n")
+            diags = sl.process_file(p, fix=False)
+            self.assertFalse(any(d.fixable for d in diags))
+
+    def test_check_main_passes_on_long_line_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            with open(p, "w") as f:
+                f.write("// " + ("x" * 90) + "\n")
+            script = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "style_lint.py"
+            )
+            r = subprocess.run(
+                [sys.executable, script, "--check", td],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+
+    def test_check_main_fails_on_fixable(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.hpp")
+            with open(p, "wb") as f:
+                f.write(b"if(x) { y; }\n")
+            script = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "style_lint.py"
+            )
+            r = subprocess.run(
+                [sys.executable, script, "--check", td],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(r.returncode, 1, msg=r.stdout + r.stderr)
+            with open(p, "rb") as f:
+                self.assertEqual(f.read(), b"if(x) { y; }\n")
+
+
+class TestAtomicWrite(unittest.TestCase):
+    def test_overwrites_existing_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.txt")
+            with open(p, "w") as f:
+                f.write("old content")
+            sl.atomic_write(p, "new content")
+            with open(p) as f:
+                self.assertEqual(f.read(), "new content")
+
+    def test_no_temp_file_left_behind_on_success(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.txt")
+            sl.atomic_write(p, "hello")
+            self.assertEqual(os.listdir(td), ["f.txt"])
+
+    def test_preserves_file_mode(self):
+        if sys.platform == "win32":
+            self.skipTest("POSIX file modes not meaningful on Windows")
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, "f.txt")
+            with open(p, "w") as f:
+                f.write("old")
+            os.chmod(p, 0o640)
+            sl.atomic_write(p, "new")
+            got = stat.S_IMODE(os.stat(p).st_mode)
+            self.assertEqual(got, 0o640)
+
+
+class TestDigitSeparators(unittest.TestCase):
+    """C++14 lets `'` act as a digit separator inside numeric literals.
+    The tokenizer must not mistake those for char-literal openers."""
+
+    def test_decimal_separator(self):
+        # 1'000 is a pp-number; the apostrophe is code, not a char-lit
+        # start, so the trailing semicolon must stay code.
+        mask = sl.classify("int x = 1'000;")
+        self.assertEqual(mask[-1], "c")
+        self.assertNotIn("s", mask)
+
+    def test_hex_separator(self):
+        mask = sl.classify("auto m = 0xFF'00'FF;")
+        self.assertEqual(mask[-1], "c")
+        self.assertNotIn("s", mask)
+
+    def test_odd_number_of_separators_does_not_poison_semicolon(self):
+        mask = sl.classify("auto m = 0xFF'00'FF'00;")
+        self.assertEqual(mask[-1], "c")
+
+    def test_u8_char_literal_is_not_a_separator(self):
+        # u8'a' is a UTF-8 char literal. The `'` must open a char-lit
+        # even though the preceding char (`8`) is a digit.
+        mask = sl.classify("auto c = u8'a';")
+        self.assertIn("s", mask)
+        self.assertEqual(mask[-1], "c")
+
+    def test_L_char_literal(self):
+        mask = sl.classify("wchar_t c = L'x';")
+        self.assertIn("s", mask)
+
+    def test_fix_rewrites_if_paren_after_digit_separator(self):
+        text = "int m = 1'000; if(x) { y; }\n"
+        new_text, _ = sl.lint_text(text, fix=True)
+        self.assertIn("if (", new_text)
+        self.assertIn("1'000", new_text)
+
+
+class TestEdgeCases(unittest.TestCase):
+    def test_empty_file(self):
+        new_text, diags = sl.lint_text("", fix=True)
+        self.assertEqual(new_text, "")
+        self.assertEqual(diags, [])
+
+    def test_lone_newline(self):
+        new_text, diags = sl.lint_text("\n", fix=True)
+        self.assertEqual(new_text, "\n")
+        self.assertEqual([d.code for d in diags], [])
+
+    def test_long_line_with_less_than_comparison_is_flagged(self):
+        # A single-line `<` comparison must not suppress long-line on
+        # its own line. This is the regression test for the template
+        # context heuristic that used to trip on any `<`.
+        long_cond = "if (a < " + "bbbbbbbb + " * 8 + "0) { }"
+        self.assertGreater(len(long_cond), 80)
+        _, diags = sl.lint_text(long_cond + "\n", fix=False)
+        self.assertTrue(
+            any(d.code == "long-line" for d in diags),
+            msg=f"long line with `<` was incorrectly suppressed; diags={diags}",
+        )
+
+    def test_template_identifier_not_false_positive(self):
+        # `myTemplateCount` is an identifier that contains the substring
+        # 'template'. The old substring check would skip the brace fix on
+        # this line; the word-boundary regex must let it through.
+        self.assertFalse(
+            sl._is_template_context_line("int myTemplateCount = 0;")
+        )
+        self.assertFalse(
+            sl._is_template_context_line("void templateRegistration();")
+        )
+        self.assertTrue(
+            sl._is_template_context_line("template<typename T> void foo();")
+        )
+
+        text = "if (myTemplateCount < 10) {\n  y;\n}\n"
+        new_text, diags = sl.lint_text(text, fix=True)
+        self.assertIn("if (myTemplateCount < 10)\n{", new_text)
+        self.assertTrue(any(d.code == "brace-same-line" for d in diags))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a small Python linter under `scripts/lint/` that targets the narrow class of mechanical C++ style issues where `clang-format` overreaches on mlpack's heavy template code. It fixes trailing whitespace, tabs, `if(`/`for(`/`while(` spacing, Allman brace placement, blank line runs, CRLF, missing EOF newlines, and non-UTF-8 source encodings. Long lines are reported but never auto-wrapped, since wrapping template argument lists is a judgment call that belongs to the maintainer.

Every rewrite is gated on a single-pass C++ tokenizer that masks string literals, character literals, raw strings (including `u8R`/`uR`/`UR`/`LR` prefixes and custom delimiters), comments, and C++14 digit separators. A string like `const char* msg = "if(x) failed";` passes through `--fix` completely untouched while the same `if(` in code becomes `if (`. Long-line detection tracks angle-bracket depth across lines so template parameter lists and multi-line instantiations are correctly suppressed, while single-line comparison operators do not poison the rest of the file. Writes are atomic via `tempfile` plus `os.replace` and preserve the original file's POSIX mode bits.

The linter has three modes: plain invocation reports everything and fails on any finding, `--fix` applies mechanical rewrites in place, and `--check` is the CI-facing variant that reports every diagnostic for visibility but only exits non-zero on auto-fixable issues so baseline long-line warnings do not block PRs. The companion workflow at `.github/workflows/style-lint.yml` runs the linter's 78-case unittest suite and then `--check` on the full tree.

Runtime on the full mlpack tree (1549 source files after exclusions), measured on an M-series Mac:

| Mode | Wall | User CPU |
|---|---|---|
| `--check` | 1.55s | 1.67s |
| `--fix` | 1.94s | 1.71s |

Nothing under `src/` changes in this PR. Next steps are a follow-up PR that runs `--fix` against the existing tree so the cleanup diff can be reviewed by a human, after which the CI check will start blocking new regressions on `master`.

We ran `--fix` on a separate repo; see the resulting changes here: [coatless-mlpack/mlpack-format-test `style-lint-fix`](https://github.com/coatless-mlpack/mlpack-format-test/compare/master...style-lint-fix).