### PR TITLE
[R] No longer need ARMA_USE_CURRENT as RcppArmadillo defaults to Armadillo (>= 15.0.0)

### DIFF
--- a/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
+++ b/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
@@ -13,11 +13,6 @@
 #ifndef MLPACK_BINDINGS_R_MLPACK_H
 #define MLPACK_BINDINGS_R_MLPACK_H
 
-// With RcppArmadillo 15.0.1-1 or later, prefer current Armadillo
-#if !defined(ARMA_USE_CURRENT)
-  #define ARMA_USE_CURRENT
-#endif
-
 // Armadillo does not provide an official support for unsigned / signed 8 bits
 // integers.
 // Since `char` might be represented differently on various hardware.


### PR DESCRIPTION
The switch was only needed for a transitory period for packages using C++11; mlpack will continue to build fine.
