### PR TITLE
Loosen LMNN tolerance just a bit

### DIFF
--- a/src/mlpack/tests/ann/recurrent_network_test.cpp
+++ b/src/mlpack/tests/ann/recurrent_network_test.cpp
@@ -569,6 +569,9 @@ TEST_CASE("SequenceClassificationTest", "[RecurrentNetworkTest]")
   // specified number of iterations using random weights. If this works 1 of 5
   // times, I'm fine with that. All I want to know is that the network is able
   // to escape from local minima and to solve the task.
+  //
+  // (Note: in the strong majority of cases, this passes on the first trial.
+  // Over tons of different trials, though, sometimes it can take a few!)
   size_t successes = 0;
   const size_t rho = 10;
 
@@ -586,7 +589,7 @@ TEST_CASE("SequenceClassificationTest", "[RecurrentNetworkTest]")
     model.Add<Linear>(2);
     model.Add<LogSoftMax>();
 
-    StandardSGD opt(0.005, 16, 15 * input.n_cols, -100);
+    StandardSGD opt(0.0075, 16, 25 * input.n_cols, -100);
     model.Train(input, labels, opt);
 
     arma::cube predictions;

--- a/src/mlpack/tests/lmnn_test.cpp
+++ b/src/mlpack/tests/lmnn_test.cpp
@@ -544,8 +544,8 @@ TEMPLATE_TEST_CASE("LMNNLowRankAccuracyLBFGSTest", "[LMNNTest]", float, double)
     double acc2 = KnnAccuracy(transformedData, labels, 1);
 
     // We keep the tolerance very high.  We need to ensure the accuracy drop
-    // isn't any more than 10%.
-    success = ((acc1 - acc2) <= 10.0);
+    // isn't any more than 12.5%.
+    success = ((acc1 - acc2) <= 12.5);
     if (success)
       break;
   }
@@ -603,8 +603,8 @@ TEMPLATE_TEST_CASE("LMNNLowRankAccuracyTest", "[LMNNTest]", float, double)
     double acc2 = KnnAccuracy(transformedData, labels, 1);
 
     // We keep the tolerance very high.  We need to ensure the accuracy drop
-    // isn't any more than 10%.
-    success = ((acc1 - acc2) <= 10.0);
+    // isn't any more than 12.5%.
+    success = ((acc1 - acc2) <= 12.5);
     if (success)
       break;
   }


### PR DESCRIPTION
I noticed that `LMNNLowRankAccuracy` test randomly failed in #4146.  I ran it 1000 times locally and got one failure.  Basically the test first runs LMNN to learn a full-rank distance matrix, and then again to learn a low-rank distance matrix, and checks that the kNN accuracy of the data with the learned low-rank distance measure is not too much worse than the kNN accuracy with the full-rank distance matrix.

After watching what the accuracies typically were (usually a drop of up to 5% kNN accuracy), I chose to loosen it from a 10% accuracy drop to 12.5%.  I don't think anything is wrong algorithmically, I just think the bounds weren't loose enough to begin with.