### PR TITLE
Fix robustness of cover tree float test

### DIFF
--- a/src/mlpack/tests/knn_test.cpp
+++ b/src/mlpack/tests/knn_test.cpp
@@ -805,21 +805,29 @@ TEMPLATE_TEST_CASE("KNNSingleCoverTreeTest", "[KNNTest]", float, double)
   NeighborSearch<NearestNeighborSort, LMetric<2>, arma::Mat<eT>,
       StandardCoverTree> coverTreeSearch(std::move(tree), SINGLE_TREE);
 
-  arma::mat naiveData = arma::conv_to<arma::mat>::from(data);
-  KNN naive(naiveData, NAIVE);
+  NeighborSearch<NearestNeighborSort, LMetric<2>, arma::Mat<eT>>
+      naive(data, NAIVE);
 
   arma::Mat<size_t> coverTreeNeighbors;
   arma::Mat<eT> coverTreeDistances;
   coverTreeSearch.Search(15, coverTreeNeighbors, coverTreeDistances);
 
   arma::Mat<size_t> naiveNeighbors;
-  arma::mat naiveDistances;
+  arma::Mat<eT> naiveDistances;
   naive.Search(15, naiveNeighbors, naiveDistances);
 
-  const eT eps = (std::is_same_v<eT, float> ? 1e-4 : 1e-7);
+  const eT eps = (std::is_same_v<eT, float> ? 1e-5 : 1e-7);
   for (size_t i = 0; i < coverTreeNeighbors.n_elem; ++i)
   {
-    REQUIRE(coverTreeNeighbors[i] == naiveNeighbors[i]);
+    // When using floats, the probability of two neighbors being out of order
+    // due to floating point imprecision is high.  That is, the error is a
+    // computed distance may cause its value (when represented as float) to be
+    // exactly equivalent to the next neighbor's distance.  In that situation,
+    // the neighbors may be returned out of order.  So, we only check the
+    // neighbor indices for double.
+    if (std::is_same_v<eT, double>)
+      REQUIRE(coverTreeNeighbors[i] == naiveNeighbors[i]);
+
     REQUIRE(coverTreeDistances[i] ==
         Approx(eT(naiveDistances[i])).epsilon(eps));
   }


### PR DESCRIPTION
I noticed on a couple other PRs that the cover tree kNN test was sometimes failing when `float` was used as an element type.  I found that the actual computed distances were just fine, but the neighbor ordering may be different due to float32 imprecision (as compared to float64).

After a little math, I convinced myself that it is reasonably likely that for three uniform random points in high dimension `x1`, `x2`, and `x3`, `d(x1, x3) ~= d(x1, x2)`.  This situation happens reasonably often with `d = 75`, and when float32 is used the inaccuracy can cause the ordering of neighbors to flip.

So, to resolve the issue I commented out the neighbor index check, and now only check the distances, when float32 is used.