### PR TITLE
ci: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,13 +322,13 @@ jobs:
         run: mkdir exe_archive && cp -r build/*.exe exe_archive/
 
       - name: Publish Windows no-libs archive
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: mlpack-windows-vs17-no-libs
           path: exe_archive/
 
       - name: Publish Windows libs archive
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: mlpack-windows-vs17
           path: build/
@@ -396,7 +396,7 @@ jobs:
               mlpack-win-installer.wixproj
 
       - name: Publish MSI installer
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: mlpack-windows-installer
           path: dist/win-installer/mlpack-win-installer/bin/x64/Release/mlpack-windows.msi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 7


### PR DESCRIPTION
Updates pinned GitHub Actions in `.github/workflows/` to their latest major versions.

- `actions/upload-artifact` v4.4.0 → v7 (in `ci.yml`)
- `actions/stale` v9 → v10 (in `stale.yml`)

Note: `r-lib/actions/*` and `rcurtin/actions/*` are unchanged (no new releases). Other `actions/*` already on current majors upstream.