### PR TITLE
Add read timeout to file downloads

### DIFF
--- a/src/mlpack/core/data/download_file.hpp
+++ b/src/mlpack/core/data/download_file.hpp
@@ -44,11 +44,14 @@ inline void ParseURL(const std::string& url, std::string& host,
  * @param url Given URL to download dataset from.
  * @param filename The path to save the downloaded file to; if empty,
  * then `filename` is set to a generated temporary filename.
+ * @param readTimeout Timeout for reading the response body, in seconds.
+ * If set to 0, the default httplib read timeout is retained.
  * @return true if download is successful, otherwise, throw error on failure, or
  * return false.
  */
 inline bool DownloadFile(const std::string& url,
-                         std::string& filename);
+                         std::string& filename,
+                         const size_t readTimeout = 0);
 
 } // namespace mlpack
 

--- a/src/mlpack/core/data/download_file.hpp
+++ b/src/mlpack/core/data/download_file.hpp
@@ -45,7 +45,6 @@ inline void ParseURL(const std::string& url, std::string& host,
  * @param filename The path to save the downloaded file to; if empty,
  * then `filename` is set to a generated temporary filename.
  * @param readTimeout Timeout for reading the response body, in seconds.
- * If set to 0, the default httplib read timeout is retained.
  * @return true if download is successful, otherwise, throw error on failure, or
  * return false.
  */

--- a/src/mlpack/core/data/download_file_impl.hpp
+++ b/src/mlpack/core/data/download_file_impl.hpp
@@ -157,10 +157,7 @@ inline bool DownloadFile(const std::string& url,
   httplib::Client cli(host, port);
 #endif
   cli.set_connection_timeout(2);
-  if (readTimeout > 0)
-  {
-    cli.set_read_timeout(readTimeout);
-  }
+  cli.set_read_timeout(readTimeout);
   httplib::Result res = cli.Get(url);
   if (!res)
   {

--- a/src/mlpack/core/data/download_file_impl.hpp
+++ b/src/mlpack/core/data/download_file_impl.hpp
@@ -129,7 +129,8 @@ inline void ParseURL(const std::string& url, std::string& host,
 }
 
 inline bool DownloadFile(const std::string& url,
-                         std::string& filename)
+                         std::string& filename,
+                         const size_t readTimeout)
 {
   std::fstream stream;
   int port = -1;
@@ -156,6 +157,10 @@ inline bool DownloadFile(const std::string& url,
   httplib::Client cli(host, port);
 #endif
   cli.set_connection_timeout(2);
+  if (readTimeout > 0)
+  {
+    cli.set_read_timeout(readTimeout);
+  }
   httplib::Result res = cli.Get(url);
   if (!res)
   {
@@ -223,7 +228,8 @@ inline void ParseURL(const std::string& url, std::string& host,
 }
 
 inline bool DownloadFile(const std::string& url,
-                         std::string& filename)
+                         std::string& filename,
+                         const size_t /* readTimeout */)
 {
   filename = "";
   throw std::runtime_error("DownloadFile(): httplib support not enabled; cannot"


### PR DESCRIPTION
## Summary
- add an explicit read timeout to httplib-backed DownloadFile() requests

## Why
DownloadFile() already bounds connection establishment with set_connection_timeout(2), but a server can still stall while sending the response body. A read timeout gives the download path a bounded failure mode after the connection succeeds.

## Testing
- git diff --check