### PR TITLE
Use half the core count on failing CI platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             name: 'Debug',
             # Disable [DEBUG] output from the tests because it's WAY too verbose.
             cmakeVars: '-DCMAKE_BUILD_TYPE=Debug -DBUILD_CLI_EXECUTABLES=OFF -DCMAKE_CXX_FLAGS="-DMLPACK_NO_PRINT_DEBUG" -DENABLE_HTTPLIB=ON',
-            cores: 4
+            cores: 2
           },
           {
             runner: ubuntu-latest,
@@ -90,7 +90,7 @@ jobs:
             # Up to 3 cores are supported but the amount of ram provided
             # leads to severe swapping and massive slowdowns, using 2 is
             # the best compromise between cores and ram given our C++ load
-            cores: 2
+            cores: 1
           },
           {
             runner: macOS-latest,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
             name: 'Debug',
             # Disable [DEBUG] output from the tests because it's WAY too verbose.
             cmakeVars: '-DCMAKE_BUILD_TYPE=Debug -DBUILD_CLI_EXECUTABLES=OFF -DCMAKE_CXX_FLAGS="-DMLPACK_NO_PRINT_DEBUG" -DENABLE_HTTPLIB=ON',
+            # Core count intentionally reduced to 2 as resource exhaustion
+            # seen when compiling with four cores given our C++ load
             cores: 2
           },
           {
@@ -88,7 +90,7 @@ jobs:
             name: 'CLI',
             cmakeVars: '-DBUILD_CLI_EXECUTABLES=ON -DENABLE_HTTPLIB=ON',
             # Up to 3 cores are supported but the amount of ram provided
-            # leads to severe swapping and massive slowdowns, using 2 is
+            # leads to severe swapping and massive slowdowns, using 1 is
             # the best compromise between cores and ram given our C++ load
             cores: 1
           },


### PR DESCRIPTION
PR #4182 saw CI fail for the first few commits, with apparent resource exhaustion for Linux/debug and macOS/cli.  After adjusting the number of cores, all subsequent attempts passed: three resulted in 'green', one ended on an unrelated (markdown) issue but well after the earlier failures due to resource exhaustion.

