### PR TITLE
Extend 'braziltourism' data set documentation

### DIFF
--- a/src/mlpack/tests/data/braziltourism.arff
+++ b/src/mlpack/tests/data/braziltourism.arff
@@ -1,18 +1,21 @@
 % analcatdata    A collection of data sets used in the book "Analyzing Categorical Data,"
 %                by Jeffrey S. Simonoff, Springer-Verlag, New York, 2003. The submission
-%                consists of a zip file containing two versions of each of 84 data sets, 
+%                consists of a zip file containing two versions of each of 84 data sets,
 %                plus this README file. Each data set is given in comma-delimited ASCII
 %                (.csv) form, and Microsoft Excel (.xls) form.
-% 
+%
 % NOTICE: These data sets may be used freely for scientific, educational and/or
 %         noncommercial purposes, provided suitable acknowledgment is given (by citing
 %         the above-named reference).
-% 
+%
 % Further details concerning the book, including information on statistical software
 % (including sample S-PLUS/R and SAS code), are available at the web site
-% 
+%
 %             http://www.stern.nyu.edu/~jsimonof/AnalCatData
 %
+% with the data sets available (in csv and xls format) as file
+%
+%             https://pages.stern.nyu.edu/~jsimonof/AnalCatData/Data/data.zip
 %
 % Information about the dataset
 % CLASSTYPE: nominal
@@ -20,8 +23,13 @@
 %
 %
 % Note: Quotes, Single-Quotes and Backslashes were removed, Blanks replaced
-%       with Underscores
+%       with Underscores. Rows with missing values in the original data have
+%       been replaced.
 %
+%       The file 'braziltourism_test.arff' contains additional data used for testing.
+%
+%       The file 'braziltourism_labels.txt' contains the dependent categorical
+%       variable 'Trips' encoded as 'INTEGER'.
 
 @relation analcatdata-braziltourism
 

--- a/src/mlpack/tests/data/braziltourism_test.arff
+++ b/src/mlpack/tests/data/braziltourism_test.arff
@@ -1,18 +1,21 @@
 % analcatdata    A collection of data sets used in the book "Analyzing Categorical Data,"
 %                by Jeffrey S. Simonoff, Springer-Verlag, New York, 2003. The submission
-%                consists of a zip file containing two versions of each of 84 data sets, 
+%                consists of a zip file containing two versions of each of 84 data sets,
 %                plus this README file. Each data set is given in comma-delimited ASCII
 %                (.csv) form, and Microsoft Excel (.xls) form.
-% 
+%
 % NOTICE: These data sets may be used freely for scientific, educational and/or
 %         noncommercial purposes, provided suitable acknowledgment is given (by citing
 %         the above-named reference).
-% 
+%
 % Further details concerning the book, including information on statistical software
 % (including sample S-PLUS/R and SAS code), are available at the web site
-% 
+%
 %             http://www.stern.nyu.edu/~jsimonof/AnalCatData
 %
+% with the data sets available (in csv and xls format) as file
+%
+%             https://pages.stern.nyu.edu/~jsimonof/AnalCatData/Data/data.zip
 %
 % Information about the dataset
 % CLASSTYPE: nominal
@@ -20,8 +23,13 @@
 %
 %
 % Note: Quotes, Single-Quotes and Backslashes were removed, Blanks replaced
-%       with Underscores
+%       with Underscores. Rows with missing values in the original data have
+%       been replaced.
 %
+%       The file 'braziltourism.arff' contains additional data used for training.
+%
+%       The file 'braziltourism_labels.txt' contains the dependent categorical
+%       variable 'Trips' encoded as 'INTEGER'.
 
 @relation analcatdata-braziltourism
 


### PR DESCRIPTION
The 'braziltourism' data set in the `tests/data` directory is comparatively well documented.  It is debatable whether permanently splitting in training or test helps, but what is clearly missing is a note about the 'bare' labels data set column in a csv file.  It is worth adding a) what the variable is (number of trips) and b) how it is encoded (given that the other columns are documented).  It is also worth noting that this copy of the data has rows with missing data removed.
