### PR TITLE
Fix NumFOCUS leadership team link in governance document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,7 +24,7 @@ more information.
 
 To keep overhead minimal, mlpack's teams and roles are simple: there is only
 the [Committers](https://github.com/orgs/mlpack/teams/contributors) team, and
-the [NumFOCUS leadership team](TODO:link).
+the [NumFOCUS leadership team](https://numfocus.org/community/governance).
 
 Members of the Committers team have commit access to all mlpack repositories
 and help guide the development directions and goals of mlpack.  Committers

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,10 +32,6 @@ _If you use mlpack, please [cite the software](citation.md)._
     (Your browser does not support inline SVG objects.  Browse the mlpack
      pipeline using the navigation sidebar instead.)
 </object>
-<object data="img/pipeline-narrow.svg" type="image/svg+xml" id="pipeline-narrow">
-    (Your browser does not support inline SVG objects.  Browse the mlpack
-     pipeline using the navigation sidebar instead.)
-</object>
 
 ## Changelog
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,6 +32,10 @@ _If you use mlpack, please [cite the software](citation.md)._
     (Your browser does not support inline SVG objects.  Browse the mlpack
      pipeline using the navigation sidebar instead.)
 </object>
+<object data="img/pipeline-narrow.svg" type="image/svg+xml" id="pipeline-narrow">
+    (Your browser does not support inline SVG objects.  Browse the mlpack
+     pipeline using the navigation sidebar instead.)
+</object>
 
 ## Changelog
 


### PR DESCRIPTION
This pull request replaces the TODO placeholder link for the NumFOCUS leadership team in GOVERNANCE.md with a valid URL.

The change fixes a broken placeholder link in the governance documentation and improves navigation for readers.
