### PR TITLE
Add a simple `Scale` layer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,8 @@ _????-??-??_
  * Update `LinearSVM` documentation: `Classify()` returns class scores, not
    class probabilities (#4187).
 
+ * Add `Scale` layer for scalar multiplication of neural network layers (#4196).
+
 ## mlpack 4.8.0
 
 _2026-06-07_

--- a/src/mlpack/methods/ann/layer/layer_types.hpp
+++ b/src/mlpack/methods/ann/layer/layer_types.hpp
@@ -57,6 +57,7 @@
 #include <mlpack/methods/ann/layer/radial_basis_function.hpp>
 #include <mlpack/methods/ann/layer/relu6.hpp>
 #include <mlpack/methods/ann/layer/repeat.hpp>
+#include <mlpack/methods/ann/layer/scale.hpp>
 #include <mlpack/methods/ann/layer/softmax.hpp>
 #include <mlpack/methods/ann/layer/softmin.hpp>
 #include <mlpack/methods/ann/layer/sum_reduce.hpp>

--- a/src/mlpack/methods/ann/layer/scale.hpp
+++ b/src/mlpack/methods/ann/layer/scale.hpp
@@ -86,9 +86,9 @@ class Scale : public Layer<MatType>
                 MatType& g);
 
   // Get the scale factor..
-  double const& ScaleFactor() const { return scaleFactor; }
+  const ElemType& ScaleFactor() const { return scaleFactor; }
   // Modify the scale factor.
-  double& ScaleFactor() { return scaleFactor; }
+  ElemType& ScaleFactor() { return scaleFactor; }
 
   //! Serialize the layer.
   template<typename Archive>

--- a/src/mlpack/methods/ann/layer/scale.hpp
+++ b/src/mlpack/methods/ann/layer/scale.hpp
@@ -96,7 +96,7 @@ class Scale : public Layer<MatType>
 
  private:
   // Factor to scale the inputs by.
-  double scaleFactor;
+  ElemType scaleFactor;
 }; // class Scale
 
 } // namespace mlpack

--- a/src/mlpack/methods/ann/layer/scale.hpp
+++ b/src/mlpack/methods/ann/layer/scale.hpp
@@ -1,0 +1,107 @@
+/**
+ * @file methods/ann/layer/scale.hpp
+ * @author Ryan Curtin
+ *
+ * Definition of the Scale layer, which multiplies its inputs by a constant
+ * value.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LAYER_SCALE_HPP
+#define MLPACK_METHODS_ANN_LAYER_SCALE_HPP
+
+#include <mlpack/prereqs.hpp>
+
+#include "layer.hpp"
+
+namespace mlpack {
+
+/**
+ * The Scale layer allows the input to be scaled by a fixed constant, whose
+ * value is specified in the constructor.
+ *
+ * @tparam InputType The type of the layer's inputs. The layer automatically
+ *     cast inputs to this type (Default: arma::mat).
+ * @tparam OutputType The type of the computation which also causes the output
+ *     to also be in this type. The type also allows the computation and weight
+ *     type to differ from the input type (Default: arma::mat).
+ */
+template<typename MatType = arma::mat>
+class Scale : public Layer<MatType>
+{
+ public:
+  // Convenience typedef to access the element type of the weights and data.
+  using ElemType = typename MatType::elem_type;
+
+  /**
+   * Create the Scale layer with the specified parameter.
+   *
+   * @param scaleFactor Value to multiple the inputs by.
+   */
+  Scale(const ElemType scaleFactor = 1.0);
+
+  //! Clone the CELU object. This handles polymorphism correctly.
+  Scale* Clone() const { return new Scale(*this); }
+
+  // Virtual destructor.
+  virtual ~Scale() { }
+
+  // Copy constructor.
+  Scale(const Scale& other);
+
+  // Move constructor.
+  Scale(Scale&& other);
+
+  // Copy assignment operator.
+  Scale& operator=(const Scale& other);
+
+  // Move assignement operator.
+  Scale& operator=(Scale&& other);
+
+  /**
+   * Ordinary feed forward pass of a neural network, evaluating the function
+   * f(x) by propagating the activity forward through f.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param output Resulting output activation.
+   */
+  void Forward(const MatType& input, MatType& output);
+
+  /**
+   * Ordinary feed backward pass of a neural network, calculating the function
+   * f(x) by propagating x backwards through f. Using the results from the feed
+   * forward pass.
+   *
+   * @param input The input data (x) given to the forward pass.
+   * @param output The propagated data (f(x)) resulting from Forward()
+   * @param gy The backpropagated error.
+   * @param g The calculated gradient.
+   */
+  void Backward(const MatType& /* input */,
+                const MatType& /* output */,
+                const MatType& gy,
+                MatType& g);
+
+  // Get the scale factor..
+  double const& ScaleFactor() const { return scaleFactor; }
+  // Modify the scale factor.
+  double& ScaleFactor() { return scaleFactor; }
+
+  //! Serialize the layer.
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */);
+
+ private:
+  // Factor to scale the inputs by.
+  double scaleFactor;
+}; // class Scale
+
+} // namespace mlpack
+
+// Include implementation.
+#include "scale_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/layer/scale_impl.hpp
+++ b/src/mlpack/methods/ann/layer/scale_impl.hpp
@@ -1,0 +1,102 @@
+/**
+ * @file methods/ann/layer/scale_impl.hpp
+ * @author Ryan Curtin
+ *
+ * Implementation of the Scale layer, which multiplies its inputs by a constant
+ * value.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LAYER_SCALE_IMPL_HPP
+#define MLPACK_METHODS_ANN_LAYER_SCALE_IMPL_HPP
+
+// In case it hasn't yet been included.
+#include "scale.hpp"
+
+namespace mlpack {
+
+template<typename MatType>
+Scale<MatType>::Scale(const typename MatType::elem_type scaleFactor) :
+    Layer<MatType>(),
+    scaleFactor(scaleFactor)
+{
+  // Nothing to do.
+}
+
+template<typename MatType>
+Scale<MatType>::Scale(const Scale& other) :
+    Layer<MatType>(other),
+    scaleFactor(other.scaleFactor)
+{
+  // Nothing to do.
+}
+
+template<typename MatType>
+Scale<MatType>::Scale(
+    Scale&& other) :
+    Layer<MatType>(std::move(other)),
+    scaleFactor(std::move(other.scaleFactor))
+{
+  // Nothing to do.
+}
+
+template<typename MatType>
+Scale<MatType>&
+Scale<MatType>::operator=(const Scale& other)
+{
+  if (&other != this)
+  {
+    Layer<MatType>::operator=(other);
+    scaleFactor = other.scaleFactor;
+  }
+
+  return *this;
+}
+
+template<typename MatType>
+Scale<MatType>&
+Scale<MatType>::operator=(Scale&& other)
+{
+  if (&other != this)
+  {
+    Layer<MatType>::operator=(std::move(other));
+    scaleFactor = std::move(other.scaleFactor);
+  }
+
+  return *this;
+}
+
+template<typename MatType>
+void Scale<MatType>::Forward(
+    const MatType& input, MatType& output)
+{
+  output = input * scaleFactor;
+}
+
+template<typename MatType>
+void Scale<MatType>::Backward(
+    const MatType& /* input */,
+    const MatType& /* output */,
+    const MatType& gy,
+    MatType& g)
+{
+  g = gy * scaleFactor;
+}
+
+template<typename MatType>
+template<typename Archive>
+void Scale<MatType>::serialize(
+    Archive& ar,
+    const uint32_t /* version */)
+{
+  ar(cereal::base_class<Layer<MatType>>(this));
+
+  ar(CEREAL_NVP(scaleFactor));
+}
+
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/layer/serialization.hpp
+++ b/src/mlpack/methods/ann/layer/serialization.hpp
@@ -91,6 +91,7 @@
     CEREAL_REGISTER_TYPE(mlpack::RBF<__VA_ARGS__>); \
     CEREAL_REGISTER_TYPE(mlpack::ReLU6<__VA_ARGS__>); \
     CEREAL_REGISTER_TYPE(mlpack::Repeat<__VA_ARGS__>); \
+    CEREAL_REGISTER_TYPE(mlpack::Scale<__VA_ARGS__>); \
     CEREAL_REGISTER_TYPE(mlpack::Softmax<__VA_ARGS__>); \
     CEREAL_REGISTER_TYPE(mlpack::Softmin<__VA_ARGS__>); \
     CEREAL_REGISTER_TYPE(mlpack::HardTanH<__VA_ARGS__>); \

--- a/src/mlpack/tests/ann/layer/scale.cpp
+++ b/src/mlpack/tests/ann/layer/scale.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file tests/ann/layer/celu.cpp
+ * @author Ryan Curtin
+ *
+ * Tests the CELU layer.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#include <mlpack/core.hpp>
+#include <mlpack/methods/ann.hpp>
+
+#include "../../test_catch_tools.hpp"
+#include "../../catch.hpp"
+#include "../../serialization.hpp"
+#include "../ann_test_tools.hpp"
+
+using namespace mlpack;
+
+/**
+ * Scale layer numerical gradient test.
+ */
+TEST_CASE("GradientScaleTest", "[ANNLayerTest]")
+{
+  // Softmax function gradient instantiation.
+  struct GradientFunction
+  {
+    GradientFunction() :
+        input(arma::randu(10, 1) - 0.5),
+        target(arma::mat("1; 0"))
+    {
+      model = new FFN<MeanSquaredError, RandomInitialization>;
+      model->ResetData(input, target);
+      model->Add<Linear>(10);
+      model->Add<Scale>(0.5);
+      model->Add<Linear>(2);
+      model->Add<Softmax>();
+    }
+
+    ~GradientFunction()
+    {
+      delete model;
+    }
+
+    double Gradient(arma::mat& gradient) const
+    {
+      double error = model->Evaluate(model->Parameters(), 0, 1);
+      model->Gradient(model->Parameters(), 0, gradient, 1);
+      return error;
+    }
+
+    arma::mat& Parameters() { return model->Parameters(); }
+
+    FFN<MeanSquaredError>* model;
+    arma::mat input, target;
+  } function;
+
+  REQUIRE(CheckGradient(function) <= 1e-4);
+}

--- a/src/mlpack/tests/ann/layer_test.cpp
+++ b/src/mlpack/tests/ann/layer_test.cpp
@@ -48,6 +48,7 @@
 #include "layer/parametric_relu.cpp"
 #include "layer/relu6.cpp"
 #include "layer/repeat.cpp"
+#include "layer/scale.cpp"
 #include "layer/softmax.cpp"
 #include "layer/softmin.cpp"
 #include "layer/ftswish.cpp"


### PR DESCRIPTION
Some of the ONNX networks I am working with converting have simple scalar multiplications as parts of the ONNX graph.  For instance, the TinyYOLO ONNX model I have first multiplies the input by `1/255` in order to scale the input images to `[0, 1]`.

In order to be able to convert this to an mlpack `DAGNetwork`, I need to have some kind of simple layer that applies a scalar multiplication.  So, I implemented the quite simple `Scale` layer here.  I don't expect it will have too many uses other than its use in the ONNX/mlpack translator, but it would still be useful to have.