### PR TITLE
Remove unused variable to quieten build under default settings

### DIFF
--- a/src/mlpack/core/transforms/mfe_impl.hpp
+++ b/src/mlpack/core/transforms/mfe_impl.hpp
@@ -104,8 +104,6 @@ inline void MFE(const arma::Mat<eT>& inputSignal,
     Log::Fatal << "MFE(): nFFT cannot be lower than window length in samples. "
                << "nFFT needs to be >= windowLength x sampleRate." << std::endl;
 
-  size_t numBins = nFFT / 2 + 1;
-
   arma::Mat<eT> filterBanks = MelFilterbank<eT>(numMelFilters, nFFT, sampleRate,
       lowFreq, highFreq);
 


### PR DESCRIPTION
This minimal PR removes a single variable declaration which via the flagging of 'unused var' triggers an actual screenful of compilation noise we may as well suppress.

No code addition, no test changes.