### PR TITLE
Fix `LinearSVM` documentation to discuss scores instead of probabilities

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,10 @@
 
 _????-??-??_
 
- * Accelerated `LeakyReLU` ANN Layer (#4174)
+ * Accelerated `LeakyReLU` ANN Layer (#4174).
+
+ * Update `LinearSVM` documentation: `Classify()` returns class scores, not
+   class probabilities (#4187).
 
 ## mlpack 4.8.0
 

--- a/doc/user/methods/linear_svm.md
+++ b/doc/user/methods/linear_svm.md
@@ -138,11 +138,12 @@ can be used to make class predictions for new data.
 
 ---
 
- * `svm.Classify(point, prediction, probabilitiesVec)`
+ * `svm.Classify(point, prediction, scoresVec)`
    - ***(Single-point)***
-   - Classify a single point and compute class probabilities.
+   - Classify a single point and compute class scores.
    - The predicted class is stored in `prediction`.
-   - The probability of class `i` can be accessed with `probabilitiesVec[i]`.
+   - The score of class `i` can be accessed with `scoresVec[i]`.  Scores are not
+     normalized to `[0, 1]`.
 
 ---
 
@@ -153,12 +154,12 @@ can be used to make class predictions for new data.
 
 ---
 
- * `svm.Classify(data, predictions, probabilities)`
+ * `svm.Classify(data, predictions, scores)`
    - ***(Multi-point)***
-   - Classify a set of points and compute class probabilities.
+   - Classify a set of points and compute class scores.
    - The prediction for data point `i` can be accessed with `predictions[i]`.
-   - The probability of class `j` for data point `i` can be accessed with
-     `probabilities(j, i)`.
+   - The score of class `j` for data point `i` can be accessed with
+     `scores(j, i)`.  Scores are not normalized to `[0, 1]`.
 
 ---
 
@@ -168,11 +169,11 @@ can be used to make class predictions for new data.
 |-----------|----------|----------|-----------------|
 | _single-point_ | `point` | [`arma::vec`](../matrices.md) | Single point for classification. |
 | _single-point_ | `prediction` | `size_t&` | `size_t` to store class prediction into. |
-| _single-point_ | `probabilitiesVec` | [`arma::vec&`](../matrices.md) | `arma::vec&` to store class probabilities into; will have length 2. |
+| _single-point_ | `scoresVec` | [`arma::vec&`](../matrices.md) | `arma::vec&` to store class scores into; will have length `numClasses`. |
 ||||
 | _multi-point_ | `data` | [`arma::mat`](../matrices.md) | Set of [column-major](../matrices.md) points for classification. |
 | _multi-point_ | `predictions` | [`arma::Row<size_t>&`](../matrices.md) | Vector of `size_t`s to store class prediction into; will be set to length `data.n_cols`. |
-| _multi-point_ | `probabilities` | [`arma::mat&`](../matrices.md) | Matrix to store class probabilities into (number of rows will be equal to 2; number of columns will be equal to `data.n_cols`). |
+| _multi-point_ | `scores` | [`arma::mat&`](../matrices.md) | Matrix to store class scores into (number of rows will be equal to `numClasses`; number of columns will be equal to `data.n_cols`). |
 
 ### Other Functionality
 
@@ -361,13 +362,12 @@ arma::sp_fvec point;
 point.sprandu(100, 1, 0.3);
 
 size_t prediction;
-arma::fvec probabilitiesVec;
-svm.Classify(point, prediction, probabilitiesVec);
+arma::fvec scoresVec;
+svm.Classify(point, prediction, scoresVec);
 
 std::cout << "Prediction for random test point: " << prediction << "."
     << std::endl;
-std::cout << "Class probabilities for random test point: "
-    << probabilitiesVec.t();
+std::cout << "Class scores for random test point: " << scoresVec.t();
 ```
 
 ***Note:*** dense objects should be used for `ModelMatType`, since in general

--- a/src/mlpack/methods/linear_svm/linear_svm.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm.hpp
@@ -335,9 +335,8 @@ class LinearSVM
 
   /**
    * Classify the given points, returning the predicted labels for each point.
-   * The function calculates the probabilities for every class, given a data
-   * point. It then chooses the class which has the highest probability among
-   * all.
+   * The function calculates the scores for every class, given a data point. It
+   * then chooses the class which has the highest score among all.
    *
    * @param data Set of points to classify.
    * @param labels Predicted labels for each point.
@@ -348,14 +347,15 @@ class LinearSVM
 
   /**
    * Classify the given points, returning class scores and predicted
-   * class label for each point.
-   * The function calculates the scores for every class, given a data
-   * point. It then chooses the class which has the highest probability among
-   * all.
+   * class label for each point.  Note that class scores are not normalized to
+   * [0, 1] (they are not class probabilities); they can take any value.
+   *
+   * The function calculates the scores for every class, given a data point. It
+   * then chooses the class which has the highest score among all.
    *
    * @param data Matrix of data points to be classified.
    * @param labels Predicted labels for each point.
-   * @param scores Class probabilities for each point.
+   * @param scores Class scores for each point.
    */
   template<typename MatType>
   void Classify(const MatType& data,
@@ -376,7 +376,7 @@ class LinearSVM
   /**
    * Classify the given point. The predicted class label is returned.
    * The function calculates the scores for every class, given the point.
-   * It then chooses the class which has the highest probability among all.
+   * It then chooses the class which has the highest score among all.
    *
    * @param point Point to be classified.
    * @return Predicted class label of the point.
@@ -386,17 +386,19 @@ class LinearSVM
 
   /**
    * Classify the given point. The predicted class label is stored in `label`,
-   * and the probability of each class is stored in `probabilities`..
+   * and the score of each class is stored in `scores`.  Note that `scores` are
+   * class scores, not probabilities, and thus may take any value (they are not
+   * limited to the range [0, 1]).
    *
    * @param point Point to be classified.
    * @param label size_t to store predicted label into.
-   * @param probabilities Vector to store class probabilities into.
+   * @param scores Vector to store class scores into.
    * @return Predicted class label of the point.
    */
   template<typename VecType>
   void Classify(const VecType& point,
                 size_t& label,
-                DenseColType& probabilities) const;
+                DenseColType& scores) const;
 
   /**
    * Computes accuracy of the learned model given the feature data and the

--- a/src/mlpack/methods/linear_svm/linear_svm_impl.hpp
+++ b/src/mlpack/methods/linear_svm/linear_svm_impl.hpp
@@ -287,10 +287,10 @@ template<typename VecType>
 void LinearSVM<ModelMatType>::Classify(
     const VecType& point,
     size_t& label,
-    typename LinearSVM<ModelMatType>::DenseColType& probabilities) const
+    typename LinearSVM<ModelMatType>::DenseColType& scores) const
 {
   arma::Row<size_t> labelRow(1);
-  Classify(point, labelRow, probabilities);
+  Classify(point, labelRow, scores);
   label = labelRow[0];
 }
 

--- a/src/mlpack/tests/linear_svm_test.cpp
+++ b/src/mlpack/tests/linear_svm_test.cpp
@@ -13,6 +13,7 @@
 #include <mlpack/methods/linear_svm.hpp>
 
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace mlpack;
 
@@ -910,23 +911,12 @@ TEMPLATE_TEST_CASE("LinearSVMLBFGSMultipleClasses", "[LinearSVMTest][tiny]",
 {
   using ElemType = TestType;
   using MatType = arma::Mat<ElemType>;
-  using VecType = arma::Col<ElemType>;
 
   const size_t points = 1000;
-  const size_t inputSize = 5;
-  const size_t numClasses = 5;
   const double lambda = 0.5;
 
-  // Generate five-Gaussian dataset.
-  MatType identity = arma::eye<MatType>(5, 5);
-  GaussianDistribution<MatType> g1(VecType("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<MatType> g2(VecType("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<MatType> g3(VecType("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<MatType> g4(VecType("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<MatType> g5(VecType("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  MatType data(inputSize, points);
-  arma::Row<size_t> labels(points);
+  MatType data;
+  arma::Row<size_t> labels;
 
   // This loop can be removed when ensmallen PR #136 is merged into a version
   // of ensmallen that is the minimum required ensmallen version for mlpack.
@@ -936,34 +926,11 @@ TEMPLATE_TEST_CASE("LinearSVMLBFGSMultipleClasses", "[LinearSVMTest][tiny]",
   bool success = false;
   for (size_t trial = 0; trial < 5; ++trial)
   {
-    for (size_t i = 0; i < points / 5; ++i)
-    {
-      data.col(i) = g1.Random();
-      labels(i) = 0;
-    }
-    for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-    {
-      data.col(i) = g2.Random();
-      labels(i) = 1;
-    }
-    for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-    {
-      data.col(i) = g3.Random();
-      labels(i) = 2;
-    }
-    for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-    {
-      data.col(i) = g4.Random();
-      labels(i) = 3;
-    }
-    for (size_t i = (4 * points) / 5; i < points; ++i)
-    {
-      data.col(i) = g5.Random();
-      labels(i) = 4;
-    }
+    // Generate five-Gaussian dataset.
+    GenerateFiveGaussianDataset(data, labels, points);
 
     // Train linear svm object using L-BFGS optimizer.
-    LinearSVM<MatType> lsvm(data, labels, numClasses, lambda);
+    LinearSVM<MatType> lsvm(data, labels, 5, lambda);
 
     // Compare training accuracy to 1.
     const double acc = lsvm.ComputeAccuracy(data, labels);
@@ -971,31 +938,7 @@ TEMPLATE_TEST_CASE("LinearSVMLBFGSMultipleClasses", "[LinearSVMTest][tiny]",
       continue;
 
     // Create test dataset.
-    for (size_t i = 0; i < points / 5; ++i)
-    {
-      data.col(i) = ConvTo<VecType>::From(g1.Random());
-      labels(i) = 0;
-    }
-    for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-    {
-      data.col(i) = ConvTo<VecType>::From(g2.Random());
-      labels(i) = 1;
-    }
-    for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-    {
-      data.col(i) = ConvTo<VecType>::From(g3.Random());
-      labels(i) = 2;
-    }
-    for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-    {
-      data.col(i) = ConvTo<VecType>::From(g4.Random());
-      labels(i) = 3;
-    }
-    for (size_t i = (4 * points) / 5; i < points; ++i)
-    {
-      data.col(i) = ConvTo<VecType>::From(g5.Random());
-      labels(i) = 4;
-    }
+    GenerateFiveGaussianDataset(data, labels, points);
 
     // Compare test accuracy to 1.
     const double testAcc = lsvm.ComputeAccuracy(data, labels);
@@ -1020,76 +963,19 @@ TEMPLATE_TEST_CASE("LinearSVMClassifySinglePointTest", "[LinearSVMTest]", float,
   using VecType = arma::Col<ElemType>;
 
   const size_t points = 500;
-  const size_t inputSize = 5;
   const size_t numClasses = 5;
   const double lambda = 0.5;
 
   // Generate five-Gaussian dataset.
-  MatType identity = arma::eye<MatType>(5, 5);
-  GaussianDistribution<MatType> g1(VecType("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<MatType> g2(VecType("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<MatType> g3(VecType("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<MatType> g4(VecType("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<MatType> g5(VecType("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  MatType data(inputSize, points);
-  arma::Row<size_t> labels(points);
-
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  MatType data;
+  arma::Row<size_t> labels;
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Train linear svm object.
   LinearSVM<MatType> lsvm(data, labels, numClasses, lambda);
 
   // Create test dataset.
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  GenerateFiveGaussianDataset(data, labels, points);
 
   MatType scores;
   lsvm.Classify(data, labels, scores);
@@ -1115,76 +1001,18 @@ TEMPLATE_TEST_CASE("LinearSVMClassifySinglePointTest", "[LinearSVMTest]", float,
 TEST_CASE("SinglePointClassifyTest", "[LinearSVMTest]")
 {
   const size_t points = 500;
-  const size_t inputSize = 5;
-  const size_t numClasses = 5;
   const double lambda = 0.5;
 
   // Generate five-Gaussian dataset.
-  arma::mat identity = arma::eye<arma::mat>(5, 5);
-  GaussianDistribution<> g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<> g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<> g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<> g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<> g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  arma::mat data(inputSize, points);
-  arma::Row<size_t> labels(points);
-
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  arma::mat data;
+  arma::Row<size_t> labels;
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Train linear svm object.
-  LinearSVM<arma::mat> lsvm(data, labels, numClasses, lambda);
+  LinearSVM<arma::mat> lsvm(data, labels, 5, lambda);
 
   // Create test dataset.
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  GenerateFiveGaussianDataset(data, labels, points);
 
   arma::Row<size_t> predictions;
   lsvm.Classify(data, predictions);

--- a/src/mlpack/tests/softmax_regression_test.cpp
+++ b/src/mlpack/tests/softmax_regression_test.cpp
@@ -13,6 +13,7 @@
 #include <mlpack/methods/softmax_regression.hpp>
 
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace mlpack;
 
@@ -273,49 +274,15 @@ TEMPLATE_TEST_CASE("SoftmaxRegressionMultipleClasses",
     "[SoftmaxRegressionTest]", arma::fmat, arma::mat)
 {
   using MatType = TestType;
-  using VecType = typename GetColType<TestType>::type;
 
   const size_t points = 5000;
-  const size_t inputSize = 5;
   const size_t numClasses = 5;
   const double lambda = 0.5;
 
   // Generate five-Gaussian dataset.
-  MatType identity = arma::eye<MatType>(5, 5);
-  GaussianDistribution<MatType> g1(VecType("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<MatType> g2(VecType("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<MatType> g3(VecType("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<MatType> g4(VecType("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<MatType> g5(VecType("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  MatType data(inputSize, points);
-  arma::Row<size_t> labels(points);
-
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  MatType data;
+  arma::Row<size_t> labels;
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Train softmax regression object.
   SoftmaxRegression<MatType> sr(data, labels, numClasses, lambda);
@@ -325,31 +292,7 @@ TEMPLATE_TEST_CASE("SoftmaxRegressionMultipleClasses",
   REQUIRE(acc == Approx(100.0).epsilon(0.02));
 
   // Create test dataset.
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = ConvTo<MatType>::From(g1.Random());
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = ConvTo<MatType>::From(g2.Random());
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = ConvTo<MatType>::From(g3.Random());
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = ConvTo<MatType>::From(g4.Random());
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = ConvTo<MatType>::From(g5.Random());
-    labels(i) = 4;
-  }
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Compare test accuracy to 100.
   const double testAcc = sr.ComputeAccuracy(data, labels);
@@ -425,76 +368,19 @@ TEST_CASE("SoftmaxRegressionClassifySinglePointTest",
           "[SoftmaxRegressionTest]")
 {
   const size_t points = 5000;
-  const size_t inputSize = 5;
   const size_t numClasses = 5;
   const double lambda = 0.5;
 
   // Generate five-Gaussian dataset.
-  arma::mat identity = arma::eye<arma::mat>(5, 5);
-  GaussianDistribution<> g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<> g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<> g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<> g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<> g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  arma::mat data(inputSize, points);
-  arma::Row<size_t> labels(points);
-
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  arma::mat data;
+  arma::Row<size_t> labels;
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Train softmax regression object.
   SoftmaxRegression<> sr(data, labels, numClasses, lambda);
 
   // Create test dataset.
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  GenerateFiveGaussianDataset(data, labels, points);
 
   sr.Classify(data, labels);
 
@@ -508,76 +394,19 @@ TEST_CASE("SoftmaxRegressionComputeProbabilitiesTest",
           "[SoftmaxRegressionTest]")
 {
   const size_t points = 5000;
-  const size_t inputSize = 5;
   const size_t numClasses = 5;
   const double lambda = 0.5;
 
   // Generate five-Gaussian dataset.
-  arma::mat identity = arma::eye<arma::mat>(5, 5);
-  GaussianDistribution<> g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<> g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<> g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<> g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<> g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  arma::mat data(inputSize, points);
-  arma::Row<size_t> labels(points);
-
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  arma::mat data;
+  arma::Row<size_t> labels;
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Train softmax regression object.
   SoftmaxRegression<> sr(data, labels, numClasses, lambda);
 
   // Create test dataset.
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  GenerateFiveGaussianDataset(data, labels, points);
 
   arma::Row<size_t> predictions;
   arma::mat probabilities;
@@ -608,76 +437,19 @@ TEST_CASE("SoftmaxRegressionComputeProbabilitiesAndLabelsTest",
           "[SoftmaxRegressionTest]")
 {
   const size_t points = 5000;
-  const size_t inputSize = 5;
   const size_t numClasses = 5;
   const double lambda = 0.5;
 
   // Generate five-Gaussian dataset.
-  arma::mat identity = arma::eye<arma::mat>(5, 5);
-  GaussianDistribution<> g1(arma::vec("1.0 9.0 1.0 2.0 2.0"), identity);
-  GaussianDistribution<> g2(arma::vec("4.0 3.0 4.0 2.0 2.0"), identity);
-  GaussianDistribution<> g3(arma::vec("3.0 2.0 7.0 0.0 5.0"), identity);
-  GaussianDistribution<> g4(arma::vec("4.0 1.0 1.0 2.0 7.0"), identity);
-  GaussianDistribution<> g5(arma::vec("1.0 0.0 1.0 8.0 3.0"), identity);
-
-  arma::mat data(inputSize, points);
-  arma::Row<size_t> labels(points);
-
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  arma::mat data;
+  arma::Row<size_t> labels;
+  GenerateFiveGaussianDataset(data, labels, points);
 
   // Train softmax regression object.
   SoftmaxRegression<> sr(data, labels, numClasses, lambda);
 
   // Create test dataset.
-  for (size_t i = 0; i < points / 5; ++i)
-  {
-    data.col(i) = g1.Random();
-    labels(i) = 0;
-  }
-  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
-  {
-    data.col(i) = g2.Random();
-    labels(i) = 1;
-  }
-  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
-  {
-    data.col(i) = g3.Random();
-    labels(i) = 2;
-  }
-  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
-  {
-    data.col(i) = g4.Random();
-    labels(i) = 3;
-  }
-  for (size_t i = (4 * points) / 5; i < points; ++i)
-  {
-    data.col(i) = g5.Random();
-    labels(i) = 4;
-  }
+  GenerateFiveGaussianDataset(data, labels, points);
 
   arma::mat probabilities;
   arma::Row<size_t> testLabels;

--- a/src/mlpack/tests/test_function_tools.hpp
+++ b/src/mlpack/tests/test_function_tools.hpp
@@ -116,4 +116,48 @@ inline ElemType RMSE(const arma::Row<ElemType>& predictions,
   return sqrt(mse);
 }
 
+template<typename MatType>
+void GenerateFiveGaussianDataset(MatType& data,
+                                 arma::Row<size_t>& labels,
+                                 const size_t points)
+{
+  using VecType = typename GetColType<MatType>::type;
+
+  MatType identity = arma::eye<MatType>(5, 5);
+  GaussianDistribution<MatType> g1(VecType("1.0 9.0 1.0 2.0 2.0"), identity);
+  GaussianDistribution<MatType> g2(VecType("4.0 3.0 4.0 2.0 2.0"), identity);
+  GaussianDistribution<MatType> g3(VecType("3.0 2.0 7.0 0.0 5.0"), identity);
+  GaussianDistribution<MatType> g4(VecType("4.0 1.0 1.0 2.0 7.0"), identity);
+  GaussianDistribution<MatType> g5(VecType("1.0 0.0 1.0 8.0 3.0"), identity);
+
+  data.set_size(5, points);
+  labels.set_size(points);
+
+  for (size_t i = 0; i < points / 5; ++i)
+  {
+    data.col(i) = g1.Random();
+    labels(i) = 0;
+  }
+  for (size_t i = points / 5; i < (2 * points) / 5; ++i)
+  {
+    data.col(i) = g2.Random();
+    labels(i) = 1;
+  }
+  for (size_t i = (2 * points) / 5; i < (3 * points) / 5; ++i)
+  {
+    data.col(i) = g3.Random();
+    labels(i) = 2;
+  }
+  for (size_t i = (3 * points) / 5; i < (4 * points) / 5; ++i)
+  {
+    data.col(i) = g4.Random();
+    labels(i) = 3;
+  }
+  for (size_t i = (4 * points) / 5; i < points; ++i)
+  {
+    data.col(i) = g5.Random();
+    labels(i) = 4;
+  }
+}
+
 #endif


### PR DESCRIPTION
@eddelbuettel found that the `LinearSVM::Classify()` results for class probabilities don't actually return probabilities.  It turns that LinearSVM doesn't have easy-to-calculate class probabilities, and the current implementation returns class *scores* and not *probabilities*, which are super different things.

So, seemingly the best thing to do here is to update the documentation to be clear that what we are returning are non-normalized class *scores*, and not something that could be interpreted as a probability.

(During this process I also did some experiments and ended up refactoring some code for the softmax regression and linear SVM tests; they had lots of duplicated code creating 5-Gaussian datasets, so I just moved it all to one place.  In the end it is entirely unrelated to the subject of this PR but still useful to do!)