### PR TITLE
Fix cover tree to actually support different element types.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,8 @@ _????-??-??_
  * Efficiency improvements for `MeanImputation` and `MedianImputation` with
    newer Armadillo versions (#4149).
 
+ * Fix `CoverTree` compilation errors with non-default element types (#4160).
+
 ## mlpack 4.7.0
 
 _2026-01-30_

--- a/src/mlpack/core/tree/cover_tree/cover_tree.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree.hpp
@@ -371,11 +371,18 @@ class CoverTree
   ElemType MinDistance(const CoverTree& other, const ElemType distance) const;
 
   //! Return the minimum distance to another point.
-  ElemType MinDistance(const arma::vec& other) const;
+  template<typename VecType>
+  ElemType MinDistance(
+      const VecType& other,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
   //! Return the minimum distance to another point given that the distance from
   //! the center to the point has already been calculated.
-  ElemType MinDistance(const arma::vec& other, const ElemType distance) const;
+  template<typename VecType>
+  ElemType MinDistance(
+      const VecType& other,
+      const ElemType distance,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
   //! Return the maximum distance to another node.
   ElemType MaxDistance(const CoverTree& other) const;
@@ -385,11 +392,18 @@ class CoverTree
   ElemType MaxDistance(const CoverTree& other, const ElemType distance) const;
 
   //! Return the maximum distance to another point.
-  ElemType MaxDistance(const arma::vec& other) const;
+  template<typename VecType>
+  ElemType MaxDistance(
+      const VecType& other,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
   //! Return the maximum distance to another point given that the distance from
   //! the center to the point has already been calculated.
-  ElemType MaxDistance(const arma::vec& other, const ElemType distance) const;
+  template<typename VecType>
+  ElemType MaxDistance(
+      const VecType& other,
+      const ElemType distance,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
   //! Return the minimum and maximum distance to another node.
   RangeType<ElemType> RangeDistance(const CoverTree& other) const;
@@ -397,15 +411,21 @@ class CoverTree
   //! Return the minimum and maximum distance to another node given that the
   //! point-to-point distance has already been calculated.
   RangeType<ElemType> RangeDistance(const CoverTree& other,
-                                          const ElemType distance) const;
+                                    const ElemType distance) const;
 
   //! Return the minimum and maximum distance to another point.
-  RangeType<ElemType> RangeDistance(const arma::vec& other) const;
+  template<typename VecType>
+  RangeType<ElemType> RangeDistance(
+      const VecType& other,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
   //! Return the minimum and maximum distance to another point given that the
   //! point-to-point distance has already been calculated.
-  RangeType<ElemType> RangeDistance(const arma::vec& other,
-                                          const ElemType distance) const;
+  template<typename VecType>
+  RangeType<ElemType> RangeDistance(
+      const VecType& other,
+      const ElemType distance,
+      const typename std::enable_if_t<IsVector<VecType>::value>* = 0) const;
 
   //! Get the parent node.
   CoverTree* Parent() const { return parent; }
@@ -432,9 +452,9 @@ class CoverTree
   ElemType MinimumBoundDistance() const { return furthestDescendantDistance; }
 
   //! Get the center of the node and store it in the given vector.
-  void Center(arma::vec& center) const
+  void Center(arma::Col<ElemType>& center) const
   {
-    center = arma::vec(dataset->col(point));
+    center = dataset->col(point);
   }
 
   //! Get the instantiated distance metric.

--- a/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/cover_tree_impl.hpp
@@ -937,7 +937,8 @@ CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
   // Every cover tree node will contain points up to base^(scale + 1) away.
   return std::max(distance->Evaluate(dataset->col(point),
       other.Dataset().col(other.Point())) -
-      furthestDescendantDistance - other.FurthestDescendantDistance(), 0.0);
+      furthestDescendantDistance - other.FurthestDescendantDistance(),
+      ElemType(0));
 }
 
 template<
@@ -953,7 +954,7 @@ CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
 {
   // We already have the distance as evaluated by the metric.
   return std::max(distance - furthestDescendantDistance -
-      other.FurthestDescendantDistance(), 0.0);
+      other.FurthestDescendantDistance(), ElemType(0));
 }
 
 template<
@@ -962,13 +963,15 @@ template<
     typename MatType,
     typename RootPointPolicy
 >
+template<typename VecType>
 typename CoverTree<DistanceType, StatisticType, MatType,
     RootPointPolicy>::ElemType
-CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-    MinDistance(const arma::vec& other) const
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::MinDistance(
+    const VecType& other,
+    const typename std::enable_if_t<IsVector<VecType>::value>*) const
 {
   return std::max(distance->Evaluate(dataset->col(point), other) -
-      furthestDescendantDistance, 0.0);
+      furthestDescendantDistance, ElemType(0));
 }
 
 template<
@@ -977,12 +980,15 @@ template<
     typename MatType,
     typename RootPointPolicy
 >
+template<typename VecType>
 typename CoverTree<DistanceType, StatisticType, MatType,
     RootPointPolicy>::ElemType
-CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-    MinDistance(const arma::vec& /* other */, const ElemType distance) const
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::MinDistance(
+    const VecType& /* other */,
+    const ElemType distance,
+    const typename std::enable_if_t<IsVector<VecType>::value>*) const
 {
-  return std::max(distance - furthestDescendantDistance, 0.0);
+  return std::max(distance - furthestDescendantDistance, ElemType(0));
 }
 
 template<
@@ -1023,10 +1029,12 @@ template<
     typename MatType,
     typename RootPointPolicy
 >
+template<typename VecType>
 typename CoverTree<DistanceType, StatisticType, MatType,
     RootPointPolicy>::ElemType
-CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-    MaxDistance(const arma::vec& other) const
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::MaxDistance(
+    const VecType& other,
+    const typename std::enable_if_t<IsVector<VecType>::value>*) const
 {
   return distance->Evaluate(dataset->col(point), other) +
       furthestDescendantDistance;
@@ -1038,10 +1046,13 @@ template<
     typename MatType,
     typename RootPointPolicy
 >
+template<typename VecType>
 typename CoverTree<DistanceType, StatisticType, MatType,
     RootPointPolicy>::ElemType
-CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-    MaxDistance(const arma::vec& /* other */, const ElemType distance) const
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::MaxDistance(
+    const VecType& /* other */,
+    const ElemType distance,
+    const typename std::enable_if_t<IsVector<VecType>::value>*) const
 {
   return distance + furthestDescendantDistance;
 }
@@ -1063,7 +1074,7 @@ CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
 
   RangeType<ElemType> result;
   result.Lo() = std::max(dist - furthestDescendantDistance -
-      other.FurthestDescendantDistance(), 0.0);
+      other.FurthestDescendantDistance(), ElemType(0));
   result.Hi() = dist + furthestDescendantDistance +
       other.FurthestDescendantDistance();
 
@@ -1086,7 +1097,7 @@ CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
 {
   RangeType<ElemType> result;
   result.Lo() = std::max(distance - furthestDescendantDistance -
-      other.FurthestDescendantDistance(), 0.0);
+      other.FurthestDescendantDistance(), ElemType(0));
   result.Hi() = distance + furthestDescendantDistance +
       other.FurthestDescendantDistance();
 
@@ -1100,15 +1111,17 @@ template<
     typename MatType,
     typename RootPointPolicy
 >
+template<typename VecType>
 RangeType<typename
     CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::ElemType>
-CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-    RangeDistance(const arma::vec& other) const
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::RangeDistance(
+    const VecType& other,
+    const typename std::enable_if_t<IsVector<VecType>::value>*) const
 {
   const ElemType dist = distance->Evaluate(dataset->col(point), other);
 
   return RangeType<ElemType>(
-      std::max(dist - furthestDescendantDistance, 0.0),
+      std::max(dist - furthestDescendantDistance, ElemType(0)),
       dist + furthestDescendantDistance);
 }
 
@@ -1120,14 +1133,16 @@ template<
     typename MatType,
     typename RootPointPolicy
 >
+template<typename VecType>
 RangeType<typename
     CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::ElemType>
-CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-    RangeDistance(const arma::vec& /* other */,
-                  const ElemType distance) const
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::RangeDistance(
+    const VecType& /* other */,
+    const ElemType distance,
+    const typename std::enable_if_t<IsVector<VecType>::value>*) const
 {
   return RangeType<ElemType>(
-      std::max(distance - furthestDescendantDistance, 0.0),
+      std::max(distance - furthestDescendantDistance, ElemType(0)),
       distance + furthestDescendantDistance);
 }
 
@@ -1402,8 +1417,8 @@ void CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
   distanceComps += pointSetSize;
   for (size_t i = 0; i < pointSetSize; ++i)
   {
-    distances[i] = distance->Evaluate(dataset->col(pointIndex),
-        dataset->col(indices[i]));
+    distances[i] = double(distance->Evaluate(dataset->col(pointIndex),
+        dataset->col(indices[i])));
   }
 }
 
@@ -1432,7 +1447,7 @@ size_t CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
     return (childFarSetSize + farSetSize);
 
   size_t* indicesBuffer = new size_t[bufferSize];
-  ElemType* distancesBuffer = new ElemType[bufferSize];
+  double* distancesBuffer = new double[bufferSize];
 
   // The start of the memory region to copy to the buffer.
   const size_t bufferFromLocation = ((bufferSize == farSetSize) ?
@@ -1451,19 +1466,19 @@ size_t CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
   memcpy(indicesBuffer, indices.memptr() + bufferFromLocation,
       sizeof(size_t) * bufferSize);
   memcpy(distancesBuffer, distances.memptr() + bufferFromLocation,
-      sizeof(ElemType) * bufferSize);
+      sizeof(double) * bufferSize);
 
   // Now move the other memory.
   memmove(indices.memptr() + directToLocation,
       indices.memptr() + directFromLocation, sizeof(size_t) * bigCopySize);
   memmove(distances.memptr() + directToLocation,
-      distances.memptr() + directFromLocation, sizeof(ElemType) * bigCopySize);
+      distances.memptr() + directFromLocation, sizeof(double) * bigCopySize);
 
   // Now copy the temporary memory to the right place.
   memcpy(indices.memptr() + bufferToLocation, indicesBuffer,
       sizeof(size_t) * bufferSize);
   memcpy(distances.memptr() + bufferToLocation, distancesBuffer,
-      sizeof(ElemType) * bufferSize);
+      sizeof(double) * bufferSize);
 
   delete[] indicesBuffer;
   delete[] distancesBuffer;

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -792,31 +792,35 @@ TEST_CASE("KNNSingleTreeVsNaiveF32", "[KNNTest]")
  *
  * Errors are produced if the results are not identical.
  */
-TEST_CASE("KNNSingleCoverTreeTest", "[KNNTest]")
+TEMPLATE_TEST_CASE("KNNSingleCoverTreeTest", "[KNNTest]", float, double)
 {
-  arma::mat data;
+  typedef TestType eT;
+
+  arma::Mat<eT> data;
   data.randu(75, 1000); // 75 dimensional, 1000 points.
 
   StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> tree(data);
+      arma::Mat<eT>> tree(data);
 
-  NeighborSearch<NearestNeighborSort, LMetric<2>, arma::mat, StandardCoverTree>
-      coverTreeSearch(std::move(tree), SINGLE_TREE);
+  NeighborSearch<NearestNeighborSort, LMetric<2>, arma::Mat<eT>,
+      StandardCoverTree> coverTreeSearch(std::move(tree), SINGLE_TREE);
 
-  KNN naive(data, NAIVE);
+  arma::mat naiveData = arma::conv_to<arma::mat>::from(data);
+  KNN naive(naiveData, NAIVE);
 
   arma::Mat<size_t> coverTreeNeighbors;
-  arma::mat coverTreeDistances;
+  arma::Mat<eT> coverTreeDistances;
   coverTreeSearch.Search(15, coverTreeNeighbors, coverTreeDistances);
 
   arma::Mat<size_t> naiveNeighbors;
   arma::mat naiveDistances;
   naive.Search(15, naiveNeighbors, naiveDistances);
 
+  const eT eps = (std::is_same_v<eT, float> ? 1e-4 : 1e-7);
   for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
   {
     REQUIRE(coverTreeNeighbors[i] ==naiveNeighbors[i]);
-    REQUIRE(coverTreeDistances[i] == Approx(naiveDistances[i]).epsilon(1e-7));
+    REQUIRE(coverTreeDistances[i] == Approx(eT(naiveDistances[i])).epsilon(eps));
   }
 }
 
@@ -824,32 +828,35 @@ TEST_CASE("KNNSingleCoverTreeTest", "[KNNTest]")
  * Test the cover tree dual-tree nearest neighbors method against the naive
  * method.
  */
-TEST_CASE("KNNDualCoverTreeTest", "[KNNTest]")
+TEMPLATE_TEST_CASE("KNNDualCoverTreeTest", "[KNNTest]", float, double)
 {
-  arma::mat dataset;
+  typedef TestType eT;
+
+  arma::Mat<eT> dataset;
   if (!Load("test_data_3_1000.csv", dataset))
     FAIL("Cannot load test dataset test_data_3_1000.csv");
 
-  KNN tree(dataset);
+  KNNType<EuclideanDistance, KDTree, arma::Mat<eT>> tree(dataset);
 
   arma::Mat<size_t> kdNeighbors;
-  arma::mat kdDistances;
+  arma::Mat<eT> kdDistances;
   tree.Search(dataset, 5, kdNeighbors, kdDistances);
 
   StandardCoverTree<EuclideanDistance, NeighborSearchStat<NearestNeighborSort>,
-      arma::mat> referenceTree(dataset);
+      arma::Mat<eT>> referenceTree(dataset);
 
-  NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::mat,
+  NeighborSearch<NearestNeighborSort, EuclideanDistance, arma::Mat<eT>,
       StandardCoverTree> coverTreeSearch(std::move(referenceTree));
 
   arma::Mat<size_t> coverNeighbors;
-  arma::mat coverDistances;
+  arma::Mat<eT> coverDistances;
   coverTreeSearch.Search(dataset, 5, coverNeighbors, coverDistances);
 
+  const eT eps = (std::is_same_v<eT, float> ? 1e-4 : 1e-7);
   for (size_t i = 0; i < coverNeighbors.n_elem; ++i)
   {
-    REQUIRE(coverNeighbors(i) ==kdNeighbors(i));
-    REQUIRE(coverDistances(i) == Approx(kdDistances(i)).epsilon(1e-7));
+    REQUIRE(coverNeighbors(i) == kdNeighbors(i));
+    REQUIRE(coverDistances(i) == Approx(kdDistances(i)).epsilon(eps));
   }
 }
 
@@ -887,7 +894,7 @@ TEST_CASE("KNNSingleBallTreeTest", "[KNNTest]")
 
   for (size_t i = 0; i < ballTreeNeighbors.n_elem; ++i)
   {
-    REQUIRE(ballTreeNeighbors[i] ==naiveNeighbors[i]);
+    REQUIRE(ballTreeNeighbors[i] == naiveNeighbors[i]);
     REQUIRE(ballTreeDistances[i] == Approx(naiveDistances[i]).epsilon(1e-7));
   }
 }

--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -819,8 +819,9 @@ TEMPLATE_TEST_CASE("KNNSingleCoverTreeTest", "[KNNTest]", float, double)
   const eT eps = (std::is_same_v<eT, float> ? 1e-4 : 1e-7);
   for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
   {
-    REQUIRE(coverTreeNeighbors[i] ==naiveNeighbors[i]);
-    REQUIRE(coverTreeDistances[i] == Approx(eT(naiveDistances[i])).epsilon(eps));
+    REQUIRE(coverTreeNeighbors[i] == naiveNeighbors[i]);
+    REQUIRE(coverTreeDistances[i] ==
+        Approx(eT(naiveDistances[i])).epsilon(eps));
   }
 }
 


### PR DESCRIPTION
While debugging #4155, I noticed that I couldn't actually create a cover tree on float data.  This is because there were some overloads for distance computation that had `arma::vec`s hardcoded.  So, this PR:

 * adapts those distance computations to use templated vector arguments,
 * fixes a subtle memcpy type issue that only shows up if you use a different `ElemType`, and
 * tests float support by templatizing a couple tests.