### PR TITLE
Improve cover tree single tree traverser

### DIFF
--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser.hpp
@@ -51,8 +51,7 @@ class CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
   size_t& NumPrunes() { return numPrunes; }
 
  private:
-  size_t ScaleIndex(const int scale, arma::ivec::fixed<8>& hotScaleVector)
-      const;
+  size_t ScaleIndex(const int scale);
 
   // Reference to the rules with which the tree will be traversed.
   RuleType& rule;

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser.hpp
@@ -51,11 +51,47 @@ class CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
   size_t& NumPrunes() { return numPrunes; }
 
  private:
-  //! Reference to the rules with which the tree will be traversed.
+  size_t ScaleIndex(const int scale, arma::ivec::fixed<8>& hotScaleVector)
+      const;
+
+  // Reference to the rules with which the tree will be traversed.
   RuleType& rule;
 
-  //! The number of nodes which have been pruned during traversal.
+  // The number of nodes which have been pruned during traversal.
   size_t numPrunes;
+
+  // As we traverse, we will hold onto these MapEntry objects to track the
+  // reference nodes that need further recursion.
+  struct CoverTreeMapEntry
+  {
+    //! The node this entry refers to.
+    CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>* node;
+    //! The score of the node.
+    double score;
+    //! The base case evaluation.
+    double baseCase;
+
+    //! Comparison operator.
+    bool operator<(const CoverTreeMapEntry& other) const
+    {
+      return (score < other.score);
+    }
+  };
+
+  // Auxiliary data structures used during search.  We keep them at the class
+  // level, because the memory allocated with them can be reused for each query
+  // point.
+
+  // The scale levels for each of the eight "hot" vectors of reference nodes.
+  arma::ivec::fixed<8> hotScaleLevels;
+  // Eight vectors of "hot" reference nodes; these will contain the next levels
+  // to be recursed into.
+  std::vector<CoverTreeMapEntry> hotScaleVectors[8];
+  // A "cold" map of reference nodes with scales that are less than the smallest
+  // scale contained in any of the hot vectors.
+  std::map<int, std::vector<CoverTreeMapEntry>, std::greater<int>> mapQueue;
+  // A vector of leaves (reference nodes with scale INT_MIN).
+  std::vector<CoverTreeMapEntry> leafVector;
 };
 
 } // namespace mlpack

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
@@ -260,9 +260,6 @@ SingleTreeTraverser<RuleType>::Traverse(
     maxIndex = hotScaleLevels.index_max();
   }
 
-  std::vector<CoverTreeMapEntry> unprunedLeafVector;
-  unprunedLeafVector.reserve(leafVector.size());
-
   for (size_t i = 0; i < leafVector.size(); ++i)
   {
     CoverTreeMapEntry& frame = leafVector.at(i);

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
@@ -44,21 +44,44 @@ template<
 template<typename RuleType>
 inline size_t
 CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
-SingleTreeTraverser<RuleType>::ScaleIndex(
-    const int scale,
-    arma::ivec::fixed<8>& hotScales) const
+SingleTreeTraverser<RuleType>::ScaleIndex(const int scale)
 {
   // If it's a leaf, we have to put it in the leaf vector.
   if (scale == INT_MIN)
     return size_t(-1);
 
   // Loop through the hot scales.  Allocate one, if it's unallocated.
+  int minScale = INT_MAX;
   for (size_t i = 0; i < 8; ++i)
   {
-    if (hotScales[i] == INT_MIN)
-      hotScales[i] = scale;
-    if (hotScales[i] == scale)
+    if (hotScaleLevels[i] == INT_MIN)
+      hotScaleLevels[i] = scale;
+    if (hotScaleLevels[i] == scale)
       return i;
+    if (hotScaleLevels[i] < minScale)
+      minScale = hotScaleLevels[i];
+  }
+
+  if (scale > minScale)
+  {
+    // In this case, we are encountering a scale that *should* be in the hot
+    // scale set but isn't!  So, we need to evict an existing one.
+    size_t minScaleIndex = 8;
+    minScale = INT_MAX;
+    for (size_t i = 0; i < 8; ++i)
+    {
+      if (hotScaleLevels[i] < minScale)
+      {
+        minScaleIndex = i;
+        minScale = hotScaleLevels[i];
+      }
+    }
+
+    // Move the smallest-scale vector into the cold map and claim the hot
+    // vector for this scale.
+    mapQueue[minScale] = std::move(hotScaleVectors[minScaleIndex]);
+    hotScaleLevels[minScaleIndex] = scale;
+    return minScaleIndex;
   }
 
   // If there are no hot scales for this scale level, we will need to put it in
@@ -119,8 +142,7 @@ SingleTreeTraverser<RuleType>::Traverse(
       newFrame.baseCase = rootBaseCase;
 
       // Put it into the map.
-      const size_t scaleIndex = ScaleIndex(newFrame.node->Scale(),
-          hotScaleLevels);
+      const size_t scaleIndex = ScaleIndex(newFrame.node->Scale());
       if (scaleIndex < 8)
         hotScaleVectors[scaleIndex].push_back(std::move(newFrame));
       else if (scaleIndex == size_t(-1))
@@ -204,8 +226,7 @@ SingleTreeTraverser<RuleType>::Traverse(
         newFrame.baseCase = frame.baseCase;
 
         // Determine which vector to add the child to.
-        const size_t scaleIndex = ScaleIndex(newFrame.node->Scale(),
-            hotScaleLevels);
+        const size_t scaleIndex = ScaleIndex(newFrame.node->Scale());
         if (scaleIndex < 8)
           hotScaleVectors[scaleIndex].push_back(std::move(newFrame));
         else if (scaleIndex == size_t(-1))

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
@@ -20,31 +20,6 @@
 
 namespace mlpack {
 
-//! This is the structure the cover tree map will use for traversal.
-template<
-    typename DistanceType,
-    typename StatisticType,
-    typename MatType,
-    typename RootPointPolicy
->
-struct CoverTreeMapEntry
-{
-  //! The node this entry refers to.
-  CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>* node;
-  //! The score of the node.
-  double score;
-  //! The index of the parent node.
-  size_t parent;
-  //! The base case evaluation.
-  double baseCase;
-
-  //! Comparison operator.
-  bool operator<(const CoverTreeMapEntry& other) const
-  {
-    return (score < other.score);
-  }
-};
-
 template<
     typename DistanceType,
     typename StatisticType,
@@ -56,7 +31,40 @@ CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
 SingleTreeTraverser<RuleType>::SingleTreeTraverser(RuleType& rule) :
     rule(rule),
     numPrunes(0)
-{ /* Nothing to do. */ }
+{
+  hotScaleLevels.fill(INT_MIN);
+}
+
+template<
+    typename DistanceType,
+    typename StatisticType,
+    typename MatType,
+    typename RootPointPolicy
+>
+template<typename RuleType>
+inline size_t
+CoverTree<DistanceType, StatisticType, MatType, RootPointPolicy>::
+SingleTreeTraverser<RuleType>::ScaleIndex(
+    const int scale,
+    arma::ivec::fixed<8>& hotScales) const
+{
+  // If it's a leaf, we have to put it in the leaf vector.
+  if (scale == INT_MIN)
+    return size_t(-1);
+
+  // Loop through the hot scales.  Allocate one, if it's unallocated.
+  for (size_t i = 0; i < 8; ++i)
+  {
+    if (hotScales[i] == INT_MIN)
+      hotScales[i] = scale;
+    if (hotScales[i] == scale)
+      return i;
+  }
+
+  // If there are no hot scales for this scale level, we will need to put it in
+  // the std::map.
+  return 8;
+}
 
 template<
     typename DistanceType,
@@ -72,20 +80,17 @@ SingleTreeTraverser<RuleType>::Traverse(
 {
   // This is a non-recursive implementation (which should be faster than a
   // recursive implementation).
-  using MapEntryType = CoverTreeMapEntry<DistanceType, StatisticType, MatType,
-      RootPointPolicy>;
 
-  // We will use this map as a priority queue.  Each key represents the scale,
-  // and then the vector is all the nodes in that scale which need to be
-  // investigated.  Because no point in a scale can add a point in its own
-  // scale, we know that the vector for each scale is final when we get to it.
-  // In addition, the map is organized in such a way that begin() will return
-  // the largest scale.
-  std::map<int, std::vector<MapEntryType>, std::greater<int>> mapQueue;
+  // Generally, a single-tree traversal will only have a couple active scale
+  // levels at any given time; the vast majority of times we descend any
+  // reference node, the child we descend to is either the next scale level, or
+  // perhaps two scale levels away.  Therefore, we maintain a "hot" set of scale
+  // vectors for quick lookup, and in the odd case that we get something at a
+  // totally different level, we use a std::map as a priority queue.  These are
+  // all members of the SingleTreeTraverser class.
 
   // Create the score for the children.
   double rootChildScore = rule.Score(queryIndex, referenceNode);
-
   if (rootChildScore == DBL_MAX)
   {
     numPrunes += referenceNode.NumChildren();
@@ -108,108 +113,136 @@ SingleTreeTraverser<RuleType>::Traverse(
 
     for (/* i was set above. */; i < referenceNode.NumChildren(); ++i)
     {
-      MapEntryType newFrame;
+      CoverTreeMapEntry newFrame;
       newFrame.node = &referenceNode.Child(i);
       newFrame.score = rootChildScore;
       newFrame.baseCase = rootBaseCase;
-      newFrame.parent = referenceNode.Point();
 
       // Put it into the map.
-      mapQueue[newFrame.node->Scale()].push_back(newFrame);
+      const size_t scaleIndex = ScaleIndex(newFrame.node->Scale(),
+          hotScaleLevels);
+      if (scaleIndex < 8)
+        hotScaleVectors[scaleIndex].push_back(std::move(newFrame));
+      else if (scaleIndex == size_t(-1))
+        leafVector.push_back(std::move(newFrame));
+      else
+        mapQueue[newFrame.node->Scale()].push_back(newFrame);
     }
   }
 
-  // Now begin the iteration through the map, but only if it has anything in it.
-  if (mapQueue.empty())
-    return;
-  int maxScale = mapQueue.cbegin()->first;
-
-  // We will treat the leaves differently (below).
-  while (maxScale != INT_MIN)
+  // Now begin the iteration through the levels of the tree.  We will treat the
+  // leaves differently (below).
+  size_t maxIndex = hotScaleLevels.index_max();
+  while (hotScaleLevels[maxIndex] != INT_MIN)
   {
     // Get a reference to the current scale.
-    std::vector<MapEntryType>& scaleVector = mapQueue[maxScale];
+    std::vector<CoverTreeMapEntry>& scaleVector = hotScaleVectors[maxIndex];
 
-    // Before traversing all the points in this scale, sort by score.
-    std::sort(scaleVector.begin(), scaleVector.end());
+    std::vector<CoverTreeMapEntry> unprunedScaleVector;
+    unprunedScaleVector.reserve(scaleVector.size());
 
-    // Now loop over each element.
+    // TODO: can we be clever and iterate backwards, so that we can swap things
+    // to the back and then sort in-place?
+
+    // Iterate over all the nodes at the current scale, pruning if we can.
     for (size_t i = 0; i < scaleVector.size(); ++i)
     {
-      // Get a reference to the current element.
-      const MapEntryType& frame = scaleVector.at(i);
+      CoverTreeMapEntry& frame = scaleVector.at(i);
+      if (rule.Rescore(queryIndex, *frame.node, frame.score) == DBL_MAX)
+      {
+        ++numPrunes;
+        frame.score = DBL_MAX;
+        continue;
+      }
 
-      CoverTree* node = frame.node;
-      const double score = frame.score;
-      const size_t parent = frame.parent;
-      const size_t point = node->Point();
-      double baseCase = frame.baseCase;
-
-      // First we recalculate the score of this node to find if we can prune it.
-      if (rule.Rescore(queryIndex, *node, score) == DBL_MAX)
+      frame.score = rule.Score(queryIndex, *frame.node);
+      if (frame.score == DBL_MAX)
       {
         ++numPrunes;
         continue;
       }
 
-      // Create the score for the children.
-      const double childScore = rule.Score(queryIndex, *node);
+      // Compute the base case if we are not a self-child.
+      const size_t point = frame.node->Point();
+      if (frame.node->Parent()->Point() != point)
+        frame.baseCase = rule.BaseCase(queryIndex, point);
 
-      // Now if this childScore is DBL_MAX we can prune all children.  In this
-      // recursion setup pruning is all or nothing for children.
-      if (childScore == DBL_MAX)
+      unprunedScaleVector.push_back(std::move(frame));
+    }
+
+    // For what remains, sort the vector so that we compute base cases with the
+    // most likely good nodes first.
+    std::sort(unprunedScaleVector.begin(), unprunedScaleVector.end());
+
+    // In a second pass, add the children of nodes that weren't pruned.
+    for (size_t i = 0; i < unprunedScaleVector.size(); ++i)
+    {
+      const CoverTreeMapEntry& frame = unprunedScaleVector.at(i);
+      // One more pruning attempt.
+      if (frame.score == DBL_MAX ||
+          rule.Rescore(queryIndex, *frame.node, frame.score) == DBL_MAX)
       {
-        numPrunes += node->NumChildren();
+        numPrunes += frame.node->NumChildren();
         continue;
       }
 
-      // If we are a self-child, the base case has already been evaluated.
-      // Often, a ruleset will return without doing any computation on cover
-      // trees using TreeTraits::FirstPointIsCentroid; this is an optimization
-      // that (theoretically) the compiler should get right.
-      if (point != parent)
+      for (size_t c = 0; c < frame.node->NumChildren(); ++c)
       {
-        baseCase = rule.BaseCase(queryIndex, point);
-      }
+        // Don't add a self-leaf.
+        if (c == 0 && frame.node->Child(0).NumChildren() == 0)
+        {
+          ++numPrunes;
+          continue;
+        }
 
-      // Don't add the self-leaf.
-      size_t j = 0;
-      if (node->Child(0).NumChildren() == 0)
-      {
-        ++numPrunes;
-        j = 1;
-      }
+        CoverTreeMapEntry newFrame;
+        newFrame.node = &frame.node->Child(c);
+        newFrame.score = frame.score;
+        newFrame.baseCase = frame.baseCase;
 
-      for (/* j is already set. */; j < node->NumChildren(); ++j)
-      {
-        MapEntryType newFrame;
-        newFrame.node = &node->Child(j);
-        newFrame.score = childScore;
-        newFrame.baseCase = baseCase;
-        newFrame.parent = point;
-
-        mapQueue[newFrame.node->Scale()].push_back(newFrame);
+        // Determine which vector to add the child to.
+        const size_t scaleIndex = ScaleIndex(newFrame.node->Scale(),
+            hotScaleLevels);
+        if (scaleIndex < 8)
+          hotScaleVectors[scaleIndex].push_back(std::move(newFrame));
+        else if (scaleIndex == size_t(-1))
+          leafVector.push_back(std::move(newFrame));
+        else
+          mapQueue[newFrame.node->Scale()].push_back(newFrame);
       }
     }
 
     // Now clear the memory for this scale; it isn't needed anymore.
-    mapQueue.erase(maxScale);
-    maxScale = mapQueue.begin()->first;
+    if (!mapQueue.empty())
+    {
+      // Reallocate the hot vector to the next largest scale level we have been
+      // collecting points for.
+      hotScaleVectors[maxIndex] = std::move(mapQueue.begin()->second);
+      hotScaleLevels[maxIndex] = mapQueue.begin()->first;
+      mapQueue.erase(mapQueue.begin()->first);
+    }
+    else
+    {
+      hotScaleVectors[maxIndex].clear();
+      hotScaleLevels[maxIndex] = INT_MIN;
+    }
+
+    maxIndex = hotScaleLevels.index_max();
   }
 
-  // Now deal with the leaves.
-  for (size_t i = 0; i < mapQueue[INT_MIN].size(); ++i)
+  std::vector<CoverTreeMapEntry> unprunedLeafVector;
+  unprunedLeafVector.reserve(leafVector.size());
+
+  for (size_t i = 0; i < leafVector.size(); ++i)
   {
-    const MapEntryType& frame = mapQueue[INT_MIN].at(i);
+    CoverTreeMapEntry& frame = leafVector.at(i);
 
     CoverTree* node = frame.node;
     const double score = frame.score;
     const size_t point = node->Point();
 
     // First, recalculate the score of this node to find if we can prune it.
-    double rescore = rule.Rescore(queryIndex, *node, score);
-
-    if (rescore == DBL_MAX)
+    if (rule.Rescore(queryIndex, *node, score) == DBL_MAX)
     {
       ++numPrunes;
       continue;
@@ -234,6 +267,8 @@ SingleTreeTraverser<RuleType>::Traverse(
       rule.BaseCase(queryIndex, point);
     }
   }
+
+  leafVector.clear(); // For next call to Traverse().
 }
 
 } // namespace mlpack

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
@@ -138,13 +138,8 @@ SingleTreeTraverser<RuleType>::Traverse(
     // Get a reference to the current scale.
     std::vector<CoverTreeMapEntry>& scaleVector = hotScaleVectors[maxIndex];
 
-    std::vector<CoverTreeMapEntry> unprunedScaleVector;
-    unprunedScaleVector.reserve(scaleVector.size());
-
-    // TODO: can we be clever and iterate backwards, so that we can swap things
-    // to the back and then sort in-place?
-
     // Iterate over all the nodes at the current scale, pruning if we can.
+    size_t firstGoodIndex = 0;
     for (size_t i = 0; i < scaleVector.size(); ++i)
     {
       CoverTreeMapEntry& frame = scaleVector.at(i);
@@ -152,6 +147,11 @@ SingleTreeTraverser<RuleType>::Traverse(
       {
         ++numPrunes;
         frame.score = DBL_MAX;
+        if (i > firstGoodIndex)
+        {
+          std::swap(frame, scaleVector.at(firstGoodIndex));
+          ++firstGoodIndex;
+        }
         continue;
       }
 
@@ -159,6 +159,11 @@ SingleTreeTraverser<RuleType>::Traverse(
       if (frame.score == DBL_MAX)
       {
         ++numPrunes;
+        if (i > firstGoodIndex)
+        {
+          std::swap(frame, scaleVector.at(firstGoodIndex));
+          ++firstGoodIndex;
+        }
         continue;
       }
 
@@ -166,18 +171,16 @@ SingleTreeTraverser<RuleType>::Traverse(
       const size_t point = frame.node->Point();
       if (frame.node->Parent()->Point() != point)
         frame.baseCase = rule.BaseCase(queryIndex, point);
-
-      unprunedScaleVector.push_back(std::move(frame));
     }
 
     // For what remains, sort the vector so that we compute base cases with the
     // most likely good nodes first.
-    std::sort(unprunedScaleVector.begin(), unprunedScaleVector.end());
+    std::sort(scaleVector.begin() + firstGoodIndex, scaleVector.end());
 
     // In a second pass, add the children of nodes that weren't pruned.
-    for (size_t i = 0; i < unprunedScaleVector.size(); ++i)
+    for (size_t i = firstGoodIndex; i < scaleVector.size(); ++i)
     {
-      const CoverTreeMapEntry& frame = unprunedScaleVector.at(i);
+      const CoverTreeMapEntry& frame = scaleVector.at(i);
       // One more pruning attempt.
       if (frame.score == DBL_MAX ||
           rule.Rescore(queryIndex, *frame.node, frame.score) == DBL_MAX)

--- a/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
+++ b/src/mlpack/core/tree/cover_tree/single_tree_traverser_impl.hpp
@@ -52,14 +52,20 @@ SingleTreeTraverser<RuleType>::ScaleIndex(const int scale)
 
   // Loop through the hot scales.  Allocate one, if it's unallocated.
   int minScale = INT_MAX;
+  int firstMinScale = 8;
   for (size_t i = 0; i < 8; ++i)
   {
     if (hotScaleLevels[i] == INT_MIN)
-      hotScaleLevels[i] = scale;
+      firstMinScale = i; // We will allocate this vector.
     if (hotScaleLevels[i] == scale)
       return i;
     if (hotScaleLevels[i] < minScale)
       minScale = hotScaleLevels[i];
+  }
+  if (firstMinScale != 8)
+  {
+    hotScaleLevels[firstMinScale] = scale;
+    return firstMinScale;
   }
 
   if (scale > minScale)


### PR DESCRIPTION
Next up for improvement is the single tree traversal of the cover tree.

For a slight bit of background, single-tree traversal is when we recurse the entire tree, looking for e.g. the nearest neighbor of a single query point.  (You can also solve other tasks than nearest neighbor, but that is the most common example.)  As the traversal goes on, we are able to prune away parts of the tree, and this is how we achieve speedup.

The cover tree does this recursion in a breadth-first manner.  Each node in a cover tree is inspected for pruning (with `Score()`), and if the node is not pruned, then the base case (point-to-point comparison) is performed.

In order to maximize the chances for pruning, at each level of the recursion, we sort the points so we check the ones with lowest score first.

The general algorithm remains the same in this PR; but I was able to apply a number of improvements:

 * Sorting every node in a single level is expensive... so now a two-stage approach is used which first tries to prune with `Rescore()` (which will not do a distance computation), and then only sorts those nodes that were not pruned.
 * To reduce the overhead of lookups into a `std::map`, now the code maintains 8 "hot" scale vectors that a child will be added to, and then a `std::map` which is used if a child is not one of the 8 "hot" scales.
 * All of these vectors are held at the class level, so they do not get reallocated on each call to `Traverse()` for an additional query point.

I tested along three axes for a few datasets, using the `mlpack_knn` program for k=5.

```
runtime     before    after
covertype   114.222s  68.267s
corel        19.369s  15.622s
higgs-200k  5398.79s  4313.138s
LCDM_r      2020.71s  1280.823s
mnist_train 2481.43s  2271.500s
```

```                                            
base cases  before    after
covertype   692.9M    689.4M
corel       187.1M    184.1M
higgs-200k  22.19B    21.44B
LCDM_r      8.593B    8.579B
mnist_train 2.842B    2.832B
```

```                                          
nodes visited
            before    after
covertype   743.3M    739.8M
corel       190.1M    187.1M
higgs-200k  22.19B    21.44B
LCDM_r      9.578B    9.565B
mnist_train 2.843B    2.833B
```