### PR TITLE
Add licenses to files that are missing them.

### DIFF
--- a/src/mlpack/bindings/util/validate_methods.hpp
+++ b/src/mlpack/bindings/util/validate_methods.hpp
@@ -4,6 +4,11 @@
  *
  * Ensure that the parameters for each of the individual methods of a grouped
  * binding satisfy a handful of requirements.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #ifndef MLPACK_BINDINGS_UTIL_VALIDATE_METHODS_HPP
 #define MLPACK_BINDINGS_UTIL_VALIDATE_METHODS_HPP

--- a/src/mlpack/bindings/util/validate_methods_impl.hpp
+++ b/src/mlpack/bindings/util/validate_methods_impl.hpp
@@ -4,6 +4,11 @@
  *
  * Ensure that the parameters for each of the individual methods of a grouped
  * binding satisfy a handful of requirements.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #ifndef MLPACK_BINDINGS_UTIL_VALIDATE_METHODS_IMPL_HPP
 #define MLPACK_BINDINGS_UTIL_VALIDATE_METHODS_IMPL_HPP


### PR DESCRIPTION
I went to release mlpack 4.8.0 using the script, but two files that got added don't have licenses (oops, my bad).  This PR just adds the license to those files, and after this I'll run the script to release mlpack 4.8.0.  Other "nearly-there" PRs can get included in a follow-up release.