### PR TITLE
fix DAGNetwork error when connecting layer A multiple times to layer B

### DIFF
--- a/src/mlpack/methods/ann/dag_network.hpp
+++ b/src/mlpack/methods/ann/dag_network.hpp
@@ -21,12 +21,6 @@
 
 #include <ensmallen.hpp>
 
-enum ConnectionTypes
-{
-  CONCATENATE,
-  ADDITION
-};
-
 namespace mlpack {
 
 /**
@@ -61,6 +55,13 @@ namespace mlpack {
  * @tparam InitializationRuleType Rule used to initialize the weight matrix.
  * @tparam MatType Type of matrix to be given as input to the network.
  */
+
+enum ConnectionTypes
+{
+  CONCATENATE,
+  ADDITION
+};
+
 template<
     typename OutputLayerType = NegativeLogLikelihood,
     typename InitializationRuleType = RandomInitialization,

--- a/src/mlpack/methods/ann/dag_network_impl.hpp
+++ b/src/mlpack/methods/ann/dag_network_impl.hpp
@@ -274,7 +274,14 @@ void DAGNetwork<
   std::vector<size_t>& childNodeParents = parentsList[childNodeId];
   for (size_t i = 0; i < childNodeParents.size(); i++)
   {
-    if (childNodeParents[i] == parentNodeId)
+    if (childNodeParents[i] == parentNodeId) {
+      std::ostringstream errMessage;
+      errMessage << "DAGNetwork::Connect(): Layer " << parentNodeId
+          << " is already connected to layer " << childNodeId;
+      throw std::logic_error(errMessage.str());
+    }
+
+    if (childNodeParents[i] == childNodeId)
     {
       std::ostringstream errMessage;
       errMessage << "DAGNetwork::Connect(): Layer " << parentNodeId

--- a/src/mlpack/methods/ann/dag_network_impl.hpp
+++ b/src/mlpack/methods/ann/dag_network_impl.hpp
@@ -235,7 +235,8 @@ void DAGNetwork<
     throw std::logic_error(errMessage.str());
   }
 
-  if (connection > ConnectionTypes::ADDITION) {
+  if (connection > ConnectionTypes::ADDITION)
+  {
     std::ostringstream errMessage;
     errMessage << "DAGNetwork::SetConnection(): Connection type "
         << connection << " does not exist.";
@@ -281,10 +282,11 @@ void DAGNetwork<
   std::vector<size_t>& childNodeParents = parentsList[childNodeId];
   for (size_t i = 0; i < childNodeParents.size(); i++)
   {
-    if (childNodeParents[i] == parentNodeId) {
+    if (childNodeParents[i] == parentNodeId)
+    {
       std::ostringstream errMessage;
       errMessage << "DAGNetwork::Connect(): Layer " << parentNodeId
-          << " is already connected to layer " << childNodeId;
+          << " is already connected to layer " << childNodeId << "!";
       throw std::logic_error(errMessage.str());
     }
 

--- a/src/mlpack/methods/ann/dag_network_impl.hpp
+++ b/src/mlpack/methods/ann/dag_network_impl.hpp
@@ -235,6 +235,13 @@ void DAGNetwork<
     throw std::logic_error(errMessage.str());
   }
 
+  if (connection > ConnectionTypes::ADDITION) {
+    std::ostringstream errMessage;
+    errMessage << "DAGNetwork::SetConnection(): Connection type "
+        << connection << " does not exist.";
+    throw std::logic_error(errMessage.str());
+  }
+
   layerConnections[layerId] = connection;
 
   validOutputDimensions = false;


### PR DESCRIPTION
Fixes an error message in `DAGNetwork` when connecting layer A to layer B multiple times as well as fixing an error message when connecting layer A to it self.
