### PR TITLE
Document why cores=3 for ci on macos is not advisable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,20 @@ jobs:
             os: 'macOS',
             name: 'CLI',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=ON -DENABLE_HTTPLIB=ON',
-            cores: 3
+            # Up to 3 cores are supported but the amount of ram provided
+            # leads to severe swapping and massive slowdowns, using 2 is
+            # the best compromise between cores and ram given our C++ load
+            cores: 2
           },
           {
             runner: macOS-latest,
             os: 'macOS',
             name: 'Python',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_PYTHON_BINDINGS=ON -DENABLE_HTTPLIB=ON -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++',
-            cores: 3
+            # Up to 3 cores are supported but the amount of ram provided
+            # leads to severe swapping and massive slowdowns, using 2 is
+            # the best compromise between cores and ram given our C++ load
+            cores: 2
           }
         ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,14 @@ jobs:
             os: 'macOS',
             name: 'CLI',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=ON -DENABLE_HTTPLIB=ON',
-            cores: 2
+            cores: 3
           },
           {
             runner: macOS-latest,
             os: 'macOS',
             name: 'Python',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_PYTHON_BINDINGS=ON -DENABLE_HTTPLIB=ON -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++',
-            cores: 2
+            cores: 3
           }
         ]
 


### PR DESCRIPTION
We currently run ci on macos with two cores, but as [document at GitHub](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners) one can go up to three for M1 cores macos-latest.