### PR TITLE
[tests, ci] Farm ann batch_norm serialization tests off into a separate file

### DIFF
--- a/src/mlpack/tests/CMakeLists.txt
+++ b/src/mlpack/tests/CMakeLists.txt
@@ -7,8 +7,10 @@ add_executable(mlpack_test
   # Tests for neural network code (and reinforcement learning code).
   ann/activation_functions_test.cpp
   ann/ann_dist_test.cpp
-  # This includes all files in ann/layer/.
+  # This includes all files in ann/layer/ excluding serialization
   ann/layer_test.cpp
+  # This includes all files in ann/layer/ with serialization
+  ann/layer_test_serialization.cpp
   ann/ann_regularizer_test.cpp
   ann/ann_test_tools.hpp
   ann/convolutional_network_test.cpp

--- a/src/mlpack/tests/ann/layer/batch_norm.cpp
+++ b/src/mlpack/tests/ann/layer/batch_norm.cpp
@@ -15,7 +15,6 @@
 
 #include "../../test_catch_tools.hpp"
 #include "../../catch.hpp"
-#include "../../serialization.hpp"
 #include "../ann_test_tools.hpp"
 
 using namespace mlpack;
@@ -167,53 +166,6 @@ TEST_CASE("GradientBatchNormTest", "[ANNLayerTest]")
   double gradient = CheckGradient(function);
 
   REQUIRE(gradient < 1e-1);
-}
-
-// General ANN serialization test.
-template<typename LayerType>
-void ANNLayerSerializationTest(LayerType& layer)
-{
-  arma::mat input(5, 100, arma::fill::randu);
-  arma::mat output = arma::randi<arma::mat>(1, 100,
-      arma::distr_param(0, 4));
-
-  FFN<> model;
-  model.Add<Linear>(10);
-  model.Add<LayerType>(layer);
-  model.Add<ReLU>();
-  model.Add<Linear>(5);
-  model.Add<LogSoftMax>();
-
-  ens::StandardSGD opt(0.1, 1, 5, -100, false);
-  model.Train(input, output, opt);
-
-  arma::mat originalOutput;
-  model.Predict(input, originalOutput);
-
-  // Now serialize the model.
-  FFN<> xmlModel, jsonModel, binaryModel;
-  SerializeObjectAll(model, xmlModel, jsonModel, binaryModel);
-
-  // Ensure that predictions are the same.
-  arma::mat modelOutput, xmlOutput, jsonOutput, binaryOutput;
-  model.Predict(input, modelOutput);
-  xmlModel.Predict(input, xmlOutput);
-  jsonModel.Predict(input, jsonOutput);
-  binaryModel.Predict(input, binaryOutput);
-
-  CheckMatrices(originalOutput, modelOutput, 1e-5);
-  CheckMatrices(originalOutput, xmlOutput, 1e-5);
-  CheckMatrices(originalOutput, jsonOutput, 1e-5);
-  CheckMatrices(originalOutput, binaryOutput, 1e-5);
-}
-
-/**
- * Simple serialization test for batch normalization layer.
- */
-TEST_CASE("BatchNormSerializationTest", "[ANNLayerTest]")
-{
-  BatchNorm layer;
-  ANNLayerSerializationTest(layer);
 }
 
 TEST_CASE("BatchNormWithMinBatchesTest", "[ANNLayerTest]")

--- a/src/mlpack/tests/ann/layer/batch_norm_serialization.cpp
+++ b/src/mlpack/tests/ann/layer/batch_norm_serialization.cpp
@@ -1,0 +1,68 @@
+/**
+ * @file tests/ann/layer/batch_norm_serialization.cpp
+ * @author Marcus Edel
+ * @author Praveen Ch
+ *
+ * Tests the ann layer modules involving serialization.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/ann.hpp>
+
+#include "../../test_catch_tools.hpp"
+#include "../../catch.hpp"
+#include "../../serialization.hpp"
+#include "../ann_test_tools.hpp"
+
+using namespace mlpack;
+
+// General ANN serialization test.
+template<typename LayerType>
+void ANNLayerSerializationTest(LayerType& layer)
+{
+  arma::mat input(5, 100, arma::fill::randu);
+  arma::mat output = arma::randi<arma::mat>(1, 100,
+      arma::distr_param(0, 4));
+
+  FFN<> model;
+  model.Add<Linear>(10);
+  model.Add<LayerType>(layer);
+  model.Add<ReLU>();
+  model.Add<Linear>(5);
+  model.Add<LogSoftMax>();
+
+  ens::StandardSGD opt(0.1, 1, 5, -100, false);
+  model.Train(input, output, opt);
+
+  arma::mat originalOutput;
+  model.Predict(input, originalOutput);
+
+  // Now serialize the model.
+  FFN<> xmlModel, jsonModel, binaryModel;
+  SerializeObjectAll(model, xmlModel, jsonModel, binaryModel);
+
+  // Ensure that predictions are the same.
+  arma::mat modelOutput, xmlOutput, jsonOutput, binaryOutput;
+  model.Predict(input, modelOutput);
+  xmlModel.Predict(input, xmlOutput);
+  jsonModel.Predict(input, jsonOutput);
+  binaryModel.Predict(input, binaryOutput);
+
+  CheckMatrices(originalOutput, modelOutput, 1e-5);
+  CheckMatrices(originalOutput, xmlOutput, 1e-5);
+  CheckMatrices(originalOutput, jsonOutput, 1e-5);
+  CheckMatrices(originalOutput, binaryOutput, 1e-5);
+}
+
+/**
+ * Simple serialization test for batch normalization layer.
+ */
+TEST_CASE("BatchNormSerializationTest", "[ANNLayerTest]")
+{
+  BatchNorm layer;
+  ANNLayerSerializationTest(layer);
+}

--- a/src/mlpack/tests/ann/layer_test.cpp
+++ b/src/mlpack/tests/ann/layer_test.cpp
@@ -15,9 +15,6 @@
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef MLPACK_ENABLE_ANN_SERIALIZATION
-  #define MLPACK_ENABLE_ANN_SERIALIZATION
-#endif
 
 #include "layer/adaptive_max_pooling.cpp"
 #include "layer/adaptive_mean_pooling.cpp"

--- a/src/mlpack/tests/ann/layer_test_serialization.cpp
+++ b/src/mlpack/tests/ann/layer_test_serialization.cpp
@@ -3,7 +3,7 @@
  * @author Ryan Curtin
  *
  * This file includes the subset of tests in ann/layer/ involving serialization,
- * which is taxing on machine with limited memory such as those used for
+ * which is taxing on machines with limited memory such as those used for
  * continuous integration. See file 'layer_test.cpp' for general concerns
  * about compilation demands. While keeping the non-serializing tests in one file
  * reduces compilation time and memory usage, having the serialization tests here

--- a/src/mlpack/tests/ann/layer_test_serialization.cpp
+++ b/src/mlpack/tests/ann/layer_test_serialization.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file layer_serialization_test.cpp
+ * @author Ryan Curtin
+ *
+ * This file includes the subset of tests in ann/layer/ involving serialization,
+ * which is taxing on machine with limited memory such as those used for
+ * continuous integration. See file 'layer_test.cpp' for general concerns
+ * about compilation demands. While keeping the non-serializing tests in one file
+ * reduces compilation time and memory usage, having the serialization tests here
+ * permit switching them on or off from cmake.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_ENABLE_ANN_SERIALIZATION
+  #define MLPACK_ENABLE_ANN_SERIALIZATION
+#endif
+
+#include "layer/batch_norm_serialization.cpp"


### PR DESCRIPTION
PR #4171 revealed that the ann tests with serialization strained the systems used at github action sufficiently to fail, leading us in #4171 to comment out some tests reducing the test surface.

By moving the serialization-based tests into a separate caller and implmentation, we manage to complete all test in the branch exhibiting issues, see [this run following the corresponding commit  a827a9f](https://github.com/mlpack/mlpack/actions/runs/27027032991) (plus Jenkins-based tests also passing).

As that change is orthogonal to the issue underpinning #4171, this PR spins it off for individual reviews.  It is suggested to, if accepted, merge this first and then rebase the branch under #4171 for a more minimal and concise change set.
