### PR TITLE
Reorder classification and regression methods in CMakeLists.txt

### DIFF
--- a/doc/user/bindings/cli.md
+++ b/doc/user/bindings/cli.md
@@ -36,6 +36,84 @@ mlpack bindings for CLI take and return a restricted set of types, for simplicit
 </div>
 
 
+## mlpack_adaboost
+{: #adaboost }
+
+#### AdaBoost
+{: #adaboost_descr }
+
+```bash
+$ mlpack_adaboost [--help] [--info <string>] [--input_model_file
+        <string>] [--iterations 1000] [--labels_file <string>] [--test_file
+        <string>] [--tolerance 1e-10] [--training_file <string>] [--verbose]
+        [--version] [--weak_learner 'decision_stump'] [--output_model_file
+        <string>] [--predictions_file <string>] [--probabilities_file <string>]
+```
+
+An implementation of the AdaBoost.MH (Adaptive Boosting) algorithm for classification.  This can be used to train an AdaBoost model on labeled data or use an existing AdaBoost model to predict the classes of new points. [Detailed documentation](#adaboost_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_model_file (-m)` | [`AdaBoostModel file`](#doc_model) | Input AdaBoost model. | `''` |
+| `--iterations (-i)` | [`int`](#doc_int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
+| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Labels for the training set. | `''` |
+| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Test dataset. | `''` |
+| `--tolerance (-e)` | [`double`](#doc_double) | The tolerance for change in values of the weighted error during training. | `1e-10` |
+| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Dataset for training AdaBoost. | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--weak_learner (-w)` | [`string`](#doc_string) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `'decision_stump'` |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`AdaBoostModel file`](#doc_model) | Output trained AdaBoost model. | 
+| `--predictions_file (-P)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Predicted labels for the test set. | 
+| `--probabilities_file (-p)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Predicted class probabilities for each point in the test set. | 
+
+### Detailed documentation
+{: #adaboost_detailed-documentation }
+
+This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
+
+For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
+
+This program allows training of an AdaBoost model, and then application of that model to a test dataset.  To train a model, a dataset must be passed with the `--training_file (-t)` option.  Labels can be given with the `--labels_file (-l)` option; if no labels are specified, the labels will be assumed to be the last column of the input dataset.  Alternately, an AdaBoost model may be loaded with the `--input_model_file (-m)` option.
+
+Once a model is trained or loaded, it may be used to provide class predictions for a given test dataset.  A test dataset may be specified with the `--test_file (-T)` parameter.  The predicted classes for each point in the test dataset are output to the `--predictions_file (-P)` output parameter.  The AdaBoost model itself is output to the `--output_model_file (-M)` output parameter.
+
+### Example
+For example, to run AdaBoost on an input dataset `'data.csv'` with labels `'labels.csv'`and perceptrons as the weak learner type, storing the trained model in `'model.bin'`, one could use the following command: 
+
+```bash
+$ mlpack_adaboost --training_file data.csv --labels_file labels.csv
+  --output_model_file model.bin --weak_learner perceptron
+```
+
+Similarly, an already-trained model in `'model.bin'` can be used to provide class predictions from test data `'test_data.csv'` and store the output in `'predictions.csv'` with the following command: 
+
+```bash
+$ mlpack_adaboost --input_model_file model.bin --test_file test_data.csv
+  --predictions_file predictions.csv
+```
+
+### See also
+
+ - [AdaBoost on Wikipedia](https://en.wikipedia.org/wiki/AdaBoost)
+ - [Improved boosting algorithms using confidence-rated predictions (pdf)](http://www.schapire.net/papers/SchapireSi98.pdf)
+ - [Perceptron](#perceptron)
+ - [Decision Trees](#decision_tree)
+ - [AdaBoost C++ class documentation](../../user/methods/adaboost.md)
+
 ## mlpack_approx_kfn
 {: #approx_kfn }
 
@@ -132,6 +210,91 @@ $ mlpack_approx_kfn --input_model_file model.bin --query_file
  - [Approximate furthest neighbor in high dimensions (pdf)](https://www.rasmuspagh.net/papers/approx-furthest-neighbor-SISAP15.pdf)
  - [QDAFN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/qdafn.hpp)
  - [DrusillaSelect class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/drusilla_select.hpp)
+
+## mlpack_bayesian_linear_regression
+{: #bayesian_linear_regression }
+
+#### BayesianLinearRegression
+{: #bayesian_linear_regression_descr }
+
+```bash
+$ mlpack_bayesian_linear_regression [--center] [--help] [--info
+        <string>] [--input_file <string>] [--input_model_file <string>]
+        [--responses_file <string>] [--scale] [--test_file <string>] [--verbose]
+        [--version] [--output_model_file <string>] [--predictions_file <string>]
+        [--stds_file <string>]
+```
+
+An implementation of the Bayesian linear regression. [Detailed documentation](#bayesian_linear_regression_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--center (-c)` | [`flag`](#doc_flag) | Center the data and fit the intercept if enabled. |  |
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_file (-i)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix of covariates (X). | `''` |
+| `--input_model_file (-m)` | [`BayesianLinearRegression<> file`](#doc_model) | Trained BayesianLinearRegression model to use. | `''` |
+| `--responses_file (-r)` | [`1-d matrix file`](#doc_a_1_d_matrix_file) | Matrix of responses/observations (y). | `''` |
+| `--scale (-s)` | [`flag`](#doc_flag) | Scale each feature by their standard deviations if enabled. |  |
+| `--test_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing points to regress on (test points). | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`BayesianLinearRegression<> file`](#doc_model) | Output BayesianLinearRegression model. | 
+| `--predictions_file (-o)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | If --test_file is specified, this file is where the predicted responses will be saved. | 
+| `--stds_file (-u)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | If specified, this is where the standard deviations of the predictive distribution will be saved. | 
+
+### Detailed documentation
+{: #bayesian_linear_regression_detailed-documentation }
+
+An implementation of the Bayesian linear regression.
+This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
+Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
+
+This program is able to train a Bayesian linear regression model or load a model from file, output regression predictions for a test set, and save the trained model to a file.
+
+To train a BayesianLinearRegression model, the `--input_file (-i)` and `--responses_file (-r)`parameters must be given. The `--center (-c)`and `--scale (-s)` parameters control the centering and the normalizing options. A trained model can be saved with the `--output_model_file (-M)`. If no training is desired at all, a model can be passed via the `--input_model_file (-m)` parameter.
+
+The program can also provide predictions for test data using either the trained model or the given input model.  Test points can be specified with the `--test_file (-t)` parameter.  Predicted responses to the test points can be saved with the `--predictions_file (-o)` output parameter. The corresponding standard deviation can be save by precising the `--stds_file (-u)` parameter.
+
+### Example
+For example, the following command trains a model on the data `'data.csv'` and responses `'responses.csv'`with center set to true and scale set to false (so, Bayesian linear regression is being solved, and then the model is saved to `'blr_model.bin'`:
+
+```bash
+$ mlpack_bayesian_linear_regression --input_file data.csv --responses_file
+  responses.csv --center --scale --output_model_file blr_model.bin
+```
+
+The following command uses the `'blr_model.bin'` to provide predicted  responses for the data `'test.csv'` and save those  responses to `'test_predictions.csv'`: 
+
+```bash
+$ mlpack_bayesian_linear_regression --input_model_file blr_model.bin
+  --test_file test.csv --predictions_file test_predictions.csv
+```
+
+Because the estimator computes a predictive distribution instead of a simple point estimate, the `--stds_file (-u)` parameter allows one to save the prediction uncertainties: 
+
+```bash
+$ mlpack_bayesian_linear_regression --input_model_file blr_model.bin
+  --test_file test.csv --predictions_file test_predictions.csv --stds_file
+  stds.csv
+```
+
+### See also
+
+ - [Bayesian Interpolation](https://cs.uwaterloo.ca/~mannr/cs886-w10/mackay-bayesian.pdf)
+ - [Bayesian Linear Regression, Section 3.3](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
+ - [BayesianLinearRegression C++ class documentation](../../user/methods/bayesian_linear_regression.md)
 
 ## mlpack_cf
 {: #cf }
@@ -322,6 +485,89 @@ $ mlpack_dbscan --input_file input.csv --epsilon 0.5 --min_size 5
  - [DBSCAN on Wikipedia](https://en.wikipedia.org/wiki/DBSCAN)
  - [A density-based algorithm for discovering clusters in large spatial databases with noise (pdf)](https://cdn.aaai.org/KDD/1996/KDD96-037.pdf)
  - [DBSCAN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/dbscan/dbscan.hpp)
+
+## mlpack_decision_tree
+{: #decision_tree }
+
+#### Decision tree
+{: #decision_tree_descr }
+
+```bash
+$ mlpack_decision_tree [--help] [--info <string>] [--input_model_file
+        <string>] [--labels_file <string>] [--maximum_depth 0]
+        [--minimum_gain_split 1e-07] [--minimum_leaf_size 20]
+        [--print_training_accuracy] [--test_file <string>] [--test_labels_file
+        <string>] [--training_file <string>] [--verbose] [--version]
+        [--weights_file <string>] [--output_model_file <string>]
+        [--predictions_file <string>] [--probabilities_file <string>]
+```
+
+An implementation of an ID3-style decision tree for classification, which supports categorical data.  Given labeled data with numeric or categorical features, a decision tree can be trained and saved; or, an existing decision tree can be used for classification on new points. [Detailed documentation](#decision_tree_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_model_file (-m)` | [`DecisionTreeModel file`](#doc_model) | Pre-trained decision tree, to be used with test points. | `''` |
+| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Training labels. | `''` |
+| `--maximum_depth (-D)` | [`int`](#doc_int) | Maximum depth of the tree (0 means no limit). | `0` |
+| `--minimum_gain_split (-g)` | [`double`](#doc_double) | Minimum gain for node splitting. | `1e-07` |
+| `--minimum_leaf_size (-n)` | [`int`](#doc_int) | Minimum number of points in a leaf. | `20` |
+| `--print_training_accuracy (-a)` | [`flag`](#doc_flag) | Print the training accuracy. |  |
+| `--test_file (-T)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Testing dataset (may be categorical). | `''` |
+| `--test_labels_file (-L)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Test point labels, if accuracy calculation is desired. | `''` |
+| `--training_file (-t)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Training dataset (may be categorical). | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--weights_file (-w)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | The weight of labels | `''` |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`DecisionTreeModel file`](#doc_model) | Output for trained decision tree. | 
+| `--predictions_file (-p)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Class predictions for each test point. | 
+| `--probabilities_file (-P)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Class probabilities for each test point. | 
+
+### Detailed documentation
+{: #decision_tree_detailed-documentation }
+
+Train and evaluate using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
+
+The training set and associated labels are specified with the `--training_file (-t)` and `--labels_file (-l)` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `--labels_file (-l)` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+When a model is trained, the `--output_model_file (-M)` output parameter may be used to save the trained model.  A model may be loaded for predictions with the `--input_model_file (-m)` parameter.  The `--input_model_file (-m)` parameter may not be specified when the `--training_file (-t)` parameter is specified.  The `--minimum_leaf_size (-n)` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `--minimum_gain_split (-g)` parameter specifies the minimum gain that is needed for the node to split.  The `--maximum_depth (-D)` parameter specifies the maximum depth of the tree.  If `--print_training_accuracy (-a)` is specified, the training accuracy will be printed.
+
+Test data may be specified with the `--test_file (-T)` parameter, and if performance numbers are desired for that test set, labels may be specified with the `--test_labels_file (-L)` parameter.  Predictions for each test point may be saved via the `--predictions_file (-p)` output parameter.  Class probabilities for each prediction may be saved with the `--probabilities_file (-P)` output parameter.
+
+### Example
+For example, to train a decision tree with a minimum leaf size of 20 on the dataset contained in `'data.csv'` with labels `'labels.csv'`, saving the output model to `'tree.bin'` and printing the training error, one could call
+
+```bash
+$ mlpack_decision_tree --training_file data.arff --labels_file labels.csv
+  --output_model_file tree.bin --minimum_leaf_size 20 --minimum_gain_split 0.001
+  --print_training_accuracy
+```
+
+Then, to use that model to classify points in `'test_set.csv'` and print the test error given the labels `'test_labels.csv'` using that model, while saving the predictions for each point to `'predictions.csv'`, one could call 
+
+```bash
+$ mlpack_decision_tree --input_model_file tree.bin --test_file test_set.arff
+  --test_labels_file test_labels.csv --predictions_file predictions.csv
+```
+
+### See also
+
+ - [Random forest](#random_forest)
+ - [Decision trees on Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning)
+ - [Induction of Decision Trees (pdf)](https://www.hunch.net/~coms-4771/quinlan.pdf)
+ - [DecisionTree C++ class documentation](../../user/methods/decision_tree.md)
 
 ## mlpack_det
 {: #det }
@@ -956,6 +1202,94 @@ $ mlpack_hmm_viterbi --input_file obs.csv --input_model_file hmm.bin
  - [Hidden Mixture Models on Wikipedia](https://en.wikipedia.org/wiki/Hidden_Markov_model)
  - [HMM class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/hmm/hmm.hpp)
 
+## mlpack_hoeffding_tree
+{: #hoeffding_tree }
+
+#### Hoeffding trees
+{: #hoeffding_tree_descr }
+
+```bash
+$ mlpack_hoeffding_tree [--batch_mode] [--bins 10] [--confidence 0.95]
+        [--help] [--info <string>] [--info_gain] [--input_model_file <string>]
+        [--labels_file <string>] [--max_samples 5000] [--min_samples 100]
+        [--numeric_split_strategy 'binary'] [--observations_before_binning 100]
+        [--passes 1] [--test_file <string>] [--test_labels_file <string>]
+        [--training_file <string>] [--verbose] [--version] [--output_model_file
+        <string>] [--predictions_file <string>] [--probabilities_file <string>]
+```
+
+An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data, a Hoeffding tree can be trained and saved for later use, or a pre-trained Hoeffding tree can be used for predicting the classifications of new points. [Detailed documentation](#hoeffding_tree_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--batch_mode (-b)` | [`flag`](#doc_flag) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. |  |
+| `--bins (-B)` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--confidence (-c)` | [`double`](#doc_double) | Confidence before splitting (between 0 and 1). | `0.95` |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--info_gain (-i)` | [`flag`](#doc_flag) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. |  |
+| `--input_model_file (-m)` | [`HoeffdingTreeModel file`](#doc_model) | Input trained Hoeffding tree model. | `''` |
+| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Labels for training dataset. | `''` |
+| `--max_samples (-n)` | [`int`](#doc_int) | Maximum number of samples before splitting. | `5000` |
+| `--min_samples (-I)` | [`int`](#doc_int) | Minimum number of samples before splitting. | `100` |
+| `--numeric_split_strategy (-N)` | [`string`](#doc_string) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `'binary'` |
+| `--observations_before_binning (-o)` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
+| `--passes (-s)` | [`int`](#doc_int) | Number of passes to take over the dataset. | `1` |
+| `--test_file (-T)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Testing dataset (may be categorical). | `''` |
+| `--test_labels_file (-L)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Labels of test data. | `''` |
+| `--training_file (-t)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Training dataset (may be categorical). | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`HoeffdingTreeModel file`](#doc_model) | Output for trained Hoeffding tree model. | 
+| `--predictions_file (-p)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Matrix to output label predictions for test data into. | 
+| `--probabilities_file (-P)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
+
+### Detailed documentation
+{: #hoeffding_tree_detailed-documentation }
+
+This program implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets.  This program supports both categorical and numeric data.  Given an input dataset, this program is able to train the tree with numerous training options, and save the model to a file.  The program is also able to use a trained model or a model from file in order to predict classes for a given test set.
+
+The training file and associated labels are specified with the `--training_file (-t)` and `--labels_file (-l)` parameters, respectively. Optionally, if `--labels_file (-l)` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `--batch_mode (-b)` option, but this may not be the best option for large datasets.
+
+When a model is trained, it may be saved via the `--output_model_file (-M)` output parameter.  A model may be loaded from file for further training or testing with the `--input_model_file (-m)` parameter.
+
+Test data may be specified with the `--test_file (-T)` parameter, and if performance statistics are desired for that test set, labels may be specified with the `--test_labels_file (-L)` parameter.  Predictions for each test point may be saved with the `--predictions_file (-p)` output parameter, and class probabilities for each prediction may be saved with the `--probabilities_file (-P)` output parameter.
+
+### Example
+For example, to train a Hoeffding tree with confidence 0.99 with data `'dataset.csv'`, saving the trained tree to `'tree.bin'`, the following command may be used:
+
+```bash
+$ mlpack_hoeffding_tree --training_file dataset.arff --confidence 0.99
+  --output_model_file tree.bin
+```
+
+Then, this tree may be used to make predictions on the test set `'test_set.csv'`, saving the predictions into `'predictions.csv'` and the class probabilities into `'class_probs.csv'` with the following command: 
+
+```bash
+$ mlpack_hoeffding_tree --input_model_file tree.bin --test_file test_set.arff
+  --predictions_file predictions.csv --probabilities_file class_probs.csv
+```
+
+### See also
+
+ - [mlpack_decision_tree](#decision_tree)
+ - [mlpack_random_forest](#random_forest)
+ - [Mining High-Speed Data Streams (pdf)](https://www.cs.rhodes.edu/~welshc/COMP465_S15/Papers/kdd00.pdf)
+ - [HoeffdingTree class documentation](../../user/methods/hoeffding_tree.md)
+
 ## mlpack_image_converter
 {: #image_converter }
 
@@ -1298,91 +1632,6 @@ $ mlpack_kmeans --input_file data.csv --initial_centroids_file initial.csv
  - [A dual-tree algorithm for fast k-means clustering with large k (pdf)](http://www.ratml.org/pub/pdf/2017dual.pdf)
  - [KMeans class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/kmeans/kmeans.hpp)
 
-## mlpack_bayesian_linear_regression
-{: #bayesian_linear_regression }
-
-#### BayesianLinearRegression
-{: #bayesian_linear_regression_descr }
-
-```bash
-$ mlpack_bayesian_linear_regression [--center] [--help] [--info
-        <string>] [--input_file <string>] [--input_model_file <string>]
-        [--responses_file <string>] [--scale] [--test_file <string>] [--verbose]
-        [--version] [--output_model_file <string>] [--predictions_file <string>]
-        [--stds_file <string>]
-```
-
-An implementation of the Bayesian linear regression. [Detailed documentation](#bayesian_linear_regression_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--center (-c)` | [`flag`](#doc_flag) | Center the data and fit the intercept if enabled. |  |
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_file (-i)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix of covariates (X). | `''` |
-| `--input_model_file (-m)` | [`BayesianLinearRegression<> file`](#doc_model) | Trained BayesianLinearRegression model to use. | `''` |
-| `--responses_file (-r)` | [`1-d matrix file`](#doc_a_1_d_matrix_file) | Matrix of responses/observations (y). | `''` |
-| `--scale (-s)` | [`flag`](#doc_flag) | Scale each feature by their standard deviations if enabled. |  |
-| `--test_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing points to regress on (test points). | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--output_model_file (-M)` | [`BayesianLinearRegression<> file`](#doc_model) | Output BayesianLinearRegression model. | 
-| `--predictions_file (-o)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | If --test_file is specified, this file is where the predicted responses will be saved. | 
-| `--stds_file (-u)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | If specified, this is where the standard deviations of the predictive distribution will be saved. | 
-
-### Detailed documentation
-{: #bayesian_linear_regression_detailed-documentation }
-
-An implementation of the Bayesian linear regression.
-This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
-Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
-
-This program is able to train a Bayesian linear regression model or load a model from file, output regression predictions for a test set, and save the trained model to a file.
-
-To train a BayesianLinearRegression model, the `--input_file (-i)` and `--responses_file (-r)`parameters must be given. The `--center (-c)`and `--scale (-s)` parameters control the centering and the normalizing options. A trained model can be saved with the `--output_model_file (-M)`. If no training is desired at all, a model can be passed via the `--input_model_file (-m)` parameter.
-
-The program can also provide predictions for test data using either the trained model or the given input model.  Test points can be specified with the `--test_file (-t)` parameter.  Predicted responses to the test points can be saved with the `--predictions_file (-o)` output parameter. The corresponding standard deviation can be save by precising the `--stds_file (-u)` parameter.
-
-### Example
-For example, the following command trains a model on the data `'data.csv'` and responses `'responses.csv'`with center set to true and scale set to false (so, Bayesian linear regression is being solved, and then the model is saved to `'blr_model.bin'`:
-
-```bash
-$ mlpack_bayesian_linear_regression --input_file data.csv --responses_file
-  responses.csv --center --scale --output_model_file blr_model.bin
-```
-
-The following command uses the `'blr_model.bin'` to provide predicted  responses for the data `'test.csv'` and save those  responses to `'test_predictions.csv'`: 
-
-```bash
-$ mlpack_bayesian_linear_regression --input_model_file blr_model.bin
-  --test_file test.csv --predictions_file test_predictions.csv
-```
-
-Because the estimator computes a predictive distribution instead of a simple point estimate, the `--stds_file (-u)` parameter allows one to save the prediction uncertainties: 
-
-```bash
-$ mlpack_bayesian_linear_regression --input_model_file blr_model.bin
-  --test_file test.csv --predictions_file test_predictions.csv --stds_file
-  stds.csv
-```
-
-### See also
-
- - [Bayesian Interpolation](https://cs.uwaterloo.ca/~mannr/cs886-w10/mackay-bayesian.pdf)
- - [Bayesian Linear Regression, Section 3.3](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
- - [BayesianLinearRegression C++ class documentation](../../user/methods/bayesian_linear_regression.md)
-
 ## mlpack_lars
 {: #lars }
 
@@ -1473,6 +1722,175 @@ $ mlpack_lars --input_model_file lasso_model.bin --test_file test.csv
  - [mlpack_linear_regression](#linear_regression)
  - [Least angle regression (pdf)](https://mlpack.org/papers/lars.pdf)
  - [LARS C++ class documentation](../../user/methods/lars.md)
+
+## mlpack_linear_regression
+{: #linear_regression }
+
+#### Simple Linear Regression and Prediction
+{: #linear_regression_descr }
+
+```bash
+$ mlpack_linear_regression [--help] [--info <string>]
+        [--input_model_file <string>] [--lambda 0] [--test_file <string>]
+        [--training_file <string>] [--training_responses_file <string>]
+        [--verbose] [--version] [--output_model_file <string>]
+        [--output_predictions_file <string>]
+```
+
+An implementation of simple linear regression and ridge regression using ordinary least squares.  Given a dataset and responses, a model can be trained and saved for later use, or a pre-trained model can be used to output regression predictions for a test set. [Detailed documentation](#linear_regression_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_model_file (-m)` | [`LinearRegression<> file`](#doc_model) | Existing LinearRegression model to use. | `''` |
+| `--lambda (-l)` | [`double`](#doc_double) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
+| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing X' (test regressors). | `''` |
+| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing training set X (regressors). | `''` |
+| `--training_responses_file (-r)` | [`1-d matrix file`](#doc_a_1_d_matrix_file) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`LinearRegression<> file`](#doc_model) | Output LinearRegression model. | 
+| `--output_predictions_file (-o)` | [`1-d matrix file`](#doc_a_1_d_matrix_file) | If --test_file is specified, this matrix is where the predicted responses will be saved. | 
+
+### Detailed documentation
+{: #linear_regression_detailed-documentation }
+
+An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+
+  y = X * b + e
+
+where X (specified by `--training_file (-t)`) and y (specified either as the last column of the input matrix `--training_file (-t)` or via the `--training_responses_file (-r)` parameter) are known and b is the desired variable.  If the covariance matrix (X'X) is not invertible, or if the solution is overdetermined, then specify a Tikhonov regularization constant (with `--lambda (-l)`) greater than 0, which will regularize the covariance matrix to make it invertible.  The calculated b may be saved with the `--output_predictions_file (-o)` output parameter.
+
+Optionally, the calculated value of b is used to predict the responses for another matrix X' (specified by the `--test_file (-T)` parameter):
+
+   y' = X' * b
+
+and the predicted responses y' may be saved with the `--output_predictions_file (-o)` output parameter.  This type of regression is related to least-angle regression, which mlpack implements as the 'lars' program.
+
+### Example
+For example, to run a linear regression on the dataset `'X.csv'` with responses `'y.csv'`, saving the trained model to `'lr_model.bin'`, the following command could be used:
+
+```bash
+$ mlpack_linear_regression --training_file X.csv --training_responses_file
+  y.csv --output_model_file lr_model.bin
+```
+
+Then, to use `'lr_model.bin'` to predict responses for a test set `'X_test.csv'`, saving the predictions to `'X_test_responses.csv'`, the following command could be used:
+
+```bash
+$ mlpack_linear_regression --input_model_file lr_model.bin --test_file
+  X_test.csv --output_predictions_file X_test_responses.csv
+```
+
+### See also
+
+ - [mlpack_lars](#lars)
+ - [Linear regression on Wikipedia](https://en.wikipedia.org/wiki/Linear_regression)
+ - [LinearRegression C++ class documentation](../../user/methods/linear_regression.md)
+
+## mlpack_linear_svm
+{: #linear_svm }
+
+#### Linear SVM is an L2-regularized support vector machine.
+{: #linear_svm_descr }
+
+```bash
+$ mlpack_linear_svm [--delta 1] [--epochs 50] [--help] [--info <string>]
+        [--input_model_file <string>] [--labels_file <string>] [--lambda 0.0001]
+        [--max_iterations 10000] [--no_intercept] [--num_classes 0] [--optimizer
+        'lbfgs'] [--seed 0] [--shuffle] [--step_size 0.01] [--test_file
+        <string>] [--test_labels_file <string>] [--tolerance 1e-10]
+        [--training_file <string>] [--verbose] [--version] [--output_model_file
+        <string>] [--predictions_file <string>] [--probabilities_file <string>]
+```
+
+An implementation of linear SVM for multiclass classification. Given labeled data, a model can be trained and saved for future use; or, a pre-trained model can be used to classify new points. [Detailed documentation](#linear_svm_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--delta (-d)` | [`double`](#doc_double) | Margin of difference between correct class and other classes. | `1` |
+| `--epochs (-E)` | [`int`](#doc_int) | Maximum number of full epochs over dataset for psgd | `50` |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_model_file (-m)` | [`LinearSVMModel file`](#doc_model) | Existing model (parameters). | `''` |
+| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | A matrix containing labels (0 or 1) for the points in the training set (y). | `''` |
+| `--lambda (-r)` | [`double`](#doc_double) | L2-regularization parameter for training. | `0.0001` |
+| `--max_iterations (-n)` | [`int`](#doc_int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
+| `--no_intercept (-N)` | [`flag`](#doc_flag) | Do not add the intercept term to the model. |  |
+| `--num_classes (-c)` | [`int`](#doc_int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
+| `--optimizer (-O)` | [`string`](#doc_string) | Optimizer to use for training ('lbfgs' or 'psgd'). | `'lbfgs'` |
+| `--seed (-s)` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `--shuffle (-S)` | [`flag`](#doc_flag) | Don't shuffle the order in which data points are visited for parallel SGD. |  |
+| `--step_size (-a)` | [`double`](#doc_double) | Step size for parallel SGD optimizer. | `0.01` |
+| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing test dataset. | `''` |
+| `--test_labels_file (-L)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Matrix containing test labels. | `''` |
+| `--tolerance (-e)` | [`double`](#doc_double) | Convergence tolerance for optimizer. | `1e-10` |
+| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the training set (the matrix of predictors, X). | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`LinearSVMModel file`](#doc_model) | Output for trained linear svm model. | 
+| `--predictions_file (-P)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
+| `--probabilities_file (-p)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | If test data is specified, this matrix is where the class probabilities for the test set will be saved. | 
+
+### Detailed documentation
+{: #linear_svm_detailed-documentation }
+
+An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
+
+This program allows loading a linear SVM model (via the `--input_model_file (-m)` parameter) or training a linear SVM model given training data (specified with the `--training_file (-t)` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (specified with the `--test_file (-T)` parameter) and the classification results may be saved with the `--predictions_file (-P)` output parameter. The trained linear SVM model may be saved using the `--output_model_file (-M)` output parameter.
+
+The training data, if specified, may have class labels as its last dimension.  Alternately, the `--labels_file (-l)` parameter may be used to specify a separate vector of labels.
+
+When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `--lambda (-r)` option, and the number of classes can be manually specified with the `--num_classes (-c)`and if an intercept term is not desired in the model, the `--no_intercept (-N)` parameter can be specified.
+
+Margin of difference between correct class and other classes can be specified with the `--delta (-d)` option.The optimizer used to train the model can be specified with the `--optimizer (-O)` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `--max_iterations (-n)` parameter specifies the maximum number of allowed iterations, and the `--tolerance (-e)` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `--step_size (-a)` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `--epochs (-E)`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
+
+Optionally, the model can be used to predict the labels for another matrix of data points, if `--test_file (-T)` is specified.  The `--test_file (-T)` parameter can be specified without the `--training_file (-t)` parameter, so long as an existing linear SVM model is given with the `--input_model_file (-m)` parameter.  The output predictions from the linear SVM model may be saved with the `--predictions_file (-P)` parameter.
+
+### Example
+As an example, to train a LinaerSVM on the data '`'data.csv'`' with labels '`'labels.csv'`' with L2 regularization of 0.1, saving the model to '`'lsvm_model.bin'`', the following command may be used:
+
+```bash
+$ mlpack_linear_svm --training_file data.csv --labels_file labels.csv --lambda
+  0.1 --delta 1 --num_classes 0 --output_model_file lsvm_model.bin
+```
+
+Then, to use that model to predict classes for the dataset '`'test.csv'`', storing the output predictions in '`'predictions.csv'`', the following command may be used: 
+
+```bash
+$ mlpack_linear_svm --input_model_file lsvm_model.bin --test_file test.csv
+  --predictions_file predictions.csv
+```
+
+### See also
+
+ - [mlpack_random_forest](#random_forest)
+ - [mlpack_logistic_regression](#logistic_regression)
+ - [LinearSVM on Wikipedia](https://en.wikipedia.org/wiki/Support-vector_machine)
+ - [LinearSVM C++ class documentation](../../user/methods/linear_svm.md)
 
 ## mlpack_lmnn
 {: #lmnn }
@@ -1895,6 +2313,85 @@ $ mlpack_mean_shift --input_file data.csv --centroid_file centroids.csv
  - [Mean Shift, Mode Seeking, and Clustering (pdf)](https://members.loria.fr/MOBerger/Enseignement/Master2/Exposes/meanShiftCluster.pdf)
  - [mlpack::mean_shift::MeanShift C++ class documentation](../../user/methods/mean_shift.md)
 
+## mlpack_nbc
+{: #nbc }
+
+#### Parametric Naive Bayes Classifier
+{: #nbc_descr }
+
+```bash
+$ mlpack_nbc [--help] [--incremental_variance] [--info <string>]
+        [--input_model_file <string>] [--labels_file <string>] [--test_file
+        <string>] [--training_file <string>] [--verbose] [--version]
+        [--output_model_file <string>] [--predictions_file <string>]
+        [--probabilities_file <string>]
+```
+
+An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model can be trained and saved, or, a pre-trained model can be used for classification. [Detailed documentation](#nbc_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--incremental_variance (-I)` | [`flag`](#doc_flag) | The variance of each class will be calculated incrementally. |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_model_file (-m)` | [`NBCModel file`](#doc_model) | Input Naive Bayes model. | `''` |
+| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | A file containing labels for the training set. | `''` |
+| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the test set. | `''` |
+| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the training set. | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`NBCModel file`](#doc_model) | File to save trained Naive Bayes model to. | 
+| `--predictions_file (-a)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | The matrix in which the predicted labels for the test set will be written. | 
+| `--probabilities_file (-p)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | The matrix in which the predicted probability of labels for the test set will be written. | 
+
+### Detailed documentation
+{: #nbc_detailed-documentation }
+
+This program trains the Naive Bayes classifier on the given labeled training set, or loads a model from the given model file, and then may use that trained model to classify the points in a given test set.
+
+The training set is specified with the `--training_file (-t)` parameter.  Labels may be either the last row of the training set, or alternately the `--labels_file (-l)` parameter may be specified to pass a separate matrix of labels.
+
+If training is not desired, a pre-existing model may be loaded with the `--input_model_file (-m)` parameter.
+
+
+
+The `--incremental_variance (-I)` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
+
+If classifying a test set is desired, the test set may be specified with the `--test_file (-T)` parameter, and the classifications may be saved with the `--predictions_file (-a)`predictions  parameter.  If saving the trained model is desired, this may be done with the `--output_model_file (-M)` output parameter.
+
+### Example
+For example, to train a Naive Bayes classifier on the dataset `'data.csv'` with labels `'labels.csv'` and save the model to `'nbc_model.bin'`, the following command may be used:
+
+```bash
+$ mlpack_nbc --training_file data.csv --labels_file labels.csv
+  --output_model_file nbc_model.bin
+```
+
+Then, to use `'nbc_model.bin'` to predict the classes of the dataset `'test_set.csv'` and save the predicted classes to `'predictions.csv'`, the following command may be used:
+
+```bash
+$ mlpack_nbc --input_model_file nbc_model.bin --test_file test_set.csv
+  --predictions_file predictions.csv
+```
+
+### See also
+
+ - [mlpack_softmax_regression](#softmax_regression)
+ - [mlpack_random_forest](#random_forest)
+ - [Naive Bayes classifier on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
+ - [NaiveBayesClassifier C++ class documentation](../../user/methods/naive_bayes_classifier.md)
+
 ## mlpack_nca
 {: #nca }
 
@@ -2255,6 +2752,78 @@ $ mlpack_pca --input_file data.csv --new_dimensionality 5
 
  - [Principal component analysis on Wikipedia](https://en.wikipedia.org/wiki/Principal_component_analysis)
  - [PCA C++ class documentation](../../user/methods/pca.md)
+
+## mlpack_perceptron
+{: #perceptron }
+
+#### Perceptron
+{: #perceptron_descr }
+
+```bash
+$ mlpack_perceptron [--help] [--info <string>] [--input_model_file
+        <string>] [--labels_file <string>] [--max_iterations 1000] [--test_file
+        <string>] [--training_file <string>] [--verbose] [--version]
+        [--output_model_file <string>] [--predictions_file <string>]
+```
+
+An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and saved for future use; or, a pre-trained perceptron can be used for classification on new points. [Detailed documentation](#perceptron_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
+| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
+| `--input_model_file (-m)` | [`PerceptronModel file`](#doc_model) | Input perceptron model. | `''` |
+| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | A matrix containing labels for the training set. | `''` |
+| `--max_iterations (-n)` | [`int`](#doc_int) | The maximum number of iterations the perceptron is to be run | `1000` |
+| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the test set. | `''` |
+| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the training set. | `''` |
+| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
+| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
+
+### Output options
+
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `--output_model_file (-M)` | [`PerceptronModel file`](#doc_model) | Output for trained perceptron model. | 
+| `--predictions_file (-P)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | The matrix in which the predicted labels for the test set will be written. | 
+
+### Detailed documentation
+{: #perceptron_detailed-documentation }
+
+This program implements a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `--max_iterations (-n)` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
+
+This program allows loading a perceptron from a model (via the `--input_model_file (-m)` parameter) or training a perceptron given training data (via the `--training_file (-t)` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (via the `--test_file (-T)` parameter) and the classification results on the test set may be saved with the `--predictions_file (-P)` output parameter.  The perceptron model may be saved with the `--output_model_file (-M)` output parameter.
+
+### Example
+The training data given with the `--training_file (-t)` option may have class labels as its last dimension (so, if the training data is in CSV format, labels should be the last column).  Alternately, the `--labels_file (-l)` parameter may be used to specify a separate matrix of labels.
+
+All these options make it easy to train a perceptron, and then re-use that perceptron for later classification.  The invocation below trains a perceptron on `'training_data.csv'` with labels `'training_labels.csv'`, and saves the model to `'perceptron_model.bin'`.
+
+```bash
+$ mlpack_perceptron --training_file training_data.csv --labels_file
+  training_labels.csv --output_model_file perceptron_model.bin
+```
+
+Then, this model can be re-used for classification on the test data `'test_data.csv'`.  The example below does precisely that, saving the predicted classes to `'predictions.csv'`.
+
+```bash
+$ mlpack_perceptron --input_model_file perceptron_model.bin --test_file
+  test_data.csv --predictions_file predictions.csv
+```
+
+Note that all of the options may be specified at once: predictions may be calculated right after training a model, and model training can occur even if an existing perceptron model is passed with the `--input_model_file (-m)` parameter.  However, note that the number of classes and the dimensionality of all data must match.  So you cannot pass a perceptron model trained on 2 classes and then re-train with a 4-class dataset.  Similarly, attempting classification on a 3-dimensional dataset with a perceptron that has been trained on 8 dimensions will cause an error.
+
+### See also
+
+ - [mlpack_adaboost](#adaboost)
+ - [Perceptron on Wikipedia](https://en.wikipedia.org/wiki/Perceptron)
+ - [Perceptron C++ class documentation](../../user/methods/perceptron.md)
 
 ## mlpack_preprocess_split
 {: #preprocess_split }
@@ -2673,171 +3242,6 @@ $ mlpack_radical --input_file X.csv --replicates 40 --output_ic_file ic.csv
  - [ICA using spacings estimates of entropy (pdf)](https://www.jmlr.org/papers/volume4/learned-miller03a/learned-miller03a.pdf)
  - [Radical C++ class documentation](../../user/methods/radical.md)
 
-## mlpack_krann
-{: #krann }
-
-#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
-{: #krann_descr }
-
-```bash
-$ mlpack_krann [--alpha 0.95] [--first_leaf_exact] [--help] [--info
-        <string>] [--input_model_file <string>] [--k 0] [--leaf_size 20]
-        [--naive] [--query_file <string>] [--random_basis] [--reference_file
-        <string>] [--sample_at_leaves] [--seed 0] [--single_mode]
-        [--single_sample_limit 20] [--tau 5] [--tree_type 'kd'] [--verbose]
-        [--version] [--distances_file <string>] [--neighbors_file <string>]
-        [--output_model_file <string>]
-```
-
-An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--alpha (-a)` | [`double`](#doc_double) | The desired success probability. | `0.95` |
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--first_leaf_exact (-X)` | [`flag`](#doc_flag) | The flag to trigger sampling only after exactly exploring the first leaf. |  |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`RAModel file`](#doc_model) | Pre-trained kNN model. | `''` |
-| `--k (-k)` | [`int`](#doc_int) | Number of nearest neighbors to find. | `0` |
-| `--leaf_size (-l)` | [`int`](#doc_int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
-| `--naive (-N)` | [`flag`](#doc_flag) | If true, sampling will be done without using a tree. |  |
-| `--query_file (-q)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing query points (optional). | `''` |
-| `--random_basis (-R)` | [`flag`](#doc_flag) | Before tree-building, project the data onto a random orthogonal basis. |  |
-| `--reference_file (-r)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing the reference dataset. | `''` |
-| `--sample_at_leaves (-L)` | [`flag`](#doc_flag) | The flag to trigger sampling at leaves. |  |
-| `--seed (-s)` | [`int`](#doc_int) | Random seed (if 0, std::time(NULL) is used). | `0` |
-| `--single_mode (-S)` | [`flag`](#doc_flag) | If true, single-tree search is used (as opposed to dual-tree search. |  |
-| `--single_sample_limit (-z)` | [`int`](#doc_int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
-| `--tau (-T)` | [`double`](#doc_double) | The allowed rank-error in terms of the percentile of the data. | `5` |
-| `--tree_type (-t)` | [`string`](#doc_string) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `'kd'` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--distances_file (-d)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix to output distances into. | 
-| `--neighbors_file (-n)` | [`2-d index matrix file`](#doc_a_2_d_index_matrix_file) | Matrix to output neighbors into. | 
-| `--output_model_file (-M)` | [`RAModel file`](#doc_model) | If specified, the kNN model will be output here. | 
-
-### Detailed documentation
-{: #krann_detailed-documentation }
-
-This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
-
-### Example
-For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `'input.csv'` and store the distances in `'distances.csv'` and the neighbors in `'neighbors.csv.csv'`:
-
-```bash
-$ mlpack_krann --reference_file input.csv --k 5 --distances_file distances.csv
-  --neighbors_file neighbors.csv --tau 0.1
-```
-
-Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
-
-The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
-
-### See also
-
- - [mlpack_knn](#knn)
- - [mlpack_lsh](#lsh)
- - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
- - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
-
-## mlpack_sparse_coding
-{: #sparse_coding }
-
-#### Sparse Coding
-{: #sparse_coding_descr }
-
-```bash
-$ mlpack_sparse_coding [--atoms 15] [--help] [--info <string>]
-        [--initial_dictionary_file <string>] [--input_model_file <string>]
-        [--lambda1 0] [--lambda2 0] [--max_iterations 0] [--newton_tolerance
-        1e-06] [--normalize] [--objective_tolerance 0.01] [--seed 0]
-        [--test_file <string>] [--training_file <string>] [--verbose]
-        [--version] [--codes_file <string>] [--dictionary_file <string>]
-        [--output_model_file <string>]
-```
-
-An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--atoms (-k)` | [`int`](#doc_int) | Number of atoms in the dictionary. | `15` |
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--initial_dictionary_file (-i)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Optional initial dictionary matrix. | `''` |
-| `--input_model_file (-m)` | [`SparseCoding<> file`](#doc_model) | File containing input sparse coding model. | `''` |
-| `--lambda1 (-l)` | [`double`](#doc_double) | Sparse coding l1-norm regularization parameter. | `0` |
-| `--lambda2 (-L)` | [`double`](#doc_double) | Sparse coding l2-norm regularization parameter. | `0` |
-| `--max_iterations (-n)` | [`int`](#doc_int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
-| `--newton_tolerance (-w)` | [`double`](#doc_double) | Tolerance for convergence of Newton method. | `1e-06` |
-| `--normalize (-N)` | [`flag`](#doc_flag) | If set, the input data matrix will be normalized before coding. |  |
-| `--objective_tolerance (-o)` | [`double`](#doc_double) | Tolerance for convergence of the objective function. | `0.01` |
-| `--seed (-s)` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Optional matrix to be encoded by trained model. | `''` |
-| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix of training data (X). | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--codes_file (-c)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
-| `--dictionary_file (-d)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix to save the output dictionary to. | 
-| `--output_model_file (-M)` | [`SparseCoding<> file`](#doc_model) | File to save trained sparse coding model to. | 
-
-### Detailed documentation
-{: #sparse_coding_detailed-documentation }
-
-An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
-
-The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
-
-The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
-
-Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
-
-To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `--training_file (-t)` option, along with the number of atoms in the dictionary (specified with the `--atoms (-k)` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `--initial_dictionary_file (-i)` parameter.  An input model may be specified with the `--input_model_file (-m)` parameter.
-
-### Example
-As an example, to build a sparse coding model on the dataset `'data.csv'` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `'model.bin'`, use 
-
-```bash
-$ mlpack_sparse_coding --training_file data.csv --atoms 200 --lambda1 0.1
-  --output_model_file model.bin
-```
-
-Then, this model could be used to encode a new matrix, `'otherdata.csv'`, and save the output codes to `'codes.csv'`: 
-
-```bash
-$ mlpack_sparse_coding --input_model_file model.bin --test_file otherdata.csv
-  --codes_file codes.csv
-```
-
-### See also
-
- - [mlpack_local_coordinate_coding](#local_coordinate_coding)
- - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
- - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
- - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
- - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
-
 ## mlpack_random_forest
 {: #random_forest }
 
@@ -2927,23 +3331,23 @@ $ mlpack_random_forest --input_model_file rf_model.bin --test_file
  - [Random forests (pdf)](https://www.eecis.udel.edu/~shatkay/Course/papers/BreimanRandomForests2001.pdf)
  - [RandomForest C++ class documentation](../../user/methods/random_forest.md)
 
-## mlpack_decision_tree
-{: #decision_tree }
+## mlpack_krann
+{: #krann }
 
-#### Decision tree
-{: #decision_tree_descr }
+#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
+{: #krann_descr }
 
 ```bash
-$ mlpack_decision_tree [--help] [--info <string>] [--input_model_file
-        <string>] [--labels_file <string>] [--maximum_depth 0]
-        [--minimum_gain_split 1e-07] [--minimum_leaf_size 20]
-        [--print_training_accuracy] [--test_file <string>] [--test_labels_file
-        <string>] [--training_file <string>] [--verbose] [--version]
-        [--weights_file <string>] [--output_model_file <string>]
-        [--predictions_file <string>] [--probabilities_file <string>]
+$ mlpack_krann [--alpha 0.95] [--first_leaf_exact] [--help] [--info
+        <string>] [--input_model_file <string>] [--k 0] [--leaf_size 20]
+        [--naive] [--query_file <string>] [--random_basis] [--reference_file
+        <string>] [--sample_at_leaves] [--seed 0] [--single_mode]
+        [--single_sample_limit 20] [--tau 5] [--tree_type 'kd'] [--verbose]
+        [--version] [--distances_file <string>] [--neighbors_file <string>]
+        [--output_model_file <string>]
 ```
 
-An implementation of an ID3-style decision tree for classification, which supports categorical data.  Given labeled data with numeric or categorical features, a decision tree can be trained and saved; or, an existing decision tree can be used for classification on new points. [Detailed documentation](#decision_tree_detailed-documentation).
+An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
 
 
 
@@ -2951,94 +3355,24 @@ An implementation of an ID3-style decision tree for classification, which suppor
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `--alpha (-a)` | [`double`](#doc_double) | The desired success probability. | `0.95` |
 | `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
+| `--first_leaf_exact (-X)` | [`flag`](#doc_flag) | The flag to trigger sampling only after exactly exploring the first leaf. |  |
 | `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
 | `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`DecisionTreeModel file`](#doc_model) | Pre-trained decision tree, to be used with test points. | `''` |
-| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Training labels. | `''` |
-| `--maximum_depth (-D)` | [`int`](#doc_int) | Maximum depth of the tree (0 means no limit). | `0` |
-| `--minimum_gain_split (-g)` | [`double`](#doc_double) | Minimum gain for node splitting. | `1e-07` |
-| `--minimum_leaf_size (-n)` | [`int`](#doc_int) | Minimum number of points in a leaf. | `20` |
-| `--print_training_accuracy (-a)` | [`flag`](#doc_flag) | Print the training accuracy. |  |
-| `--test_file (-T)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Testing dataset (may be categorical). | `''` |
-| `--test_labels_file (-L)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Test point labels, if accuracy calculation is desired. | `''` |
-| `--training_file (-t)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Training dataset (may be categorical). | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--weights_file (-w)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | The weight of labels | `''` |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--output_model_file (-M)` | [`DecisionTreeModel file`](#doc_model) | Output for trained decision tree. | 
-| `--predictions_file (-p)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Class predictions for each test point. | 
-| `--probabilities_file (-P)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Class probabilities for each test point. | 
-
-### Detailed documentation
-{: #decision_tree_detailed-documentation }
-
-Train and evaluate using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
-
-The training set and associated labels are specified with the `--training_file (-t)` and `--labels_file (-l)` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `--labels_file (-l)` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-When a model is trained, the `--output_model_file (-M)` output parameter may be used to save the trained model.  A model may be loaded for predictions with the `--input_model_file (-m)` parameter.  The `--input_model_file (-m)` parameter may not be specified when the `--training_file (-t)` parameter is specified.  The `--minimum_leaf_size (-n)` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `--minimum_gain_split (-g)` parameter specifies the minimum gain that is needed for the node to split.  The `--maximum_depth (-D)` parameter specifies the maximum depth of the tree.  If `--print_training_accuracy (-a)` is specified, the training accuracy will be printed.
-
-Test data may be specified with the `--test_file (-T)` parameter, and if performance numbers are desired for that test set, labels may be specified with the `--test_labels_file (-L)` parameter.  Predictions for each test point may be saved via the `--predictions_file (-p)` output parameter.  Class probabilities for each prediction may be saved with the `--probabilities_file (-P)` output parameter.
-
-### Example
-For example, to train a decision tree with a minimum leaf size of 20 on the dataset contained in `'data.csv'` with labels `'labels.csv'`, saving the output model to `'tree.bin'` and printing the training error, one could call
-
-```bash
-$ mlpack_decision_tree --training_file data.arff --labels_file labels.csv
-  --output_model_file tree.bin --minimum_leaf_size 20 --minimum_gain_split 0.001
-  --print_training_accuracy
-```
-
-Then, to use that model to classify points in `'test_set.csv'` and print the test error given the labels `'test_labels.csv'` using that model, while saving the predictions for each point to `'predictions.csv'`, one could call 
-
-```bash
-$ mlpack_decision_tree --input_model_file tree.bin --test_file test_set.arff
-  --test_labels_file test_labels.csv --predictions_file predictions.csv
-```
-
-### See also
-
- - [Random forest](#random_forest)
- - [Decision trees on Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning)
- - [Induction of Decision Trees (pdf)](https://www.hunch.net/~coms-4771/quinlan.pdf)
- - [DecisionTree C++ class documentation](../../user/methods/decision_tree.md)
-
-## mlpack_perceptron
-{: #perceptron }
-
-#### Perceptron
-{: #perceptron_descr }
-
-```bash
-$ mlpack_perceptron [--help] [--info <string>] [--input_model_file
-        <string>] [--labels_file <string>] [--max_iterations 1000] [--test_file
-        <string>] [--training_file <string>] [--verbose] [--version]
-        [--output_model_file <string>] [--predictions_file <string>]
-```
-
-An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and saved for future use; or, a pre-trained perceptron can be used for classification on new points. [Detailed documentation](#perceptron_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`PerceptronModel file`](#doc_model) | Input perceptron model. | `''` |
-| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | A matrix containing labels for the training set. | `''` |
-| `--max_iterations (-n)` | [`int`](#doc_int) | The maximum number of iterations the perceptron is to be run | `1000` |
-| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the test set. | `''` |
-| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the training set. | `''` |
+| `--input_model_file (-m)` | [`RAModel file`](#doc_model) | Pre-trained kNN model. | `''` |
+| `--k (-k)` | [`int`](#doc_int) | Number of nearest neighbors to find. | `0` |
+| `--leaf_size (-l)` | [`int`](#doc_int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
+| `--naive (-N)` | [`flag`](#doc_flag) | If true, sampling will be done without using a tree. |  |
+| `--query_file (-q)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing query points (optional). | `''` |
+| `--random_basis (-R)` | [`flag`](#doc_flag) | Before tree-building, project the data onto a random orthogonal basis. |  |
+| `--reference_file (-r)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing the reference dataset. | `''` |
+| `--sample_at_leaves (-L)` | [`flag`](#doc_flag) | The flag to trigger sampling at leaves. |  |
+| `--seed (-s)` | [`int`](#doc_int) | Random seed (if 0, std::time(NULL) is used). | `0` |
+| `--single_mode (-S)` | [`flag`](#doc_flag) | If true, single-tree search is used (as opposed to dual-tree search. |  |
+| `--single_sample_limit (-z)` | [`int`](#doc_int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
+| `--tau (-T)` | [`double`](#doc_double) | The allowed rank-error in terms of the percentile of the data. | `5` |
+| `--tree_type (-t)` | [`string`](#doc_string) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `'kd'` |
 | `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
 | `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
 
@@ -3047,377 +3381,33 @@ An implementation of a perceptron---a single level neural network---for classifi
 
 | ***name*** | ***type*** | ***description*** |
 |------------|------------|-------------------|
-| `--output_model_file (-M)` | [`PerceptronModel file`](#doc_model) | Output for trained perceptron model. | 
-| `--predictions_file (-P)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | The matrix in which the predicted labels for the test set will be written. | 
+| `--distances_file (-d)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix to output distances into. | 
+| `--neighbors_file (-n)` | [`2-d index matrix file`](#doc_a_2_d_index_matrix_file) | Matrix to output neighbors into. | 
+| `--output_model_file (-M)` | [`RAModel file`](#doc_model) | If specified, the kNN model will be output here. | 
 
 ### Detailed documentation
-{: #perceptron_detailed-documentation }
+{: #krann_detailed-documentation }
 
-This program implements a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `--max_iterations (-n)` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
-
-This program allows loading a perceptron from a model (via the `--input_model_file (-m)` parameter) or training a perceptron given training data (via the `--training_file (-t)` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (via the `--test_file (-T)` parameter) and the classification results on the test set may be saved with the `--predictions_file (-P)` output parameter.  The perceptron model may be saved with the `--output_model_file (-M)` output parameter.
+This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
 
 ### Example
-The training data given with the `--training_file (-t)` option may have class labels as its last dimension (so, if the training data is in CSV format, labels should be the last column).  Alternately, the `--labels_file (-l)` parameter may be used to specify a separate matrix of labels.
-
-All these options make it easy to train a perceptron, and then re-use that perceptron for later classification.  The invocation below trains a perceptron on `'training_data.csv'` with labels `'training_labels.csv'`, and saves the model to `'perceptron_model.bin'`.
+For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `'input.csv'` and store the distances in `'distances.csv'` and the neighbors in `'neighbors.csv.csv'`:
 
 ```bash
-$ mlpack_perceptron --training_file training_data.csv --labels_file
-  training_labels.csv --output_model_file perceptron_model.bin
+$ mlpack_krann --reference_file input.csv --k 5 --distances_file distances.csv
+  --neighbors_file neighbors.csv --tau 0.1
 ```
 
-Then, this model can be re-used for classification on the test data `'test_data.csv'`.  The example below does precisely that, saving the predicted classes to `'predictions.csv'`.
+Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
 
-```bash
-$ mlpack_perceptron --input_model_file perceptron_model.bin --test_file
-  test_data.csv --predictions_file predictions.csv
-```
-
-Note that all of the options may be specified at once: predictions may be calculated right after training a model, and model training can occur even if an existing perceptron model is passed with the `--input_model_file (-m)` parameter.  However, note that the number of classes and the dimensionality of all data must match.  So you cannot pass a perceptron model trained on 2 classes and then re-train with a 4-class dataset.  Similarly, attempting classification on a 3-dimensional dataset with a perceptron that has been trained on 8 dimensions will cause an error.
+The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
 
 ### See also
 
- - [mlpack_adaboost](#adaboost)
- - [Perceptron on Wikipedia](https://en.wikipedia.org/wiki/Perceptron)
- - [Perceptron C++ class documentation](../../user/methods/perceptron.md)
-
-## mlpack_linear_svm
-{: #linear_svm }
-
-#### Linear SVM is an L2-regularized support vector machine.
-{: #linear_svm_descr }
-
-```bash
-$ mlpack_linear_svm [--delta 1] [--epochs 50] [--help] [--info <string>]
-        [--input_model_file <string>] [--labels_file <string>] [--lambda 0.0001]
-        [--max_iterations 10000] [--no_intercept] [--num_classes 0] [--optimizer
-        'lbfgs'] [--seed 0] [--shuffle] [--step_size 0.01] [--test_file
-        <string>] [--test_labels_file <string>] [--tolerance 1e-10]
-        [--training_file <string>] [--verbose] [--version] [--output_model_file
-        <string>] [--predictions_file <string>] [--probabilities_file <string>]
-```
-
-An implementation of linear SVM for multiclass classification. Given labeled data, a model can be trained and saved for future use; or, a pre-trained model can be used to classify new points. [Detailed documentation](#linear_svm_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--delta (-d)` | [`double`](#doc_double) | Margin of difference between correct class and other classes. | `1` |
-| `--epochs (-E)` | [`int`](#doc_int) | Maximum number of full epochs over dataset for psgd | `50` |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`LinearSVMModel file`](#doc_model) | Existing model (parameters). | `''` |
-| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | A matrix containing labels (0 or 1) for the points in the training set (y). | `''` |
-| `--lambda (-r)` | [`double`](#doc_double) | L2-regularization parameter for training. | `0.0001` |
-| `--max_iterations (-n)` | [`int`](#doc_int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
-| `--no_intercept (-N)` | [`flag`](#doc_flag) | Do not add the intercept term to the model. |  |
-| `--num_classes (-c)` | [`int`](#doc_int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
-| `--optimizer (-O)` | [`string`](#doc_string) | Optimizer to use for training ('lbfgs' or 'psgd'). | `'lbfgs'` |
-| `--seed (-s)` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `--shuffle (-S)` | [`flag`](#doc_flag) | Don't shuffle the order in which data points are visited for parallel SGD. |  |
-| `--step_size (-a)` | [`double`](#doc_double) | Step size for parallel SGD optimizer. | `0.01` |
-| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing test dataset. | `''` |
-| `--test_labels_file (-L)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Matrix containing test labels. | `''` |
-| `--tolerance (-e)` | [`double`](#doc_double) | Convergence tolerance for optimizer. | `1e-10` |
-| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the training set (the matrix of predictors, X). | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--output_model_file (-M)` | [`LinearSVMModel file`](#doc_model) | Output for trained linear svm model. | 
-| `--predictions_file (-P)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
-| `--probabilities_file (-p)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | If test data is specified, this matrix is where the class probabilities for the test set will be saved. | 
-
-### Detailed documentation
-{: #linear_svm_detailed-documentation }
-
-An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
-
-This program allows loading a linear SVM model (via the `--input_model_file (-m)` parameter) or training a linear SVM model given training data (specified with the `--training_file (-t)` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (specified with the `--test_file (-T)` parameter) and the classification results may be saved with the `--predictions_file (-P)` output parameter. The trained linear SVM model may be saved using the `--output_model_file (-M)` output parameter.
-
-The training data, if specified, may have class labels as its last dimension.  Alternately, the `--labels_file (-l)` parameter may be used to specify a separate vector of labels.
-
-When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `--lambda (-r)` option, and the number of classes can be manually specified with the `--num_classes (-c)`and if an intercept term is not desired in the model, the `--no_intercept (-N)` parameter can be specified.
-
-Margin of difference between correct class and other classes can be specified with the `--delta (-d)` option.The optimizer used to train the model can be specified with the `--optimizer (-O)` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `--max_iterations (-n)` parameter specifies the maximum number of allowed iterations, and the `--tolerance (-e)` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `--step_size (-a)` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `--epochs (-E)`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
-
-Optionally, the model can be used to predict the labels for another matrix of data points, if `--test_file (-T)` is specified.  The `--test_file (-T)` parameter can be specified without the `--training_file (-t)` parameter, so long as an existing linear SVM model is given with the `--input_model_file (-m)` parameter.  The output predictions from the linear SVM model may be saved with the `--predictions_file (-P)` parameter.
-
-### Example
-As an example, to train a LinaerSVM on the data '`'data.csv'`' with labels '`'labels.csv'`' with L2 regularization of 0.1, saving the model to '`'lsvm_model.bin'`', the following command may be used:
-
-```bash
-$ mlpack_linear_svm --training_file data.csv --labels_file labels.csv --lambda
-  0.1 --delta 1 --num_classes 0 --output_model_file lsvm_model.bin
-```
-
-Then, to use that model to predict classes for the dataset '`'test.csv'`', storing the output predictions in '`'predictions.csv'`', the following command may be used: 
-
-```bash
-$ mlpack_linear_svm --input_model_file lsvm_model.bin --test_file test.csv
-  --predictions_file predictions.csv
-```
-
-### See also
-
- - [mlpack_random_forest](#random_forest)
- - [mlpack_logistic_regression](#logistic_regression)
- - [LinearSVM on Wikipedia](https://en.wikipedia.org/wiki/Support-vector_machine)
- - [LinearSVM C++ class documentation](../../user/methods/linear_svm.md)
-
-## mlpack_adaboost
-{: #adaboost }
-
-#### AdaBoost
-{: #adaboost_descr }
-
-```bash
-$ mlpack_adaboost [--help] [--info <string>] [--input_model_file
-        <string>] [--iterations 1000] [--labels_file <string>] [--test_file
-        <string>] [--tolerance 1e-10] [--training_file <string>] [--verbose]
-        [--version] [--weak_learner 'decision_stump'] [--output_model_file
-        <string>] [--predictions_file <string>] [--probabilities_file <string>]
-```
-
-An implementation of the AdaBoost.MH (Adaptive Boosting) algorithm for classification.  This can be used to train an AdaBoost model on labeled data or use an existing AdaBoost model to predict the classes of new points. [Detailed documentation](#adaboost_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`AdaBoostModel file`](#doc_model) | Input AdaBoost model. | `''` |
-| `--iterations (-i)` | [`int`](#doc_int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
-| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Labels for the training set. | `''` |
-| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Test dataset. | `''` |
-| `--tolerance (-e)` | [`double`](#doc_double) | The tolerance for change in values of the weighted error during training. | `1e-10` |
-| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Dataset for training AdaBoost. | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--weak_learner (-w)` | [`string`](#doc_string) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `'decision_stump'` |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--output_model_file (-M)` | [`AdaBoostModel file`](#doc_model) | Output trained AdaBoost model. | 
-| `--predictions_file (-P)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Predicted labels for the test set. | 
-| `--probabilities_file (-p)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Predicted class probabilities for each point in the test set. | 
-
-### Detailed documentation
-{: #adaboost_detailed-documentation }
-
-This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
-
-For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
-
-This program allows training of an AdaBoost model, and then application of that model to a test dataset.  To train a model, a dataset must be passed with the `--training_file (-t)` option.  Labels can be given with the `--labels_file (-l)` option; if no labels are specified, the labels will be assumed to be the last column of the input dataset.  Alternately, an AdaBoost model may be loaded with the `--input_model_file (-m)` option.
-
-Once a model is trained or loaded, it may be used to provide class predictions for a given test dataset.  A test dataset may be specified with the `--test_file (-T)` parameter.  The predicted classes for each point in the test dataset are output to the `--predictions_file (-P)` output parameter.  The AdaBoost model itself is output to the `--output_model_file (-M)` output parameter.
-
-### Example
-For example, to run AdaBoost on an input dataset `'data.csv'` with labels `'labels.csv'`and perceptrons as the weak learner type, storing the trained model in `'model.bin'`, one could use the following command: 
-
-```bash
-$ mlpack_adaboost --training_file data.csv --labels_file labels.csv
-  --output_model_file model.bin --weak_learner perceptron
-```
-
-Similarly, an already-trained model in `'model.bin'` can be used to provide class predictions from test data `'test_data.csv'` and store the output in `'predictions.csv'` with the following command: 
-
-```bash
-$ mlpack_adaboost --input_model_file model.bin --test_file test_data.csv
-  --predictions_file predictions.csv
-```
-
-### See also
-
- - [AdaBoost on Wikipedia](https://en.wikipedia.org/wiki/AdaBoost)
- - [Improved boosting algorithms using confidence-rated predictions (pdf)](http://www.schapire.net/papers/SchapireSi98.pdf)
- - [Perceptron](#perceptron)
- - [Decision Trees](#decision_tree)
- - [AdaBoost C++ class documentation](../../user/methods/adaboost.md)
-
-## mlpack_hoeffding_tree
-{: #hoeffding_tree }
-
-#### Hoeffding trees
-{: #hoeffding_tree_descr }
-
-```bash
-$ mlpack_hoeffding_tree [--batch_mode] [--bins 10] [--confidence 0.95]
-        [--help] [--info <string>] [--info_gain] [--input_model_file <string>]
-        [--labels_file <string>] [--max_samples 5000] [--min_samples 100]
-        [--numeric_split_strategy 'binary'] [--observations_before_binning 100]
-        [--passes 1] [--test_file <string>] [--test_labels_file <string>]
-        [--training_file <string>] [--verbose] [--version] [--output_model_file
-        <string>] [--predictions_file <string>] [--probabilities_file <string>]
-```
-
-An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data, a Hoeffding tree can be trained and saved for later use, or a pre-trained Hoeffding tree can be used for predicting the classifications of new points. [Detailed documentation](#hoeffding_tree_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--batch_mode (-b)` | [`flag`](#doc_flag) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. |  |
-| `--bins (-B)` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--confidence (-c)` | [`double`](#doc_double) | Confidence before splitting (between 0 and 1). | `0.95` |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--info_gain (-i)` | [`flag`](#doc_flag) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. |  |
-| `--input_model_file (-m)` | [`HoeffdingTreeModel file`](#doc_model) | Input trained Hoeffding tree model. | `''` |
-| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Labels for training dataset. | `''` |
-| `--max_samples (-n)` | [`int`](#doc_int) | Maximum number of samples before splitting. | `5000` |
-| `--min_samples (-I)` | [`int`](#doc_int) | Minimum number of samples before splitting. | `100` |
-| `--numeric_split_strategy (-N)` | [`string`](#doc_string) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `'binary'` |
-| `--observations_before_binning (-o)` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
-| `--passes (-s)` | [`int`](#doc_int) | Number of passes to take over the dataset. | `1` |
-| `--test_file (-T)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Testing dataset (may be categorical). | `''` |
-| `--test_labels_file (-L)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Labels of test data. | `''` |
-| `--training_file (-t)` | [`2-d categorical matrix file`](#doc_a_2_d_categorical_matrix_file) | Training dataset (may be categorical). | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--output_model_file (-M)` | [`HoeffdingTreeModel file`](#doc_model) | Output for trained Hoeffding tree model. | 
-| `--predictions_file (-p)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | Matrix to output label predictions for test data into. | 
-| `--probabilities_file (-P)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
-
-### Detailed documentation
-{: #hoeffding_tree_detailed-documentation }
-
-This program implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets.  This program supports both categorical and numeric data.  Given an input dataset, this program is able to train the tree with numerous training options, and save the model to a file.  The program is also able to use a trained model or a model from file in order to predict classes for a given test set.
-
-The training file and associated labels are specified with the `--training_file (-t)` and `--labels_file (-l)` parameters, respectively. Optionally, if `--labels_file (-l)` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `--batch_mode (-b)` option, but this may not be the best option for large datasets.
-
-When a model is trained, it may be saved via the `--output_model_file (-M)` output parameter.  A model may be loaded from file for further training or testing with the `--input_model_file (-m)` parameter.
-
-Test data may be specified with the `--test_file (-T)` parameter, and if performance statistics are desired for that test set, labels may be specified with the `--test_labels_file (-L)` parameter.  Predictions for each test point may be saved with the `--predictions_file (-p)` output parameter, and class probabilities for each prediction may be saved with the `--probabilities_file (-P)` output parameter.
-
-### Example
-For example, to train a Hoeffding tree with confidence 0.99 with data `'dataset.csv'`, saving the trained tree to `'tree.bin'`, the following command may be used:
-
-```bash
-$ mlpack_hoeffding_tree --training_file dataset.arff --confidence 0.99
-  --output_model_file tree.bin
-```
-
-Then, this tree may be used to make predictions on the test set `'test_set.csv'`, saving the predictions into `'predictions.csv'` and the class probabilities into `'class_probs.csv'` with the following command: 
-
-```bash
-$ mlpack_hoeffding_tree --input_model_file tree.bin --test_file test_set.arff
-  --predictions_file predictions.csv --probabilities_file class_probs.csv
-```
-
-### See also
-
- - [mlpack_decision_tree](#decision_tree)
- - [mlpack_random_forest](#random_forest)
- - [Mining High-Speed Data Streams (pdf)](https://www.cs.rhodes.edu/~welshc/COMP465_S15/Papers/kdd00.pdf)
- - [HoeffdingTree class documentation](../../user/methods/hoeffding_tree.md)
-
-## mlpack_nbc
-{: #nbc }
-
-#### Parametric Naive Bayes Classifier
-{: #nbc_descr }
-
-```bash
-$ mlpack_nbc [--help] [--incremental_variance] [--info <string>]
-        [--input_model_file <string>] [--labels_file <string>] [--test_file
-        <string>] [--training_file <string>] [--verbose] [--version]
-        [--output_model_file <string>] [--predictions_file <string>]
-        [--probabilities_file <string>]
-```
-
-An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model can be trained and saved, or, a pre-trained model can be used for classification. [Detailed documentation](#nbc_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
-| `--incremental_variance (-I)` | [`flag`](#doc_flag) | The variance of each class will be calculated incrementally. |  |
-| `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`NBCModel file`](#doc_model) | Input Naive Bayes model. | `''` |
-| `--labels_file (-l)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | A file containing labels for the training set. | `''` |
-| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the test set. | `''` |
-| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | A matrix containing the training set. | `''` |
-| `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
-| `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
-
-### Output options
-
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `--output_model_file (-M)` | [`NBCModel file`](#doc_model) | File to save trained Naive Bayes model to. | 
-| `--predictions_file (-a)` | [`1-d index matrix file`](#doc_a_1_d_index_matrix_file) | The matrix in which the predicted labels for the test set will be written. | 
-| `--probabilities_file (-p)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | The matrix in which the predicted probability of labels for the test set will be written. | 
-
-### Detailed documentation
-{: #nbc_detailed-documentation }
-
-This program trains the Naive Bayes classifier on the given labeled training set, or loads a model from the given model file, and then may use that trained model to classify the points in a given test set.
-
-The training set is specified with the `--training_file (-t)` parameter.  Labels may be either the last row of the training set, or alternately the `--labels_file (-l)` parameter may be specified to pass a separate matrix of labels.
-
-If training is not desired, a pre-existing model may be loaded with the `--input_model_file (-m)` parameter.
-
-
-
-The `--incremental_variance (-I)` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
-
-If classifying a test set is desired, the test set may be specified with the `--test_file (-T)` parameter, and the classifications may be saved with the `--predictions_file (-a)`predictions  parameter.  If saving the trained model is desired, this may be done with the `--output_model_file (-M)` output parameter.
-
-### Example
-For example, to train a Naive Bayes classifier on the dataset `'data.csv'` with labels `'labels.csv'` and save the model to `'nbc_model.bin'`, the following command may be used:
-
-```bash
-$ mlpack_nbc --training_file data.csv --labels_file labels.csv
-  --output_model_file nbc_model.bin
-```
-
-Then, to use `'nbc_model.bin'` to predict the classes of the dataset `'test_set.csv'` and save the predicted classes to `'predictions.csv'`, the following command may be used:
-
-```bash
-$ mlpack_nbc --input_model_file nbc_model.bin --test_file test_set.csv
-  --predictions_file predictions.csv
-```
-
-### See also
-
- - [mlpack_softmax_regression](#softmax_regression)
- - [mlpack_random_forest](#random_forest)
- - [Naive Bayes classifier on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
- - [NaiveBayesClassifier C++ class documentation](../../user/methods/naive_bayes_classifier.md)
+ - [mlpack_knn](#knn)
+ - [mlpack_lsh](#lsh)
+ - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
+ - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
 
 ## mlpack_softmax_regression
 {: #softmax_regression }
@@ -3499,21 +3489,23 @@ $ mlpack_softmax_regression --input_model_file sr_model.bin --test_file
  - [Multinomial logistic regression (softmax regression) on Wikipedia](https://en.wikipedia.org/wiki/Multinomial_logistic_regression)
  - [SoftmaxRegression C++ class documentation](../../user/methods/softmax_regression.md)
 
-## mlpack_linear_regression
-{: #linear_regression }
+## mlpack_sparse_coding
+{: #sparse_coding }
 
-#### Simple Linear Regression and Prediction
-{: #linear_regression_descr }
+#### Sparse Coding
+{: #sparse_coding_descr }
 
 ```bash
-$ mlpack_linear_regression [--help] [--info <string>]
-        [--input_model_file <string>] [--lambda 0] [--test_file <string>]
-        [--training_file <string>] [--training_responses_file <string>]
-        [--verbose] [--version] [--output_model_file <string>]
-        [--output_predictions_file <string>]
+$ mlpack_sparse_coding [--atoms 15] [--help] [--info <string>]
+        [--initial_dictionary_file <string>] [--input_model_file <string>]
+        [--lambda1 0] [--lambda2 0] [--max_iterations 0] [--newton_tolerance
+        1e-06] [--normalize] [--objective_tolerance 0.01] [--seed 0]
+        [--test_file <string>] [--training_file <string>] [--verbose]
+        [--version] [--codes_file <string>] [--dictionary_file <string>]
+        [--output_model_file <string>]
 ```
 
-An implementation of simple linear regression and ridge regression using ordinary least squares.  Given a dataset and responses, a model can be trained and saved for later use, or a pre-trained model can be used to output regression predictions for a test set. [Detailed documentation](#linear_regression_detailed-documentation).
+An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
 
 
 
@@ -3521,14 +3513,21 @@ An implementation of simple linear regression and ridge regression using ordinar
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `--atoms (-k)` | [`int`](#doc_int) | Number of atoms in the dictionary. | `15` |
 | `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
 | `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
 | `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
-| `--input_model_file (-m)` | [`LinearRegression<> file`](#doc_model) | Existing LinearRegression model to use. | `''` |
-| `--lambda (-l)` | [`double`](#doc_double) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
-| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing X' (test regressors). | `''` |
-| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix containing training set X (regressors). | `''` |
-| `--training_responses_file (-r)` | [`1-d matrix file`](#doc_a_1_d_matrix_file) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | `''` |
+| `--initial_dictionary_file (-i)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Optional initial dictionary matrix. | `''` |
+| `--input_model_file (-m)` | [`SparseCoding<> file`](#doc_model) | File containing input sparse coding model. | `''` |
+| `--lambda1 (-l)` | [`double`](#doc_double) | Sparse coding l1-norm regularization parameter. | `0` |
+| `--lambda2 (-L)` | [`double`](#doc_double) | Sparse coding l2-norm regularization parameter. | `0` |
+| `--max_iterations (-n)` | [`int`](#doc_int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
+| `--newton_tolerance (-w)` | [`double`](#doc_double) | Tolerance for convergence of Newton method. | `1e-06` |
+| `--normalize (-N)` | [`flag`](#doc_flag) | If set, the input data matrix will be normalized before coding. |  |
+| `--objective_tolerance (-o)` | [`double`](#doc_double) | Tolerance for convergence of the objective function. | `0.01` |
+| `--seed (-s)` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `--test_file (-T)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Optional matrix to be encoded by trained model. | `''` |
+| `--training_file (-t)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix of training data (X). | `''` |
 | `--verbose (-v)` | [`flag`](#doc_flag) | Display informational messages and the full list of parameters and timers at the end of execution. |  |
 | `--version (-V)` | [`flag`](#doc_flag) | Display the version of mlpack.  <span class="special">Only exists in CLI binding.</span> |  |
 
@@ -3537,44 +3536,45 @@ An implementation of simple linear regression and ridge regression using ordinar
 
 | ***name*** | ***type*** | ***description*** |
 |------------|------------|-------------------|
-| `--output_model_file (-M)` | [`LinearRegression<> file`](#doc_model) | Output LinearRegression model. | 
-| `--output_predictions_file (-o)` | [`1-d matrix file`](#doc_a_1_d_matrix_file) | If --test_file is specified, this matrix is where the predicted responses will be saved. | 
+| `--codes_file (-c)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
+| `--dictionary_file (-d)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Matrix to save the output dictionary to. | 
+| `--output_model_file (-M)` | [`SparseCoding<> file`](#doc_model) | File to save trained sparse coding model to. | 
 
 ### Detailed documentation
-{: #linear_regression_detailed-documentation }
+{: #sparse_coding_detailed-documentation }
 
-An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
 
-  y = X * b + e
+The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
 
-where X (specified by `--training_file (-t)`) and y (specified either as the last column of the input matrix `--training_file (-t)` or via the `--training_responses_file (-r)` parameter) are known and b is the desired variable.  If the covariance matrix (X'X) is not invertible, or if the solution is overdetermined, then specify a Tikhonov regularization constant (with `--lambda (-l)`) greater than 0, which will regularize the covariance matrix to make it invertible.  The calculated b may be saved with the `--output_predictions_file (-o)` output parameter.
+The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
 
-Optionally, the calculated value of b is used to predict the responses for another matrix X' (specified by the `--test_file (-T)` parameter):
+Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
 
-   y' = X' * b
-
-and the predicted responses y' may be saved with the `--output_predictions_file (-o)` output parameter.  This type of regression is related to least-angle regression, which mlpack implements as the 'lars' program.
+To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `--training_file (-t)` option, along with the number of atoms in the dictionary (specified with the `--atoms (-k)` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `--initial_dictionary_file (-i)` parameter.  An input model may be specified with the `--input_model_file (-m)` parameter.
 
 ### Example
-For example, to run a linear regression on the dataset `'X.csv'` with responses `'y.csv'`, saving the trained model to `'lr_model.bin'`, the following command could be used:
+As an example, to build a sparse coding model on the dataset `'data.csv'` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `'model.bin'`, use 
 
 ```bash
-$ mlpack_linear_regression --training_file X.csv --training_responses_file
-  y.csv --output_model_file lr_model.bin
+$ mlpack_sparse_coding --training_file data.csv --atoms 200 --lambda1 0.1
+  --output_model_file model.bin
 ```
 
-Then, to use `'lr_model.bin'` to predict responses for a test set `'X_test.csv'`, saving the predictions to `'X_test_responses.csv'`, the following command could be used:
+Then, this model could be used to encode a new matrix, `'otherdata.csv'`, and save the output codes to `'codes.csv'`: 
 
 ```bash
-$ mlpack_linear_regression --input_model_file lr_model.bin --test_file
-  X_test.csv --output_predictions_file X_test_responses.csv
+$ mlpack_sparse_coding --input_model_file model.bin --test_file otherdata.csv
+  --codes_file codes.csv
 ```
 
 ### See also
 
- - [mlpack_lars](#lars)
- - [Linear regression on Wikipedia](https://en.wikipedia.org/wiki/Linear_regression)
- - [LinearRegression C++ class documentation](../../user/methods/linear_regression.md)
+ - [mlpack_local_coordinate_coding](#local_coordinate_coding)
+ - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
+ - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+ - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
+ - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
 
 ## mlpack_preprocess_imputer
 {: #preprocess_imputer }

--- a/doc/user/bindings/cli.sidebar.html
+++ b/doc/user/bindings/cli.sidebar.html
@@ -8,14 +8,14 @@
 <li><a href="LINKROOTuser/bindings/cli.html#data-formats">Data Formats</a></li>
 <li><details><summary>Classification</summary>
 <ul>
-<li><a href="LINKROOTuser/bindings/cli.html#logistic_regression">mlpack_logistic_regression</a></li>
-<li><a href="LINKROOTuser/bindings/cli.html#random_forest">mlpack_random_forest</a></li>
-<li><a href="LINKROOTuser/bindings/cli.html#decision_tree">mlpack_decision_tree</a></li>
-<li><a href="LINKROOTuser/bindings/cli.html#perceptron">mlpack_perceptron</a></li>
-<li><a href="LINKROOTuser/bindings/cli.html#linear_svm">mlpack_linear_svm</a></li>
 <li><a href="LINKROOTuser/bindings/cli.html#adaboost">mlpack_adaboost</a></li>
+<li><a href="LINKROOTuser/bindings/cli.html#decision_tree">mlpack_decision_tree</a></li>
 <li><a href="LINKROOTuser/bindings/cli.html#hoeffding_tree">mlpack_hoeffding_tree</a></li>
+<li><a href="LINKROOTuser/bindings/cli.html#linear_svm">mlpack_linear_svm</a></li>
+<li><a href="LINKROOTuser/bindings/cli.html#logistic_regression">mlpack_logistic_regression</a></li>
 <li><a href="LINKROOTuser/bindings/cli.html#nbc">mlpack_nbc</a></li>
+<li><a href="LINKROOTuser/bindings/cli.html#perceptron">mlpack_perceptron</a></li>
+<li><a href="LINKROOTuser/bindings/cli.html#random_forest">mlpack_random_forest</a></li>
 <li><a href="LINKROOTuser/bindings/cli.html#softmax_regression">mlpack_softmax_regression</a></li>
 </ul>
 </details>

--- a/doc/user/bindings/go.md
+++ b/doc/user/bindings/go.md
@@ -34,6 +34,104 @@ mlpack bindings for Go take and return a restricted set of types, for simplicity
 </div>
 
 
+## Adaboost()
+{: #adaboost }
+
+#### AdaBoost
+{: #adaboost_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for Adaboost().
+param := mlpack.AdaboostOptions()
+param.InputModel = nil
+param.Iterations = 1000
+param.Labels = mat.NewDense(1, 1, nil)
+param.Test = mat.NewDense(1, 1, nil)
+param.Tolerance = 1e-10
+param.Training = mat.NewDense(1, 1, nil)
+param.Verbose = false
+param.WeakLearner = "decision_stump"
+
+output_model, predictions, probabilities := mlpack.Adaboost(param)
+```
+
+An implementation of the AdaBoost.MH (Adaptive Boosting) algorithm for classification.  This can be used to train an AdaBoost model on labeled data or use an existing AdaBoost model to predict the classes of new points. [Detailed documentation](#adaboost_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `InputModel` | [`adaBoostModel`](#doc_model) | Input AdaBoost model. | `nil` |
+| `Iterations` | [`int`](#doc_int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
+| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Labels for the training set. | `mat.NewDense(1, 1, nil)` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Test dataset. | `mat.NewDense(1, 1, nil)` |
+| `Tolerance` | [`float64`](#doc_float64) | The tolerance for change in values of the weighted error during training. | `1e-10` |
+| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | Dataset for training AdaBoost. | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+| `WeakLearner` | [`string`](#doc_string) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `"decision_stump"` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`adaBoostModel`](#doc_model) | Output trained AdaBoost model. | 
+| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Predicted labels for the test set. | 
+| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | Predicted class probabilities for each point in the test set. | 
+
+### Detailed documentation
+{: #adaboost_detailed-documentation }
+
+This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
+
+For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
+
+This program allows training of an AdaBoost model, and then application of that model to a test dataset.  To train a model, a dataset must be passed with the `Training` option.  Labels can be given with the `Labels` option; if no labels are specified, the labels will be assumed to be the last column of the input dataset.  Alternately, an AdaBoost model may be loaded with the `InputModel` option.
+
+Once a model is trained or loaded, it may be used to provide class predictions for a given test dataset.  A test dataset may be specified with the `Test` parameter.  The predicted classes for each point in the test dataset are output to the `Predictions` output parameter.  The AdaBoost model itself is output to the `OutputModel` output parameter.
+
+### Example
+For example, to run AdaBoost on an input dataset `data` with labels `labels`and perceptrons as the weak learner type, storing the trained model in `model`, one could use the following command: 
+
+```go
+// Initialize optional parameters for Adaboost().
+param := mlpack.AdaboostOptions()
+param.Training = data
+param.Labels = labels
+param.WeakLearner = "perceptron"
+
+model, _, _ := mlpack.Adaboost(param)
+```
+
+Similarly, an already-trained model in `model` can be used to provide class predictions from test data `test_data` and store the output in `predictions` with the following command: 
+
+```go
+// Initialize optional parameters for Adaboost().
+param := mlpack.AdaboostOptions()
+param.InputModel = &model
+param.Test = test_data
+
+_, predictions, _ := mlpack.Adaboost(param)
+```
+
+### See also
+
+ - [AdaBoost on Wikipedia](https://en.wikipedia.org/wiki/AdaBoost)
+ - [Improved boosting algorithms using confidence-rated predictions (pdf)](http://www.schapire.net/papers/SchapireSi98.pdf)
+ - [Perceptron](#perceptron)
+ - [Decision Trees](#decision_tree)
+ - [AdaBoost C++ class documentation](../../user/methods/adaboost.md)
+
 ## ApproxKfn()
 {: #approx_kfn }
 
@@ -156,6 +254,114 @@ _, neighbors, _ := mlpack.ApproxKfn(param)
  - [Approximate furthest neighbor in high dimensions (pdf)](https://www.rasmuspagh.net/papers/approx-furthest-neighbor-SISAP15.pdf)
  - [QDAFN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/qdafn.hpp)
  - [DrusillaSelect class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/drusilla_select.hpp)
+
+## BayesianLinearRegression()
+{: #bayesian_linear_regression }
+
+#### BayesianLinearRegression
+{: #bayesian_linear_regression_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for BayesianLinearRegression().
+param := mlpack.BayesianLinearRegressionOptions()
+param.Center = false
+param.Input = mat.NewDense(1, 1, nil)
+param.InputModel = nil
+param.Responses = mat.NewDense(1, 1, nil)
+param.Scale = false
+param.Test = mat.NewDense(1, 1, nil)
+param.Verbose = false
+
+output_model, predictions, stds := mlpack.BayesianLinearRegression(param)
+```
+
+An implementation of the Bayesian linear regression. [Detailed documentation](#bayesian_linear_regression_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `Center` | [`bool`](#doc_bool) | Center the data and fit the intercept if enabled. | `false` |
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `Input` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix of covariates (X). | `mat.NewDense(1, 1, nil)` |
+| `InputModel` | [`bayesianLinearRegression`](#doc_model) | Trained BayesianLinearRegression model to use. | `nil` |
+| `Responses` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Matrix of responses/observations (y). | `mat.NewDense(1, 1, nil)` |
+| `Scale` | [`bool`](#doc_bool) | Scale each feature by their standard deviations if enabled. | `false` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing points to regress on (test points). | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`bayesianLinearRegression`](#doc_model) | Output BayesianLinearRegression model. | 
+| `Predictions` | [`*mat.Dense`](#doc_a__mat_Dense) | If --test_file is specified, this file is where the predicted responses will be saved. | 
+| `Stds` | [`*mat.Dense`](#doc_a__mat_Dense) | If specified, this is where the standard deviations of the predictive distribution will be saved. | 
+
+### Detailed documentation
+{: #bayesian_linear_regression_detailed-documentation }
+
+An implementation of the Bayesian linear regression.
+This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
+Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
+
+This program is able to train a Bayesian linear regression model or load a model from file, output regression predictions for a test set, and save the trained model to a file.
+
+To train a BayesianLinearRegression model, the `Input` and `Responses`parameters must be given. The `Center`and `Scale` parameters control the centering and the normalizing options. A trained model can be saved with the `OutputModel`. If no training is desired at all, a model can be passed via the `InputModel` parameter.
+
+The program can also provide predictions for test data using either the trained model or the given input model.  Test points can be specified with the `Test` parameter.  Predicted responses to the test points can be saved with the `Predictions` output parameter. The corresponding standard deviation can be save by precising the `Stds` parameter.
+
+### Example
+For example, the following command trains a model on the data `data` and responses `responses`with center set to true and scale set to false (so, Bayesian linear regression is being solved, and then the model is saved to `blr_model`:
+
+```go
+// Initialize optional parameters for BayesianLinearRegression().
+param := mlpack.BayesianLinearRegressionOptions()
+param.Input = data
+param.Responses = responses
+param.Center = 1
+param.Scale = 0
+
+blr_model, _, _ := mlpack.BayesianLinearRegression(param)
+```
+
+The following command uses the `blr_model` to provide predicted  responses for the data `test` and save those  responses to `test_predictions`: 
+
+```go
+// Initialize optional parameters for BayesianLinearRegression().
+param := mlpack.BayesianLinearRegressionOptions()
+param.InputModel = &blr_model
+param.Test = test
+
+_, test_predictions, _ := mlpack.BayesianLinearRegression(param)
+```
+
+Because the estimator computes a predictive distribution instead of a simple point estimate, the `Stds` parameter allows one to save the prediction uncertainties: 
+
+```go
+// Initialize optional parameters for BayesianLinearRegression().
+param := mlpack.BayesianLinearRegressionOptions()
+param.InputModel = &blr_model
+param.Test = test
+
+_, test_predictions, stds := mlpack.BayesianLinearRegression(param)
+```
+
+### See also
+
+ - [Bayesian Interpolation](https://cs.uwaterloo.ca/~mannr/cs886-w10/mackay-bayesian.pdf)
+ - [Bayesian Linear Regression, Section 3.3](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
+ - [BayesianLinearRegression C++ class documentation](../../user/methods/bayesian_linear_regression.md)
 
 ## Cf()
 {: #cf }
@@ -388,6 +594,112 @@ _, _ := mlpack.Dbscan(input, param)
  - [DBSCAN on Wikipedia](https://en.wikipedia.org/wiki/DBSCAN)
  - [A density-based algorithm for discovering clusters in large spatial databases with noise (pdf)](https://cdn.aaai.org/KDD/1996/KDD96-037.pdf)
  - [DBSCAN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/dbscan/dbscan.hpp)
+
+## DecisionTree()
+{: #decision_tree }
+
+#### Decision tree
+{: #decision_tree_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for DecisionTree().
+param := mlpack.DecisionTreeOptions()
+param.InputModel = nil
+param.Labels = mat.NewDense(1, 1, nil)
+param.MaximumDepth = 0
+param.MinimumGainSplit = 1e-07
+param.MinimumLeafSize = 20
+param.PrintTrainingAccuracy = false
+param.Test = mat.NewDense(1, 1, nil)
+param.TestLabels = mat.NewDense(1, 1, nil)
+param.Training = mat.NewDense(1, 1, nil)
+param.Verbose = false
+param.Weights = mat.NewDense(1, 1, nil)
+
+output_model, predictions, probabilities := mlpack.DecisionTree(param)
+```
+
+An implementation of an ID3-style decision tree for classification, which supports categorical data.  Given labeled data with numeric or categorical features, a decision tree can be trained and saved; or, an existing decision tree can be used for classification on new points. [Detailed documentation](#decision_tree_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `InputModel` | [`decisionTreeModel`](#doc_model) | Pre-trained decision tree, to be used with test points. | `nil` |
+| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Training labels. | `mat.NewDense(1, 1, nil)` |
+| `MaximumDepth` | [`int`](#doc_int) | Maximum depth of the tree (0 means no limit). | `0` |
+| `MinimumGainSplit` | [`float64`](#doc_float64) | Minimum gain for node splitting. | `1e-07` |
+| `MinimumLeafSize` | [`int`](#doc_int) | Minimum number of points in a leaf. | `20` |
+| `PrintTrainingAccuracy` | [`bool`](#doc_bool) | Print the training accuracy. | `false` |
+| `Test` | [`matrixWithInfo`](#doc_matrixWithInfo) | Testing dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
+| `TestLabels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Test point labels, if accuracy calculation is desired. | `mat.NewDense(1, 1, nil)` |
+| `Training` | [`matrixWithInfo`](#doc_matrixWithInfo) | Training dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+| `Weights` | [`*mat.Dense`](#doc_a__mat_Dense) | The weight of labels | `mat.NewDense(1, 1, nil)` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`decisionTreeModel`](#doc_model) | Output for trained decision tree. | 
+| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Class predictions for each test point. | 
+| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | Class probabilities for each test point. | 
+
+### Detailed documentation
+{: #decision_tree_detailed-documentation }
+
+Train and evaluate using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
+
+The training set and associated labels are specified with the `Training` and `Labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `Labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+When a model is trained, the `OutputModel` output parameter may be used to save the trained model.  A model may be loaded for predictions with the `InputModel` parameter.  The `InputModel` parameter may not be specified when the `Training` parameter is specified.  The `MinimumLeafSize` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `MinimumGainSplit` parameter specifies the minimum gain that is needed for the node to split.  The `MaximumDepth` parameter specifies the maximum depth of the tree.  If `PrintTrainingAccuracy` is specified, the training accuracy will be printed.
+
+Test data may be specified with the `Test` parameter, and if performance numbers are desired for that test set, labels may be specified with the `TestLabels` parameter.  Predictions for each test point may be saved via the `Predictions` output parameter.  Class probabilities for each prediction may be saved with the `Probabilities` output parameter.
+
+### Example
+For example, to train a decision tree with a minimum leaf size of 20 on the dataset contained in `data` with labels `labels`, saving the output model to `tree` and printing the training error, one could call
+
+```go
+// Initialize optional parameters for DecisionTree().
+param := mlpack.DecisionTreeOptions()
+param.Training = data
+param.Labels = labels
+param.MinimumLeafSize = 20
+param.MinimumGainSplit = 0.001
+param.PrintTrainingAccuracy = true
+
+tree, _, _ := mlpack.DecisionTree(param)
+```
+
+Then, to use that model to classify points in `test_set` and print the test error given the labels `test_labels` using that model, while saving the predictions for each point to `predictions`, one could call 
+
+```go
+// Initialize optional parameters for DecisionTree().
+param := mlpack.DecisionTreeOptions()
+param.InputModel = &tree
+param.Test = test_set
+param.TestLabels = test_labels
+
+_, predictions, _ := mlpack.DecisionTree(param)
+```
+
+### See also
+
+ - [Random forest](#random_forest)
+ - [Decision trees on Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning)
+ - [Induction of Decision Trees (pdf)](https://www.hunch.net/~coms-4771/quinlan.pdf)
+ - [DecisionTree C++ class documentation](../../user/methods/decision_tree.md)
 
 ## Det()
 {: #det }
@@ -1143,6 +1455,118 @@ states := mlpack.HmmViterbi(obs, &hmm, param)
  - [Hidden Mixture Models on Wikipedia](https://en.wikipedia.org/wiki/Hidden_Markov_model)
  - [HMM class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/hmm/hmm.hpp)
 
+## HoeffdingTree()
+{: #hoeffding_tree }
+
+#### Hoeffding trees
+{: #hoeffding_tree_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for HoeffdingTree().
+param := mlpack.HoeffdingTreeOptions()
+param.BatchMode = false
+param.Bins = 10
+param.Confidence = 0.95
+param.InfoGain = false
+param.InputModel = nil
+param.Labels = mat.NewDense(1, 1, nil)
+param.MaxSamples = 5000
+param.MinSamples = 100
+param.NumericSplitStrategy = "binary"
+param.ObservationsBeforeBinning = 100
+param.Passes = 1
+param.Test = mat.NewDense(1, 1, nil)
+param.TestLabels = mat.NewDense(1, 1, nil)
+param.Training = mat.NewDense(1, 1, nil)
+param.Verbose = false
+
+output_model, predictions, probabilities := mlpack.HoeffdingTree(param)
+```
+
+An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data, a Hoeffding tree can be trained and saved for later use, or a pre-trained Hoeffding tree can be used for predicting the classifications of new points. [Detailed documentation](#hoeffding_tree_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `BatchMode` | [`bool`](#doc_bool) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `false` |
+| `Bins` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `Confidence` | [`float64`](#doc_float64) | Confidence before splitting (between 0 and 1). | `0.95` |
+| `InfoGain` | [`bool`](#doc_bool) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `false` |
+| `InputModel` | [`hoeffdingTreeModel`](#doc_model) | Input trained Hoeffding tree model. | `nil` |
+| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Labels for training dataset. | `mat.NewDense(1, 1, nil)` |
+| `MaxSamples` | [`int`](#doc_int) | Maximum number of samples before splitting. | `5000` |
+| `MinSamples` | [`int`](#doc_int) | Minimum number of samples before splitting. | `100` |
+| `NumericSplitStrategy` | [`string`](#doc_string) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `"binary"` |
+| `ObservationsBeforeBinning` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
+| `Passes` | [`int`](#doc_int) | Number of passes to take over the dataset. | `1` |
+| `Test` | [`matrixWithInfo`](#doc_matrixWithInfo) | Testing dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
+| `TestLabels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Labels of test data. | `mat.NewDense(1, 1, nil)` |
+| `Training` | [`matrixWithInfo`](#doc_matrixWithInfo) | Training dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`hoeffdingTreeModel`](#doc_model) | Output for trained Hoeffding tree model. | 
+| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Matrix to output label predictions for test data into. | 
+| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
+
+### Detailed documentation
+{: #hoeffding_tree_detailed-documentation }
+
+This program implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets.  This program supports both categorical and numeric data.  Given an input dataset, this program is able to train the tree with numerous training options, and save the model to a file.  The program is also able to use a trained model or a model from file in order to predict classes for a given test set.
+
+The training file and associated labels are specified with the `Training` and `Labels` parameters, respectively. Optionally, if `Labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `BatchMode` option, but this may not be the best option for large datasets.
+
+When a model is trained, it may be saved via the `OutputModel` output parameter.  A model may be loaded from file for further training or testing with the `InputModel` parameter.
+
+Test data may be specified with the `Test` parameter, and if performance statistics are desired for that test set, labels may be specified with the `TestLabels` parameter.  Predictions for each test point may be saved with the `Predictions` output parameter, and class probabilities for each prediction may be saved with the `Probabilities` output parameter.
+
+### Example
+For example, to train a Hoeffding tree with confidence 0.99 with data `dataset`, saving the trained tree to `tree`, the following command may be used:
+
+```go
+// Initialize optional parameters for HoeffdingTree().
+param := mlpack.HoeffdingTreeOptions()
+param.Training = dataset
+param.Confidence = 0.99
+
+tree, _, _ := mlpack.HoeffdingTree(param)
+```
+
+Then, this tree may be used to make predictions on the test set `test_set`, saving the predictions into `predictions` and the class probabilities into `class_probs` with the following command: 
+
+```go
+// Initialize optional parameters for HoeffdingTree().
+param := mlpack.HoeffdingTreeOptions()
+param.InputModel = &tree
+param.Test = test_set
+
+_, predictions, class_probs := mlpack.HoeffdingTree(param)
+```
+
+### See also
+
+ - [DecisionTree()](#decision_tree)
+ - [RandomForest()](#random_forest)
+ - [Mining High-Speed Data Streams (pdf)](https://www.cs.rhodes.edu/~welshc/COMP465_S15/Papers/kdd00.pdf)
+ - [HoeffdingTree class documentation](../../user/methods/hoeffding_tree.md)
+
 ## ImageConverter()
 {: #image_converter }
 
@@ -1577,114 +2001,6 @@ final, _ := mlpack.Kmeans(data, 10, param)
  - [A dual-tree algorithm for fast k-means clustering with large k (pdf)](http://www.ratml.org/pub/pdf/2017dual.pdf)
  - [KMeans class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/kmeans/kmeans.hpp)
 
-## BayesianLinearRegression()
-{: #bayesian_linear_regression }
-
-#### BayesianLinearRegression
-{: #bayesian_linear_regression_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for BayesianLinearRegression().
-param := mlpack.BayesianLinearRegressionOptions()
-param.Center = false
-param.Input = mat.NewDense(1, 1, nil)
-param.InputModel = nil
-param.Responses = mat.NewDense(1, 1, nil)
-param.Scale = false
-param.Test = mat.NewDense(1, 1, nil)
-param.Verbose = false
-
-output_model, predictions, stds := mlpack.BayesianLinearRegression(param)
-```
-
-An implementation of the Bayesian linear regression. [Detailed documentation](#bayesian_linear_regression_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `Center` | [`bool`](#doc_bool) | Center the data and fit the intercept if enabled. | `false` |
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `Input` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix of covariates (X). | `mat.NewDense(1, 1, nil)` |
-| `InputModel` | [`bayesianLinearRegression`](#doc_model) | Trained BayesianLinearRegression model to use. | `nil` |
-| `Responses` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Matrix of responses/observations (y). | `mat.NewDense(1, 1, nil)` |
-| `Scale` | [`bool`](#doc_bool) | Scale each feature by their standard deviations if enabled. | `false` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing points to regress on (test points). | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `OutputModel` | [`bayesianLinearRegression`](#doc_model) | Output BayesianLinearRegression model. | 
-| `Predictions` | [`*mat.Dense`](#doc_a__mat_Dense) | If --test_file is specified, this file is where the predicted responses will be saved. | 
-| `Stds` | [`*mat.Dense`](#doc_a__mat_Dense) | If specified, this is where the standard deviations of the predictive distribution will be saved. | 
-
-### Detailed documentation
-{: #bayesian_linear_regression_detailed-documentation }
-
-An implementation of the Bayesian linear regression.
-This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
-Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
-
-This program is able to train a Bayesian linear regression model or load a model from file, output regression predictions for a test set, and save the trained model to a file.
-
-To train a BayesianLinearRegression model, the `Input` and `Responses`parameters must be given. The `Center`and `Scale` parameters control the centering and the normalizing options. A trained model can be saved with the `OutputModel`. If no training is desired at all, a model can be passed via the `InputModel` parameter.
-
-The program can also provide predictions for test data using either the trained model or the given input model.  Test points can be specified with the `Test` parameter.  Predicted responses to the test points can be saved with the `Predictions` output parameter. The corresponding standard deviation can be save by precising the `Stds` parameter.
-
-### Example
-For example, the following command trains a model on the data `data` and responses `responses`with center set to true and scale set to false (so, Bayesian linear regression is being solved, and then the model is saved to `blr_model`:
-
-```go
-// Initialize optional parameters for BayesianLinearRegression().
-param := mlpack.BayesianLinearRegressionOptions()
-param.Input = data
-param.Responses = responses
-param.Center = 1
-param.Scale = 0
-
-blr_model, _, _ := mlpack.BayesianLinearRegression(param)
-```
-
-The following command uses the `blr_model` to provide predicted  responses for the data `test` and save those  responses to `test_predictions`: 
-
-```go
-// Initialize optional parameters for BayesianLinearRegression().
-param := mlpack.BayesianLinearRegressionOptions()
-param.InputModel = &blr_model
-param.Test = test
-
-_, test_predictions, _ := mlpack.BayesianLinearRegression(param)
-```
-
-Because the estimator computes a predictive distribution instead of a simple point estimate, the `Stds` parameter allows one to save the prediction uncertainties: 
-
-```go
-// Initialize optional parameters for BayesianLinearRegression().
-param := mlpack.BayesianLinearRegressionOptions()
-param.InputModel = &blr_model
-param.Test = test
-
-_, test_predictions, stds := mlpack.BayesianLinearRegression(param)
-```
-
-### See also
-
- - [Bayesian Interpolation](https://cs.uwaterloo.ca/~mannr/cs886-w10/mackay-bayesian.pdf)
- - [Bayesian Linear Regression, Section 3.3](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
- - [BayesianLinearRegression C++ class documentation](../../user/methods/bayesian_linear_regression.md)
-
 ## Lars()
 {: #lars }
 
@@ -1798,6 +2114,221 @@ _, test_predictions := mlpack.Lars(param)
  - [LinearRegression()](#linear_regression)
  - [Least angle regression (pdf)](https://mlpack.org/papers/lars.pdf)
  - [LARS C++ class documentation](../../user/methods/lars.md)
+
+## LinearRegression()
+{: #linear_regression }
+
+#### Simple Linear Regression and Prediction
+{: #linear_regression_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for LinearRegression().
+param := mlpack.LinearRegressionOptions()
+param.InputModel = nil
+param.Lambda = 0
+param.Test = mat.NewDense(1, 1, nil)
+param.Training = mat.NewDense(1, 1, nil)
+param.TrainingResponses = mat.NewDense(1, 1, nil)
+param.Verbose = false
+
+output_model, output_predictions := mlpack.LinearRegression(param)
+```
+
+An implementation of simple linear regression and ridge regression using ordinary least squares.  Given a dataset and responses, a model can be trained and saved for later use, or a pre-trained model can be used to output regression predictions for a test set. [Detailed documentation](#linear_regression_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `InputModel` | [`linearRegression`](#doc_model) | Existing LinearRegression model to use. | `nil` |
+| `Lambda` | [`float64`](#doc_float64) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing X' (test regressors). | `mat.NewDense(1, 1, nil)` |
+| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing training set X (regressors). | `mat.NewDense(1, 1, nil)` |
+| `TrainingResponses` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`linearRegression`](#doc_model) | Output LinearRegression model. | 
+| `OutputPredictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | If --test_file is specified, this matrix is where the predicted responses will be saved. | 
+
+### Detailed documentation
+{: #linear_regression_detailed-documentation }
+
+An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+
+  y = X * b + e
+
+where X (specified by `Training`) and y (specified either as the last column of the input matrix `Training` or via the `TrainingResponses` parameter) are known and b is the desired variable.  If the covariance matrix (X'X) is not invertible, or if the solution is overdetermined, then specify a Tikhonov regularization constant (with `Lambda`) greater than 0, which will regularize the covariance matrix to make it invertible.  The calculated b may be saved with the `OutputPredictions` output parameter.
+
+Optionally, the calculated value of b is used to predict the responses for another matrix X' (specified by the `Test` parameter):
+
+   y' = X' * b
+
+and the predicted responses y' may be saved with the `OutputPredictions` output parameter.  This type of regression is related to least-angle regression, which mlpack implements as the 'lars' program.
+
+### Example
+For example, to run a linear regression on the dataset `X` with responses `y`, saving the trained model to `lr_model`, the following command could be used:
+
+```go
+// Initialize optional parameters for LinearRegression().
+param := mlpack.LinearRegressionOptions()
+param.Training = X
+param.TrainingResponses = y
+
+lr_model, _ := mlpack.LinearRegression(param)
+```
+
+Then, to use `lr_model` to predict responses for a test set `X_test`, saving the predictions to `X_test_responses`, the following command could be used:
+
+```go
+// Initialize optional parameters for LinearRegression().
+param := mlpack.LinearRegressionOptions()
+param.InputModel = &lr_model
+param.Test = X_test
+
+_, X_test_responses := mlpack.LinearRegression(param)
+```
+
+### See also
+
+ - [Lars()](#lars)
+ - [Linear regression on Wikipedia](https://en.wikipedia.org/wiki/Linear_regression)
+ - [LinearRegression C++ class documentation](../../user/methods/linear_regression.md)
+
+## LinearSvm()
+{: #linear_svm }
+
+#### Linear SVM is an L2-regularized support vector machine.
+{: #linear_svm_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for LinearSvm().
+param := mlpack.LinearSvmOptions()
+param.Delta = 1
+param.Epochs = 50
+param.InputModel = nil
+param.Labels = mat.NewDense(1, 1, nil)
+param.Lambda = 0.0001
+param.MaxIterations = 10000
+param.NoIntercept = false
+param.NumClasses = 0
+param.Optimizer = "lbfgs"
+param.Seed = 0
+param.Shuffle = false
+param.StepSize = 0.01
+param.Test = mat.NewDense(1, 1, nil)
+param.TestLabels = mat.NewDense(1, 1, nil)
+param.Tolerance = 1e-10
+param.Training = mat.NewDense(1, 1, nil)
+param.Verbose = false
+
+output_model, predictions, probabilities := mlpack.LinearSvm(param)
+```
+
+An implementation of linear SVM for multiclass classification. Given labeled data, a model can be trained and saved for future use; or, a pre-trained model can be used to classify new points. [Detailed documentation](#linear_svm_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `Delta` | [`float64`](#doc_float64) | Margin of difference between correct class and other classes. | `1` |
+| `Epochs` | [`int`](#doc_int) | Maximum number of full epochs over dataset for psgd | `50` |
+| `InputModel` | [`linearsvmModel`](#doc_model) | Existing model (parameters). | `nil` |
+| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | A matrix containing labels (0 or 1) for the points in the training set (y). | `mat.NewDense(1, 1, nil)` |
+| `Lambda` | [`float64`](#doc_float64) | L2-regularization parameter for training. | `0.0001` |
+| `MaxIterations` | [`int`](#doc_int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
+| `NoIntercept` | [`bool`](#doc_bool) | Do not add the intercept term to the model. | `false` |
+| `NumClasses` | [`int`](#doc_int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
+| `Optimizer` | [`string`](#doc_string) | Optimizer to use for training ('lbfgs' or 'psgd'). | `"lbfgs"` |
+| `Seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `Shuffle` | [`bool`](#doc_bool) | Don't shuffle the order in which data points are visited for parallel SGD. | `false` |
+| `StepSize` | [`float64`](#doc_float64) | Step size for parallel SGD optimizer. | `0.01` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing test dataset. | `mat.NewDense(1, 1, nil)` |
+| `TestLabels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Matrix containing test labels. | `mat.NewDense(1, 1, nil)` |
+| `Tolerance` | [`float64`](#doc_float64) | Convergence tolerance for optimizer. | `1e-10` |
+| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the training set (the matrix of predictors, X). | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`linearsvmModel`](#doc_model) | Output for trained linear svm model. | 
+| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
+| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | If test data is specified, this matrix is where the class probabilities for the test set will be saved. | 
+
+### Detailed documentation
+{: #linear_svm_detailed-documentation }
+
+An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
+
+This program allows loading a linear SVM model (via the `InputModel` parameter) or training a linear SVM model given training data (specified with the `Training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (specified with the `Test` parameter) and the classification results may be saved with the `Predictions` output parameter. The trained linear SVM model may be saved using the `OutputModel` output parameter.
+
+The training data, if specified, may have class labels as its last dimension.  Alternately, the `Labels` parameter may be used to specify a separate vector of labels.
+
+When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `Lambda` option, and the number of classes can be manually specified with the `NumClasses`and if an intercept term is not desired in the model, the `NoIntercept` parameter can be specified.
+
+Margin of difference between correct class and other classes can be specified with the `Delta` option.The optimizer used to train the model can be specified with the `Optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `MaxIterations` parameter specifies the maximum number of allowed iterations, and the `Tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `StepSize` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `Epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
+
+Optionally, the model can be used to predict the labels for another matrix of data points, if `Test` is specified.  The `Test` parameter can be specified without the `Training` parameter, so long as an existing linear SVM model is given with the `InputModel` parameter.  The output predictions from the linear SVM model may be saved with the `Predictions` parameter.
+
+### Example
+As an example, to train a LinaerSVM on the data '`data`' with labels '`labels`' with L2 regularization of 0.1, saving the model to '`lsvm_model`', the following command may be used:
+
+```go
+// Initialize optional parameters for LinearSvm().
+param := mlpack.LinearSvmOptions()
+param.Training = data
+param.Labels = labels
+param.Lambda = 0.1
+param.Delta = 1
+param.NumClasses = 0
+
+lsvm_model, _, _ := mlpack.LinearSvm(param)
+```
+
+Then, to use that model to predict classes for the dataset '`test`', storing the output predictions in '`predictions`', the following command may be used: 
+
+```go
+// Initialize optional parameters for LinearSvm().
+param := mlpack.LinearSvmOptions()
+param.InputModel = &lsvm_model
+param.Test = test
+
+_, predictions, _ := mlpack.LinearSvm(param)
+```
+
+### See also
+
+ - [RandomForest()](#random_forest)
+ - [LogisticRegression()](#logistic_regression)
+ - [LinearSVM on Wikipedia](https://en.wikipedia.org/wiki/Support-vector_machine)
+ - [LinearSVM C++ class documentation](../../user/methods/linear_svm.md)
 
 ## Lmnn()
 {: #lmnn }
@@ -2327,6 +2858,102 @@ centroids, _ := mlpack.MeanShift(data, param)
  - [Mean Shift, Mode Seeking, and Clustering (pdf)](https://members.loria.fr/MOBerger/Enseignement/Master2/Exposes/meanShiftCluster.pdf)
  - [mlpack::mean_shift::MeanShift C++ class documentation](../../user/methods/mean_shift.md)
 
+## Nbc()
+{: #nbc }
+
+#### Parametric Naive Bayes Classifier
+{: #nbc_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for Nbc().
+param := mlpack.NbcOptions()
+param.IncrementalVariance = false
+param.InputModel = nil
+param.Labels = mat.NewDense(1, 1, nil)
+param.Test = mat.NewDense(1, 1, nil)
+param.Training = mat.NewDense(1, 1, nil)
+param.Verbose = false
+
+output_model, predictions, probabilities := mlpack.Nbc(param)
+```
+
+An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model can be trained and saved, or, a pre-trained model can be used for classification. [Detailed documentation](#nbc_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `IncrementalVariance` | [`bool`](#doc_bool) | The variance of each class will be calculated incrementally. | `false` |
+| `InputModel` | [`nbcModel`](#doc_model) | Input Naive Bayes model. | `nil` |
+| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | A file containing labels for the training set. | `mat.NewDense(1, 1, nil)` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the test set. | `mat.NewDense(1, 1, nil)` |
+| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the training set. | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`nbcModel`](#doc_model) | File to save trained Naive Bayes model to. | 
+| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | The matrix in which the predicted labels for the test set will be written. | 
+| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | The matrix in which the predicted probability of labels for the test set will be written. | 
+
+### Detailed documentation
+{: #nbc_detailed-documentation }
+
+This program trains the Naive Bayes classifier on the given labeled training set, or loads a model from the given model file, and then may use that trained model to classify the points in a given test set.
+
+The training set is specified with the `Training` parameter.  Labels may be either the last row of the training set, or alternately the `Labels` parameter may be specified to pass a separate matrix of labels.
+
+If training is not desired, a pre-existing model may be loaded with the `InputModel` parameter.
+
+
+
+The `IncrementalVariance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
+
+If classifying a test set is desired, the test set may be specified with the `Test` parameter, and the classifications may be saved with the `Predictions`predictions  parameter.  If saving the trained model is desired, this may be done with the `OutputModel` output parameter.
+
+### Example
+For example, to train a Naive Bayes classifier on the dataset `data` with labels `labels` and save the model to `nbc_model`, the following command may be used:
+
+```go
+// Initialize optional parameters for Nbc().
+param := mlpack.NbcOptions()
+param.Training = data
+param.Labels = labels
+
+nbc_model, _, _ := mlpack.Nbc(param)
+```
+
+Then, to use `nbc_model` to predict the classes of the dataset `test_set` and save the predicted classes to `predictions`, the following command may be used:
+
+```go
+// Initialize optional parameters for Nbc().
+param := mlpack.NbcOptions()
+param.InputModel = &nbc_model
+param.Test = test_set
+
+_, predictions, _ := mlpack.Nbc(param)
+```
+
+### See also
+
+ - [SoftmaxRegression()](#softmax_regression)
+ - [RandomForest()](#random_forest)
+ - [Naive Bayes classifier on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
+ - [NaiveBayesClassifier C++ class documentation](../../user/methods/naive_bayes_classifier.md)
+
 ## Nca()
 {: #nca }
 
@@ -2771,6 +3398,96 @@ data_mod := mlpack.Pca(data, param)
 
  - [Principal component analysis on Wikipedia](https://en.wikipedia.org/wiki/Principal_component_analysis)
  - [PCA C++ class documentation](../../user/methods/pca.md)
+
+## Perceptron()
+{: #perceptron }
+
+#### Perceptron
+{: #perceptron_descr }
+
+```go
+import (
+  "mlpack.org/v1/mlpack"
+  "gonum.org/v1/gonum/mat"
+)
+
+// Initialize optional parameters for Perceptron().
+param := mlpack.PerceptronOptions()
+param.InputModel = nil
+param.Labels = mat.NewDense(1, 1, nil)
+param.MaxIterations = 1000
+param.Test = mat.NewDense(1, 1, nil)
+param.Training = mat.NewDense(1, 1, nil)
+param.Verbose = false
+
+output_model, predictions := mlpack.Perceptron(param)
+```
+
+An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and saved for future use; or, a pre-trained perceptron can be used for classification on new points. [Detailed documentation](#perceptron_detailed-documentation).
+
+
+
+### Input options
+There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `InputModel` | [`perceptronModel`](#doc_model) | Input perceptron model. | `nil` |
+| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | A matrix containing labels for the training set. | `mat.NewDense(1, 1, nil)` |
+| `MaxIterations` | [`int`](#doc_int) | The maximum number of iterations the perceptron is to be run | `1000` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the test set. | `mat.NewDense(1, 1, nil)` |
+| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the training set. | `mat.NewDense(1, 1, nil)` |
+| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Output options are returned via Go's support for multiple return values, in the order listed below.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `OutputModel` | [`perceptronModel`](#doc_model) | Output for trained perceptron model. | 
+| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | The matrix in which the predicted labels for the test set will be written. | 
+
+### Detailed documentation
+{: #perceptron_detailed-documentation }
+
+This program implements a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `MaxIterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
+
+This program allows loading a perceptron from a model (via the `InputModel` parameter) or training a perceptron given training data (via the `Training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (via the `Test` parameter) and the classification results on the test set may be saved with the `Predictions` output parameter.  The perceptron model may be saved with the `OutputModel` output parameter.
+
+### Example
+The training data given with the `Training` option may have class labels as its last dimension (so, if the training data is in CSV format, labels should be the last column).  Alternately, the `Labels` parameter may be used to specify a separate matrix of labels.
+
+All these options make it easy to train a perceptron, and then re-use that perceptron for later classification.  The invocation below trains a perceptron on `training_data` with labels `training_labels`, and saves the model to `perceptron_model`.
+
+```go
+// Initialize optional parameters for Perceptron().
+param := mlpack.PerceptronOptions()
+param.Training = training_data
+param.Labels = training_labels
+
+perceptron_model, _ := mlpack.Perceptron(param)
+```
+
+Then, this model can be re-used for classification on the test data `test_data`.  The example below does precisely that, saving the predicted classes to `predictions`.
+
+```go
+// Initialize optional parameters for Perceptron().
+param := mlpack.PerceptronOptions()
+param.InputModel = &perceptron_model
+param.Test = test_data
+
+_, predictions := mlpack.Perceptron(param)
+```
+
+Note that all of the options may be specified at once: predictions may be calculated right after training a model, and model training can occur even if an existing perceptron model is passed with the `InputModel` parameter.  However, note that the number of classes and the dimensionality of all data must match.  So you cannot pass a perceptron model trained on 2 classes and then re-train with a 4-class dataset.  Similarly, attempting classification on a 3-dimensional dataset with a perceptron that has been trained on 8 dimensions will cause an error.
+
+### See also
+
+ - [Adaboost()](#adaboost)
+ - [Perceptron on Wikipedia](https://en.wikipedia.org/wiki/Perceptron)
+ - [Perceptron C++ class documentation](../../user/methods/perceptron.md)
 
 ## PreprocessSplit()
 {: #preprocess_split }
@@ -3300,216 +4017,6 @@ ic, _ := mlpack.Radical(X, param)
  - [ICA using spacings estimates of entropy (pdf)](https://www.jmlr.org/papers/volume4/learned-miller03a/learned-miller03a.pdf)
  - [Radical C++ class documentation](../../user/methods/radical.md)
 
-## Krann()
-{: #krann }
-
-#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
-{: #krann_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for Krann().
-param := mlpack.KrannOptions()
-param.Alpha = 0.95
-param.FirstLeafExact = false
-param.InputModel = nil
-param.K = 0
-param.LeafSize = 20
-param.Naive = false
-param.Query = mat.NewDense(1, 1, nil)
-param.RandomBasis = false
-param.Reference = mat.NewDense(1, 1, nil)
-param.SampleAtLeaves = false
-param.Seed = 0
-param.SingleMode = false
-param.SingleSampleLimit = 20
-param.Tau = 5
-param.TreeType = "kd"
-param.Verbose = false
-
-distances, neighbors, output_model := mlpack.Krann(param)
-```
-
-An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `Alpha` | [`float64`](#doc_float64) | The desired success probability. | `0.95` |
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `FirstLeafExact` | [`bool`](#doc_bool) | The flag to trigger sampling only after exactly exploring the first leaf. | `false` |
-| `InputModel` | [`raModel`](#doc_model) | Pre-trained kNN model. | `nil` |
-| `K` | [`int`](#doc_int) | Number of nearest neighbors to find. | `0` |
-| `LeafSize` | [`int`](#doc_int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
-| `Naive` | [`bool`](#doc_bool) | If true, sampling will be done without using a tree. | `false` |
-| `Query` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing query points (optional). | `mat.NewDense(1, 1, nil)` |
-| `RandomBasis` | [`bool`](#doc_bool) | Before tree-building, project the data onto a random orthogonal basis. | `false` |
-| `Reference` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing the reference dataset. | `mat.NewDense(1, 1, nil)` |
-| `SampleAtLeaves` | [`bool`](#doc_bool) | The flag to trigger sampling at leaves. | `false` |
-| `Seed` | [`int`](#doc_int) | Random seed (if 0, std::time(NULL) is used). | `0` |
-| `SingleMode` | [`bool`](#doc_bool) | If true, single-tree search is used (as opposed to dual-tree search. | `false` |
-| `SingleSampleLimit` | [`int`](#doc_int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
-| `Tau` | [`float64`](#doc_float64) | The allowed rank-error in terms of the percentile of the data. | `5` |
-| `TreeType` | [`string`](#doc_string) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `"kd"` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `Distances` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to output distances into. | 
-| `Neighbors` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to output neighbors into. | 
-| `OutputModel` | [`raModel`](#doc_model) | If specified, the kNN model will be output here. | 
-
-### Detailed documentation
-{: #krann_detailed-documentation }
-
-This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
-
-### Example
-For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `input` and store the distances in `distances` and the neighbors in `neighbors.csv`:
-
-```go
-// Initialize optional parameters for Krann().
-param := mlpack.KrannOptions()
-param.Reference = input
-param.K = 5
-param.Tau = 0.1
-
-distances, neighbors, _ := mlpack.Krann(param)
-```
-
-Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
-
-The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
-
-### See also
-
- - [Knn()](#knn)
- - [Lsh()](#lsh)
- - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
- - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
-
-## SparseCoding()
-{: #sparse_coding }
-
-#### Sparse Coding
-{: #sparse_coding_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for SparseCoding().
-param := mlpack.SparseCodingOptions()
-param.Atoms = 15
-param.InitialDictionary = mat.NewDense(1, 1, nil)
-param.InputModel = nil
-param.Lambda1 = 0
-param.Lambda2 = 0
-param.MaxIterations = 0
-param.NewtonTolerance = 1e-06
-param.Normalize = false
-param.ObjectiveTolerance = 0.01
-param.Seed = 0
-param.Test = mat.NewDense(1, 1, nil)
-param.Training = mat.NewDense(1, 1, nil)
-param.Verbose = false
-
-codes, dictionary, output_model := mlpack.SparseCoding(param)
-```
-
-An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `Atoms` | [`int`](#doc_int) | Number of atoms in the dictionary. | `15` |
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `InitialDictionary` | [`*mat.Dense`](#doc_a__mat_Dense) | Optional initial dictionary matrix. | `mat.NewDense(1, 1, nil)` |
-| `InputModel` | [`sparseCoding`](#doc_model) | File containing input sparse coding model. | `nil` |
-| `Lambda1` | [`float64`](#doc_float64) | Sparse coding l1-norm regularization parameter. | `0` |
-| `Lambda2` | [`float64`](#doc_float64) | Sparse coding l2-norm regularization parameter. | `0` |
-| `MaxIterations` | [`int`](#doc_int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
-| `NewtonTolerance` | [`float64`](#doc_float64) | Tolerance for convergence of Newton method. | `1e-06` |
-| `Normalize` | [`bool`](#doc_bool) | If set, the input data matrix will be normalized before coding. | `false` |
-| `ObjectiveTolerance` | [`float64`](#doc_float64) | Tolerance for convergence of the objective function. | `0.01` |
-| `Seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Optional matrix to be encoded by trained model. | `mat.NewDense(1, 1, nil)` |
-| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix of training data (X). | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `Codes` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
-| `Dictionary` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to save the output dictionary to. | 
-| `OutputModel` | [`sparseCoding`](#doc_model) | File to save trained sparse coding model to. | 
-
-### Detailed documentation
-{: #sparse_coding_detailed-documentation }
-
-An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
-
-The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
-
-The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
-
-Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
-
-To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `Training` option, along with the number of atoms in the dictionary (specified with the `Atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `InitialDictionary` parameter.  An input model may be specified with the `InputModel` parameter.
-
-### Example
-As an example, to build a sparse coding model on the dataset `data` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `model`, use 
-
-```go
-// Initialize optional parameters for SparseCoding().
-param := mlpack.SparseCodingOptions()
-param.Training = data
-param.Atoms = 200
-param.Lambda1 = 0.1
-
-_, _, model := mlpack.SparseCoding(param)
-```
-
-Then, this model could be used to encode a new matrix, `otherdata`, and save the output codes to `codes`: 
-
-```go
-// Initialize optional parameters for SparseCoding().
-param := mlpack.SparseCodingOptions()
-param.InputModel = &model
-param.Test = otherdata
-
-codes, _, _ := mlpack.SparseCoding(param)
-```
-
-### See also
-
- - [LocalCoordinateCoding()](#local_coordinate_coding)
- - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
- - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
- - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
- - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
-
 ## RandomForest()
 {: #random_forest }
 
@@ -3624,117 +4131,11 @@ _, predictions, _ := mlpack.RandomForest(param)
  - [Random forests (pdf)](https://www.eecis.udel.edu/~shatkay/Course/papers/BreimanRandomForests2001.pdf)
  - [RandomForest C++ class documentation](../../user/methods/random_forest.md)
 
-## DecisionTree()
-{: #decision_tree }
+## Krann()
+{: #krann }
 
-#### Decision tree
-{: #decision_tree_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for DecisionTree().
-param := mlpack.DecisionTreeOptions()
-param.InputModel = nil
-param.Labels = mat.NewDense(1, 1, nil)
-param.MaximumDepth = 0
-param.MinimumGainSplit = 1e-07
-param.MinimumLeafSize = 20
-param.PrintTrainingAccuracy = false
-param.Test = mat.NewDense(1, 1, nil)
-param.TestLabels = mat.NewDense(1, 1, nil)
-param.Training = mat.NewDense(1, 1, nil)
-param.Verbose = false
-param.Weights = mat.NewDense(1, 1, nil)
-
-output_model, predictions, probabilities := mlpack.DecisionTree(param)
-```
-
-An implementation of an ID3-style decision tree for classification, which supports categorical data.  Given labeled data with numeric or categorical features, a decision tree can be trained and saved; or, an existing decision tree can be used for classification on new points. [Detailed documentation](#decision_tree_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `InputModel` | [`decisionTreeModel`](#doc_model) | Pre-trained decision tree, to be used with test points. | `nil` |
-| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Training labels. | `mat.NewDense(1, 1, nil)` |
-| `MaximumDepth` | [`int`](#doc_int) | Maximum depth of the tree (0 means no limit). | `0` |
-| `MinimumGainSplit` | [`float64`](#doc_float64) | Minimum gain for node splitting. | `1e-07` |
-| `MinimumLeafSize` | [`int`](#doc_int) | Minimum number of points in a leaf. | `20` |
-| `PrintTrainingAccuracy` | [`bool`](#doc_bool) | Print the training accuracy. | `false` |
-| `Test` | [`matrixWithInfo`](#doc_matrixWithInfo) | Testing dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
-| `TestLabels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Test point labels, if accuracy calculation is desired. | `mat.NewDense(1, 1, nil)` |
-| `Training` | [`matrixWithInfo`](#doc_matrixWithInfo) | Training dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-| `Weights` | [`*mat.Dense`](#doc_a__mat_Dense) | The weight of labels | `mat.NewDense(1, 1, nil)` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `OutputModel` | [`decisionTreeModel`](#doc_model) | Output for trained decision tree. | 
-| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Class predictions for each test point. | 
-| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | Class probabilities for each test point. | 
-
-### Detailed documentation
-{: #decision_tree_detailed-documentation }
-
-Train and evaluate using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
-
-The training set and associated labels are specified with the `Training` and `Labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `Labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-When a model is trained, the `OutputModel` output parameter may be used to save the trained model.  A model may be loaded for predictions with the `InputModel` parameter.  The `InputModel` parameter may not be specified when the `Training` parameter is specified.  The `MinimumLeafSize` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `MinimumGainSplit` parameter specifies the minimum gain that is needed for the node to split.  The `MaximumDepth` parameter specifies the maximum depth of the tree.  If `PrintTrainingAccuracy` is specified, the training accuracy will be printed.
-
-Test data may be specified with the `Test` parameter, and if performance numbers are desired for that test set, labels may be specified with the `TestLabels` parameter.  Predictions for each test point may be saved via the `Predictions` output parameter.  Class probabilities for each prediction may be saved with the `Probabilities` output parameter.
-
-### Example
-For example, to train a decision tree with a minimum leaf size of 20 on the dataset contained in `data` with labels `labels`, saving the output model to `tree` and printing the training error, one could call
-
-```go
-// Initialize optional parameters for DecisionTree().
-param := mlpack.DecisionTreeOptions()
-param.Training = data
-param.Labels = labels
-param.MinimumLeafSize = 20
-param.MinimumGainSplit = 0.001
-param.PrintTrainingAccuracy = true
-
-tree, _, _ := mlpack.DecisionTree(param)
-```
-
-Then, to use that model to classify points in `test_set` and print the test error given the labels `test_labels` using that model, while saving the predictions for each point to `predictions`, one could call 
-
-```go
-// Initialize optional parameters for DecisionTree().
-param := mlpack.DecisionTreeOptions()
-param.InputModel = &tree
-param.Test = test_set
-param.TestLabels = test_labels
-
-_, predictions, _ := mlpack.DecisionTree(param)
-```
-
-### See also
-
- - [Random forest](#random_forest)
- - [Decision trees on Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning)
- - [Induction of Decision Trees (pdf)](https://www.hunch.net/~coms-4771/quinlan.pdf)
- - [DecisionTree C++ class documentation](../../user/methods/decision_tree.md)
-
-## Perceptron()
-{: #perceptron }
-
-#### Perceptron
-{: #perceptron_descr }
+#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
+{: #krann_descr }
 
 ```go
 import (
@@ -3742,120 +4143,29 @@ import (
   "gonum.org/v1/gonum/mat"
 )
 
-// Initialize optional parameters for Perceptron().
-param := mlpack.PerceptronOptions()
+// Initialize optional parameters for Krann().
+param := mlpack.KrannOptions()
+param.Alpha = 0.95
+param.FirstLeafExact = false
 param.InputModel = nil
-param.Labels = mat.NewDense(1, 1, nil)
-param.MaxIterations = 1000
-param.Test = mat.NewDense(1, 1, nil)
-param.Training = mat.NewDense(1, 1, nil)
-param.Verbose = false
-
-output_model, predictions := mlpack.Perceptron(param)
-```
-
-An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and saved for future use; or, a pre-trained perceptron can be used for classification on new points. [Detailed documentation](#perceptron_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `InputModel` | [`perceptronModel`](#doc_model) | Input perceptron model. | `nil` |
-| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | A matrix containing labels for the training set. | `mat.NewDense(1, 1, nil)` |
-| `MaxIterations` | [`int`](#doc_int) | The maximum number of iterations the perceptron is to be run | `1000` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the test set. | `mat.NewDense(1, 1, nil)` |
-| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the training set. | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `OutputModel` | [`perceptronModel`](#doc_model) | Output for trained perceptron model. | 
-| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | The matrix in which the predicted labels for the test set will be written. | 
-
-### Detailed documentation
-{: #perceptron_detailed-documentation }
-
-This program implements a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `MaxIterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
-
-This program allows loading a perceptron from a model (via the `InputModel` parameter) or training a perceptron given training data (via the `Training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (via the `Test` parameter) and the classification results on the test set may be saved with the `Predictions` output parameter.  The perceptron model may be saved with the `OutputModel` output parameter.
-
-### Example
-The training data given with the `Training` option may have class labels as its last dimension (so, if the training data is in CSV format, labels should be the last column).  Alternately, the `Labels` parameter may be used to specify a separate matrix of labels.
-
-All these options make it easy to train a perceptron, and then re-use that perceptron for later classification.  The invocation below trains a perceptron on `training_data` with labels `training_labels`, and saves the model to `perceptron_model`.
-
-```go
-// Initialize optional parameters for Perceptron().
-param := mlpack.PerceptronOptions()
-param.Training = training_data
-param.Labels = training_labels
-
-perceptron_model, _ := mlpack.Perceptron(param)
-```
-
-Then, this model can be re-used for classification on the test data `test_data`.  The example below does precisely that, saving the predicted classes to `predictions`.
-
-```go
-// Initialize optional parameters for Perceptron().
-param := mlpack.PerceptronOptions()
-param.InputModel = &perceptron_model
-param.Test = test_data
-
-_, predictions := mlpack.Perceptron(param)
-```
-
-Note that all of the options may be specified at once: predictions may be calculated right after training a model, and model training can occur even if an existing perceptron model is passed with the `InputModel` parameter.  However, note that the number of classes and the dimensionality of all data must match.  So you cannot pass a perceptron model trained on 2 classes and then re-train with a 4-class dataset.  Similarly, attempting classification on a 3-dimensional dataset with a perceptron that has been trained on 8 dimensions will cause an error.
-
-### See also
-
- - [Adaboost()](#adaboost)
- - [Perceptron on Wikipedia](https://en.wikipedia.org/wiki/Perceptron)
- - [Perceptron C++ class documentation](../../user/methods/perceptron.md)
-
-## LinearSvm()
-{: #linear_svm }
-
-#### Linear SVM is an L2-regularized support vector machine.
-{: #linear_svm_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for LinearSvm().
-param := mlpack.LinearSvmOptions()
-param.Delta = 1
-param.Epochs = 50
-param.InputModel = nil
-param.Labels = mat.NewDense(1, 1, nil)
-param.Lambda = 0.0001
-param.MaxIterations = 10000
-param.NoIntercept = false
-param.NumClasses = 0
-param.Optimizer = "lbfgs"
+param.K = 0
+param.LeafSize = 20
+param.Naive = false
+param.Query = mat.NewDense(1, 1, nil)
+param.RandomBasis = false
+param.Reference = mat.NewDense(1, 1, nil)
+param.SampleAtLeaves = false
 param.Seed = 0
-param.Shuffle = false
-param.StepSize = 0.01
-param.Test = mat.NewDense(1, 1, nil)
-param.TestLabels = mat.NewDense(1, 1, nil)
-param.Tolerance = 1e-10
-param.Training = mat.NewDense(1, 1, nil)
+param.SingleMode = false
+param.SingleSampleLimit = 20
+param.Tau = 5
+param.TreeType = "kd"
 param.Verbose = false
 
-output_model, predictions, probabilities := mlpack.LinearSvm(param)
+distances, neighbors, output_model := mlpack.Krann(param)
 ```
 
-An implementation of linear SVM for multiclass classification. Given labeled data, a model can be trained and saved for future use; or, a pre-trained model can be used to classify new points. [Detailed documentation](#linear_svm_detailed-documentation).
+An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
 
 
 
@@ -3864,23 +4174,22 @@ There are two types of input options: required options, which are passed directl
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `Alpha` | [`float64`](#doc_float64) | The desired success probability. | `0.95` |
 | `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `Delta` | [`float64`](#doc_float64) | Margin of difference between correct class and other classes. | `1` |
-| `Epochs` | [`int`](#doc_int) | Maximum number of full epochs over dataset for psgd | `50` |
-| `InputModel` | [`linearsvmModel`](#doc_model) | Existing model (parameters). | `nil` |
-| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | A matrix containing labels (0 or 1) for the points in the training set (y). | `mat.NewDense(1, 1, nil)` |
-| `Lambda` | [`float64`](#doc_float64) | L2-regularization parameter for training. | `0.0001` |
-| `MaxIterations` | [`int`](#doc_int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
-| `NoIntercept` | [`bool`](#doc_bool) | Do not add the intercept term to the model. | `false` |
-| `NumClasses` | [`int`](#doc_int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
-| `Optimizer` | [`string`](#doc_string) | Optimizer to use for training ('lbfgs' or 'psgd'). | `"lbfgs"` |
-| `Seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `Shuffle` | [`bool`](#doc_bool) | Don't shuffle the order in which data points are visited for parallel SGD. | `false` |
-| `StepSize` | [`float64`](#doc_float64) | Step size for parallel SGD optimizer. | `0.01` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing test dataset. | `mat.NewDense(1, 1, nil)` |
-| `TestLabels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Matrix containing test labels. | `mat.NewDense(1, 1, nil)` |
-| `Tolerance` | [`float64`](#doc_float64) | Convergence tolerance for optimizer. | `1e-10` |
-| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the training set (the matrix of predictors, X). | `mat.NewDense(1, 1, nil)` |
+| `FirstLeafExact` | [`bool`](#doc_bool) | The flag to trigger sampling only after exactly exploring the first leaf. | `false` |
+| `InputModel` | [`raModel`](#doc_model) | Pre-trained kNN model. | `nil` |
+| `K` | [`int`](#doc_int) | Number of nearest neighbors to find. | `0` |
+| `LeafSize` | [`int`](#doc_int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
+| `Naive` | [`bool`](#doc_bool) | If true, sampling will be done without using a tree. | `false` |
+| `Query` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing query points (optional). | `mat.NewDense(1, 1, nil)` |
+| `RandomBasis` | [`bool`](#doc_bool) | Before tree-building, project the data onto a random orthogonal basis. | `false` |
+| `Reference` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing the reference dataset. | `mat.NewDense(1, 1, nil)` |
+| `SampleAtLeaves` | [`bool`](#doc_bool) | The flag to trigger sampling at leaves. | `false` |
+| `Seed` | [`int`](#doc_int) | Random seed (if 0, std::time(NULL) is used). | `0` |
+| `SingleMode` | [`bool`](#doc_bool) | If true, single-tree search is used (as opposed to dual-tree search. | `false` |
+| `SingleSampleLimit` | [`int`](#doc_int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
+| `Tau` | [`float64`](#doc_float64) | The allowed rank-error in terms of the percentile of the data. | `5` |
+| `TreeType` | [`string`](#doc_string) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `"kd"` |
 | `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
 
 ### Output options
@@ -3889,363 +4198,38 @@ Output options are returned via Go's support for multiple return values, in the 
 
 | ***name*** | ***type*** | ***description*** |
 |------------|------------|-------------------|
-| `OutputModel` | [`linearsvmModel`](#doc_model) | Output for trained linear svm model. | 
-| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
-| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | If test data is specified, this matrix is where the class probabilities for the test set will be saved. | 
+| `Distances` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to output distances into. | 
+| `Neighbors` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to output neighbors into. | 
+| `OutputModel` | [`raModel`](#doc_model) | If specified, the kNN model will be output here. | 
 
 ### Detailed documentation
-{: #linear_svm_detailed-documentation }
+{: #krann_detailed-documentation }
 
-An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
-
-This program allows loading a linear SVM model (via the `InputModel` parameter) or training a linear SVM model given training data (specified with the `Training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (specified with the `Test` parameter) and the classification results may be saved with the `Predictions` output parameter. The trained linear SVM model may be saved using the `OutputModel` output parameter.
-
-The training data, if specified, may have class labels as its last dimension.  Alternately, the `Labels` parameter may be used to specify a separate vector of labels.
-
-When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `Lambda` option, and the number of classes can be manually specified with the `NumClasses`and if an intercept term is not desired in the model, the `NoIntercept` parameter can be specified.
-
-Margin of difference between correct class and other classes can be specified with the `Delta` option.The optimizer used to train the model can be specified with the `Optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `MaxIterations` parameter specifies the maximum number of allowed iterations, and the `Tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `StepSize` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `Epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
-
-Optionally, the model can be used to predict the labels for another matrix of data points, if `Test` is specified.  The `Test` parameter can be specified without the `Training` parameter, so long as an existing linear SVM model is given with the `InputModel` parameter.  The output predictions from the linear SVM model may be saved with the `Predictions` parameter.
+This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
 
 ### Example
-As an example, to train a LinaerSVM on the data '`data`' with labels '`labels`' with L2 regularization of 0.1, saving the model to '`lsvm_model`', the following command may be used:
+For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `input` and store the distances in `distances` and the neighbors in `neighbors.csv`:
 
 ```go
-// Initialize optional parameters for LinearSvm().
-param := mlpack.LinearSvmOptions()
-param.Training = data
-param.Labels = labels
-param.Lambda = 0.1
-param.Delta = 1
-param.NumClasses = 0
+// Initialize optional parameters for Krann().
+param := mlpack.KrannOptions()
+param.Reference = input
+param.K = 5
+param.Tau = 0.1
 
-lsvm_model, _, _ := mlpack.LinearSvm(param)
+distances, neighbors, _ := mlpack.Krann(param)
 ```
 
-Then, to use that model to predict classes for the dataset '`test`', storing the output predictions in '`predictions`', the following command may be used: 
+Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
 
-```go
-// Initialize optional parameters for LinearSvm().
-param := mlpack.LinearSvmOptions()
-param.InputModel = &lsvm_model
-param.Test = test
-
-_, predictions, _ := mlpack.LinearSvm(param)
-```
+The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
 
 ### See also
 
- - [RandomForest()](#random_forest)
- - [LogisticRegression()](#logistic_regression)
- - [LinearSVM on Wikipedia](https://en.wikipedia.org/wiki/Support-vector_machine)
- - [LinearSVM C++ class documentation](../../user/methods/linear_svm.md)
-
-## Adaboost()
-{: #adaboost }
-
-#### AdaBoost
-{: #adaboost_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for Adaboost().
-param := mlpack.AdaboostOptions()
-param.InputModel = nil
-param.Iterations = 1000
-param.Labels = mat.NewDense(1, 1, nil)
-param.Test = mat.NewDense(1, 1, nil)
-param.Tolerance = 1e-10
-param.Training = mat.NewDense(1, 1, nil)
-param.Verbose = false
-param.WeakLearner = "decision_stump"
-
-output_model, predictions, probabilities := mlpack.Adaboost(param)
-```
-
-An implementation of the AdaBoost.MH (Adaptive Boosting) algorithm for classification.  This can be used to train an AdaBoost model on labeled data or use an existing AdaBoost model to predict the classes of new points. [Detailed documentation](#adaboost_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `InputModel` | [`adaBoostModel`](#doc_model) | Input AdaBoost model. | `nil` |
-| `Iterations` | [`int`](#doc_int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
-| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Labels for the training set. | `mat.NewDense(1, 1, nil)` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Test dataset. | `mat.NewDense(1, 1, nil)` |
-| `Tolerance` | [`float64`](#doc_float64) | The tolerance for change in values of the weighted error during training. | `1e-10` |
-| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | Dataset for training AdaBoost. | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-| `WeakLearner` | [`string`](#doc_string) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `"decision_stump"` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `OutputModel` | [`adaBoostModel`](#doc_model) | Output trained AdaBoost model. | 
-| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Predicted labels for the test set. | 
-| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | Predicted class probabilities for each point in the test set. | 
-
-### Detailed documentation
-{: #adaboost_detailed-documentation }
-
-This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
-
-For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
-
-This program allows training of an AdaBoost model, and then application of that model to a test dataset.  To train a model, a dataset must be passed with the `Training` option.  Labels can be given with the `Labels` option; if no labels are specified, the labels will be assumed to be the last column of the input dataset.  Alternately, an AdaBoost model may be loaded with the `InputModel` option.
-
-Once a model is trained or loaded, it may be used to provide class predictions for a given test dataset.  A test dataset may be specified with the `Test` parameter.  The predicted classes for each point in the test dataset are output to the `Predictions` output parameter.  The AdaBoost model itself is output to the `OutputModel` output parameter.
-
-### Example
-For example, to run AdaBoost on an input dataset `data` with labels `labels`and perceptrons as the weak learner type, storing the trained model in `model`, one could use the following command: 
-
-```go
-// Initialize optional parameters for Adaboost().
-param := mlpack.AdaboostOptions()
-param.Training = data
-param.Labels = labels
-param.WeakLearner = "perceptron"
-
-model, _, _ := mlpack.Adaboost(param)
-```
-
-Similarly, an already-trained model in `model` can be used to provide class predictions from test data `test_data` and store the output in `predictions` with the following command: 
-
-```go
-// Initialize optional parameters for Adaboost().
-param := mlpack.AdaboostOptions()
-param.InputModel = &model
-param.Test = test_data
-
-_, predictions, _ := mlpack.Adaboost(param)
-```
-
-### See also
-
- - [AdaBoost on Wikipedia](https://en.wikipedia.org/wiki/AdaBoost)
- - [Improved boosting algorithms using confidence-rated predictions (pdf)](http://www.schapire.net/papers/SchapireSi98.pdf)
- - [Perceptron](#perceptron)
- - [Decision Trees](#decision_tree)
- - [AdaBoost C++ class documentation](../../user/methods/adaboost.md)
-
-## HoeffdingTree()
-{: #hoeffding_tree }
-
-#### Hoeffding trees
-{: #hoeffding_tree_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for HoeffdingTree().
-param := mlpack.HoeffdingTreeOptions()
-param.BatchMode = false
-param.Bins = 10
-param.Confidence = 0.95
-param.InfoGain = false
-param.InputModel = nil
-param.Labels = mat.NewDense(1, 1, nil)
-param.MaxSamples = 5000
-param.MinSamples = 100
-param.NumericSplitStrategy = "binary"
-param.ObservationsBeforeBinning = 100
-param.Passes = 1
-param.Test = mat.NewDense(1, 1, nil)
-param.TestLabels = mat.NewDense(1, 1, nil)
-param.Training = mat.NewDense(1, 1, nil)
-param.Verbose = false
-
-output_model, predictions, probabilities := mlpack.HoeffdingTree(param)
-```
-
-An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data, a Hoeffding tree can be trained and saved for later use, or a pre-trained Hoeffding tree can be used for predicting the classifications of new points. [Detailed documentation](#hoeffding_tree_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `BatchMode` | [`bool`](#doc_bool) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `false` |
-| `Bins` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `Confidence` | [`float64`](#doc_float64) | Confidence before splitting (between 0 and 1). | `0.95` |
-| `InfoGain` | [`bool`](#doc_bool) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `false` |
-| `InputModel` | [`hoeffdingTreeModel`](#doc_model) | Input trained Hoeffding tree model. | `nil` |
-| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Labels for training dataset. | `mat.NewDense(1, 1, nil)` |
-| `MaxSamples` | [`int`](#doc_int) | Maximum number of samples before splitting. | `5000` |
-| `MinSamples` | [`int`](#doc_int) | Minimum number of samples before splitting. | `100` |
-| `NumericSplitStrategy` | [`string`](#doc_string) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `"binary"` |
-| `ObservationsBeforeBinning` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
-| `Passes` | [`int`](#doc_int) | Number of passes to take over the dataset. | `1` |
-| `Test` | [`matrixWithInfo`](#doc_matrixWithInfo) | Testing dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
-| `TestLabels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Labels of test data. | `mat.NewDense(1, 1, nil)` |
-| `Training` | [`matrixWithInfo`](#doc_matrixWithInfo) | Training dataset (may be categorical). | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `OutputModel` | [`hoeffdingTreeModel`](#doc_model) | Output for trained Hoeffding tree model. | 
-| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Matrix to output label predictions for test data into. | 
-| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
-
-### Detailed documentation
-{: #hoeffding_tree_detailed-documentation }
-
-This program implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets.  This program supports both categorical and numeric data.  Given an input dataset, this program is able to train the tree with numerous training options, and save the model to a file.  The program is also able to use a trained model or a model from file in order to predict classes for a given test set.
-
-The training file and associated labels are specified with the `Training` and `Labels` parameters, respectively. Optionally, if `Labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `BatchMode` option, but this may not be the best option for large datasets.
-
-When a model is trained, it may be saved via the `OutputModel` output parameter.  A model may be loaded from file for further training or testing with the `InputModel` parameter.
-
-Test data may be specified with the `Test` parameter, and if performance statistics are desired for that test set, labels may be specified with the `TestLabels` parameter.  Predictions for each test point may be saved with the `Predictions` output parameter, and class probabilities for each prediction may be saved with the `Probabilities` output parameter.
-
-### Example
-For example, to train a Hoeffding tree with confidence 0.99 with data `dataset`, saving the trained tree to `tree`, the following command may be used:
-
-```go
-// Initialize optional parameters for HoeffdingTree().
-param := mlpack.HoeffdingTreeOptions()
-param.Training = dataset
-param.Confidence = 0.99
-
-tree, _, _ := mlpack.HoeffdingTree(param)
-```
-
-Then, this tree may be used to make predictions on the test set `test_set`, saving the predictions into `predictions` and the class probabilities into `class_probs` with the following command: 
-
-```go
-// Initialize optional parameters for HoeffdingTree().
-param := mlpack.HoeffdingTreeOptions()
-param.InputModel = &tree
-param.Test = test_set
-
-_, predictions, class_probs := mlpack.HoeffdingTree(param)
-```
-
-### See also
-
- - [DecisionTree()](#decision_tree)
- - [RandomForest()](#random_forest)
- - [Mining High-Speed Data Streams (pdf)](https://www.cs.rhodes.edu/~welshc/COMP465_S15/Papers/kdd00.pdf)
- - [HoeffdingTree class documentation](../../user/methods/hoeffding_tree.md)
-
-## Nbc()
-{: #nbc }
-
-#### Parametric Naive Bayes Classifier
-{: #nbc_descr }
-
-```go
-import (
-  "mlpack.org/v1/mlpack"
-  "gonum.org/v1/gonum/mat"
-)
-
-// Initialize optional parameters for Nbc().
-param := mlpack.NbcOptions()
-param.IncrementalVariance = false
-param.InputModel = nil
-param.Labels = mat.NewDense(1, 1, nil)
-param.Test = mat.NewDense(1, 1, nil)
-param.Training = mat.NewDense(1, 1, nil)
-param.Verbose = false
-
-output_model, predictions, probabilities := mlpack.Nbc(param)
-```
-
-An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model can be trained and saved, or, a pre-trained model can be used for classification. [Detailed documentation](#nbc_detailed-documentation).
-
-
-
-### Input options
-There are two types of input options: required options, which are passed directly to the function call, and optional options, which are passed via an initialized struct, which allows keyword access to each of the options.
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `IncrementalVariance` | [`bool`](#doc_bool) | The variance of each class will be calculated incrementally. | `false` |
-| `InputModel` | [`nbcModel`](#doc_model) | Input Naive Bayes model. | `nil` |
-| `Labels` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | A file containing labels for the training set. | `mat.NewDense(1, 1, nil)` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the test set. | `mat.NewDense(1, 1, nil)` |
-| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | A matrix containing the training set. | `mat.NewDense(1, 1, nil)` |
-| `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Output options are returned via Go's support for multiple return values, in the order listed below.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `OutputModel` | [`nbcModel`](#doc_model) | File to save trained Naive Bayes model to. | 
-| `Predictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | The matrix in which the predicted labels for the test set will be written. | 
-| `Probabilities` | [`*mat.Dense`](#doc_a__mat_Dense) | The matrix in which the predicted probability of labels for the test set will be written. | 
-
-### Detailed documentation
-{: #nbc_detailed-documentation }
-
-This program trains the Naive Bayes classifier on the given labeled training set, or loads a model from the given model file, and then may use that trained model to classify the points in a given test set.
-
-The training set is specified with the `Training` parameter.  Labels may be either the last row of the training set, or alternately the `Labels` parameter may be specified to pass a separate matrix of labels.
-
-If training is not desired, a pre-existing model may be loaded with the `InputModel` parameter.
-
-
-
-The `IncrementalVariance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
-
-If classifying a test set is desired, the test set may be specified with the `Test` parameter, and the classifications may be saved with the `Predictions`predictions  parameter.  If saving the trained model is desired, this may be done with the `OutputModel` output parameter.
-
-### Example
-For example, to train a Naive Bayes classifier on the dataset `data` with labels `labels` and save the model to `nbc_model`, the following command may be used:
-
-```go
-// Initialize optional parameters for Nbc().
-param := mlpack.NbcOptions()
-param.Training = data
-param.Labels = labels
-
-nbc_model, _, _ := mlpack.Nbc(param)
-```
-
-Then, to use `nbc_model` to predict the classes of the dataset `test_set` and save the predicted classes to `predictions`, the following command may be used:
-
-```go
-// Initialize optional parameters for Nbc().
-param := mlpack.NbcOptions()
-param.InputModel = &nbc_model
-param.Test = test_set
-
-_, predictions, _ := mlpack.Nbc(param)
-```
-
-### See also
-
- - [SoftmaxRegression()](#softmax_regression)
- - [RandomForest()](#random_forest)
- - [Naive Bayes classifier on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
- - [NaiveBayesClassifier C++ class documentation](../../user/methods/naive_bayes_classifier.md)
+ - [Knn()](#knn)
+ - [Lsh()](#lsh)
+ - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
+ - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
 
 ## SoftmaxRegression()
 {: #softmax_regression }
@@ -4347,11 +4331,11 @@ _, predictions, _ := mlpack.SoftmaxRegression(param)
  - [Multinomial logistic regression (softmax regression) on Wikipedia](https://en.wikipedia.org/wiki/Multinomial_logistic_regression)
  - [SoftmaxRegression C++ class documentation](../../user/methods/softmax_regression.md)
 
-## LinearRegression()
-{: #linear_regression }
+## SparseCoding()
+{: #sparse_coding }
 
-#### Simple Linear Regression and Prediction
-{: #linear_regression_descr }
+#### Sparse Coding
+{: #sparse_coding_descr }
 
 ```go
 import (
@@ -4359,19 +4343,26 @@ import (
   "gonum.org/v1/gonum/mat"
 )
 
-// Initialize optional parameters for LinearRegression().
-param := mlpack.LinearRegressionOptions()
+// Initialize optional parameters for SparseCoding().
+param := mlpack.SparseCodingOptions()
+param.Atoms = 15
+param.InitialDictionary = mat.NewDense(1, 1, nil)
 param.InputModel = nil
-param.Lambda = 0
+param.Lambda1 = 0
+param.Lambda2 = 0
+param.MaxIterations = 0
+param.NewtonTolerance = 1e-06
+param.Normalize = false
+param.ObjectiveTolerance = 0.01
+param.Seed = 0
 param.Test = mat.NewDense(1, 1, nil)
 param.Training = mat.NewDense(1, 1, nil)
-param.TrainingResponses = mat.NewDense(1, 1, nil)
 param.Verbose = false
 
-output_model, output_predictions := mlpack.LinearRegression(param)
+codes, dictionary, output_model := mlpack.SparseCoding(param)
 ```
 
-An implementation of simple linear regression and ridge regression using ordinary least squares.  Given a dataset and responses, a model can be trained and saved for later use, or a pre-trained model can be used to output regression predictions for a test set. [Detailed documentation](#linear_regression_detailed-documentation).
+An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
 
 
 
@@ -4380,12 +4371,19 @@ There are two types of input options: required options, which are passed directl
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `Atoms` | [`int`](#doc_int) | Number of atoms in the dictionary. | `15` |
 | `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `InputModel` | [`linearRegression`](#doc_model) | Existing LinearRegression model to use. | `nil` |
-| `Lambda` | [`float64`](#doc_float64) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
-| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing X' (test regressors). | `mat.NewDense(1, 1, nil)` |
-| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix containing training set X (regressors). | `mat.NewDense(1, 1, nil)` |
-| `TrainingResponses` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | `mat.NewDense(1, 1, nil)` |
+| `InitialDictionary` | [`*mat.Dense`](#doc_a__mat_Dense) | Optional initial dictionary matrix. | `mat.NewDense(1, 1, nil)` |
+| `InputModel` | [`sparseCoding`](#doc_model) | File containing input sparse coding model. | `nil` |
+| `Lambda1` | [`float64`](#doc_float64) | Sparse coding l1-norm regularization parameter. | `0` |
+| `Lambda2` | [`float64`](#doc_float64) | Sparse coding l2-norm regularization parameter. | `0` |
+| `MaxIterations` | [`int`](#doc_int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
+| `NewtonTolerance` | [`float64`](#doc_float64) | Tolerance for convergence of Newton method. | `1e-06` |
+| `Normalize` | [`bool`](#doc_bool) | If set, the input data matrix will be normalized before coding. | `false` |
+| `ObjectiveTolerance` | [`float64`](#doc_float64) | Tolerance for convergence of the objective function. | `0.01` |
+| `Seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `Test` | [`*mat.Dense`](#doc_a__mat_Dense) | Optional matrix to be encoded by trained model. | `mat.NewDense(1, 1, nil)` |
+| `Training` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix of training data (X). | `mat.NewDense(1, 1, nil)` |
 | `Verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
 
 ### Output options
@@ -4394,50 +4392,52 @@ Output options are returned via Go's support for multiple return values, in the 
 
 | ***name*** | ***type*** | ***description*** |
 |------------|------------|-------------------|
-| `OutputModel` | [`linearRegression`](#doc_model) | Output LinearRegression model. | 
-| `OutputPredictions` | [`*mat.Dense (1d)`](#doc_a__mat_Dense__1d_) | If --test_file is specified, this matrix is where the predicted responses will be saved. | 
+| `Codes` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
+| `Dictionary` | [`*mat.Dense`](#doc_a__mat_Dense) | Matrix to save the output dictionary to. | 
+| `OutputModel` | [`sparseCoding`](#doc_model) | File to save trained sparse coding model to. | 
 
 ### Detailed documentation
-{: #linear_regression_detailed-documentation }
+{: #sparse_coding_detailed-documentation }
 
-An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
 
-  y = X * b + e
+The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
 
-where X (specified by `Training`) and y (specified either as the last column of the input matrix `Training` or via the `TrainingResponses` parameter) are known and b is the desired variable.  If the covariance matrix (X'X) is not invertible, or if the solution is overdetermined, then specify a Tikhonov regularization constant (with `Lambda`) greater than 0, which will regularize the covariance matrix to make it invertible.  The calculated b may be saved with the `OutputPredictions` output parameter.
+The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
 
-Optionally, the calculated value of b is used to predict the responses for another matrix X' (specified by the `Test` parameter):
+Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
 
-   y' = X' * b
-
-and the predicted responses y' may be saved with the `OutputPredictions` output parameter.  This type of regression is related to least-angle regression, which mlpack implements as the 'lars' program.
+To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `Training` option, along with the number of atoms in the dictionary (specified with the `Atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `InitialDictionary` parameter.  An input model may be specified with the `InputModel` parameter.
 
 ### Example
-For example, to run a linear regression on the dataset `X` with responses `y`, saving the trained model to `lr_model`, the following command could be used:
+As an example, to build a sparse coding model on the dataset `data` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `model`, use 
 
 ```go
-// Initialize optional parameters for LinearRegression().
-param := mlpack.LinearRegressionOptions()
-param.Training = X
-param.TrainingResponses = y
+// Initialize optional parameters for SparseCoding().
+param := mlpack.SparseCodingOptions()
+param.Training = data
+param.Atoms = 200
+param.Lambda1 = 0.1
 
-lr_model, _ := mlpack.LinearRegression(param)
+_, _, model := mlpack.SparseCoding(param)
 ```
 
-Then, to use `lr_model` to predict responses for a test set `X_test`, saving the predictions to `X_test_responses`, the following command could be used:
+Then, this model could be used to encode a new matrix, `otherdata`, and save the output codes to `codes`: 
 
 ```go
-// Initialize optional parameters for LinearRegression().
-param := mlpack.LinearRegressionOptions()
-param.InputModel = &lr_model
-param.Test = X_test
+// Initialize optional parameters for SparseCoding().
+param := mlpack.SparseCodingOptions()
+param.InputModel = &model
+param.Test = otherdata
 
-_, X_test_responses := mlpack.LinearRegression(param)
+codes, _, _ := mlpack.SparseCoding(param)
 ```
 
 ### See also
 
- - [Lars()](#lars)
- - [Linear regression on Wikipedia](https://en.wikipedia.org/wiki/Linear_regression)
- - [LinearRegression C++ class documentation](../../user/methods/linear_regression.md)
+ - [LocalCoordinateCoding()](#local_coordinate_coding)
+ - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
+ - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+ - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
+ - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
 

--- a/doc/user/bindings/go.sidebar.html
+++ b/doc/user/bindings/go.sidebar.html
@@ -8,14 +8,14 @@
 <li><a href="LINKROOTuser/bindings/go.html#data-formats">Data Formats</a></li>
 <li><details><summary>Classification</summary>
 <ul>
-<li><a href="LINKROOTuser/bindings/go.html#logistic_regression">LogisticRegression()</a></li>
-<li><a href="LINKROOTuser/bindings/go.html#random_forest">RandomForest()</a></li>
-<li><a href="LINKROOTuser/bindings/go.html#decision_tree">DecisionTree()</a></li>
-<li><a href="LINKROOTuser/bindings/go.html#perceptron">Perceptron()</a></li>
-<li><a href="LINKROOTuser/bindings/go.html#linear_svm">LinearSvm()</a></li>
 <li><a href="LINKROOTuser/bindings/go.html#adaboost">Adaboost()</a></li>
+<li><a href="LINKROOTuser/bindings/go.html#decision_tree">DecisionTree()</a></li>
 <li><a href="LINKROOTuser/bindings/go.html#hoeffding_tree">HoeffdingTree()</a></li>
+<li><a href="LINKROOTuser/bindings/go.html#linear_svm">LinearSvm()</a></li>
+<li><a href="LINKROOTuser/bindings/go.html#logistic_regression">LogisticRegression()</a></li>
 <li><a href="LINKROOTuser/bindings/go.html#nbc">Nbc()</a></li>
+<li><a href="LINKROOTuser/bindings/go.html#perceptron">Perceptron()</a></li>
+<li><a href="LINKROOTuser/bindings/go.html#random_forest">RandomForest()</a></li>
 <li><a href="LINKROOTuser/bindings/go.html#softmax_regression">SoftmaxRegression()</a></li>
 </ul>
 </details>

--- a/doc/user/bindings/julia.md
+++ b/doc/user/bindings/julia.md
@@ -36,6 +36,87 @@ mlpack bindings for Julia take and return a restricted set of types, for simplic
 </div>
 
 
+## adaboost()
+{: #adaboost }
+
+#### AdaBoost
+{: #adaboost_descr }
+
+```julia
+julia> using mlpack: adaboost
+julia> output_model, predictions, probabilities = adaboost( ;
+          input_model=nothing, iterations=1000, labels=Int[], test=zeros(0, 0),
+          tolerance=1e-10, training=zeros(0, 0), verbose=false,
+          weak_learner="decision_stump")
+```
+
+An implementation of the AdaBoost.MH (Adaptive Boosting) algorithm for classification.  This can be used to train an AdaBoost model on labeled data or use an existing AdaBoost model to predict the classes of new points. [Detailed documentation](#adaboost_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `input_model` | [`AdaBoostModel`](#doc_model) | Input AdaBoost model. | `nothing` |
+| `iterations` | [`Int`](#doc_Int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
+| `labels` | [`Int vector-like`](#doc_Int_vector_like) | Labels for the training set. | `Int[]` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Test dataset. | `zeros(0, 0)` |
+| `tolerance` | [`Float64`](#doc_Float64) | The tolerance for change in values of the weighted error during training. | `1e-10` |
+| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Dataset for training AdaBoost. | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+| `weak_learner` | [`String`](#doc_String) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `"decision_stump"` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`AdaBoostModel`](#doc_model) | Output trained AdaBoost model. | 
+| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | Predicted labels for the test set. | 
+| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Predicted class probabilities for each point in the test set. | 
+
+### Detailed documentation
+{: #adaboost_detailed-documentation }
+
+This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
+
+For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
+
+This program allows training of an AdaBoost model, and then application of that model to a test dataset.  To train a model, a dataset must be passed with the `training` option.  Labels can be given with the `labels` option; if no labels are specified, the labels will be assumed to be the last column of the input dataset.  Alternately, an AdaBoost model may be loaded with the `input_model` option.
+
+Once a model is trained or loaded, it may be used to provide class predictions for a given test dataset.  A test dataset may be specified with the `test` parameter.  The predicted classes for each point in the test dataset are output to the `predictions` output parameter.  The AdaBoost model itself is output to the `output_model` output parameter.
+
+### Example
+For example, to run AdaBoost on an input dataset ``data`` with labels ``labels``and perceptrons as the weak learner type, storing the trained model in ``model``, one could use the following command: 
+
+```julia
+julia> using CSV
+julia> data = CSV.read("data.csv")
+julia> labels = CSV.read("labels.csv"; type=Int)
+julia> model, _, _ = adaboost(labels=labels, training=data,
+            weak_learner="perceptron")
+```
+
+Similarly, an already-trained model in ``model`` can be used to provide class predictions from test data ``test_data`` and store the output in ``predictions`` with the following command: 
+
+```julia
+julia> using CSV
+julia> test_data = CSV.read("test_data.csv")
+julia> _, predictions, _ = adaboost(input_model=model,
+            test=test_data)
+```
+
+### See also
+
+ - [AdaBoost on Wikipedia](https://en.wikipedia.org/wiki/AdaBoost)
+ - [Improved boosting algorithms using confidence-rated predictions (pdf)](http://www.schapire.net/papers/SchapireSi98.pdf)
+ - [Perceptron](#perceptron)
+ - [Decision Trees](#decision_tree)
+ - [AdaBoost C++ class documentation](../../user/methods/adaboost.md)
+
 ## approx_kfn()
 {: #approx_kfn }
 
@@ -134,6 +215,94 @@ julia> _, neighbors, _ = approx_kfn(input_model=model, k=3,
  - [Approximate furthest neighbor in high dimensions (pdf)](https://www.rasmuspagh.net/papers/approx-furthest-neighbor-SISAP15.pdf)
  - [QDAFN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/qdafn.hpp)
  - [DrusillaSelect class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/drusilla_select.hpp)
+
+## bayesian_linear_regression()
+{: #bayesian_linear_regression }
+
+#### BayesianLinearRegression
+{: #bayesian_linear_regression_descr }
+
+```julia
+julia> using mlpack: bayesian_linear_regression
+julia> output_model, predictions, stds = bayesian_linear_regression( ;
+          center=false, input=zeros(0, 0), input_model=nothing,
+          responses=Float64[], scale=false, test=zeros(0, 0), verbose=false)
+```
+
+An implementation of the Bayesian linear regression. [Detailed documentation](#bayesian_linear_regression_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `center` | [`Bool`](#doc_Bool) | Center the data and fit the intercept if enabled. | `false` |
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `input` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix of covariates (X). | `zeros(0, 0)` |
+| `input_model` | [`BayesianLinearRegression`](#doc_model) | Trained BayesianLinearRegression model to use. | `nothing` |
+| `responses` | [`Float64 vector-like`](#doc_Float64_vector_like) | Matrix of responses/observations (y). | `Float64[]` |
+| `scale` | [`Bool`](#doc_Bool) | Scale each feature by their standard deviations if enabled. | `false` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing points to regress on (test points). | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`BayesianLinearRegression`](#doc_model) | Output BayesianLinearRegression model. | 
+| `predictions` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | If --test_file is specified, this file is where the predicted responses will be saved. | 
+| `stds` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | If specified, this is where the standard deviations of the predictive distribution will be saved. | 
+
+### Detailed documentation
+{: #bayesian_linear_regression_detailed-documentation }
+
+An implementation of the Bayesian linear regression.
+This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
+Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
+
+This program is able to train a Bayesian linear regression model or load a model from file, output regression predictions for a test set, and save the trained model to a file.
+
+To train a BayesianLinearRegression model, the `input` and `responses`parameters must be given. The `center`and `scale` parameters control the centering and the normalizing options. A trained model can be saved with the `output_model`. If no training is desired at all, a model can be passed via the `input_model` parameter.
+
+The program can also provide predictions for test data using either the trained model or the given input model.  Test points can be specified with the `test` parameter.  Predicted responses to the test points can be saved with the `predictions` output parameter. The corresponding standard deviation can be save by precising the `stds` parameter.
+
+### Example
+For example, the following command trains a model on the data ``data`` and responses ``responses``with center set to true and scale set to false (so, Bayesian linear regression is being solved, and then the model is saved to ``blr_model``:
+
+```julia
+julia> using CSV
+julia> data = CSV.read("data.csv")
+julia> responses = CSV.read("responses.csv")
+julia> blr_model, _, _ = bayesian_linear_regression(center=1,
+            input=data, responses=responses, scale=0)
+```
+
+The following command uses the ``blr_model`` to provide predicted  responses for the data ``test`` and save those  responses to ``test_predictions``: 
+
+```julia
+julia> using CSV
+julia> test = CSV.read("test.csv")
+julia> _, test_predictions, _ =
+            bayesian_linear_regression(input_model=blr_model, test=test)
+```
+
+Because the estimator computes a predictive distribution instead of a simple point estimate, the `stds` parameter allows one to save the prediction uncertainties: 
+
+```julia
+julia> using CSV
+julia> test = CSV.read("test.csv")
+julia> _, test_predictions, stds =
+            bayesian_linear_regression(input_model=blr_model, test=test)
+```
+
+### See also
+
+ - [Bayesian Interpolation](https://cs.uwaterloo.ca/~mannr/cs886-w10/mackay-bayesian.pdf)
+ - [Bayesian Linear Regression, Section 3.3](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
+ - [BayesianLinearRegression C++ class documentation](../../user/methods/bayesian_linear_regression.md)
 
 ## cf()
 {: #cf }
@@ -329,6 +498,92 @@ julia> _, _ = dbscan(input; epsilon=0.5, min_size=5)
  - [DBSCAN on Wikipedia](https://en.wikipedia.org/wiki/DBSCAN)
  - [A density-based algorithm for discovering clusters in large spatial databases with noise (pdf)](https://cdn.aaai.org/KDD/1996/KDD96-037.pdf)
  - [DBSCAN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/dbscan/dbscan.hpp)
+
+## decision_tree()
+{: #decision_tree }
+
+#### Decision tree
+{: #decision_tree_descr }
+
+```julia
+julia> using mlpack: decision_tree
+julia> output_model, predictions, probabilities = decision_tree( ;
+          input_model=nothing, labels=Int[], maximum_depth=0,
+          minimum_gain_split=1e-07, minimum_leaf_size=20,
+          print_training_accuracy=false, test=zeros(0, 0), test_labels=Int[],
+          training=zeros(0, 0), verbose=false, weights=zeros(0, 0))
+```
+
+An implementation of an ID3-style decision tree for classification, which supports categorical data.  Given labeled data with numeric or categorical features, a decision tree can be trained and saved; or, an existing decision tree can be used for classification on new points. [Detailed documentation](#decision_tree_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `input_model` | [`DecisionTreeModel`](#doc_model) | Pre-trained decision tree, to be used with test points. | `nothing` |
+| `labels` | [`Int vector-like`](#doc_Int_vector_like) | Training labels. | `Int[]` |
+| `maximum_depth` | [`Int`](#doc_Int) | Maximum depth of the tree (0 means no limit). | `0` |
+| `minimum_gain_split` | [`Float64`](#doc_Float64) | Minimum gain for node splitting. | `1e-07` |
+| `minimum_leaf_size` | [`Int`](#doc_Int) | Minimum number of points in a leaf. | `20` |
+| `print_training_accuracy` | [`Bool`](#doc_Bool) | Print the training accuracy. | `false` |
+| `test` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Testing dataset (may be categorical). | `zeros(0, 0)` |
+| `test_labels` | [`Int vector-like`](#doc_Int_vector_like) | Test point labels, if accuracy calculation is desired. | `Int[]` |
+| `training` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Training dataset (may be categorical). | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+| `weights` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | The weight of labels | `zeros(0, 0)` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`DecisionTreeModel`](#doc_model) | Output for trained decision tree. | 
+| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | Class predictions for each test point. | 
+| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Class probabilities for each test point. | 
+
+### Detailed documentation
+{: #decision_tree_detailed-documentation }
+
+Train and evaluate using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
+
+The training set and associated labels are specified with the `training` and `labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+When a model is trained, the `output_model` output parameter may be used to save the trained model.  A model may be loaded for predictions with the `input_model` parameter.  The `input_model` parameter may not be specified when the `training` parameter is specified.  The `minimum_leaf_size` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `minimum_gain_split` parameter specifies the minimum gain that is needed for the node to split.  The `maximum_depth` parameter specifies the maximum depth of the tree.  If `print_training_accuracy` is specified, the training accuracy will be printed.
+
+Test data may be specified with the `test` parameter, and if performance numbers are desired for that test set, labels may be specified with the `test_labels` parameter.  Predictions for each test point may be saved via the `predictions` output parameter.  Class probabilities for each prediction may be saved with the `probabilities` output parameter.
+
+### Example
+For example, to train a decision tree with a minimum leaf size of 20 on the dataset contained in ``data`` with labels ``labels``, saving the output model to ``tree`` and printing the training error, one could call
+
+```julia
+julia> using CSV
+julia> data = CSV.read("data.csv")
+julia> labels = CSV.read("labels.csv"; type=Int)
+julia> tree, _, _ = decision_tree(labels=labels,
+            minimum_gain_split=0.001, minimum_leaf_size=20,
+            print_training_accuracy=1, training=data)
+```
+
+Then, to use that model to classify points in ``test_set`` and print the test error given the labels ``test_labels`` using that model, while saving the predictions for each point to ``predictions``, one could call 
+
+```julia
+julia> using CSV
+julia> test_set = CSV.read("test_set.csv")
+julia> test_labels = CSV.read("test_labels.csv"; type=Int)
+julia> _, predictions, _ = decision_tree(input_model=tree,
+            test=test_set, test_labels=test_labels)
+```
+
+### See also
+
+ - [Random forest](#random_forest)
+ - [Decision trees on Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning)
+ - [Induction of Decision Trees (pdf)](https://www.hunch.net/~coms-4771/quinlan.pdf)
+ - [DecisionTree C++ class documentation](../../user/methods/decision_tree.md)
 
 ## det()
 {: #det }
@@ -953,6 +1208,96 @@ julia> states = hmm_viterbi(obs, hmm)
  - [Hidden Mixture Models on Wikipedia](https://en.wikipedia.org/wiki/Hidden_Markov_model)
  - [HMM class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/hmm/hmm.hpp)
 
+## hoeffding_tree()
+{: #hoeffding_tree }
+
+#### Hoeffding trees
+{: #hoeffding_tree_descr }
+
+```julia
+julia> using mlpack: hoeffding_tree
+julia> output_model, predictions, probabilities = hoeffding_tree( ;
+          batch_mode=false, bins=10, confidence=0.95, info_gain=false,
+          input_model=nothing, labels=Int[], max_samples=5000, min_samples=100,
+          numeric_split_strategy="binary", observations_before_binning=100,
+          passes=1, test=zeros(0, 0), test_labels=Int[], training=zeros(0, 0),
+          verbose=false)
+```
+
+An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data, a Hoeffding tree can be trained and saved for later use, or a pre-trained Hoeffding tree can be used for predicting the classifications of new points. [Detailed documentation](#hoeffding_tree_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `batch_mode` | [`Bool`](#doc_Bool) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `false` |
+| `bins` | [`Int`](#doc_Int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `confidence` | [`Float64`](#doc_Float64) | Confidence before splitting (between 0 and 1). | `0.95` |
+| `info_gain` | [`Bool`](#doc_Bool) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `false` |
+| `input_model` | [`HoeffdingTreeModel`](#doc_model) | Input trained Hoeffding tree model. | `nothing` |
+| `labels` | [`Int vector-like`](#doc_Int_vector_like) | Labels for training dataset. | `Int[]` |
+| `max_samples` | [`Int`](#doc_Int) | Maximum number of samples before splitting. | `5000` |
+| `min_samples` | [`Int`](#doc_Int) | Minimum number of samples before splitting. | `100` |
+| `numeric_split_strategy` | [`String`](#doc_String) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `"binary"` |
+| `observations_before_binning` | [`Int`](#doc_Int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
+| `passes` | [`Int`](#doc_Int) | Number of passes to take over the dataset. | `1` |
+| `test` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Testing dataset (may be categorical). | `zeros(0, 0)` |
+| `test_labels` | [`Int vector-like`](#doc_Int_vector_like) | Labels of test data. | `Int[]` |
+| `training` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Training dataset (may be categorical). | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`HoeffdingTreeModel`](#doc_model) | Output for trained Hoeffding tree model. | 
+| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | Matrix to output label predictions for test data into. | 
+| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
+
+### Detailed documentation
+{: #hoeffding_tree_detailed-documentation }
+
+This program implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets.  This program supports both categorical and numeric data.  Given an input dataset, this program is able to train the tree with numerous training options, and save the model to a file.  The program is also able to use a trained model or a model from file in order to predict classes for a given test set.
+
+The training file and associated labels are specified with the `training` and `labels` parameters, respectively. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `batch_mode` option, but this may not be the best option for large datasets.
+
+When a model is trained, it may be saved via the `output_model` output parameter.  A model may be loaded from file for further training or testing with the `input_model` parameter.
+
+Test data may be specified with the `test` parameter, and if performance statistics are desired for that test set, labels may be specified with the `test_labels` parameter.  Predictions for each test point may be saved with the `predictions` output parameter, and class probabilities for each prediction may be saved with the `probabilities` output parameter.
+
+### Example
+For example, to train a Hoeffding tree with confidence 0.99 with data ``dataset``, saving the trained tree to ``tree``, the following command may be used:
+
+```julia
+julia> using CSV
+julia> dataset = CSV.read("dataset.csv")
+julia> tree, _, _ = hoeffding_tree(confidence=0.99,
+            training=dataset)
+```
+
+Then, this tree may be used to make predictions on the test set ``test_set``, saving the predictions into ``predictions`` and the class probabilities into ``class_probs`` with the following command: 
+
+```julia
+julia> using CSV
+julia> test_set = CSV.read("test_set.csv")
+julia> _, predictions, class_probs =
+            hoeffding_tree(input_model=tree, test=test_set)
+```
+
+### See also
+
+ - [decision_tree()](#decision_tree)
+ - [random_forest()](#random_forest)
+ - [Mining High-Speed Data Streams (pdf)](https://www.cs.rhodes.edu/~welshc/COMP465_S15/Papers/kdd00.pdf)
+ - [HoeffdingTree class documentation](../../user/methods/hoeffding_tree.md)
+
 ## image_converter()
 {: #image_converter }
 
@@ -1303,94 +1648,6 @@ julia> final, _ = kmeans(10, data; initial_centroids=initial,
  - [A dual-tree algorithm for fast k-means clustering with large k (pdf)](http://www.ratml.org/pub/pdf/2017dual.pdf)
  - [KMeans class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/kmeans/kmeans.hpp)
 
-## bayesian_linear_regression()
-{: #bayesian_linear_regression }
-
-#### BayesianLinearRegression
-{: #bayesian_linear_regression_descr }
-
-```julia
-julia> using mlpack: bayesian_linear_regression
-julia> output_model, predictions, stds = bayesian_linear_regression( ;
-          center=false, input=zeros(0, 0), input_model=nothing,
-          responses=Float64[], scale=false, test=zeros(0, 0), verbose=false)
-```
-
-An implementation of the Bayesian linear regression. [Detailed documentation](#bayesian_linear_regression_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `center` | [`Bool`](#doc_Bool) | Center the data and fit the intercept if enabled. | `false` |
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `input` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix of covariates (X). | `zeros(0, 0)` |
-| `input_model` | [`BayesianLinearRegression`](#doc_model) | Trained BayesianLinearRegression model to use. | `nothing` |
-| `responses` | [`Float64 vector-like`](#doc_Float64_vector_like) | Matrix of responses/observations (y). | `Float64[]` |
-| `scale` | [`Bool`](#doc_Bool) | Scale each feature by their standard deviations if enabled. | `false` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing points to regress on (test points). | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `output_model` | [`BayesianLinearRegression`](#doc_model) | Output BayesianLinearRegression model. | 
-| `predictions` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | If --test_file is specified, this file is where the predicted responses will be saved. | 
-| `stds` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | If specified, this is where the standard deviations of the predictive distribution will be saved. | 
-
-### Detailed documentation
-{: #bayesian_linear_regression_detailed-documentation }
-
-An implementation of the Bayesian linear regression.
-This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
-Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
-
-This program is able to train a Bayesian linear regression model or load a model from file, output regression predictions for a test set, and save the trained model to a file.
-
-To train a BayesianLinearRegression model, the `input` and `responses`parameters must be given. The `center`and `scale` parameters control the centering and the normalizing options. A trained model can be saved with the `output_model`. If no training is desired at all, a model can be passed via the `input_model` parameter.
-
-The program can also provide predictions for test data using either the trained model or the given input model.  Test points can be specified with the `test` parameter.  Predicted responses to the test points can be saved with the `predictions` output parameter. The corresponding standard deviation can be save by precising the `stds` parameter.
-
-### Example
-For example, the following command trains a model on the data ``data`` and responses ``responses``with center set to true and scale set to false (so, Bayesian linear regression is being solved, and then the model is saved to ``blr_model``:
-
-```julia
-julia> using CSV
-julia> data = CSV.read("data.csv")
-julia> responses = CSV.read("responses.csv")
-julia> blr_model, _, _ = bayesian_linear_regression(center=1,
-            input=data, responses=responses, scale=0)
-```
-
-The following command uses the ``blr_model`` to provide predicted  responses for the data ``test`` and save those  responses to ``test_predictions``: 
-
-```julia
-julia> using CSV
-julia> test = CSV.read("test.csv")
-julia> _, test_predictions, _ =
-            bayesian_linear_regression(input_model=blr_model, test=test)
-```
-
-Because the estimator computes a predictive distribution instead of a simple point estimate, the `stds` parameter allows one to save the prediction uncertainties: 
-
-```julia
-julia> using CSV
-julia> test = CSV.read("test.csv")
-julia> _, test_predictions, stds =
-            bayesian_linear_regression(input_model=blr_model, test=test)
-```
-
-### See also
-
- - [Bayesian Interpolation](https://cs.uwaterloo.ca/~mannr/cs886-w10/mackay-bayesian.pdf)
- - [Bayesian Linear Regression, Section 3.3](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
- - [BayesianLinearRegression C++ class documentation](../../user/methods/bayesian_linear_regression.md)
-
 ## lars()
 {: #lars }
 
@@ -1484,6 +1741,180 @@ julia> _, test_predictions = lars(input_model=lasso_model,
  - [linear_regression()](#linear_regression)
  - [Least angle regression (pdf)](https://mlpack.org/papers/lars.pdf)
  - [LARS C++ class documentation](../../user/methods/lars.md)
+
+## linear_regression()
+{: #linear_regression }
+
+#### Simple Linear Regression and Prediction
+{: #linear_regression_descr }
+
+```julia
+julia> using mlpack: linear_regression
+julia> output_model, output_predictions = linear_regression( ;
+          input_model=nothing, lambda=0.0, test=zeros(0, 0), training=zeros(0,
+          0), training_responses=Float64[], verbose=false)
+```
+
+An implementation of simple linear regression and ridge regression using ordinary least squares.  Given a dataset and responses, a model can be trained and saved for later use, or a pre-trained model can be used to output regression predictions for a test set. [Detailed documentation](#linear_regression_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `input_model` | [`LinearRegression`](#doc_model) | Existing LinearRegression model to use. | `nothing` |
+| `lambda` | [`Float64`](#doc_Float64) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0.0` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing X' (test regressors). | `zeros(0, 0)` |
+| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing training set X (regressors). | `zeros(0, 0)` |
+| `training_responses` | [`Float64 vector-like`](#doc_Float64_vector_like) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | `Float64[]` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`LinearRegression`](#doc_model) | Output LinearRegression model. | 
+| `output_predictions` | [`Float64 vector-like`](#doc_Float64_vector_like) | If --test_file is specified, this matrix is where the predicted responses will be saved. | 
+
+### Detailed documentation
+{: #linear_regression_detailed-documentation }
+
+An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+
+  y = X * b + e
+
+where X (specified by `training`) and y (specified either as the last column of the input matrix `training` or via the `training_responses` parameter) are known and b is the desired variable.  If the covariance matrix (X'X) is not invertible, or if the solution is overdetermined, then specify a Tikhonov regularization constant (with `lambda`) greater than 0, which will regularize the covariance matrix to make it invertible.  The calculated b may be saved with the `output_predictions` output parameter.
+
+Optionally, the calculated value of b is used to predict the responses for another matrix X' (specified by the `test` parameter):
+
+   y' = X' * b
+
+and the predicted responses y' may be saved with the `output_predictions` output parameter.  This type of regression is related to least-angle regression, which mlpack implements as the 'lars' program.
+
+### Example
+For example, to run a linear regression on the dataset ``X`` with responses ``y``, saving the trained model to ``lr_model``, the following command could be used:
+
+```julia
+julia> using CSV
+julia> X = CSV.read("X.csv")
+julia> y = CSV.read("y.csv")
+julia> lr_model, _ = linear_regression(training=X,
+            training_responses=y)
+```
+
+Then, to use ``lr_model`` to predict responses for a test set ``X_test``, saving the predictions to ``X_test_responses``, the following command could be used:
+
+```julia
+julia> using CSV
+julia> X_test = CSV.read("X_test.csv")
+julia> _, X_test_responses = linear_regression(input_model=lr_model,
+            test=X_test)
+```
+
+### See also
+
+ - [lars()](#lars)
+ - [Linear regression on Wikipedia](https://en.wikipedia.org/wiki/Linear_regression)
+ - [LinearRegression C++ class documentation](../../user/methods/linear_regression.md)
+
+## linear_svm()
+{: #linear_svm }
+
+#### Linear SVM is an L2-regularized support vector machine.
+{: #linear_svm_descr }
+
+```julia
+julia> using mlpack: linear_svm
+julia> output_model, predictions, probabilities = linear_svm( ;
+          delta=1.0, epochs=50, input_model=nothing, labels=Int[],
+          lambda=0.0001, max_iterations=10000, no_intercept=false,
+          num_classes=0, optimizer="lbfgs", seed=0, shuffle=false,
+          step_size=0.01, test=zeros(0, 0), test_labels=Int[], tolerance=1e-10,
+          training=zeros(0, 0), verbose=false)
+```
+
+An implementation of linear SVM for multiclass classification. Given labeled data, a model can be trained and saved for future use; or, a pre-trained model can be used to classify new points. [Detailed documentation](#linear_svm_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `delta` | [`Float64`](#doc_Float64) | Margin of difference between correct class and other classes. | `1.0` |
+| `epochs` | [`Int`](#doc_Int) | Maximum number of full epochs over dataset for psgd | `50` |
+| `input_model` | [`LinearSVMModel`](#doc_model) | Existing model (parameters). | `nothing` |
+| `labels` | [`Int vector-like`](#doc_Int_vector_like) | A matrix containing labels (0 or 1) for the points in the training set (y). | `Int[]` |
+| `lambda` | [`Float64`](#doc_Float64) | L2-regularization parameter for training. | `0.0001` |
+| `max_iterations` | [`Int`](#doc_Int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
+| `no_intercept` | [`Bool`](#doc_Bool) | Do not add the intercept term to the model. | `false` |
+| `num_classes` | [`Int`](#doc_Int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
+| `optimizer` | [`String`](#doc_String) | Optimizer to use for training ('lbfgs' or 'psgd'). | `"lbfgs"` |
+| `seed` | [`Int`](#doc_Int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `shuffle` | [`Bool`](#doc_Bool) | Don't shuffle the order in which data points are visited for parallel SGD. | `false` |
+| `step_size` | [`Float64`](#doc_Float64) | Step size for parallel SGD optimizer. | `0.01` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing test dataset. | `zeros(0, 0)` |
+| `test_labels` | [`Int vector-like`](#doc_Int_vector_like) | Matrix containing test labels. | `Int[]` |
+| `tolerance` | [`Float64`](#doc_Float64) | Convergence tolerance for optimizer. | `1e-10` |
+| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the training set (the matrix of predictors, X). | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`LinearSVMModel`](#doc_model) | Output for trained linear svm model. | 
+| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
+| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | If test data is specified, this matrix is where the class probabilities for the test set will be saved. | 
+
+### Detailed documentation
+{: #linear_svm_detailed-documentation }
+
+An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
+
+This program allows loading a linear SVM model (via the `input_model` parameter) or training a linear SVM model given training data (specified with the `training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (specified with the `test` parameter) and the classification results may be saved with the `predictions` output parameter. The trained linear SVM model may be saved using the `output_model` output parameter.
+
+The training data, if specified, may have class labels as its last dimension.  Alternately, the `labels` parameter may be used to specify a separate vector of labels.
+
+When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `lambda` option, and the number of classes can be manually specified with the `num_classes`and if an intercept term is not desired in the model, the `no_intercept` parameter can be specified.
+
+Margin of difference between correct class and other classes can be specified with the `delta` option.The optimizer used to train the model can be specified with the `optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `max_iterations` parameter specifies the maximum number of allowed iterations, and the `tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `step_size` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
+
+Optionally, the model can be used to predict the labels for another matrix of data points, if `test` is specified.  The `test` parameter can be specified without the `training` parameter, so long as an existing linear SVM model is given with the `input_model` parameter.  The output predictions from the linear SVM model may be saved with the `predictions` parameter.
+
+### Example
+As an example, to train a LinaerSVM on the data '``data``' with labels '``labels``' with L2 regularization of 0.1, saving the model to '``lsvm_model``', the following command may be used:
+
+```julia
+julia> using CSV
+julia> data = CSV.read("data.csv")
+julia> labels = CSV.read("labels.csv"; type=Int)
+julia> lsvm_model, _, _ = linear_svm(delta=1, labels=labels,
+            lambda=0.1, num_classes=0, training=data)
+```
+
+Then, to use that model to predict classes for the dataset '``test``', storing the output predictions in '``predictions``', the following command may be used: 
+
+```julia
+julia> using CSV
+julia> test = CSV.read("test.csv")
+julia> _, predictions, _ = linear_svm(input_model=lsvm_model,
+            test=test)
+```
+
+### See also
+
+ - [random_forest()](#random_forest)
+ - [logistic_regression()](#logistic_regression)
+ - [LinearSVM on Wikipedia](https://en.wikipedia.org/wiki/Support-vector_machine)
+ - [LinearSVM C++ class documentation](../../user/methods/linear_svm.md)
 
 ## lmnn()
 {: #lmnn }
@@ -1910,6 +2341,86 @@ julia> centroids, _ = mean_shift(data)
  - [Mean Shift, Mode Seeking, and Clustering (pdf)](https://members.loria.fr/MOBerger/Enseignement/Master2/Exposes/meanShiftCluster.pdf)
  - [mlpack::mean_shift::MeanShift C++ class documentation](../../user/methods/mean_shift.md)
 
+## nbc()
+{: #nbc }
+
+#### Parametric Naive Bayes Classifier
+{: #nbc_descr }
+
+```julia
+julia> using mlpack: nbc
+julia> output_model, predictions, probabilities = nbc( ;
+          incremental_variance=false, input_model=nothing, labels=Int[],
+          test=zeros(0, 0), training=zeros(0, 0), verbose=false)
+```
+
+An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model can be trained and saved, or, a pre-trained model can be used for classification. [Detailed documentation](#nbc_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `incremental_variance` | [`Bool`](#doc_Bool) | The variance of each class will be calculated incrementally. | `false` |
+| `input_model` | [`NBCModel`](#doc_model) | Input Naive Bayes model. | `nothing` |
+| `labels` | [`Int vector-like`](#doc_Int_vector_like) | A file containing labels for the training set. | `Int[]` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the test set. | `zeros(0, 0)` |
+| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the training set. | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`NBCModel`](#doc_model) | File to save trained Naive Bayes model to. | 
+| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | The matrix in which the predicted labels for the test set will be written. | 
+| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | The matrix in which the predicted probability of labels for the test set will be written. | 
+
+### Detailed documentation
+{: #nbc_detailed-documentation }
+
+This program trains the Naive Bayes classifier on the given labeled training set, or loads a model from the given model file, and then may use that trained model to classify the points in a given test set.
+
+The training set is specified with the `training` parameter.  Labels may be either the last row of the training set, or alternately the `labels` parameter may be specified to pass a separate matrix of labels.
+
+If training is not desired, a pre-existing model may be loaded with the `input_model` parameter.
+
+
+
+The `incremental_variance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
+
+If classifying a test set is desired, the test set may be specified with the `test` parameter, and the classifications may be saved with the `predictions`predictions  parameter.  If saving the trained model is desired, this may be done with the `output_model` output parameter.
+
+### Example
+For example, to train a Naive Bayes classifier on the dataset ``data`` with labels ``labels`` and save the model to ``nbc_model``, the following command may be used:
+
+```julia
+julia> using CSV
+julia> data = CSV.read("data.csv")
+julia> labels = CSV.read("labels.csv"; type=Int)
+julia> nbc_model, _, _ = nbc(labels=labels, training=data)
+```
+
+Then, to use ``nbc_model`` to predict the classes of the dataset ``test_set`` and save the predicted classes to ``predictions``, the following command may be used:
+
+```julia
+julia> using CSV
+julia> test_set = CSV.read("test_set.csv")
+julia> _, predictions, _ = nbc(input_model=nbc_model,
+            test=test_set)
+```
+
+### See also
+
+ - [softmax_regression()](#softmax_regression)
+ - [random_forest()](#random_forest)
+ - [Naive Bayes classifier on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
+ - [NaiveBayesClassifier C++ class documentation](../../user/methods/naive_bayes_classifier.md)
+
 ## nca()
 {: #nca }
 
@@ -2266,6 +2777,81 @@ julia> data_mod = pca(data; decomposition_method="randomized",
 
  - [Principal component analysis on Wikipedia](https://en.wikipedia.org/wiki/Principal_component_analysis)
  - [PCA C++ class documentation](../../user/methods/pca.md)
+
+## perceptron()
+{: #perceptron }
+
+#### Perceptron
+{: #perceptron_descr }
+
+```julia
+julia> using mlpack: perceptron
+julia> output_model, predictions = perceptron( ; input_model=nothing,
+          labels=Int[], max_iterations=1000, test=zeros(0, 0), training=zeros(0,
+          0), verbose=false)
+```
+
+An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and saved for future use; or, a pre-trained perceptron can be used for classification on new points. [Detailed documentation](#perceptron_detailed-documentation).
+
+
+
+### Input options
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
+| `input_model` | [`PerceptronModel`](#doc_model) | Input perceptron model. | `nothing` |
+| `labels` | [`Int vector-like`](#doc_Int_vector_like) | A matrix containing labels for the training set. | `Int[]` |
+| `max_iterations` | [`Int`](#doc_Int) | The maximum number of iterations the perceptron is to be run | `1000` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the test set. | `zeros(0, 0)` |
+| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the training set. | `zeros(0, 0)` |
+| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
+
+### Output options
+
+Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `output_model` | [`PerceptronModel`](#doc_model) | Output for trained perceptron model. | 
+| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | The matrix in which the predicted labels for the test set will be written. | 
+
+### Detailed documentation
+{: #perceptron_detailed-documentation }
+
+This program implements a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `max_iterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
+
+This program allows loading a perceptron from a model (via the `input_model` parameter) or training a perceptron given training data (via the `training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (via the `test` parameter) and the classification results on the test set may be saved with the `predictions` output parameter.  The perceptron model may be saved with the `output_model` output parameter.
+
+### Example
+The training data given with the `training` option may have class labels as its last dimension (so, if the training data is in CSV format, labels should be the last column).  Alternately, the `labels` parameter may be used to specify a separate matrix of labels.
+
+All these options make it easy to train a perceptron, and then re-use that perceptron for later classification.  The invocation below trains a perceptron on ``training_data`` with labels ``training_labels``, and saves the model to ``perceptron_model``.
+
+```julia
+julia> using CSV
+julia> training_data = CSV.read("training_data.csv")
+julia> training_labels = CSV.read("training_labels.csv"; type=Int)
+julia> perceptron_model, _ = perceptron(labels=training_labels,
+            training=training_data)
+```
+
+Then, this model can be re-used for classification on the test data ``test_data``.  The example below does precisely that, saving the predicted classes to ``predictions``.
+
+```julia
+julia> using CSV
+julia> test_data = CSV.read("test_data.csv")
+julia> _, predictions = perceptron(input_model=perceptron_model,
+            test=test_data)
+```
+
+Note that all of the options may be specified at once: predictions may be calculated right after training a model, and model training can occur even if an existing perceptron model is passed with the `input_model` parameter.  However, note that the number of classes and the dimensionality of all data must match.  So you cannot pass a perceptron model trained on 2 classes and then re-train with a 4-class dataset.  Similarly, attempting classification on a 3-dimensional dataset with a perceptron that has been trained on 8 dimensions will cause an error.
+
+### See also
+
+ - [adaboost()](#adaboost)
+ - [Perceptron on Wikipedia](https://en.wikipedia.org/wiki/Perceptron)
+ - [Perceptron C++ class documentation](../../user/methods/perceptron.md)
 
 ## preprocess_split()
 {: #preprocess_split }
@@ -2694,171 +3280,6 @@ julia> ic, _ = radical(X; replicates=40)
  - [ICA using spacings estimates of entropy (pdf)](https://www.jmlr.org/papers/volume4/learned-miller03a/learned-miller03a.pdf)
  - [Radical C++ class documentation](../../user/methods/radical.md)
 
-## krann()
-{: #krann }
-
-#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
-{: #krann_descr }
-
-```julia
-julia> using mlpack: krann
-julia> distances, neighbors, output_model = krann( ; alpha=0.95,
-          first_leaf_exact=false, input_model=nothing, k=0, leaf_size=20,
-          naive=false, query=zeros(0, 0), random_basis=false, reference=zeros(0,
-          0), sample_at_leaves=false, seed=0, single_mode=false,
-          single_sample_limit=20, tau=5.0, tree_type="kd", verbose=false)
-```
-
-An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `alpha` | [`Float64`](#doc_Float64) | The desired success probability. | `0.95` |
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `first_leaf_exact` | [`Bool`](#doc_Bool) | The flag to trigger sampling only after exactly exploring the first leaf. | `false` |
-| `input_model` | [`RAModel`](#doc_model) | Pre-trained kNN model. | `nothing` |
-| `k` | [`Int`](#doc_Int) | Number of nearest neighbors to find. | `0` |
-| `leaf_size` | [`Int`](#doc_Int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
-| `naive` | [`Bool`](#doc_Bool) | If true, sampling will be done without using a tree. | `false` |
-| `query` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing query points (optional). | `zeros(0, 0)` |
-| `random_basis` | [`Bool`](#doc_Bool) | Before tree-building, project the data onto a random orthogonal basis. | `false` |
-| `reference` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing the reference dataset. | `zeros(0, 0)` |
-| `sample_at_leaves` | [`Bool`](#doc_Bool) | The flag to trigger sampling at leaves. | `false` |
-| `seed` | [`Int`](#doc_Int) | Random seed (if 0, std::time(NULL) is used). | `0` |
-| `single_mode` | [`Bool`](#doc_Bool) | If true, single-tree search is used (as opposed to dual-tree search. | `false` |
-| `single_sample_limit` | [`Int`](#doc_Int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
-| `tau` | [`Float64`](#doc_Float64) | The allowed rank-error in terms of the percentile of the data. | `5.0` |
-| `tree_type` | [`String`](#doc_String) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `"kd"` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `distances` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix to output distances into. | 
-| `neighbors` | [`Int matrix-like`](#doc_Int_matrix_like) | Matrix to output neighbors into. | 
-| `output_model` | [`RAModel`](#doc_model) | If specified, the kNN model will be output here. | 
-
-### Detailed documentation
-{: #krann_detailed-documentation }
-
-This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
-
-### Example
-For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in ``input`` and store the distances in ``distances`` and the neighbors in ``neighbors.csv``:
-
-```julia
-julia> using CSV
-julia> input = CSV.read("input.csv")
-julia> distances, neighbors, _ = krann(k=5, reference=input,
-            tau=0.1)
-```
-
-Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
-
-The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
-
-### See also
-
- - [knn()](#knn)
- - [lsh()](#lsh)
- - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
- - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
-
-## sparse_coding()
-{: #sparse_coding }
-
-#### Sparse Coding
-{: #sparse_coding_descr }
-
-```julia
-julia> using mlpack: sparse_coding
-julia> codes, dictionary, output_model = sparse_coding( ; atoms=15,
-          initial_dictionary=zeros(0, 0), input_model=nothing, lambda1=0.0,
-          lambda2=0.0, max_iterations=0, newton_tolerance=1e-06,
-          normalize=false, objective_tolerance=0.01, seed=0, test=zeros(0, 0),
-          training=zeros(0, 0), verbose=false)
-```
-
-An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `atoms` | [`Int`](#doc_Int) | Number of atoms in the dictionary. | `15` |
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `initial_dictionary` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Optional initial dictionary matrix. | `zeros(0, 0)` |
-| `input_model` | [`SparseCoding`](#doc_model) | File containing input sparse coding model. | `nothing` |
-| `lambda1` | [`Float64`](#doc_Float64) | Sparse coding l1-norm regularization parameter. | `0.0` |
-| `lambda2` | [`Float64`](#doc_Float64) | Sparse coding l2-norm regularization parameter. | `0.0` |
-| `max_iterations` | [`Int`](#doc_Int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
-| `newton_tolerance` | [`Float64`](#doc_Float64) | Tolerance for convergence of Newton method. | `1e-06` |
-| `normalize` | [`Bool`](#doc_Bool) | If set, the input data matrix will be normalized before coding. | `false` |
-| `objective_tolerance` | [`Float64`](#doc_Float64) | Tolerance for convergence of the objective function. | `0.01` |
-| `seed` | [`Int`](#doc_Int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Optional matrix to be encoded by trained model. | `zeros(0, 0)` |
-| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix of training data (X). | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `codes` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
-| `dictionary` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix to save the output dictionary to. | 
-| `output_model` | [`SparseCoding`](#doc_model) | File to save trained sparse coding model to. | 
-
-### Detailed documentation
-{: #sparse_coding_detailed-documentation }
-
-An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
-
-The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
-
-The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
-
-Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
-
-To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `training` option, along with the number of atoms in the dictionary (specified with the `atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `initial_dictionary` parameter.  An input model may be specified with the `input_model` parameter.
-
-### Example
-As an example, to build a sparse coding model on the dataset ``data`` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into ``model``, use 
-
-```julia
-julia> using CSV
-julia> data = CSV.read("data.csv")
-julia> _, _, model = sparse_coding(atoms=200, lambda1=0.1,
-            training=data)
-```
-
-Then, this model could be used to encode a new matrix, ``otherdata``, and save the output codes to ``codes``: 
-
-```julia
-julia> using CSV
-julia> otherdata = CSV.read("otherdata.csv")
-julia> codes, _, _ = sparse_coding(input_model=model,
-            test=otherdata)
-```
-
-### See also
-
- - [local_coordinate_coding()](#local_coordinate_coding)
- - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
- - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
- - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
- - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
-
 ## random_forest()
 {: #random_forest }
 
@@ -2951,22 +3372,22 @@ julia> _, predictions, _ = random_forest(input_model=rf_model,
  - [Random forests (pdf)](https://www.eecis.udel.edu/~shatkay/Course/papers/BreimanRandomForests2001.pdf)
  - [RandomForest C++ class documentation](../../user/methods/random_forest.md)
 
-## decision_tree()
-{: #decision_tree }
+## krann()
+{: #krann }
 
-#### Decision tree
-{: #decision_tree_descr }
+#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
+{: #krann_descr }
 
 ```julia
-julia> using mlpack: decision_tree
-julia> output_model, predictions, probabilities = decision_tree( ;
-          input_model=nothing, labels=Int[], maximum_depth=0,
-          minimum_gain_split=1e-07, minimum_leaf_size=20,
-          print_training_accuracy=false, test=zeros(0, 0), test_labels=Int[],
-          training=zeros(0, 0), verbose=false, weights=zeros(0, 0))
+julia> using mlpack: krann
+julia> distances, neighbors, output_model = krann( ; alpha=0.95,
+          first_leaf_exact=false, input_model=nothing, k=0, leaf_size=20,
+          naive=false, query=zeros(0, 0), random_basis=false, reference=zeros(0,
+          0), sample_at_leaves=false, seed=0, single_mode=false,
+          single_sample_limit=20, tau=5.0, tree_type="kd", verbose=false)
 ```
 
-An implementation of an ID3-style decision tree for classification, which supports categorical data.  Given labeled data with numeric or categorical features, a decision tree can be trained and saved; or, an existing decision tree can be used for classification on new points. [Detailed documentation](#decision_tree_detailed-documentation).
+An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
 
 
 
@@ -2974,96 +3395,22 @@ An implementation of an ID3-style decision tree for classification, which suppor
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `alpha` | [`Float64`](#doc_Float64) | The desired success probability. | `0.95` |
 | `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `input_model` | [`DecisionTreeModel`](#doc_model) | Pre-trained decision tree, to be used with test points. | `nothing` |
-| `labels` | [`Int vector-like`](#doc_Int_vector_like) | Training labels. | `Int[]` |
-| `maximum_depth` | [`Int`](#doc_Int) | Maximum depth of the tree (0 means no limit). | `0` |
-| `minimum_gain_split` | [`Float64`](#doc_Float64) | Minimum gain for node splitting. | `1e-07` |
-| `minimum_leaf_size` | [`Int`](#doc_Int) | Minimum number of points in a leaf. | `20` |
-| `print_training_accuracy` | [`Bool`](#doc_Bool) | Print the training accuracy. | `false` |
-| `test` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Testing dataset (may be categorical). | `zeros(0, 0)` |
-| `test_labels` | [`Int vector-like`](#doc_Int_vector_like) | Test point labels, if accuracy calculation is desired. | `Int[]` |
-| `training` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Training dataset (may be categorical). | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-| `weights` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | The weight of labels | `zeros(0, 0)` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `output_model` | [`DecisionTreeModel`](#doc_model) | Output for trained decision tree. | 
-| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | Class predictions for each test point. | 
-| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Class probabilities for each test point. | 
-
-### Detailed documentation
-{: #decision_tree_detailed-documentation }
-
-Train and evaluate using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
-
-The training set and associated labels are specified with the `training` and `labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-When a model is trained, the `output_model` output parameter may be used to save the trained model.  A model may be loaded for predictions with the `input_model` parameter.  The `input_model` parameter may not be specified when the `training` parameter is specified.  The `minimum_leaf_size` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `minimum_gain_split` parameter specifies the minimum gain that is needed for the node to split.  The `maximum_depth` parameter specifies the maximum depth of the tree.  If `print_training_accuracy` is specified, the training accuracy will be printed.
-
-Test data may be specified with the `test` parameter, and if performance numbers are desired for that test set, labels may be specified with the `test_labels` parameter.  Predictions for each test point may be saved via the `predictions` output parameter.  Class probabilities for each prediction may be saved with the `probabilities` output parameter.
-
-### Example
-For example, to train a decision tree with a minimum leaf size of 20 on the dataset contained in ``data`` with labels ``labels``, saving the output model to ``tree`` and printing the training error, one could call
-
-```julia
-julia> using CSV
-julia> data = CSV.read("data.csv")
-julia> labels = CSV.read("labels.csv"; type=Int)
-julia> tree, _, _ = decision_tree(labels=labels,
-            minimum_gain_split=0.001, minimum_leaf_size=20,
-            print_training_accuracy=1, training=data)
-```
-
-Then, to use that model to classify points in ``test_set`` and print the test error given the labels ``test_labels`` using that model, while saving the predictions for each point to ``predictions``, one could call 
-
-```julia
-julia> using CSV
-julia> test_set = CSV.read("test_set.csv")
-julia> test_labels = CSV.read("test_labels.csv"; type=Int)
-julia> _, predictions, _ = decision_tree(input_model=tree,
-            test=test_set, test_labels=test_labels)
-```
-
-### See also
-
- - [Random forest](#random_forest)
- - [Decision trees on Wikipedia](https://en.wikipedia.org/wiki/Decision_tree_learning)
- - [Induction of Decision Trees (pdf)](https://www.hunch.net/~coms-4771/quinlan.pdf)
- - [DecisionTree C++ class documentation](../../user/methods/decision_tree.md)
-
-## perceptron()
-{: #perceptron }
-
-#### Perceptron
-{: #perceptron_descr }
-
-```julia
-julia> using mlpack: perceptron
-julia> output_model, predictions = perceptron( ; input_model=nothing,
-          labels=Int[], max_iterations=1000, test=zeros(0, 0), training=zeros(0,
-          0), verbose=false)
-```
-
-An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and saved for future use; or, a pre-trained perceptron can be used for classification on new points. [Detailed documentation](#perceptron_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `input_model` | [`PerceptronModel`](#doc_model) | Input perceptron model. | `nothing` |
-| `labels` | [`Int vector-like`](#doc_Int_vector_like) | A matrix containing labels for the training set. | `Int[]` |
-| `max_iterations` | [`Int`](#doc_Int) | The maximum number of iterations the perceptron is to be run | `1000` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the test set. | `zeros(0, 0)` |
-| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the training set. | `zeros(0, 0)` |
+| `first_leaf_exact` | [`Bool`](#doc_Bool) | The flag to trigger sampling only after exactly exploring the first leaf. | `false` |
+| `input_model` | [`RAModel`](#doc_model) | Pre-trained kNN model. | `nothing` |
+| `k` | [`Int`](#doc_Int) | Number of nearest neighbors to find. | `0` |
+| `leaf_size` | [`Int`](#doc_Int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
+| `naive` | [`Bool`](#doc_Bool) | If true, sampling will be done without using a tree. | `false` |
+| `query` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing query points (optional). | `zeros(0, 0)` |
+| `random_basis` | [`Bool`](#doc_Bool) | Before tree-building, project the data onto a random orthogonal basis. | `false` |
+| `reference` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing the reference dataset. | `zeros(0, 0)` |
+| `sample_at_leaves` | [`Bool`](#doc_Bool) | The flag to trigger sampling at leaves. | `false` |
+| `seed` | [`Int`](#doc_Int) | Random seed (if 0, std::time(NULL) is used). | `0` |
+| `single_mode` | [`Bool`](#doc_Bool) | If true, single-tree search is used (as opposed to dual-tree search. | `false` |
+| `single_sample_limit` | [`Int`](#doc_Int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
+| `tau` | [`Float64`](#doc_Float64) | The allowed rank-error in terms of the percentile of the data. | `5.0` |
+| `tree_type` | [`String`](#doc_String) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `"kd"` |
 | `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
 
 ### Output options
@@ -3072,391 +3419,35 @@ Results are returned as a tuple, and can be unpacked directly into return values
 
 | ***name*** | ***type*** | ***description*** |
 |------------|------------|-------------------|
-| `output_model` | [`PerceptronModel`](#doc_model) | Output for trained perceptron model. | 
-| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | The matrix in which the predicted labels for the test set will be written. | 
+| `distances` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix to output distances into. | 
+| `neighbors` | [`Int matrix-like`](#doc_Int_matrix_like) | Matrix to output neighbors into. | 
+| `output_model` | [`RAModel`](#doc_model) | If specified, the kNN model will be output here. | 
 
 ### Detailed documentation
-{: #perceptron_detailed-documentation }
+{: #krann_detailed-documentation }
 
-This program implements a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `max_iterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
-
-This program allows loading a perceptron from a model (via the `input_model` parameter) or training a perceptron given training data (via the `training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (via the `test` parameter) and the classification results on the test set may be saved with the `predictions` output parameter.  The perceptron model may be saved with the `output_model` output parameter.
+This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
 
 ### Example
-The training data given with the `training` option may have class labels as its last dimension (so, if the training data is in CSV format, labels should be the last column).  Alternately, the `labels` parameter may be used to specify a separate matrix of labels.
-
-All these options make it easy to train a perceptron, and then re-use that perceptron for later classification.  The invocation below trains a perceptron on ``training_data`` with labels ``training_labels``, and saves the model to ``perceptron_model``.
+For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in ``input`` and store the distances in ``distances`` and the neighbors in ``neighbors.csv``:
 
 ```julia
 julia> using CSV
-julia> training_data = CSV.read("training_data.csv")
-julia> training_labels = CSV.read("training_labels.csv"; type=Int)
-julia> perceptron_model, _ = perceptron(labels=training_labels,
-            training=training_data)
+julia> input = CSV.read("input.csv")
+julia> distances, neighbors, _ = krann(k=5, reference=input,
+            tau=0.1)
 ```
 
-Then, this model can be re-used for classification on the test data ``test_data``.  The example below does precisely that, saving the predicted classes to ``predictions``.
+Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
 
-```julia
-julia> using CSV
-julia> test_data = CSV.read("test_data.csv")
-julia> _, predictions = perceptron(input_model=perceptron_model,
-            test=test_data)
-```
-
-Note that all of the options may be specified at once: predictions may be calculated right after training a model, and model training can occur even if an existing perceptron model is passed with the `input_model` parameter.  However, note that the number of classes and the dimensionality of all data must match.  So you cannot pass a perceptron model trained on 2 classes and then re-train with a 4-class dataset.  Similarly, attempting classification on a 3-dimensional dataset with a perceptron that has been trained on 8 dimensions will cause an error.
+The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
 
 ### See also
 
- - [adaboost()](#adaboost)
- - [Perceptron on Wikipedia](https://en.wikipedia.org/wiki/Perceptron)
- - [Perceptron C++ class documentation](../../user/methods/perceptron.md)
-
-## linear_svm()
-{: #linear_svm }
-
-#### Linear SVM is an L2-regularized support vector machine.
-{: #linear_svm_descr }
-
-```julia
-julia> using mlpack: linear_svm
-julia> output_model, predictions, probabilities = linear_svm( ;
-          delta=1.0, epochs=50, input_model=nothing, labels=Int[],
-          lambda=0.0001, max_iterations=10000, no_intercept=false,
-          num_classes=0, optimizer="lbfgs", seed=0, shuffle=false,
-          step_size=0.01, test=zeros(0, 0), test_labels=Int[], tolerance=1e-10,
-          training=zeros(0, 0), verbose=false)
-```
-
-An implementation of linear SVM for multiclass classification. Given labeled data, a model can be trained and saved for future use; or, a pre-trained model can be used to classify new points. [Detailed documentation](#linear_svm_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `delta` | [`Float64`](#doc_Float64) | Margin of difference between correct class and other classes. | `1.0` |
-| `epochs` | [`Int`](#doc_Int) | Maximum number of full epochs over dataset for psgd | `50` |
-| `input_model` | [`LinearSVMModel`](#doc_model) | Existing model (parameters). | `nothing` |
-| `labels` | [`Int vector-like`](#doc_Int_vector_like) | A matrix containing labels (0 or 1) for the points in the training set (y). | `Int[]` |
-| `lambda` | [`Float64`](#doc_Float64) | L2-regularization parameter for training. | `0.0001` |
-| `max_iterations` | [`Int`](#doc_Int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
-| `no_intercept` | [`Bool`](#doc_Bool) | Do not add the intercept term to the model. | `false` |
-| `num_classes` | [`Int`](#doc_Int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
-| `optimizer` | [`String`](#doc_String) | Optimizer to use for training ('lbfgs' or 'psgd'). | `"lbfgs"` |
-| `seed` | [`Int`](#doc_Int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `shuffle` | [`Bool`](#doc_Bool) | Don't shuffle the order in which data points are visited for parallel SGD. | `false` |
-| `step_size` | [`Float64`](#doc_Float64) | Step size for parallel SGD optimizer. | `0.01` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing test dataset. | `zeros(0, 0)` |
-| `test_labels` | [`Int vector-like`](#doc_Int_vector_like) | Matrix containing test labels. | `Int[]` |
-| `tolerance` | [`Float64`](#doc_Float64) | Convergence tolerance for optimizer. | `1e-10` |
-| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the training set (the matrix of predictors, X). | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `output_model` | [`LinearSVMModel`](#doc_model) | Output for trained linear svm model. | 
-| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
-| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | If test data is specified, this matrix is where the class probabilities for the test set will be saved. | 
-
-### Detailed documentation
-{: #linear_svm_detailed-documentation }
-
-An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
-
-This program allows loading a linear SVM model (via the `input_model` parameter) or training a linear SVM model given training data (specified with the `training` parameter), or both those things at once.  In addition, this program allows classification on a test dataset (specified with the `test` parameter) and the classification results may be saved with the `predictions` output parameter. The trained linear SVM model may be saved using the `output_model` output parameter.
-
-The training data, if specified, may have class labels as its last dimension.  Alternately, the `labels` parameter may be used to specify a separate vector of labels.
-
-When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `lambda` option, and the number of classes can be manually specified with the `num_classes`and if an intercept term is not desired in the model, the `no_intercept` parameter can be specified.
-
-Margin of difference between correct class and other classes can be specified with the `delta` option.The optimizer used to train the model can be specified with the `optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `max_iterations` parameter specifies the maximum number of allowed iterations, and the `tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `step_size` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
-
-Optionally, the model can be used to predict the labels for another matrix of data points, if `test` is specified.  The `test` parameter can be specified without the `training` parameter, so long as an existing linear SVM model is given with the `input_model` parameter.  The output predictions from the linear SVM model may be saved with the `predictions` parameter.
-
-### Example
-As an example, to train a LinaerSVM on the data '``data``' with labels '``labels``' with L2 regularization of 0.1, saving the model to '``lsvm_model``', the following command may be used:
-
-```julia
-julia> using CSV
-julia> data = CSV.read("data.csv")
-julia> labels = CSV.read("labels.csv"; type=Int)
-julia> lsvm_model, _, _ = linear_svm(delta=1, labels=labels,
-            lambda=0.1, num_classes=0, training=data)
-```
-
-Then, to use that model to predict classes for the dataset '``test``', storing the output predictions in '``predictions``', the following command may be used: 
-
-```julia
-julia> using CSV
-julia> test = CSV.read("test.csv")
-julia> _, predictions, _ = linear_svm(input_model=lsvm_model,
-            test=test)
-```
-
-### See also
-
- - [random_forest()](#random_forest)
- - [logistic_regression()](#logistic_regression)
- - [LinearSVM on Wikipedia](https://en.wikipedia.org/wiki/Support-vector_machine)
- - [LinearSVM C++ class documentation](../../user/methods/linear_svm.md)
-
-## adaboost()
-{: #adaboost }
-
-#### AdaBoost
-{: #adaboost_descr }
-
-```julia
-julia> using mlpack: adaboost
-julia> output_model, predictions, probabilities = adaboost( ;
-          input_model=nothing, iterations=1000, labels=Int[], test=zeros(0, 0),
-          tolerance=1e-10, training=zeros(0, 0), verbose=false,
-          weak_learner="decision_stump")
-```
-
-An implementation of the AdaBoost.MH (Adaptive Boosting) algorithm for classification.  This can be used to train an AdaBoost model on labeled data or use an existing AdaBoost model to predict the classes of new points. [Detailed documentation](#adaboost_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `input_model` | [`AdaBoostModel`](#doc_model) | Input AdaBoost model. | `nothing` |
-| `iterations` | [`Int`](#doc_Int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
-| `labels` | [`Int vector-like`](#doc_Int_vector_like) | Labels for the training set. | `Int[]` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Test dataset. | `zeros(0, 0)` |
-| `tolerance` | [`Float64`](#doc_Float64) | The tolerance for change in values of the weighted error during training. | `1e-10` |
-| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Dataset for training AdaBoost. | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-| `weak_learner` | [`String`](#doc_String) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `"decision_stump"` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `output_model` | [`AdaBoostModel`](#doc_model) | Output trained AdaBoost model. | 
-| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | Predicted labels for the test set. | 
-| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Predicted class probabilities for each point in the test set. | 
-
-### Detailed documentation
-{: #adaboost_detailed-documentation }
-
-This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
-
-For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
-
-This program allows training of an AdaBoost model, and then application of that model to a test dataset.  To train a model, a dataset must be passed with the `training` option.  Labels can be given with the `labels` option; if no labels are specified, the labels will be assumed to be the last column of the input dataset.  Alternately, an AdaBoost model may be loaded with the `input_model` option.
-
-Once a model is trained or loaded, it may be used to provide class predictions for a given test dataset.  A test dataset may be specified with the `test` parameter.  The predicted classes for each point in the test dataset are output to the `predictions` output parameter.  The AdaBoost model itself is output to the `output_model` output parameter.
-
-### Example
-For example, to run AdaBoost on an input dataset ``data`` with labels ``labels``and perceptrons as the weak learner type, storing the trained model in ``model``, one could use the following command: 
-
-```julia
-julia> using CSV
-julia> data = CSV.read("data.csv")
-julia> labels = CSV.read("labels.csv"; type=Int)
-julia> model, _, _ = adaboost(labels=labels, training=data,
-            weak_learner="perceptron")
-```
-
-Similarly, an already-trained model in ``model`` can be used to provide class predictions from test data ``test_data`` and store the output in ``predictions`` with the following command: 
-
-```julia
-julia> using CSV
-julia> test_data = CSV.read("test_data.csv")
-julia> _, predictions, _ = adaboost(input_model=model,
-            test=test_data)
-```
-
-### See also
-
- - [AdaBoost on Wikipedia](https://en.wikipedia.org/wiki/AdaBoost)
- - [Improved boosting algorithms using confidence-rated predictions (pdf)](http://www.schapire.net/papers/SchapireSi98.pdf)
- - [Perceptron](#perceptron)
- - [Decision Trees](#decision_tree)
- - [AdaBoost C++ class documentation](../../user/methods/adaboost.md)
-
-## hoeffding_tree()
-{: #hoeffding_tree }
-
-#### Hoeffding trees
-{: #hoeffding_tree_descr }
-
-```julia
-julia> using mlpack: hoeffding_tree
-julia> output_model, predictions, probabilities = hoeffding_tree( ;
-          batch_mode=false, bins=10, confidence=0.95, info_gain=false,
-          input_model=nothing, labels=Int[], max_samples=5000, min_samples=100,
-          numeric_split_strategy="binary", observations_before_binning=100,
-          passes=1, test=zeros(0, 0), test_labels=Int[], training=zeros(0, 0),
-          verbose=false)
-```
-
-An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data, a Hoeffding tree can be trained and saved for later use, or a pre-trained Hoeffding tree can be used for predicting the classifications of new points. [Detailed documentation](#hoeffding_tree_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `batch_mode` | [`Bool`](#doc_Bool) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `false` |
-| `bins` | [`Int`](#doc_Int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `confidence` | [`Float64`](#doc_Float64) | Confidence before splitting (between 0 and 1). | `0.95` |
-| `info_gain` | [`Bool`](#doc_Bool) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `false` |
-| `input_model` | [`HoeffdingTreeModel`](#doc_model) | Input trained Hoeffding tree model. | `nothing` |
-| `labels` | [`Int vector-like`](#doc_Int_vector_like) | Labels for training dataset. | `Int[]` |
-| `max_samples` | [`Int`](#doc_Int) | Maximum number of samples before splitting. | `5000` |
-| `min_samples` | [`Int`](#doc_Int) | Minimum number of samples before splitting. | `100` |
-| `numeric_split_strategy` | [`String`](#doc_String) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `"binary"` |
-| `observations_before_binning` | [`Int`](#doc_Int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
-| `passes` | [`Int`](#doc_Int) | Number of passes to take over the dataset. | `1` |
-| `test` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Testing dataset (may be categorical). | `zeros(0, 0)` |
-| `test_labels` | [`Int vector-like`](#doc_Int_vector_like) | Labels of test data. | `Int[]` |
-| `training` | [`Tuple{Array{Bool, 1}, Array{Float64, 2}}`](#doc_Tuple_Array_Bool__1___Array_Float64__2__) | Training dataset (may be categorical). | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `output_model` | [`HoeffdingTreeModel`](#doc_model) | Output for trained Hoeffding tree model. | 
-| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | Matrix to output label predictions for test data into. | 
-| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
-
-### Detailed documentation
-{: #hoeffding_tree_detailed-documentation }
-
-This program implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets.  This program supports both categorical and numeric data.  Given an input dataset, this program is able to train the tree with numerous training options, and save the model to a file.  The program is also able to use a trained model or a model from file in order to predict classes for a given test set.
-
-The training file and associated labels are specified with the `training` and `labels` parameters, respectively. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `batch_mode` option, but this may not be the best option for large datasets.
-
-When a model is trained, it may be saved via the `output_model` output parameter.  A model may be loaded from file for further training or testing with the `input_model` parameter.
-
-Test data may be specified with the `test` parameter, and if performance statistics are desired for that test set, labels may be specified with the `test_labels` parameter.  Predictions for each test point may be saved with the `predictions` output parameter, and class probabilities for each prediction may be saved with the `probabilities` output parameter.
-
-### Example
-For example, to train a Hoeffding tree with confidence 0.99 with data ``dataset``, saving the trained tree to ``tree``, the following command may be used:
-
-```julia
-julia> using CSV
-julia> dataset = CSV.read("dataset.csv")
-julia> tree, _, _ = hoeffding_tree(confidence=0.99,
-            training=dataset)
-```
-
-Then, this tree may be used to make predictions on the test set ``test_set``, saving the predictions into ``predictions`` and the class probabilities into ``class_probs`` with the following command: 
-
-```julia
-julia> using CSV
-julia> test_set = CSV.read("test_set.csv")
-julia> _, predictions, class_probs =
-            hoeffding_tree(input_model=tree, test=test_set)
-```
-
-### See also
-
- - [decision_tree()](#decision_tree)
- - [random_forest()](#random_forest)
- - [Mining High-Speed Data Streams (pdf)](https://www.cs.rhodes.edu/~welshc/COMP465_S15/Papers/kdd00.pdf)
- - [HoeffdingTree class documentation](../../user/methods/hoeffding_tree.md)
-
-## nbc()
-{: #nbc }
-
-#### Parametric Naive Bayes Classifier
-{: #nbc_descr }
-
-```julia
-julia> using mlpack: nbc
-julia> output_model, predictions, probabilities = nbc( ;
-          incremental_variance=false, input_model=nothing, labels=Int[],
-          test=zeros(0, 0), training=zeros(0, 0), verbose=false)
-```
-
-An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model can be trained and saved, or, a pre-trained model can be used for classification. [Detailed documentation](#nbc_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `incremental_variance` | [`Bool`](#doc_Bool) | The variance of each class will be calculated incrementally. | `false` |
-| `input_model` | [`NBCModel`](#doc_model) | Input Naive Bayes model. | `nothing` |
-| `labels` | [`Int vector-like`](#doc_Int_vector_like) | A file containing labels for the training set. | `Int[]` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the test set. | `zeros(0, 0)` |
-| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | A matrix containing the training set. | `zeros(0, 0)` |
-| `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
-
-### Output options
-
-Results are returned as a tuple, and can be unpacked directly into return values or stored directly as a tuple; undesired results can be ignored with the _ keyword.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `output_model` | [`NBCModel`](#doc_model) | File to save trained Naive Bayes model to. | 
-| `predictions` | [`Int vector-like`](#doc_Int_vector_like) | The matrix in which the predicted labels for the test set will be written. | 
-| `probabilities` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | The matrix in which the predicted probability of labels for the test set will be written. | 
-
-### Detailed documentation
-{: #nbc_detailed-documentation }
-
-This program trains the Naive Bayes classifier on the given labeled training set, or loads a model from the given model file, and then may use that trained model to classify the points in a given test set.
-
-The training set is specified with the `training` parameter.  Labels may be either the last row of the training set, or alternately the `labels` parameter may be specified to pass a separate matrix of labels.
-
-If training is not desired, a pre-existing model may be loaded with the `input_model` parameter.
-
-
-
-The `incremental_variance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
-
-If classifying a test set is desired, the test set may be specified with the `test` parameter, and the classifications may be saved with the `predictions`predictions  parameter.  If saving the trained model is desired, this may be done with the `output_model` output parameter.
-
-### Example
-For example, to train a Naive Bayes classifier on the dataset ``data`` with labels ``labels`` and save the model to ``nbc_model``, the following command may be used:
-
-```julia
-julia> using CSV
-julia> data = CSV.read("data.csv")
-julia> labels = CSV.read("labels.csv"; type=Int)
-julia> nbc_model, _, _ = nbc(labels=labels, training=data)
-```
-
-Then, to use ``nbc_model`` to predict the classes of the dataset ``test_set`` and save the predicted classes to ``predictions``, the following command may be used:
-
-```julia
-julia> using CSV
-julia> test_set = CSV.read("test_set.csv")
-julia> _, predictions, _ = nbc(input_model=nbc_model,
-            test=test_set)
-```
-
-### See also
-
- - [softmax_regression()](#softmax_regression)
- - [random_forest()](#random_forest)
- - [Naive Bayes classifier on Wikipedia](https://en.wikipedia.org/wiki/Naive_Bayes_classifier)
- - [NaiveBayesClassifier C++ class documentation](../../user/methods/naive_bayes_classifier.md)
+ - [knn()](#knn)
+ - [lsh()](#lsh)
+ - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
+ - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
 
 ## softmax_regression()
 {: #softmax_regression }
@@ -3541,20 +3532,22 @@ julia> _, predictions, _ = softmax_regression(input_model=sr_model,
  - [Multinomial logistic regression (softmax regression) on Wikipedia](https://en.wikipedia.org/wiki/Multinomial_logistic_regression)
  - [SoftmaxRegression C++ class documentation](../../user/methods/softmax_regression.md)
 
-## linear_regression()
-{: #linear_regression }
+## sparse_coding()
+{: #sparse_coding }
 
-#### Simple Linear Regression and Prediction
-{: #linear_regression_descr }
+#### Sparse Coding
+{: #sparse_coding_descr }
 
 ```julia
-julia> using mlpack: linear_regression
-julia> output_model, output_predictions = linear_regression( ;
-          input_model=nothing, lambda=0.0, test=zeros(0, 0), training=zeros(0,
-          0), training_responses=Float64[], verbose=false)
+julia> using mlpack: sparse_coding
+julia> codes, dictionary, output_model = sparse_coding( ; atoms=15,
+          initial_dictionary=zeros(0, 0), input_model=nothing, lambda1=0.0,
+          lambda2=0.0, max_iterations=0, newton_tolerance=1e-06,
+          normalize=false, objective_tolerance=0.01, seed=0, test=zeros(0, 0),
+          training=zeros(0, 0), verbose=false)
 ```
 
-An implementation of simple linear regression and ridge regression using ordinary least squares.  Given a dataset and responses, a model can be trained and saved for later use, or a pre-trained model can be used to output regression predictions for a test set. [Detailed documentation](#linear_regression_detailed-documentation).
+An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
 
 
 
@@ -3562,12 +3555,19 @@ An implementation of simple linear regression and ridge regression using ordinar
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `atoms` | [`Int`](#doc_Int) | Number of atoms in the dictionary. | `15` |
 | `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `input_model` | [`LinearRegression`](#doc_model) | Existing LinearRegression model to use. | `nothing` |
-| `lambda` | [`Float64`](#doc_Float64) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0.0` |
-| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing X' (test regressors). | `zeros(0, 0)` |
-| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix containing training set X (regressors). | `zeros(0, 0)` |
-| `training_responses` | [`Float64 vector-like`](#doc_Float64_vector_like) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | `Float64[]` |
+| `initial_dictionary` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Optional initial dictionary matrix. | `zeros(0, 0)` |
+| `input_model` | [`SparseCoding`](#doc_model) | File containing input sparse coding model. | `nothing` |
+| `lambda1` | [`Float64`](#doc_Float64) | Sparse coding l1-norm regularization parameter. | `0.0` |
+| `lambda2` | [`Float64`](#doc_Float64) | Sparse coding l2-norm regularization parameter. | `0.0` |
+| `max_iterations` | [`Int`](#doc_Int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
+| `newton_tolerance` | [`Float64`](#doc_Float64) | Tolerance for convergence of Newton method. | `1e-06` |
+| `normalize` | [`Bool`](#doc_Bool) | If set, the input data matrix will be normalized before coding. | `false` |
+| `objective_tolerance` | [`Float64`](#doc_Float64) | Tolerance for convergence of the objective function. | `0.01` |
+| `seed` | [`Int`](#doc_Int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `test` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Optional matrix to be encoded by trained model. | `zeros(0, 0)` |
+| `training` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix of training data (X). | `zeros(0, 0)` |
 | `verbose` | [`Bool`](#doc_Bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `false` |
 
 ### Output options
@@ -3576,47 +3576,47 @@ Results are returned as a tuple, and can be unpacked directly into return values
 
 | ***name*** | ***type*** | ***description*** |
 |------------|------------|-------------------|
-| `output_model` | [`LinearRegression`](#doc_model) | Output LinearRegression model. | 
-| `output_predictions` | [`Float64 vector-like`](#doc_Float64_vector_like) | If --test_file is specified, this matrix is where the predicted responses will be saved. | 
+| `codes` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
+| `dictionary` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Matrix to save the output dictionary to. | 
+| `output_model` | [`SparseCoding`](#doc_model) | File to save trained sparse coding model to. | 
 
 ### Detailed documentation
-{: #linear_regression_detailed-documentation }
+{: #sparse_coding_detailed-documentation }
 
-An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
 
-  y = X * b + e
+The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
 
-where X (specified by `training`) and y (specified either as the last column of the input matrix `training` or via the `training_responses` parameter) are known and b is the desired variable.  If the covariance matrix (X'X) is not invertible, or if the solution is overdetermined, then specify a Tikhonov regularization constant (with `lambda`) greater than 0, which will regularize the covariance matrix to make it invertible.  The calculated b may be saved with the `output_predictions` output parameter.
+The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
 
-Optionally, the calculated value of b is used to predict the responses for another matrix X' (specified by the `test` parameter):
+Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
 
-   y' = X' * b
-
-and the predicted responses y' may be saved with the `output_predictions` output parameter.  This type of regression is related to least-angle regression, which mlpack implements as the 'lars' program.
+To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `training` option, along with the number of atoms in the dictionary (specified with the `atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `initial_dictionary` parameter.  An input model may be specified with the `input_model` parameter.
 
 ### Example
-For example, to run a linear regression on the dataset ``X`` with responses ``y``, saving the trained model to ``lr_model``, the following command could be used:
+As an example, to build a sparse coding model on the dataset ``data`` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into ``model``, use 
 
 ```julia
 julia> using CSV
-julia> X = CSV.read("X.csv")
-julia> y = CSV.read("y.csv")
-julia> lr_model, _ = linear_regression(training=X,
-            training_responses=y)
+julia> data = CSV.read("data.csv")
+julia> _, _, model = sparse_coding(atoms=200, lambda1=0.1,
+            training=data)
 ```
 
-Then, to use ``lr_model`` to predict responses for a test set ``X_test``, saving the predictions to ``X_test_responses``, the following command could be used:
+Then, this model could be used to encode a new matrix, ``otherdata``, and save the output codes to ``codes``: 
 
 ```julia
 julia> using CSV
-julia> X_test = CSV.read("X_test.csv")
-julia> _, X_test_responses = linear_regression(input_model=lr_model,
-            test=X_test)
+julia> otherdata = CSV.read("otherdata.csv")
+julia> codes, _, _ = sparse_coding(input_model=model,
+            test=otherdata)
 ```
 
 ### See also
 
- - [lars()](#lars)
- - [Linear regression on Wikipedia](https://en.wikipedia.org/wiki/Linear_regression)
- - [LinearRegression C++ class documentation](../../user/methods/linear_regression.md)
+ - [local_coordinate_coding()](#local_coordinate_coding)
+ - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
+ - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+ - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
+ - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
 

--- a/doc/user/bindings/julia.sidebar.html
+++ b/doc/user/bindings/julia.sidebar.html
@@ -8,14 +8,14 @@
 <li><a href="LINKROOTuser/bindings/julia.html#data-formats">Data Formats</a></li>
 <li><details><summary>Classification</summary>
 <ul>
-<li><a href="LINKROOTuser/bindings/julia.html#logistic_regression">logistic_regression()</a></li>
-<li><a href="LINKROOTuser/bindings/julia.html#random_forest">random_forest()</a></li>
-<li><a href="LINKROOTuser/bindings/julia.html#decision_tree">decision_tree()</a></li>
-<li><a href="LINKROOTuser/bindings/julia.html#perceptron">perceptron()</a></li>
-<li><a href="LINKROOTuser/bindings/julia.html#linear_svm">linear_svm()</a></li>
 <li><a href="LINKROOTuser/bindings/julia.html#adaboost">adaboost()</a></li>
+<li><a href="LINKROOTuser/bindings/julia.html#decision_tree">decision_tree()</a></li>
 <li><a href="LINKROOTuser/bindings/julia.html#hoeffding_tree">hoeffding_tree()</a></li>
+<li><a href="LINKROOTuser/bindings/julia.html#linear_svm">linear_svm()</a></li>
+<li><a href="LINKROOTuser/bindings/julia.html#logistic_regression">logistic_regression()</a></li>
 <li><a href="LINKROOTuser/bindings/julia.html#nbc">nbc()</a></li>
+<li><a href="LINKROOTuser/bindings/julia.html#perceptron">perceptron()</a></li>
+<li><a href="LINKROOTuser/bindings/julia.html#random_forest">random_forest()</a></li>
 <li><a href="LINKROOTuser/bindings/julia.html#softmax_regression">softmax_regression()</a></li>
 </ul>
 </details>

--- a/doc/user/bindings/python.md
+++ b/doc/user/bindings/python.md
@@ -36,6 +36,105 @@ mlpack bindings for Python take and return a restricted set of types, for simpli
 </div>
 
 
+## class Adaboost
+{: #adaboost }
+
+#### AdaBoost
+{: #adaboost_descr }
+
+
+This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
+
+For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `iterations` | [`int`](#doc_int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
+| `tolerance` | [`float`](#doc_float) | The tolerance for change in values of the weighted error during training. | `1e-10` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+| `weak_learner` | [`str`](#doc_str) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `'decision_stump'` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import Adaboost
+>>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = Adaboost(check_input_matrices=False, copy_all_inputs=False,
+  iterations=1000, tolerance=1e-10, verbose=False,
+  weak_learner='decision_stump')
+>>> output_model = model.fit(training=X_train, labels=y_train)
+>>> predictions = model.predict(test=X_test)
+>>> probabilities = model.predict_proba(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | Training AdaBoost model. |
+| predict | Class predictions from model. |
+| predict_proba | Class probabilities from model. |
+
+### 1. fit
+
+Training AdaBoost model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`int vector`](#doc_int_vector) | Labels for the training set. | 
+| `training` | [`matrix`](#doc_matrix) | Dataset for training AdaBoost. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`AdaBoostModelType`](#doc_model) | Output trained AdaBoost model. | 
+
+### 2. predict
+
+Class predictions from model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | Test dataset. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`int vector`](#doc_int_vector) | Predicted labels for the test set. | 
+
+### 3. predict_proba
+
+Class probabilities from model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | Test dataset. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`matrix`](#doc_matrix) | Predicted class probabilities for each point in the test set. | 
+
 ## approx_kfn()
 {: #approx_kfn }
 
@@ -135,6 +234,90 @@ A trained model can be re-used.  If a model has been previously saved to `'model
  - [Approximate furthest neighbor in high dimensions (pdf)](https://www.rasmuspagh.net/papers/approx-furthest-neighbor-SISAP15.pdf)
  - [QDAFN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/qdafn.hpp)
  - [DrusillaSelect class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/drusilla_select.hpp)
+
+## class BayesianLinearRegression
+{: #bayesian_linear_regression }
+
+#### BayesianLinearRegression Training
+{: #bayesian_linear_regression_descr }
+
+
+An implementation of the Bayesian linear regression.
+This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
+Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
+
+To train a BayesianLinearRegression model, the `input_` and `responses` parameters must be given. The `center` and `scale` parameters control the centering and the normalizing options. A trained model is returned.
+
+
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `center` | [`bool`](#doc_bool) | Center the data and fit the intercept if enabled. | `False` |
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `scale` | [`bool`](#doc_bool) | Scale each feature by their standard deviations if enabled. | `False` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+| `stddevs` | [`bool`](#doc_bool) | Return standard deviations along with predictions. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import BayesianLinearRegression
+>>> X = pd.read_csv('http://datasets.mlpack.org/admission_predict.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/admission_predict.responses.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = BayesianLinearRegression(center=False, check_input_matrices=False,
+  copy_all_inputs=False, scale=False, verbose=False)
+>>> output_model = model.fit(input_=X_train, responses=y_train)
+>>> predictions = model.predict(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | An implementation of the Bayesian linear regression training. |
+| predict | An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions. |
+
+### 1. fit
+
+An implementation of the Bayesian linear regression training.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `input_` | [`matrix`](#doc_matrix) | Matrix of covariates (X). | 
+| `responses` | [`vector`](#doc_vector) | Matrix of responses/observations (y). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`BayesianLinearRegressionType`](#doc_model) | Output BayesianLinearRegression model. | 
+
+### 2. predict
+
+An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | Matrix containing points to regress on (test points). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`matrix`](#doc_matrix) | Matrix of predicted responses, with associated standard deviations if option selected. | 
 
 ## cf()
 {: #cf }
@@ -328,6 +511,111 @@ An example usage to run DBSCAN on the dataset in `'input'` with a radius of 0.5 
  - [DBSCAN on Wikipedia](https://en.wikipedia.org/wiki/DBSCAN)
  - [A density-based algorithm for discovering clusters in large spatial databases with noise (pdf)](https://cdn.aaai.org/KDD/1996/KDD96-037.pdf)
  - [DBSCAN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/dbscan/dbscan.hpp)
+
+## class DecisionTree
+{: #decision_tree }
+
+#### Decision tree training
+{: #decision_tree_descr }
+
+
+Train using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
+
+The training set and associated labels are specified with the `training` and `labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The trained model is returned, and can then be used for prediction. The `minimum_leaf_size` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `minimum_gain_split` parameter specifies the minimum gain that is needed for the node to split.  The `maximum_depth` parameter specifies the maximum depth of the tree.  If `print_training_accuracy` is specified, the training accuracy will be printed.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `maximum_depth` | [`int`](#doc_int) | Maximum depth of the tree (0 means no limit). | `0` |
+| `minimum_gain_split` | [`float`](#doc_float) | Minimum gain for node splitting. | `1e-07` |
+| `minimum_leaf_size` | [`int`](#doc_int) | Minimum number of points in a leaf. | `20` |
+| `print_training_accuracy` | [`bool`](#doc_bool) | Print the training accuracy. | `False` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import DecisionTree
+>>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = DecisionTree(check_input_matrices=False, copy_all_inputs=False,
+  maximum_depth=0, minimum_gain_split=1e-07, minimum_leaf_size=20,
+  print_training_accuracy=False, verbose=False)
+>>> output_model = model.fit(training=X_train, labels=y_train)
+>>> predictions = model.predict(test=X_test)
+>>> probabilities = model.predict_proba(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | Training ID3-style decision tree model. |
+| predict | Class predictions from train decision tree model. |
+| predict_proba | Class predictions from train decision tree model. |
+
+### 1. fit
+
+Training ID3-style decision tree model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`int vector`](#doc_int_vector) | Training labels. | 
+| `training` | [`categorical matrix`](#doc_categorical_matrix) | Training dataset (may contain categorical variables). | 
+| `weights` | [`matrix`](#doc_matrix) | The weight of labels | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`DecisionTreeModelType`](#doc_model) | Output for trained decision tree. | 
+
+### 2. predict
+
+Class predictions from train decision tree model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may contain categorical variables). | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Test point labels, if accuracy calculation is desired. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`int vector`](#doc_int_vector) | Class predictions for each test point. | 
+
+### 3. predict_proba
+
+Class predictions from train decision tree model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may contain categorical variables). | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Test point labels, if accuracy calculation is desired. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`matrix`](#doc_matrix) | Class probabilities for each test point if probabilities has been selected. | 
 
 ## det()
 {: #det }
@@ -971,6 +1259,119 @@ For example, to predict the state sequence of the observations `'obs'` using the
  - [Hidden Mixture Models on Wikipedia](https://en.wikipedia.org/wiki/Hidden_Markov_model)
  - [HMM class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/hmm/hmm.hpp)
 
+## class HoeffdingTree
+{: #hoeffding_tree }
+
+#### Hoeffding trees training
+{: #hoeffding_tree_descr }
+
+
+Implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets, supporting both categorical and numeric data.  Given an input dataset, it is able to train the tree with numerous training options, and return the model.
+
+The training file and associated labels are specified with the `training` and `labels` parameters, respectively. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `batch_mode` option, but this may not be the best option for large datasets.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `batch_mode` | [`bool`](#doc_bool) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `False` |
+| `bins` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `confidence` | [`float`](#doc_float) | Confidence before splitting (between 0 and 1). | `0.95` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `info_gain` | [`bool`](#doc_bool) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `False` |
+| `max_samples` | [`int`](#doc_int) | Maximum number of samples before splitting. | `5000` |
+| `min_samples` | [`int`](#doc_int) | Minimum number of samples before splitting. | `100` |
+| `numeric_split_strategy` | [`str`](#doc_str) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `'binary'` |
+| `observations_before_binning` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
+| `passes` | [`int`](#doc_int) | Number of passes to take over the dataset. | `1` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import HoeffdingTrees
+>>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = HoeffdingTrees(batch_mode=False, bins=10,
+  check_input_matrices=False, confidence=0.95, copy_all_inputs=False,
+  info_gain=False, max_samples=5000, min_samples=100,
+  numeric_split_strategy='binary', observations_before_binning=100, passes=1,
+  verbose=False)
+>>> output_model = model.fit(training=X_train, labels=y_train)
+>>> predictions = model.predict(test=X_test)
+>>> probabilities = model.predict_proba(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points. |
+| predict | Class predictions from Hoeffding trees model. |
+| predict_proba | Class probabilities from Hoeffding trees model. |
+
+### 1. fit
+
+An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`int vector`](#doc_int_vector) | Labels for training dataset. | 
+| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may be categorical). | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Labels of test data. | 
+| `training` | [`categorical matrix`](#doc_categorical_matrix) | Training dataset (may be categorical). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`HoeffdingTreeModelType`](#doc_model) | Output for trained Hoeffding tree model. | 
+
+### 2. predict
+
+Class predictions from Hoeffding trees model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may be categorical). | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Labels of test data. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`int vector`](#doc_int_vector) | Matrix to output label predictions for test data into. | 
+
+### 3. predict_proba
+
+Class probabilities from Hoeffding trees model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may be categorical). | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Labels of test data. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`matrix`](#doc_matrix) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
+
 ## image_converter()
 {: #image_converter }
 
@@ -1320,90 +1721,6 @@ To run k-means on that same dataset with initial centroids specified in `'initia
  - [A dual-tree algorithm for fast k-means clustering with large k (pdf)](http://www.ratml.org/pub/pdf/2017dual.pdf)
  - [KMeans class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/kmeans/kmeans.hpp)
 
-## class BayesianLinearRegression
-{: #bayesian_linear_regression }
-
-#### BayesianLinearRegression Training
-{: #bayesian_linear_regression_descr }
-
-
-An implementation of the Bayesian linear regression.
-This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
-Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
-
-To train a BayesianLinearRegression model, the `input_` and `responses` parameters must be given. The `center` and `scale` parameters control the centering and the normalizing options. A trained model is returned.
-
-
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `center` | [`bool`](#doc_bool) | Center the data and fit the intercept if enabled. | `False` |
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `scale` | [`bool`](#doc_bool) | Scale each feature by their standard deviations if enabled. | `False` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-| `stddevs` | [`bool`](#doc_bool) | Return standard deviations along with predictions. | `False` |
-
-### Example
-
-```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import BayesianLinearRegression
->>> X = pd.read_csv('http://datasets.mlpack.org/admission_predict.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/admission_predict.responses.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = BayesianLinearRegression(center=False, check_input_matrices=False,
-  copy_all_inputs=False, scale=False, verbose=False)
->>> output_model = model.fit(input_=X_train, responses=y_train)
->>> predictions = model.predict(test=X_test)
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| fit | An implementation of the Bayesian linear regression training. |
-| predict | An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions. |
-
-### 1. fit
-
-An implementation of the Bayesian linear regression training.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `input_` | [`matrix`](#doc_matrix) | Matrix of covariates (X). | 
-| `responses` | [`vector`](#doc_vector) | Matrix of responses/observations (y). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`BayesianLinearRegressionType`](#doc_model) | Output BayesianLinearRegression model. | 
-
-### 2. predict
-
-An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | Matrix containing points to regress on (test points). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`matrix`](#doc_matrix) | Matrix of predicted responses, with associated standard deviations if option selected. | 
-
 ## class Lars
 {: #lars }
 
@@ -1504,6 +1821,200 @@ An implementation of Least Angle Regression (stagewise/lasso), also known as LAR
 | **type** | **description** |
 |----------|-----------------|
 | [`matrix`](#doc_matrix) | Matrix containing predicted responses. | 
+
+## class LinearRegression
+{: #linear_regression }
+
+#### Simple Linear Regression
+{: #linear_regression_descr }
+
+
+An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+
+  y = X * b + e
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `lambda_` | [`float`](#doc_float) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import LinearRegression
+>>> X = pd.read_csv('https://datasets.mlpack.org/admission_predict.csv')
+>>> y = pd.read_csv('https://datasets.mlpack.org/admission_predict.responses.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = LinearRegression(check_input_matrices=False,
+  copy_all_inputs=False, lambda_=0, verbose=False)
+>>> output_model = model.fit(training=X_train, training_responses=y_train)
+>>> output_predictions = model.predict(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | Train a linear regression model. |
+| predict | Predictions from model. |
+
+### 1. fit
+
+Train a linear regression model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `training` | [`matrix`](#doc_matrix) | Matrix containing training set X (regressors). | 
+| `training_responses` | [`vector`](#doc_vector) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`LinearRegressionType`](#doc_model) | Output LinearRegression model. | 
+
+### 2. predict
+
+Predictions from model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | Matrix containing X' (test regressors). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`vector`](#doc_vector) | Matrix containing predicted responses. | 
+
+## class LinearSvm
+{: #linear_svm }
+
+#### Linear SVM Training
+{: #linear_svm_descr }
+
+
+An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
+
+This implementation allows training a linear SVM model given training data (specified with the `training` parameter).
+
+The training data may have class labels as its last dimension. Alternately, the `labels` parameter may be used to specify a separate vector of labels.
+
+When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `lambda_` option, and the number of classes can be manually specified with the `num_classes`and if an intercept term is not desired in the model, the `no_intercept` parameter can be specified.
+
+Margin of difference between correct class and other classes can be specified with the `delta` option.The optimizer used to train the model can be specified with the `optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `max_iterations` parameter specifies the maximum number of allowed iterations, and the `tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `step_size` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `delta` | [`float`](#doc_float) | Margin of difference between correct class and other classes. | `1` |
+| `epochs` | [`int`](#doc_int) | Maximum number of full epochs over dataset for psgd | `50` |
+| `lambda_` | [`float`](#doc_float) | L2-regularization parameter for training. | `0.0001` |
+| `max_iterations` | [`int`](#doc_int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
+| `no_intercept` | [`bool`](#doc_bool) | Do not add the intercept term to the model. | `False` |
+| `num_classes` | [`int`](#doc_int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
+| `optimizer` | [`str`](#doc_str) | Optimizer to use for training ('lbfgs' or 'psgd'). | `'lbfgs'` |
+| `seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `shuffle` | [`bool`](#doc_bool) | Don't shuffle the order in which data points are visited for parallel SGD. | `False` |
+| `step_size` | [`float`](#doc_float) | Step size for parallel SGD optimizer. | `0.01` |
+| `tolerance` | [`float`](#doc_float) | Convergence tolerance for optimizer. | `1e-10` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import LinearSvm
+>>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = LinearSvm(check_input_matrices=False, copy_all_inputs=False,
+  delta=1, epochs=50, lambda_=0.0001, max_iterations=10000, no_intercept=False,
+  num_classes=0, optimizer='lbfgs', seed=0, shuffle=False, step_size=0.01,
+  tolerance=1e-10, verbose=False)
+>>> output_model = model.fit(training=X_train, labels=y_train)
+>>> predictions = model.predict(test=X_test)
+>>> scores = model.scores(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | An implementation of linear SVM for multiclass classification. Given labeled data, a model is. |
+| predict | Class prediction from Linear SVM model. |
+| scores | Class scores from Linear SVM model. |
+
+### 1. fit
+
+An implementation of linear SVM for multiclass classification. Given labeled data, a model is.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`int vector`](#doc_int_vector) | A matrix containing labels (0 or 1) for the points in the training set (y). | 
+| `training` | [`matrix`](#doc_matrix) | A matrix containing the training set (the matrix of predictors, X). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`LinearSVMModelType`](#doc_model) | Output for trained linear svm model. | 
+
+### 2. predict
+
+Class prediction from Linear SVM model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | Matrix containing test dataset. | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Matrix containing test labels. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`int vector`](#doc_int_vector) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
+
+### 3. scores
+
+Class scores from Linear SVM model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | Matrix containing test dataset. | 
+| `test_labels` | [`int vector`](#doc_int_vector) | Matrix containing test labels. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`matrix`](#doc_matrix) | Requested scores. | 
 
 ## lmnn()
 {: #lmnn }
@@ -1959,6 +2470,104 @@ For example, to run mean shift clustering on the dataset `'data'` and store the 
  - [Mean Shift, Mode Seeking, and Clustering (pdf)](https://members.loria.fr/MOBerger/Enseignement/Master2/Exposes/meanShiftCluster.pdf)
  - [mlpack::mean_shift::MeanShift C++ class documentation](../../user/methods/mean_shift.md)
 
+## class Nbc
+{: #nbc }
+
+#### Parametric Naive Bayes Classifier training
+{: #nbc_descr }
+
+
+Implements the Naive Bayes classifier on the given labeled training set for us of that trained model to classify the points in a given test set.
+
+The training set is specified with the `training` parameter.  Labels may be either the last row of the training set, or alternately the `labels` parameter may be specified to pass a separate matrix of labels.
+
+The `incremental_variance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `incremental_variance` | [`bool`](#doc_bool) | The variance of each class will be calculated incrementally. | `False` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import NaiveBayes
+>>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = NaiveBayesTrees(check_input_matrices=False, copy_all_inputs=False,
+  incremental_variance=False, verbose=False)
+>>> output_model = model.fit(training=X_train, labels=y_train)
+>>> predictions = model.predict(test=X_test)
+>>> probabilities = model.predict_proba(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data. |
+| predict | Class predictions from a Naive Bayes Classifier model. |
+| predict_proba | Class probabilities from a Naive Bayes Classifier model. |
+
+### 1. fit
+
+An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`int vector`](#doc_int_vector) | A vector containing labels for the training set. | 
+| `training` | [`matrix`](#doc_matrix) | A matrix containing the training set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`NBCModelType`](#doc_model) | File to save trained Naive Bayes model to. | 
+
+### 2. predict
+
+Class predictions from a Naive Bayes Classifier model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | A matrix containing the test set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`int vector`](#doc_int_vector) | The matrix in which the predicted labels for the test set will be written. | 
+
+### 3. predict_proba
+
+Class probabilities from a Naive Bayes Classifier model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | A matrix containing the test set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`matrix`](#doc_matrix) | The matrix in which the predicted probability of labels for the test set will be written. | 
+
 ## nca()
 {: #nca }
 
@@ -2329,6 +2938,82 @@ For example, to reduce the dimensionality of the matrix `'data'` to 5 dimensions
 
  - [Principal component analysis on Wikipedia](https://en.wikipedia.org/wiki/Principal_component_analysis)
  - [PCA C++ class documentation](../../user/methods/pca.md)
+
+## class Perceptron
+{: #perceptron }
+
+#### Perceptron training
+{: #perceptron_descr }
+
+
+Implementation of a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `max_iterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
+| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
+| `max_iterations` | [`int`](#doc_int) | The maximum number of iterations the perceptron is to be run | `1000` |
+| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+
+### Example
+
+```python
+>>> import pandas as pd
+>>> from mlpack import preprocess_split
+>>> from mlpack import DecisionTree
+>>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
+>>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
+>>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
+>>> X_train = d['training']
+>>> y_train = d['training_labels']
+>>> X_test = d['test']
+>>> y_test = d['test_labels']
+>>> model = DecisionTree(check_input_matrices=False, copy_all_inputs=False,
+  max_iterations=1000, verbose=False)
+>>> output_model = model.fit(training=X_train, labels=y_train)
+>>> predictions = model.predict(test=X_test)
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| fit | An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points. |
+| predict | Class predictions from perceptron model. |
+
+### 1. fit
+
+An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`int vector`](#doc_int_vector) | A matrix containing labels for the training set. | 
+| `training` | [`matrix`](#doc_matrix) | A matrix containing the training set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`PerceptronModelType`](#doc_model) | Output for trained perceptron model. | 
+
+### 2. predict
+
+Class predictions from perceptron model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`matrix`](#doc_matrix) | A matrix containing the test set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`int vector`](#doc_int_vector) | The matrix in which the predicted labels for the test set will be written. | 
 
 ## preprocess_split()
 {: #preprocess_split }
@@ -2762,176 +3447,6 @@ For example, to perform ICA on the matrix `'X'` with 40 replicates, saving the i
  - [ICA using spacings estimates of entropy (pdf)](https://www.jmlr.org/papers/volume4/learned-miller03a/learned-miller03a.pdf)
  - [Radical C++ class documentation](../../user/methods/radical.md)
 
-## krann()
-{: #krann }
-
-#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
-{: #krann_descr }
-
-```python
->>> from mlpack import krann
->>> d = krann(alpha=0.95, check_input_matrices=False,
-        copy_all_inputs=False, first_leaf_exact=False, input_model=None, k=0,
-        leaf_size=20, naive=False, query=np.empty([0, 0]), random_basis=False,
-        reference=np.empty([0, 0]), sample_at_leaves=False, seed=0,
-        single_mode=False, single_sample_limit=20, tau=5, tree_type='kd',
-        verbose=False)
->>> distances = d['distances']
->>> neighbors = d['neighbors']
->>> output_model = d['output_model']
-```
-
-An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `alpha` | [`float`](#doc_float) | The desired success probability. | `0.95` |
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `first_leaf_exact` | [`bool`](#doc_bool) | The flag to trigger sampling only after exactly exploring the first leaf. | `False` |
-| `input_model` | [`RAModelType`](#doc_model) | Pre-trained kNN model. | `None` |
-| `k` | [`int`](#doc_int) | Number of nearest neighbors to find. | `0` |
-| `leaf_size` | [`int`](#doc_int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
-| `naive` | [`bool`](#doc_bool) | If true, sampling will be done without using a tree. | `False` |
-| `query` | [`matrix`](#doc_matrix) | Matrix containing query points (optional). | `np.empty([0, 0])` |
-| `random_basis` | [`bool`](#doc_bool) | Before tree-building, project the data onto a random orthogonal basis. | `False` |
-| `reference` | [`matrix`](#doc_matrix) | Matrix containing the reference dataset. | `np.empty([0, 0])` |
-| `sample_at_leaves` | [`bool`](#doc_bool) | The flag to trigger sampling at leaves. | `False` |
-| `seed` | [`int`](#doc_int) | Random seed (if 0, std::time(NULL) is used). | `0` |
-| `single_mode` | [`bool`](#doc_bool) | If true, single-tree search is used (as opposed to dual-tree search. | `False` |
-| `single_sample_limit` | [`int`](#doc_int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
-| `tau` | [`float`](#doc_float) | The allowed rank-error in terms of the percentile of the data. | `5` |
-| `tree_type` | [`str`](#doc_str) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `'kd'` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-
-### Output options
-
-Results are returned in a Python dictionary.  The keys of the dictionary are the names of the output parameters.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `distances` | [`matrix`](#doc_matrix) | Matrix to output distances into. | 
-| `neighbors` | [`int matrix`](#doc_int_matrix) | Matrix to output neighbors into. | 
-| `output_model` | [`RAModelType`](#doc_model) | If specified, the kNN model will be output here. | 
-
-### Detailed documentation
-{: #krann_detailed-documentation }
-
-This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
-
-### Example
-For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `'input'` and store the distances in `'distances'` and the neighbors in `'neighbors.csv'`:
-
-```python
->>> output = krann(reference=input, k=5, tau=0.1)
->>> distances = output['distances']
->>> neighbors = output['neighbors']
-```
-
-Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
-
-The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
-
-### See also
-
- - [knn()](#knn)
- - [lsh()](#lsh)
- - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
- - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
-
-## sparse_coding()
-{: #sparse_coding }
-
-#### Sparse Coding
-{: #sparse_coding_descr }
-
-```python
->>> from mlpack import sparse_coding
->>> d = sparse_coding(atoms=15, check_input_matrices=False,
-        copy_all_inputs=False, initial_dictionary=np.empty([0, 0]),
-        input_model=None, lambda1=0, lambda2=0, max_iterations=0,
-        newton_tolerance=1e-06, normalize=False, objective_tolerance=0.01,
-        seed=0, test=np.empty([0, 0]), training=np.empty([0, 0]),
-        verbose=False)
->>> codes = d['codes']
->>> dictionary = d['dictionary']
->>> output_model = d['output_model']
-```
-
-An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `atoms` | [`int`](#doc_int) | Number of atoms in the dictionary. | `15` |
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `initial_dictionary` | [`matrix`](#doc_matrix) | Optional initial dictionary matrix. | `np.empty([0, 0])` |
-| `input_model` | [`SparseCodingType`](#doc_model) | File containing input sparse coding model. | `None` |
-| `lambda1` | [`float`](#doc_float) | Sparse coding l1-norm regularization parameter. | `0` |
-| `lambda2` | [`float`](#doc_float) | Sparse coding l2-norm regularization parameter. | `0` |
-| `max_iterations` | [`int`](#doc_int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
-| `newton_tolerance` | [`float`](#doc_float) | Tolerance for convergence of Newton method. | `1e-06` |
-| `normalize` | [`bool`](#doc_bool) | If set, the input data matrix will be normalized before coding. | `False` |
-| `objective_tolerance` | [`float`](#doc_float) | Tolerance for convergence of the objective function. | `0.01` |
-| `seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `test` | [`matrix`](#doc_matrix) | Optional matrix to be encoded by trained model. | `np.empty([0, 0])` |
-| `training` | [`matrix`](#doc_matrix) | Matrix of training data (X). | `np.empty([0, 0])` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-
-### Output options
-
-Results are returned in a Python dictionary.  The keys of the dictionary are the names of the output parameters.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `codes` | [`matrix`](#doc_matrix) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
-| `dictionary` | [`matrix`](#doc_matrix) | Matrix to save the output dictionary to. | 
-| `output_model` | [`SparseCodingType`](#doc_model) | File to save trained sparse coding model to. | 
-
-### Detailed documentation
-{: #sparse_coding_detailed-documentation }
-
-An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
-
-The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
-
-The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
-
-Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
-
-To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `training` option, along with the number of atoms in the dictionary (specified with the `atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `initial_dictionary` parameter.  An input model may be specified with the `input_model` parameter.
-
-### Example
-As an example, to build a sparse coding model on the dataset `'data'` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `'model'`, use 
-
-```python
->>> output = sparse_coding(training=data, atoms=200, lambda1=0.1)
->>> model = output['output_model']
-```
-
-Then, this model could be used to encode a new matrix, `'otherdata'`, and save the output codes to `'codes'`: 
-
-```python
->>> output = sparse_coding(input_model=model, test=otherdata)
->>> codes = output['codes']
-```
-
-### See also
-
- - [local_coordinate_coding()](#local_coordinate_coding)
- - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
- - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
- - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
- - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
-
 ## class RandomForest
 {: #random_forest }
 
@@ -3039,612 +3554,86 @@ Class probabilities from random forest model.
 |----------|-----------------|
 | [`matrix`](#doc_matrix) | Predicted class probabilities for each point in the test set. | 
 
-## class DecisionTree
-{: #decision_tree }
+## krann()
+{: #krann }
 
-#### Decision tree training
-{: #decision_tree_descr }
+#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
+{: #krann_descr }
+
+```python
+>>> from mlpack import krann
+>>> d = krann(alpha=0.95, check_input_matrices=False,
+        copy_all_inputs=False, first_leaf_exact=False, input_model=None, k=0,
+        leaf_size=20, naive=False, query=np.empty([0, 0]), random_basis=False,
+        reference=np.empty([0, 0]), sample_at_leaves=False, seed=0,
+        single_mode=False, single_sample_limit=20, tau=5, tree_type='kd',
+        verbose=False)
+>>> distances = d['distances']
+>>> neighbors = d['neighbors']
+>>> output_model = d['output_model']
+```
+
+An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
 
 
-Train using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
 
-The training set and associated labels are specified with the `training` and `labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The trained model is returned, and can then be used for prediction. The `minimum_leaf_size` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `minimum_gain_split` parameter specifies the minimum gain that is needed for the node to split.  The `maximum_depth` parameter specifies the maximum depth of the tree.  If `print_training_accuracy` is specified, the training accuracy will be printed.
-### Parameters
+### Input options
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `alpha` | [`float`](#doc_float) | The desired success probability. | `0.95` |
 | `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
 | `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `maximum_depth` | [`int`](#doc_int) | Maximum depth of the tree (0 means no limit). | `0` |
-| `minimum_gain_split` | [`float`](#doc_float) | Minimum gain for node splitting. | `1e-07` |
-| `minimum_leaf_size` | [`int`](#doc_int) | Minimum number of points in a leaf. | `20` |
-| `print_training_accuracy` | [`bool`](#doc_bool) | Print the training accuracy. | `False` |
+| `first_leaf_exact` | [`bool`](#doc_bool) | The flag to trigger sampling only after exactly exploring the first leaf. | `False` |
+| `input_model` | [`RAModelType`](#doc_model) | Pre-trained kNN model. | `None` |
+| `k` | [`int`](#doc_int) | Number of nearest neighbors to find. | `0` |
+| `leaf_size` | [`int`](#doc_int) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
+| `naive` | [`bool`](#doc_bool) | If true, sampling will be done without using a tree. | `False` |
+| `query` | [`matrix`](#doc_matrix) | Matrix containing query points (optional). | `np.empty([0, 0])` |
+| `random_basis` | [`bool`](#doc_bool) | Before tree-building, project the data onto a random orthogonal basis. | `False` |
+| `reference` | [`matrix`](#doc_matrix) | Matrix containing the reference dataset. | `np.empty([0, 0])` |
+| `sample_at_leaves` | [`bool`](#doc_bool) | The flag to trigger sampling at leaves. | `False` |
+| `seed` | [`int`](#doc_int) | Random seed (if 0, std::time(NULL) is used). | `0` |
+| `single_mode` | [`bool`](#doc_bool) | If true, single-tree search is used (as opposed to dual-tree search. | `False` |
+| `single_sample_limit` | [`int`](#doc_int) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
+| `tau` | [`float`](#doc_float) | The allowed rank-error in terms of the percentile of the data. | `5` |
+| `tree_type` | [`str`](#doc_str) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `'kd'` |
 | `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
 
-### Example
+### Output options
 
-```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import DecisionTree
->>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = DecisionTree(check_input_matrices=False, copy_all_inputs=False,
-  maximum_depth=0, minimum_gain_split=1e-07, minimum_leaf_size=20,
-  print_training_accuracy=False, verbose=False)
->>> output_model = model.fit(training=X_train, labels=y_train)
->>> predictions = model.predict(test=X_test)
->>> probabilities = model.predict_proba(test=X_test)
-```
+Results are returned in a Python dictionary.  The keys of the dictionary are the names of the output parameters.
 
-### Methods
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `distances` | [`matrix`](#doc_matrix) | Matrix to output distances into. | 
+| `neighbors` | [`int matrix`](#doc_int_matrix) | Matrix to output neighbors into. | 
+| `output_model` | [`RAModelType`](#doc_model) | If specified, the kNN model will be output here. | 
 
-| **name** | **description** |
-|----------|-----------------|
-| fit | Training ID3-style decision tree model. |
-| predict | Class predictions from train decision tree model. |
-| predict_proba | Class predictions from train decision tree model. |
+### Detailed documentation
+{: #krann_detailed-documentation }
 
-### 1. fit
-
-Training ID3-style decision tree model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`int vector`](#doc_int_vector) | Training labels. | 
-| `training` | [`categorical matrix`](#doc_categorical_matrix) | Training dataset (may contain categorical variables). | 
-| `weights` | [`matrix`](#doc_matrix) | The weight of labels | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`DecisionTreeModelType`](#doc_model) | Output for trained decision tree. | 
-
-### 2. predict
-
-Class predictions from train decision tree model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may contain categorical variables). | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Test point labels, if accuracy calculation is desired. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`int vector`](#doc_int_vector) | Class predictions for each test point. | 
-
-### 3. predict_proba
-
-Class predictions from train decision tree model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may contain categorical variables). | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Test point labels, if accuracy calculation is desired. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`matrix`](#doc_matrix) | Class probabilities for each test point if probabilities has been selected. | 
-
-## class Perceptron
-{: #perceptron }
-
-#### Perceptron training
-{: #perceptron_descr }
-
-
-Implementation of a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `max_iterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `max_iterations` | [`int`](#doc_int) | The maximum number of iterations the perceptron is to be run | `1000` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
+This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
 
 ### Example
+For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `'input'` and store the distances in `'distances'` and the neighbors in `'neighbors.csv'`:
 
 ```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import DecisionTree
->>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = DecisionTree(check_input_matrices=False, copy_all_inputs=False,
-  max_iterations=1000, verbose=False)
->>> output_model = model.fit(training=X_train, labels=y_train)
->>> predictions = model.predict(test=X_test)
+>>> output = krann(reference=input, k=5, tau=0.1)
+>>> distances = output['distances']
+>>> neighbors = output['neighbors']
 ```
 
-### Methods
+Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
 
-| **name** | **description** |
-|----------|-----------------|
-| fit | An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points. |
-| predict | Class predictions from perceptron model. |
+The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
 
-### 1. fit
+### See also
 
-An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`int vector`](#doc_int_vector) | A matrix containing labels for the training set. | 
-| `training` | [`matrix`](#doc_matrix) | A matrix containing the training set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`PerceptronModelType`](#doc_model) | Output for trained perceptron model. | 
-
-### 2. predict
-
-Class predictions from perceptron model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | A matrix containing the test set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`int vector`](#doc_int_vector) | The matrix in which the predicted labels for the test set will be written. | 
-
-## class LinearSvm
-{: #linear_svm }
-
-#### Linear SVM Training
-{: #linear_svm_descr }
-
-
-An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
-
-This implementation allows training a linear SVM model given training data (specified with the `training` parameter).
-
-The training data may have class labels as its last dimension. Alternately, the `labels` parameter may be used to specify a separate vector of labels.
-
-When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `lambda_` option, and the number of classes can be manually specified with the `num_classes`and if an intercept term is not desired in the model, the `no_intercept` parameter can be specified.
-
-Margin of difference between correct class and other classes can be specified with the `delta` option.The optimizer used to train the model can be specified with the `optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `max_iterations` parameter specifies the maximum number of allowed iterations, and the `tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `step_size` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `delta` | [`float`](#doc_float) | Margin of difference between correct class and other classes. | `1` |
-| `epochs` | [`int`](#doc_int) | Maximum number of full epochs over dataset for psgd | `50` |
-| `lambda_` | [`float`](#doc_float) | L2-regularization parameter for training. | `0.0001` |
-| `max_iterations` | [`int`](#doc_int) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
-| `no_intercept` | [`bool`](#doc_bool) | Do not add the intercept term to the model. | `False` |
-| `num_classes` | [`int`](#doc_int) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
-| `optimizer` | [`str`](#doc_str) | Optimizer to use for training ('lbfgs' or 'psgd'). | `'lbfgs'` |
-| `seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `shuffle` | [`bool`](#doc_bool) | Don't shuffle the order in which data points are visited for parallel SGD. | `False` |
-| `step_size` | [`float`](#doc_float) | Step size for parallel SGD optimizer. | `0.01` |
-| `tolerance` | [`float`](#doc_float) | Convergence tolerance for optimizer. | `1e-10` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-
-### Example
-
-```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import LinearSvm
->>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = LinearSvm(check_input_matrices=False, copy_all_inputs=False,
-  delta=1, epochs=50, lambda_=0.0001, max_iterations=10000, no_intercept=False,
-  num_classes=0, optimizer='lbfgs', seed=0, shuffle=False, step_size=0.01,
-  tolerance=1e-10, verbose=False)
->>> output_model = model.fit(training=X_train, labels=y_train)
->>> predictions = model.predict(test=X_test)
->>> scores = model.scores(test=X_test)
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| fit | An implementation of linear SVM for multiclass classification. Given labeled data, a model is. |
-| predict | Class prediction from Linear SVM model. |
-| scores | Class scores from Linear SVM model. |
-
-### 1. fit
-
-An implementation of linear SVM for multiclass classification. Given labeled data, a model is.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`int vector`](#doc_int_vector) | A matrix containing labels (0 or 1) for the points in the training set (y). | 
-| `training` | [`matrix`](#doc_matrix) | A matrix containing the training set (the matrix of predictors, X). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`LinearSVMModelType`](#doc_model) | Output for trained linear svm model. | 
-
-### 2. predict
-
-Class prediction from Linear SVM model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | Matrix containing test dataset. | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Matrix containing test labels. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`int vector`](#doc_int_vector) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
-
-### 3. scores
-
-Class scores from Linear SVM model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | Matrix containing test dataset. | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Matrix containing test labels. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`matrix`](#doc_matrix) | Requested scores. | 
-
-## class Adaboost
-{: #adaboost }
-
-#### AdaBoost
-{: #adaboost_descr }
-
-
-This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
-
-For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `iterations` | [`int`](#doc_int) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
-| `tolerance` | [`float`](#doc_float) | The tolerance for change in values of the weighted error during training. | `1e-10` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-| `weak_learner` | [`str`](#doc_str) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `'decision_stump'` |
-
-### Example
-
-```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import Adaboost
->>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = Adaboost(check_input_matrices=False, copy_all_inputs=False,
-  iterations=1000, tolerance=1e-10, verbose=False,
-  weak_learner='decision_stump')
->>> output_model = model.fit(training=X_train, labels=y_train)
->>> predictions = model.predict(test=X_test)
->>> probabilities = model.predict_proba(test=X_test)
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| fit | Training AdaBoost model. |
-| predict | Class predictions from model. |
-| predict_proba | Class probabilities from model. |
-
-### 1. fit
-
-Training AdaBoost model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`int vector`](#doc_int_vector) | Labels for the training set. | 
-| `training` | [`matrix`](#doc_matrix) | Dataset for training AdaBoost. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`AdaBoostModelType`](#doc_model) | Output trained AdaBoost model. | 
-
-### 2. predict
-
-Class predictions from model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | Test dataset. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`int vector`](#doc_int_vector) | Predicted labels for the test set. | 
-
-### 3. predict_proba
-
-Class probabilities from model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | Test dataset. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`matrix`](#doc_matrix) | Predicted class probabilities for each point in the test set. | 
-
-## class HoeffdingTree
-{: #hoeffding_tree }
-
-#### Hoeffding trees training
-{: #hoeffding_tree_descr }
-
-
-Implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets, supporting both categorical and numeric data.  Given an input dataset, it is able to train the tree with numerous training options, and return the model.
-
-The training file and associated labels are specified with the `training` and `labels` parameters, respectively. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `batch_mode` option, but this may not be the best option for large datasets.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `batch_mode` | [`bool`](#doc_bool) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `False` |
-| `bins` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `confidence` | [`float`](#doc_float) | Confidence before splitting (between 0 and 1). | `0.95` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `info_gain` | [`bool`](#doc_bool) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `False` |
-| `max_samples` | [`int`](#doc_int) | Maximum number of samples before splitting. | `5000` |
-| `min_samples` | [`int`](#doc_int) | Minimum number of samples before splitting. | `100` |
-| `numeric_split_strategy` | [`str`](#doc_str) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `'binary'` |
-| `observations_before_binning` | [`int`](#doc_int) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
-| `passes` | [`int`](#doc_int) | Number of passes to take over the dataset. | `1` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-
-### Example
-
-```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import HoeffdingTrees
->>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = HoeffdingTrees(batch_mode=False, bins=10,
-  check_input_matrices=False, confidence=0.95, copy_all_inputs=False,
-  info_gain=False, max_samples=5000, min_samples=100,
-  numeric_split_strategy='binary', observations_before_binning=100, passes=1,
-  verbose=False)
->>> output_model = model.fit(training=X_train, labels=y_train)
->>> predictions = model.predict(test=X_test)
->>> probabilities = model.predict_proba(test=X_test)
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| fit | An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points. |
-| predict | Class predictions from Hoeffding trees model. |
-| predict_proba | Class probabilities from Hoeffding trees model. |
-
-### 1. fit
-
-An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`int vector`](#doc_int_vector) | Labels for training dataset. | 
-| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may be categorical). | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Labels of test data. | 
-| `training` | [`categorical matrix`](#doc_categorical_matrix) | Training dataset (may be categorical). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`HoeffdingTreeModelType`](#doc_model) | Output for trained Hoeffding tree model. | 
-
-### 2. predict
-
-Class predictions from Hoeffding trees model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may be categorical). | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Labels of test data. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`int vector`](#doc_int_vector) | Matrix to output label predictions for test data into. | 
-
-### 3. predict_proba
-
-Class probabilities from Hoeffding trees model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix`](#doc_categorical_matrix) | Testing dataset (may be categorical). | 
-| `test_labels` | [`int vector`](#doc_int_vector) | Labels of test data. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`matrix`](#doc_matrix) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
-
-## class Nbc
-{: #nbc }
-
-#### Parametric Naive Bayes Classifier training
-{: #nbc_descr }
-
-
-Implements the Naive Bayes classifier on the given labeled training set for us of that trained model to classify the points in a given test set.
-
-The training set is specified with the `training` parameter.  Labels may be either the last row of the training set, or alternately the `labels` parameter may be specified to pass a separate matrix of labels.
-
-The `incremental_variance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
-| `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `incremental_variance` | [`bool`](#doc_bool) | The variance of each class will be calculated incrementally. | `False` |
-| `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
-
-### Example
-
-```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import NaiveBayes
->>> X = pd.read_csv('http://datasets.mlpack.org/iris.csv')
->>> y = pd.read_csv('http://datasets.mlpack.org/iris_labels.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = NaiveBayesTrees(check_input_matrices=False, copy_all_inputs=False,
-  incremental_variance=False, verbose=False)
->>> output_model = model.fit(training=X_train, labels=y_train)
->>> predictions = model.predict(test=X_test)
->>> probabilities = model.predict_proba(test=X_test)
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| fit | An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data. |
-| predict | Class predictions from a Naive Bayes Classifier model. |
-| predict_proba | Class probabilities from a Naive Bayes Classifier model. |
-
-### 1. fit
-
-An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`int vector`](#doc_int_vector) | A vector containing labels for the training set. | 
-| `training` | [`matrix`](#doc_matrix) | A matrix containing the training set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`NBCModelType`](#doc_model) | File to save trained Naive Bayes model to. | 
-
-### 2. predict
-
-Class predictions from a Naive Bayes Classifier model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | A matrix containing the test set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`int vector`](#doc_int_vector) | The matrix in which the predicted labels for the test set will be written. | 
-
-### 3. predict_proba
-
-Class probabilities from a Naive Bayes Classifier model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | A matrix containing the test set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`matrix`](#doc_matrix) | The matrix in which the predicted probability of labels for the test set will be written. | 
+ - [knn()](#knn)
+ - [lsh()](#lsh)
+ - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
+ - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
 
 ## class SoftmaxRegression
 {: #softmax_regression }
@@ -3750,81 +3739,92 @@ An implementation of softmax regression for classification, which is a multiclas
 |----------|-----------------|
 | [`matrix`](#doc_matrix) | Matrix to save class probabilities for test dataset into. | 
 
-## class LinearRegression
-{: #linear_regression }
+## sparse_coding()
+{: #sparse_coding }
 
-#### Simple Linear Regression
-{: #linear_regression_descr }
+#### Sparse Coding
+{: #sparse_coding_descr }
+
+```python
+>>> from mlpack import sparse_coding
+>>> d = sparse_coding(atoms=15, check_input_matrices=False,
+        copy_all_inputs=False, initial_dictionary=np.empty([0, 0]),
+        input_model=None, lambda1=0, lambda2=0, max_iterations=0,
+        newton_tolerance=1e-06, normalize=False, objective_tolerance=0.01,
+        seed=0, test=np.empty([0, 0]), training=np.empty([0, 0]),
+        verbose=False)
+>>> codes = d['codes']
+>>> dictionary = d['dictionary']
+>>> output_model = d['output_model']
+```
+
+An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
 
 
-An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
 
-  y = X * b + e
-### Parameters
+### Input options
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `atoms` | [`int`](#doc_int) | Number of atoms in the dictionary. | `15` |
 | `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
 | `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `lambda_` | [`float`](#doc_float) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
+| `initial_dictionary` | [`matrix`](#doc_matrix) | Optional initial dictionary matrix. | `np.empty([0, 0])` |
+| `input_model` | [`SparseCodingType`](#doc_model) | File containing input sparse coding model. | `None` |
+| `lambda1` | [`float`](#doc_float) | Sparse coding l1-norm regularization parameter. | `0` |
+| `lambda2` | [`float`](#doc_float) | Sparse coding l2-norm regularization parameter. | `0` |
+| `max_iterations` | [`int`](#doc_int) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
+| `newton_tolerance` | [`float`](#doc_float) | Tolerance for convergence of Newton method. | `1e-06` |
+| `normalize` | [`bool`](#doc_bool) | If set, the input data matrix will be normalized before coding. | `False` |
+| `objective_tolerance` | [`float`](#doc_float) | Tolerance for convergence of the objective function. | `0.01` |
+| `seed` | [`int`](#doc_int) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `test` | [`matrix`](#doc_matrix) | Optional matrix to be encoded by trained model. | `np.empty([0, 0])` |
+| `training` | [`matrix`](#doc_matrix) | Matrix of training data (X). | `np.empty([0, 0])` |
 | `verbose` | [`bool`](#doc_bool) | Display informational messages and the full list of parameters and timers at the end of execution. | `False` |
 
+### Output options
+
+Results are returned in a Python dictionary.  The keys of the dictionary are the names of the output parameters.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `codes` | [`matrix`](#doc_matrix) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
+| `dictionary` | [`matrix`](#doc_matrix) | Matrix to save the output dictionary to. | 
+| `output_model` | [`SparseCodingType`](#doc_model) | File to save trained sparse coding model to. | 
+
+### Detailed documentation
+{: #sparse_coding_detailed-documentation }
+
+An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
+
+The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
+
+The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
+
+Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
+
+To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `training` option, along with the number of atoms in the dictionary (specified with the `atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `initial_dictionary` parameter.  An input model may be specified with the `input_model` parameter.
+
 ### Example
+As an example, to build a sparse coding model on the dataset `'data'` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `'model'`, use 
 
 ```python
->>> import pandas as pd
->>> from mlpack import preprocess_split
->>> from mlpack import LinearRegression
->>> X = pd.read_csv('https://datasets.mlpack.org/admission_predict.csv')
->>> y = pd.read_csv('https://datasets.mlpack.org/admission_predict.responses.csv')
->>> d = preprocess_split(input_=X, input_labels=y, test_ratio=0.2)
->>> X_train = d['training']
->>> y_train = d['training_labels']
->>> X_test = d['test']
->>> y_test = d['test_labels']
->>> model = LinearRegression(check_input_matrices=False,
-  copy_all_inputs=False, lambda_=0, verbose=False)
->>> output_model = model.fit(training=X_train, training_responses=y_train)
->>> output_predictions = model.predict(test=X_test)
+>>> output = sparse_coding(training=data, atoms=200, lambda1=0.1)
+>>> model = output['output_model']
 ```
 
-### Methods
+Then, this model could be used to encode a new matrix, `'otherdata'`, and save the output codes to `'codes'`: 
 
-| **name** | **description** |
-|----------|-----------------|
-| fit | Train a linear regression model. |
-| predict | Predictions from model. |
+```python
+>>> output = sparse_coding(input_model=model, test=otherdata)
+>>> codes = output['codes']
+```
 
-### 1. fit
+### See also
 
-Train a linear regression model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `training` | [`matrix`](#doc_matrix) | Matrix containing training set X (regressors). | 
-| `training_responses` | [`vector`](#doc_vector) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`LinearRegressionType`](#doc_model) | Output LinearRegression model. | 
-
-### 2. predict
-
-Predictions from model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`matrix`](#doc_matrix) | Matrix containing X' (test regressors). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`vector`](#doc_vector) | Matrix containing predicted responses. | 
+ - [local_coordinate_coding()](#local_coordinate_coding)
+ - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
+ - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+ - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
+ - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
 

--- a/doc/user/bindings/python.sidebar.html
+++ b/doc/user/bindings/python.sidebar.html
@@ -8,14 +8,14 @@
 <li><a href="LINKROOTuser/bindings/python.html#data-formats">Data Formats</a></li>
 <li><details><summary>Classification</summary>
 <ul>
-<li><a href="LINKROOTuser/bindings/python.html#logistic_regression">class LogisticRegression</a></li>
-<li><a href="LINKROOTuser/bindings/python.html#random_forest">class RandomForest</a></li>
-<li><a href="LINKROOTuser/bindings/python.html#decision_tree">class DecisionTree</a></li>
-<li><a href="LINKROOTuser/bindings/python.html#perceptron">class Perceptron</a></li>
-<li><a href="LINKROOTuser/bindings/python.html#linear_svm">class LinearSvm</a></li>
 <li><a href="LINKROOTuser/bindings/python.html#adaboost">class Adaboost</a></li>
+<li><a href="LINKROOTuser/bindings/python.html#decision_tree">class DecisionTree</a></li>
 <li><a href="LINKROOTuser/bindings/python.html#hoeffding_tree">class HoeffdingTree</a></li>
+<li><a href="LINKROOTuser/bindings/python.html#linear_svm">class LinearSvm</a></li>
+<li><a href="LINKROOTuser/bindings/python.html#logistic_regression">class LogisticRegression</a></li>
 <li><a href="LINKROOTuser/bindings/python.html#nbc">class Nbc</a></li>
+<li><a href="LINKROOTuser/bindings/python.html#perceptron">class Perceptron</a></li>
+<li><a href="LINKROOTuser/bindings/python.html#random_forest">class RandomForest</a></li>
 <li><a href="LINKROOTuser/bindings/python.html#softmax_regression">class SoftmaxRegression</a></li>
 </ul>
 </details>

--- a/doc/user/bindings/r.md
+++ b/doc/user/bindings/r.md
@@ -36,6 +36,104 @@ mlpack bindings for R take and return a restricted set of types, for simplicity.
 </div>
 
 
+## class adaboost
+{: #adaboost }
+
+#### AdaBoost
+{: #adaboost_descr }
+
+
+This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
+
+For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `iterations` | [`integer`](#doc_integer) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
+| `tolerance` | [`numeric`](#doc_numeric) | The tolerance for change in values of the weighted error during training. | `1e-10` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+| `weak_learner` | [`character`](#doc_character) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `"decision_stump"` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- adaboost_train(training=X_train, labels=y_train)
+
+pred <- predict(model, newdata=X_test) 
+prob <- predict(model, newdata=X_test, type="probabilities") 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | Training AdaBoost model. |
+| predict | Class predictions from model. |
+| probabilities | Class probabilities from model. |
+
+### 1. train
+
+Training AdaBoost model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`integer vector`](#doc_integer_vector) | Labels for the training set. | 
+| `training` | [`numeric matrix`](#doc_numeric_matrix) | Dataset for training AdaBoost. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`AdaBoostModel`](#doc_model) | Output trained AdaBoost model. | 
+
+### 2. predict
+
+Class predictions from model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Test dataset. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`integer vector`](#doc_integer_vector) | Predicted labels for the test set. | 
+
+### 3. probabilities
+
+Class probabilities from model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Test dataset. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric matrix`](#doc_numeric_matrix) | Predicted class probabilities for each point in the test set. | 
+
 ## approx_kfn()
 {: #approx_kfn }
 
@@ -134,6 +232,91 @@ R> neighbors <- output$neighbors
  - [Approximate furthest neighbor in high dimensions (pdf)](https://www.rasmuspagh.net/papers/approx-furthest-neighbor-SISAP15.pdf)
  - [QDAFN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/qdafn.hpp)
  - [DrusillaSelect class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/approx_kfn/drusilla_select.hpp)
+
+## class bayesian_linear_regression
+{: #bayesian_linear_regression }
+
+#### BayesianLinearRegression Training
+{: #bayesian_linear_regression_descr }
+
+
+An implementation of the Bayesian linear regression.
+This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
+Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
+
+To train a BayesianLinearRegression model, the `input` and `responses` parameters must be given. The `center` and `scale` parameters control the centering and the normalizing options. A trained model is returned.
+
+
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `center` | [`logical`](#doc_logical) | Center the data and fit the intercept if enabled. | `FALSE` |
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `scale` | [`logical`](#doc_logical) | Scale each feature by their standard deviations if enabled. | `FALSE` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+| `stddevs` | [`logical`](#doc_logical) | Return standard deviations along with predictions. | `FALSE` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/admission_predict.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/admission_predict.responses.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- bayesian_linear_regression_train(input=X_train, responses=y_train,
+  center=1, scale=0)
+  
+pred <- predict(model, newdata=X_test) 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | An implementation of the Bayesian linear regression training. |
+| predict | An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions. |
+
+### 1. train
+
+An implementation of the Bayesian linear regression training.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `input` | [`numeric matrix`](#doc_numeric_matrix) | Matrix of covariates (X). | 
+| `responses` | [`numeric vector`](#doc_numeric_vector) | Matrix of responses/observations (y). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`BayesianLinearRegression`](#doc_model) | Output BayesianLinearRegression model. | 
+
+### 2. predict
+
+An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing points to regress on (test points). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric matrix`](#doc_numeric_matrix) | Matrix of predicted responses, with associated standard deviations if option selected. | 
 
 ## cf()
 {: #cf }
@@ -325,6 +508,111 @@ R> dbscan(input=input, epsilon=0.5, min_size=5)
  - [DBSCAN on Wikipedia](https://en.wikipedia.org/wiki/DBSCAN)
  - [A density-based algorithm for discovering clusters in large spatial databases with noise (pdf)](https://cdn.aaai.org/KDD/1996/KDD96-037.pdf)
  - [DBSCAN class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/dbscan/dbscan.hpp)
+
+## class decision_tree
+{: #decision_tree }
+
+#### Decision tree training
+{: #decision_tree_descr }
+
+
+Train using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
+
+The training set and associated labels are specified with the `training` and `labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The trained model is returned, and can then be used for prediction. The `minimum_leaf_size` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `minimum_gain_split` parameter specifies the minimum gain that is needed for the node to split.  The `maximum_depth` parameter specifies the maximum depth of the tree.  If `print_training_accuracy` is specified, the training accuracy will be printed.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `maximum_depth` | [`integer`](#doc_integer) | Maximum depth of the tree (0 means no limit). | `0` |
+| `minimum_gain_split` | [`numeric`](#doc_numeric) | Minimum gain for node splitting. | `1e-07` |
+| `minimum_leaf_size` | [`integer`](#doc_integer) | Minimum number of points in a leaf. | `20` |
+| `print_training_accuracy` | [`logical`](#doc_logical) | Print the training accuracy. | `FALSE` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- decision_tree_train(training=X_train, labels=y_train,
+  minimum_leaf_size=20, minimum_gain_split=0.001)
+  
+pred <- predict(model, newdata=X_test) 
+prob <- predict(model, newdata=X_test, type="probabilities") 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | Training ID3-style decision tree model. |
+| predict | Class predictions from train decision tree model. |
+| probabilities | Class predictions from train decision tree model. |
+
+### 1. train
+
+Training ID3-style decision tree model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`integer vector`](#doc_integer_vector) | Training labels. | 
+| `training` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Training dataset (may contain categorical variables). | 
+| `weights` | [`numeric matrix`](#doc_numeric_matrix) | The weight of labels | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`DecisionTreeModel`](#doc_model) | Output for trained decision tree. | 
+
+### 2. predict
+
+Class predictions from train decision tree model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may contain categorical variables). | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Test point labels, if accuracy calculation is desired. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`integer vector`](#doc_integer_vector) | Class predictions for each test point. | 
+
+### 3. probabilities
+
+Class predictions from train decision tree model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may contain categorical variables). | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Test point labels, if accuracy calculation is desired. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric matrix`](#doc_numeric_matrix) | Class probabilities for each test point if probabilities has been selected. | 
 
 ## det()
 {: #det }
@@ -950,6 +1238,116 @@ R> states <- hmm_viterbi(input=obs, input_model=hmm)
  - [Hidden Mixture Models on Wikipedia](https://en.wikipedia.org/wiki/Hidden_Markov_model)
  - [HMM class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/hmm/hmm.hpp)
 
+## class hoeffding_tree
+{: #hoeffding_tree }
+
+#### Hoeffding trees training
+{: #hoeffding_tree_descr }
+
+
+Implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets, supporting both categorical and numeric data.  Given an input dataset, it is able to train the tree with numerous training options, and return the model.
+
+The training file and associated labels are specified with the `training` and `labels` parameters, respectively. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
+
+The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `batch_mode` option, but this may not be the best option for large datasets.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `batch_mode` | [`logical`](#doc_logical) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `FALSE` |
+| `bins` | [`integer`](#doc_integer) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `confidence` | [`numeric`](#doc_numeric) | Confidence before splitting (between 0 and 1). | `0.95` |
+| `info_gain` | [`logical`](#doc_logical) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `FALSE` |
+| `max_samples` | [`integer`](#doc_integer) | Maximum number of samples before splitting. | `5000` |
+| `min_samples` | [`integer`](#doc_integer) | Minimum number of samples before splitting. | `100` |
+| `numeric_split_strategy` | [`character`](#doc_character) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `"binary"` |
+| `observations_before_binning` | [`integer`](#doc_integer) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
+| `passes` | [`integer`](#doc_integer) | Number of passes to take over the dataset. | `1` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- hoeffding_tree_train(training=X_train, labels=y_train)
+
+pred <- predict(model, newdata=X_test) 
+prob <- predict(model, newdata=X_test, type="probabilities") 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points. |
+| predict | Class predictions from Hoeffding trees model. |
+| probabilities | Class probabilities from Hoeffding trees model. |
+
+### 1. train
+
+An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`integer vector`](#doc_integer_vector) | Labels for training dataset. | 
+| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may be categorical). | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Labels of test data. | 
+| `training` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Training dataset (may be categorical). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`HoeffdingTreeModel`](#doc_model) | Output for trained Hoeffding tree model. | 
+
+### 2. predict
+
+Class predictions from Hoeffding trees model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may be categorical). | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Labels of test data. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`integer vector`](#doc_integer_vector) | Matrix to output label predictions for test data into. | 
+
+### 3. probabilities
+
+Class probabilities from Hoeffding trees model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may be categorical). | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Labels of test data. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric matrix`](#doc_numeric_matrix) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
+
 ## image_converter()
 {: #image_converter }
 
@@ -1292,91 +1690,6 @@ R> final <- output$centroid
  - [A dual-tree algorithm for fast k-means clustering with large k (pdf)](http://www.ratml.org/pub/pdf/2017dual.pdf)
  - [KMeans class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/kmeans/kmeans.hpp)
 
-## class bayesian_linear_regression
-{: #bayesian_linear_regression }
-
-#### BayesianLinearRegression Training
-{: #bayesian_linear_regression_descr }
-
-
-An implementation of the Bayesian linear regression.
-This model is a probabilistic view and implementation of the linear regression. The final solution is obtained by computing a posterior distribution from gaussian likelihood and a zero mean gaussian isotropic  prior distribution on the solution. 
-Optimization is AUTOMATIC and does not require cross validation. The optimization is performed by maximization of the evidence function. Parameters are tuned during the maximization of the marginal likelihood. This procedure includes the Ockham's razor that penalizes over complex solutions. 
-
-To train a BayesianLinearRegression model, the `input` and `responses` parameters must be given. The `center` and `scale` parameters control the centering and the normalizing options. A trained model is returned.
-
-
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `center` | [`logical`](#doc_logical) | Center the data and fit the intercept if enabled. | `FALSE` |
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `scale` | [`logical`](#doc_logical) | Scale each feature by their standard deviations if enabled. | `FALSE` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-| `stddevs` | [`logical`](#doc_logical) | Return standard deviations along with predictions. | `FALSE` |
-
-### Example
-
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/admission_predict.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/admission_predict.responses.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- bayesian_linear_regression_train(input=X_train, responses=y_train,
-  center=1, scale=0)
-  
-pred <- predict(model, newdata=X_test) 
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| train | An implementation of the Bayesian linear regression training. |
-| predict | An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions. |
-
-### 1. train
-
-An implementation of the Bayesian linear regression training.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `input` | [`numeric matrix`](#doc_numeric_matrix) | Matrix of covariates (X). | 
-| `responses` | [`numeric vector`](#doc_numeric_vector) | Matrix of responses/observations (y). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`BayesianLinearRegression`](#doc_model) | Output BayesianLinearRegression model. | 
-
-### 2. predict
-
-An implementation of the Bayesian linear regression prediction: Given a pre-trained model and a test data set, it provides model predictions.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing points to regress on (test points). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric matrix`](#doc_numeric_matrix) | Matrix of predicted responses, with associated standard deviations if option selected. | 
-
 ## class lars
 {: #lars }
 
@@ -1477,6 +1790,199 @@ An implementation of Least Angle Regression (stagewise/lasso), also known as LAR
 | **type** | **description** |
 |----------|-----------------|
 | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing predicted responses. | 
+
+## class linear_regression
+{: #linear_regression }
+
+#### Simple Linear Regression
+{: #linear_regression_descr }
+
+
+An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
+
+  y = X * b + e
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `lambda` | [`numeric`](#doc_numeric) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("https://datasets.mlpack.org/admission_predict.csv", header=FALSE))
+y <- as.matrix(read.csv("https://datasets.mlpack.org/admission_predict.responses.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- linear_regression_train(training=X_train, training_responses=y_train)
+  
+pred <- predict(model, newdata=X_test) 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | Train a linear regression model. |
+| predict | Predictions from model. |
+
+### 1. train
+
+Train a linear regression model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `training` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing training set X (regressors). | 
+| `training_responses` | [`numeric vector`](#doc_numeric_vector) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`LinearRegression`](#doc_model) | Output LinearRegression model. | 
+
+### 2. predict
+
+Predictions from model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing X' (test regressors). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric vector`](#doc_numeric_vector) | Matrix containing predicted responses. | 
+
+## class linear_svm
+{: #linear_svm }
+
+#### Linear SVM Training
+{: #linear_svm_descr }
+
+
+An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
+
+This implementation allows training a linear SVM model given training data (specified with the `training` parameter).
+
+The training data may have class labels as its last dimension. Alternately, the `labels` parameter may be used to specify a separate vector of labels.
+
+When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `lambda` option, and the number of classes can be manually specified with the `num_classes`and if an intercept term is not desired in the model, the `no_intercept` parameter can be specified.
+
+Margin of difference between correct class and other classes can be specified with the `delta` option.The optimizer used to train the model can be specified with the `optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `max_iterations` parameter specifies the maximum number of allowed iterations, and the `tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `step_size` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `delta` | [`numeric`](#doc_numeric) | Margin of difference between correct class and other classes. | `1` |
+| `epochs` | [`integer`](#doc_integer) | Maximum number of full epochs over dataset for psgd | `50` |
+| `lambda` | [`numeric`](#doc_numeric) | L2-regularization parameter for training. | `0.0001` |
+| `max_iterations` | [`integer`](#doc_integer) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
+| `no_intercept` | [`logical`](#doc_logical) | Do not add the intercept term to the model. | `FALSE` |
+| `num_classes` | [`integer`](#doc_integer) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
+| `optimizer` | [`character`](#doc_character) | Optimizer to use for training ('lbfgs' or 'psgd'). | `"lbfgs"` |
+| `seed` | [`integer`](#doc_integer) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `shuffle` | [`logical`](#doc_logical) | Don't shuffle the order in which data points are visited for parallel SGD. | `FALSE` |
+| `step_size` | [`numeric`](#doc_numeric) | Step size for parallel SGD optimizer. | `0.01` |
+| `tolerance` | [`numeric`](#doc_numeric) | Convergence tolerance for optimizer. | `1e-10` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- linear_svm_train(training=X_train, labels=y_train, lambda=0.1,
+  delta=1, num_classes=0)
+  
+pred <- predict(model, newdata=X_test) 
+) 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | An implementation of linear SVM for multiclass classification. Given labeled data, a model is. |
+| predict | Class prediction from Linear SVM model. |
+| scores | Class scores from Linear SVM model. |
+
+### 1. train
+
+An implementation of linear SVM for multiclass classification. Given labeled data, a model is.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`integer vector`](#doc_integer_vector) | A matrix containing labels (0 or 1) for the points in the training set (y). | 
+| `training` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the training set (the matrix of predictors, X). | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`LinearSVMModel`](#doc_model) | Output for trained linear svm model. | 
+
+### 2. predict
+
+Class prediction from Linear SVM model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing test dataset. | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Matrix containing test labels. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`integer vector`](#doc_integer_vector) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
+
+### 3. scores
+
+Class scores from Linear SVM model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing test dataset. | 
+| `test_labels` | [`integer vector`](#doc_integer_vector) | Matrix containing test labels. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric matrix`](#doc_numeric_matrix) | Requested scores. | 
 
 ## lmnn()
 {: #lmnn }
@@ -1927,6 +2433,104 @@ R> centroids <- output$centroid
  - [Mean Shift, Mode Seeking, and Clustering (pdf)](https://members.loria.fr/MOBerger/Enseignement/Master2/Exposes/meanShiftCluster.pdf)
  - [mlpack::mean_shift::MeanShift C++ class documentation](../../user/methods/mean_shift.md)
 
+## class nbc
+{: #nbc }
+
+#### Parametric Naive Bayes Classifier training
+{: #nbc_descr }
+
+
+Implements the Naive Bayes classifier on the given labeled training set for us of that trained model to classify the points in a given test set.
+
+The training set is specified with the `training` parameter.  Labels may be either the last row of the training set, or alternately the `labels` parameter may be specified to pass a separate matrix of labels.
+
+The `incremental_variance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `incremental_variance` | [`logical`](#doc_logical) | The variance of each class will be calculated incrementally. | `FALSE` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- nbc_train(training=X_train, labels=y_train)
+
+pred <- predict(model, newdata=X_test) 
+prob <- predict(model, newdata=X_test, type="probabilities") 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data. |
+| predict | Class predictions from a Naive Bayes Classifier model. |
+| probabilities | Class probabilities from a Naive Bayes Classifier model. |
+
+### 1. train
+
+An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`integer vector`](#doc_integer_vector) | A vector containing labels for the training set. | 
+| `training` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the training set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`NBCModel`](#doc_model) | File to save trained Naive Bayes model to. | 
+
+### 2. predict
+
+Class predictions from a Naive Bayes Classifier model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the test set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`integer vector`](#doc_integer_vector) | The matrix in which the predicted labels for the test set will be written. | 
+
+### 3. probabilities
+
+Class probabilities from a Naive Bayes Classifier model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the test set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`numeric matrix`](#doc_numeric_matrix) | The matrix in which the predicted probability of labels for the test set will be written. | 
+
 ## nca()
 {: #nca }
 
@@ -2292,6 +2896,83 @@ R> data_mod <- pca(input=data, new_dimensionality=5,
 
  - [Principal component analysis on Wikipedia](https://en.wikipedia.org/wiki/Principal_component_analysis)
  - [PCA C++ class documentation](../../user/methods/pca.md)
+
+## class perceptron
+{: #perceptron }
+
+#### Perceptron training
+{: #perceptron_descr }
+
+
+Implementation of a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `max_iterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
+### Parameters
+
+| ***name*** | ***type*** | ***description*** | ***default*** |
+|------------|------------|-------------------|---------------|
+| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
+| `max_iterations` | [`integer`](#doc_integer) | The maximum number of iterations the perceptron is to be run | `1000` |
+| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+
+### Example
+
+```r
+
+
+suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
+X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
+y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
+pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
+X_train <- pp[["training"]]
+X_test <- pp[["test"]]
+# labels are indices to operate on both factors or numeric data
+y_train <- y[as.integer(pp[["training_labels"]]), 1]
+y_test <- y[as.integer(pp[["test_labels"]]), 1]
+
+model <- perceptron_train(training=X_train, labels=y_train,
+  max_iterations=100)
+  
+pred <- predict(model, newdata=X_test) 
+```
+
+### Methods
+
+| **name** | **description** |
+|----------|-----------------|
+| train | An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points. |
+| predict | Class predictions from perceptron model. |
+
+### 1. train
+
+An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `labels` | [`integer vector`](#doc_integer_vector) | A matrix containing labels for the training set. | 
+| `training` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the training set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`PerceptronModel`](#doc_model) | Output for trained perceptron model. | 
+
+### 2. predict
+
+Class predictions from perceptron model.
+
+#### Input Parameters:
+
+| **name** | **type** | **description** |
+|----------|----------|-----------------|
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the test set. | 
+
+#### Returns: 
+
+| **type** | **description** |
+|----------|-----------------|
+| [`integer vector`](#doc_integer_vector) | The matrix in which the predicted labels for the test set will be written. | 
 
 ## preprocess_split()
 {: #preprocess_split }
@@ -2715,173 +3396,6 @@ R> ic <- output$output_ic
  - [ICA using spacings estimates of entropy (pdf)](https://www.jmlr.org/papers/volume4/learned-miller03a/learned-miller03a.pdf)
  - [Radical C++ class documentation](../../user/methods/radical.md)
 
-## krann()
-{: #krann }
-
-#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
-{: #krann_descr }
-
-```R
-R> library(mlpack)
-R> d <- krann(alpha=0.95, first_leaf_exact=FALSE, input_model=NA, k=0,
-        leaf_size=20, naive=FALSE, query=matrix(numeric(), 0, 0),
-        random_basis=FALSE, reference=matrix(numeric(), 0, 0),
-        sample_at_leaves=FALSE, seed=0, single_mode=FALSE,
-        single_sample_limit=20, tau=5, tree_type="kd",
-        verbose=getOption("mlpack.verbose", FALSE))
-R> distances <- d$distances
-R> neighbors <- d$neighbors
-R> output_model <- d$output_model
-```
-
-An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `alpha` | [`numeric`](#doc_numeric) | The desired success probability. | `0.95` |
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `first_leaf_exact` | [`logical`](#doc_logical) | The flag to trigger sampling only after exactly exploring the first leaf. | `FALSE` |
-| `input_model` | [`RAModel`](#doc_model) | Pre-trained kNN model. | `NA` |
-| `k` | [`integer`](#doc_integer) | Number of nearest neighbors to find. | `0` |
-| `leaf_size` | [`integer`](#doc_integer) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
-| `naive` | [`logical`](#doc_logical) | If true, sampling will be done without using a tree. | `FALSE` |
-| `query` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing query points (optional). | `matrix(numeric(), 0, 0)` |
-| `random_basis` | [`logical`](#doc_logical) | Before tree-building, project the data onto a random orthogonal basis. | `FALSE` |
-| `reference` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing the reference dataset. | `matrix(numeric(), 0, 0)` |
-| `sample_at_leaves` | [`logical`](#doc_logical) | The flag to trigger sampling at leaves. | `FALSE` |
-| `seed` | [`integer`](#doc_integer) | Random seed (if 0, std::time(NULL) is used). | `0` |
-| `single_mode` | [`logical`](#doc_logical) | If true, single-tree search is used (as opposed to dual-tree search. | `FALSE` |
-| `single_sample_limit` | [`integer`](#doc_integer) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
-| `tau` | [`numeric`](#doc_numeric) | The allowed rank-error in terms of the percentile of the data. | `5` |
-| `tree_type` | [`character`](#doc_character) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `"kd"` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-
-### Output options
-
-Results are returned in a R list.  The keys of the list are the names of the output parameters.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `distances` | [`numeric matrix`](#doc_numeric_matrix) | Matrix to output distances into. | 
-| `neighbors` | [`integer matrix`](#doc_integer_matrix) | Matrix to output neighbors into. | 
-| `output_model` | [`RAModel`](#doc_model) | If specified, the kNN model will be output here. | 
-
-### Detailed documentation
-{: #krann_detailed-documentation }
-
-This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
-
-### Example
-For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `"input"` and store the distances in `"distances"` and the neighbors in `"neighbors.csv"`:
-
-```R
-R> output <- krann(reference=input, k=5, tau=0.1)
-R> distances <- output$distances
-R> neighbors <- output$neighbors
-```
-
-Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
-
-The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
-
-### See also
-
- - [knn()](#knn)
- - [lsh()](#lsh)
- - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
- - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
-
-## sparse_coding()
-{: #sparse_coding }
-
-#### Sparse Coding
-{: #sparse_coding_descr }
-
-```R
-R> library(mlpack)
-R> d <- sparse_coding(atoms=15, initial_dictionary=matrix(numeric(), 0,
-        0), input_model=NA, lambda1=0, lambda2=0, max_iterations=0,
-        newton_tolerance=1e-06, normalize=FALSE, objective_tolerance=0.01,
-        seed=0, test=matrix(numeric(), 0, 0), training=matrix(numeric(), 0, 0),
-        verbose=getOption("mlpack.verbose", FALSE))
-R> codes <- d$codes
-R> dictionary <- d$dictionary
-R> output_model <- d$output_model
-```
-
-An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
-
-
-
-### Input options
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `atoms` | [`integer`](#doc_integer) | Number of atoms in the dictionary. | `15` |
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `initial_dictionary` | [`numeric matrix`](#doc_numeric_matrix) | Optional initial dictionary matrix. | `matrix(numeric(), 0, 0)` |
-| `input_model` | [`SparseCoding`](#doc_model) | File containing input sparse coding model. | `NA` |
-| `lambda1` | [`numeric`](#doc_numeric) | Sparse coding l1-norm regularization parameter. | `0` |
-| `lambda2` | [`numeric`](#doc_numeric) | Sparse coding l2-norm regularization parameter. | `0` |
-| `max_iterations` | [`integer`](#doc_integer) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
-| `newton_tolerance` | [`numeric`](#doc_numeric) | Tolerance for convergence of Newton method. | `1e-06` |
-| `normalize` | [`logical`](#doc_logical) | If set, the input data matrix will be normalized before coding. | `FALSE` |
-| `objective_tolerance` | [`numeric`](#doc_numeric) | Tolerance for convergence of the objective function. | `0.01` |
-| `seed` | [`integer`](#doc_integer) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Optional matrix to be encoded by trained model. | `matrix(numeric(), 0, 0)` |
-| `training` | [`numeric matrix`](#doc_numeric_matrix) | Matrix of training data (X). | `matrix(numeric(), 0, 0)` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-
-### Output options
-
-Results are returned in a R list.  The keys of the list are the names of the output parameters.
-
-| ***name*** | ***type*** | ***description*** |
-|------------|------------|-------------------|
-| `codes` | [`numeric matrix`](#doc_numeric_matrix) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
-| `dictionary` | [`numeric matrix`](#doc_numeric_matrix) | Matrix to save the output dictionary to. | 
-| `output_model` | [`SparseCoding`](#doc_model) | File to save trained sparse coding model to. | 
-
-### Detailed documentation
-{: #sparse_coding_detailed-documentation }
-
-An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
-
-The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
-
-The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
-
-Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
-
-To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `training` option, along with the number of atoms in the dictionary (specified with the `atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `initial_dictionary` parameter.  An input model may be specified with the `input_model` parameter.
-
-### Example
-As an example, to build a sparse coding model on the dataset `"data"` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `"model"`, use 
-
-```R
-R> output <- sparse_coding(training=data, atoms=200, lambda1=0.1)
-R> model <- output$output_model
-```
-
-Then, this model could be used to encode a new matrix, `"otherdata"`, and save the output codes to `"codes"`: 
-
-```R
-R> output <- sparse_coding(input_model=model, test=otherdata)
-R> codes <- output$codes
-```
-
-### See also
-
- - [local_coordinate_coding()](#local_coordinate_coding)
- - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
- - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
- - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
- - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
-
 ## class random_forest
 {: #random_forest }
 
@@ -2989,608 +3503,85 @@ Class probabilities from random forest model.
 |----------|-----------------|
 | [`numeric matrix`](#doc_numeric_matrix) | Predicted class probabilities for each point in the test set. | 
 
-## class decision_tree
-{: #decision_tree }
+## krann()
+{: #krann }
 
-#### Decision tree training
-{: #decision_tree_descr }
+#### K-Rank-Approximate-Nearest-Neighbors (kRANN)
+{: #krann_descr }
+
+```R
+R> library(mlpack)
+R> d <- krann(alpha=0.95, first_leaf_exact=FALSE, input_model=NA, k=0,
+        leaf_size=20, naive=FALSE, query=matrix(numeric(), 0, 0),
+        random_basis=FALSE, reference=matrix(numeric(), 0, 0),
+        sample_at_leaves=FALSE, seed=0, single_mode=FALSE,
+        single_sample_limit=20, tau=5, tree_type="kd",
+        verbose=getOption("mlpack.verbose", FALSE))
+R> distances <- d$distances
+R> neighbors <- d$neighbors
+R> output_model <- d$output_model
+```
+
+An implementation of rank-approximate k-nearest-neighbor search (kRANN)  using single-tree and dual-tree algorithms.  Given a set of reference points and query points, this can find the k nearest neighbors in the reference set of each query point using trees; trees that are built can be saved for future use. [Detailed documentation](#krann_detailed-documentation).
 
 
-Train using a decision tree.  Given a dataset containing numeric or categorical features, and associated labels for each point in the dataset, this program can train a decision tree on that data.
 
-The training set and associated labels are specified with the `training` and `labels` parameters, respectively.  The labels should be in the range `[0, num_classes - 1]`. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The trained model is returned, and can then be used for prediction. The `minimum_leaf_size` parameter specifies the minimum number of training points that must fall into each leaf for it to be split.  The `minimum_gain_split` parameter specifies the minimum gain that is needed for the node to split.  The `maximum_depth` parameter specifies the maximum depth of the tree.  If `print_training_accuracy` is specified, the training accuracy will be printed.
-### Parameters
+### Input options
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `alpha` | [`numeric`](#doc_numeric) | The desired success probability. | `0.95` |
 | `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `maximum_depth` | [`integer`](#doc_integer) | Maximum depth of the tree (0 means no limit). | `0` |
-| `minimum_gain_split` | [`numeric`](#doc_numeric) | Minimum gain for node splitting. | `1e-07` |
-| `minimum_leaf_size` | [`integer`](#doc_integer) | Minimum number of points in a leaf. | `20` |
-| `print_training_accuracy` | [`logical`](#doc_logical) | Print the training accuracy. | `FALSE` |
+| `first_leaf_exact` | [`logical`](#doc_logical) | The flag to trigger sampling only after exactly exploring the first leaf. | `FALSE` |
+| `input_model` | [`RAModel`](#doc_model) | Pre-trained kNN model. | `NA` |
+| `k` | [`integer`](#doc_integer) | Number of nearest neighbors to find. | `0` |
+| `leaf_size` | [`integer`](#doc_integer) | Leaf size for tree building (used for kd-trees, UB trees, R trees, R* trees, X trees, Hilbert R trees, R+ trees, R++ trees, and octrees). | `20` |
+| `naive` | [`logical`](#doc_logical) | If true, sampling will be done without using a tree. | `FALSE` |
+| `query` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing query points (optional). | `matrix(numeric(), 0, 0)` |
+| `random_basis` | [`logical`](#doc_logical) | Before tree-building, project the data onto a random orthogonal basis. | `FALSE` |
+| `reference` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing the reference dataset. | `matrix(numeric(), 0, 0)` |
+| `sample_at_leaves` | [`logical`](#doc_logical) | The flag to trigger sampling at leaves. | `FALSE` |
+| `seed` | [`integer`](#doc_integer) | Random seed (if 0, std::time(NULL) is used). | `0` |
+| `single_mode` | [`logical`](#doc_logical) | If true, single-tree search is used (as opposed to dual-tree search. | `FALSE` |
+| `single_sample_limit` | [`integer`](#doc_integer) | The limit on the maximum number of samples (and hence the largest node you can approximate). | `20` |
+| `tau` | [`numeric`](#doc_numeric) | The allowed rank-error in terms of the percentile of the data. | `5` |
+| `tree_type` | [`character`](#doc_character) | Type of tree to use: 'kd', 'ub', 'cover', 'r', 'x', 'r-star', 'hilbert-r', 'r-plus', 'r-plus-plus', 'oct'. | `"kd"` |
 | `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
 
-### Example
+### Output options
 
-```r
+Results are returned in a R list.  The keys of the list are the names of the output parameters.
 
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `distances` | [`numeric matrix`](#doc_numeric_matrix) | Matrix to output distances into. | 
+| `neighbors` | [`integer matrix`](#doc_integer_matrix) | Matrix to output neighbors into. | 
+| `output_model` | [`RAModel`](#doc_model) | If specified, the kNN model will be output here. | 
 
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
+### Detailed documentation
+{: #krann_detailed-documentation }
 
-model <- decision_tree_train(training=X_train, labels=y_train,
-  minimum_leaf_size=20, minimum_gain_split=0.001)
-  
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| train | Training ID3-style decision tree model. |
-| predict | Class predictions from train decision tree model. |
-| probabilities | Class predictions from train decision tree model. |
-
-### 1. train
-
-Training ID3-style decision tree model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`integer vector`](#doc_integer_vector) | Training labels. | 
-| `training` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Training dataset (may contain categorical variables). | 
-| `weights` | [`numeric matrix`](#doc_numeric_matrix) | The weight of labels | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`DecisionTreeModel`](#doc_model) | Output for trained decision tree. | 
-
-### 2. predict
-
-Class predictions from train decision tree model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may contain categorical variables). | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Test point labels, if accuracy calculation is desired. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`integer vector`](#doc_integer_vector) | Class predictions for each test point. | 
-
-### 3. probabilities
-
-Class predictions from train decision tree model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may contain categorical variables). | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Test point labels, if accuracy calculation is desired. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric matrix`](#doc_numeric_matrix) | Class probabilities for each test point if probabilities has been selected. | 
-
-## class perceptron
-{: #perceptron }
-
-#### Perceptron training
-{: #perceptron_descr }
-
-
-Implementation of a perceptron, which is a single level neural network. The perceptron makes its predictions based on a linear predictor function combining a set of weights with the feature vector.  The perceptron learning rule is able to converge, given enough iterations (specified using the `max_iterations` parameter), if the data supplied is linearly separable.  The perceptron is parameterized by a matrix of weight vectors that denote the numerical weights of the neural network.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `max_iterations` | [`integer`](#doc_integer) | The maximum number of iterations the perceptron is to be run | `1000` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
+This program will calculate the k rank-approximate-nearest-neighbors of a set of points. You may specify a separate set of reference points and query points, or just a reference set which will be used as both the reference and query set. You must specify the rank approximation (in %) (and optionally the success probability).
 
 ### Example
+For example, the following will return 5 neighbors from the top 0.1% of the data (with probability 0.95) for each point in `"input"` and store the distances in `"distances"` and the neighbors in `"neighbors.csv"`:
 
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- perceptron_train(training=X_train, labels=y_train,
-  max_iterations=100)
-  
-pred <- predict(model, newdata=X_test) 
+```R
+R> output <- krann(reference=input, k=5, tau=0.1)
+R> distances <- output$distances
+R> neighbors <- output$neighbors
 ```
 
-### Methods
+Note that tau must be set such that the number of points in the corresponding percentile of the data is greater than k.  Thus, if we choose tau = 0.1 with a dataset of 1000 points and k = 5, then we are attempting to choose 5 nearest neighbors out of the closest 1 point -- this is invalid and the program will terminate with an error message.
 
-| **name** | **description** |
-|----------|-----------------|
-| train | An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points. |
-| predict | Class predictions from perceptron model. |
+The output matrices are organized such that row i and column j in the neighbors output file corresponds to the index of the point in the reference set which is the i'th nearest neighbor from the point in the query set with index j.  Row i and column j in the distances output file corresponds to the distance between those two points.
 
-### 1. train
+### See also
 
-An implementation of a perceptron---a single level neural network---for classification.  Given labeled data, a perceptron can be trained and later be used for classification on new points.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`integer vector`](#doc_integer_vector) | A matrix containing labels for the training set. | 
-| `training` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the training set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`PerceptronModel`](#doc_model) | Output for trained perceptron model. | 
-
-### 2. predict
-
-Class predictions from perceptron model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the test set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`integer vector`](#doc_integer_vector) | The matrix in which the predicted labels for the test set will be written. | 
-
-## class linear_svm
-{: #linear_svm }
-
-#### Linear SVM Training
-{: #linear_svm_descr }
-
-
-An implementation of linear SVMs that uses either L-BFGS or parallel SGD (stochastic gradient descent) to train the model.
-
-This implementation allows training a linear SVM model given training data (specified with the `training` parameter).
-
-The training data may have class labels as its last dimension. Alternately, the `labels` parameter may be used to specify a separate vector of labels.
-
-When a model is being trained, there are many options.  L2 regularization (to prevent overfitting) can be specified with the `lambda` option, and the number of classes can be manually specified with the `num_classes`and if an intercept term is not desired in the model, the `no_intercept` parameter can be specified.
-
-Margin of difference between correct class and other classes can be specified with the `delta` option.The optimizer used to train the model can be specified with the `optimizer` parameter.  Available options are 'psgd' (parallel stochastic gradient descent) and 'lbfgs' (the L-BFGS optimizer).  There are also various parameters for the optimizer; the `max_iterations` parameter specifies the maximum number of allowed iterations, and the `tolerance` parameter specifies the tolerance for convergence.  For the parallel SGD optimizer, the `step_size` parameter controls the step size taken at each iteration by the optimizer and the maximum number of epochs (specified with `epochs`). If the objective function for your data is oscillating between Inf and 0, the step size is probably too large.  There are more parameters for the optimizers, but the C++ interface must be used to access these.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `delta` | [`numeric`](#doc_numeric) | Margin of difference between correct class and other classes. | `1` |
-| `epochs` | [`integer`](#doc_integer) | Maximum number of full epochs over dataset for psgd | `50` |
-| `lambda` | [`numeric`](#doc_numeric) | L2-regularization parameter for training. | `0.0001` |
-| `max_iterations` | [`integer`](#doc_integer) | Maximum iterations for optimizer (0 indicates no limit). | `10000` |
-| `no_intercept` | [`logical`](#doc_logical) | Do not add the intercept term to the model. | `FALSE` |
-| `num_classes` | [`integer`](#doc_integer) | Number of classes for classification; if unspecified (or 0), the number of classes found in the labels will be used. | `0` |
-| `optimizer` | [`character`](#doc_character) | Optimizer to use for training ('lbfgs' or 'psgd'). | `"lbfgs"` |
-| `seed` | [`integer`](#doc_integer) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
-| `shuffle` | [`logical`](#doc_logical) | Don't shuffle the order in which data points are visited for parallel SGD. | `FALSE` |
-| `step_size` | [`numeric`](#doc_numeric) | Step size for parallel SGD optimizer. | `0.01` |
-| `tolerance` | [`numeric`](#doc_numeric) | Convergence tolerance for optimizer. | `1e-10` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-
-### Example
-
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- linear_svm_train(training=X_train, labels=y_train, lambda=0.1,
-  delta=1, num_classes=0)
-  
-pred <- predict(model, newdata=X_test) 
-) 
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| train | An implementation of linear SVM for multiclass classification. Given labeled data, a model is. |
-| predict | Class prediction from Linear SVM model. |
-| scores | Class scores from Linear SVM model. |
-
-### 1. train
-
-An implementation of linear SVM for multiclass classification. Given labeled data, a model is.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`integer vector`](#doc_integer_vector) | A matrix containing labels (0 or 1) for the points in the training set (y). | 
-| `training` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the training set (the matrix of predictors, X). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`LinearSVMModel`](#doc_model) | Output for trained linear svm model. | 
-
-### 2. predict
-
-Class prediction from Linear SVM model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing test dataset. | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Matrix containing test labels. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`integer vector`](#doc_integer_vector) | If test data is specified, this matrix is where the predictions for the test set will be saved. | 
-
-### 3. scores
-
-Class scores from Linear SVM model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing test dataset. | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Matrix containing test labels. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric matrix`](#doc_numeric_matrix) | Requested scores. | 
-
-## class adaboost
-{: #adaboost }
-
-#### AdaBoost
-{: #adaboost_descr }
-
-
-This program implements the AdaBoost (or Adaptive Boosting) algorithm. The variant of AdaBoost implemented here is AdaBoost.MH. It uses a weak learner, either decision stumps or perceptrons, and over many iterations, creates a strong learner that is a weighted ensemble of weak learners. It runs these iterations until a tolerance value is crossed for change in the value of the weighted training error.
-
-For more information about the algorithm, see the paper "Improved Boosting Algorithms Using Confidence-Rated Predictions", by R.E. Schapire and Y. Singer.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `iterations` | [`integer`](#doc_integer) | The maximum number of boosting iterations to be run (0 will run until convergence.) | `1000` |
-| `tolerance` | [`numeric`](#doc_numeric) | The tolerance for change in values of the weighted error during training. | `1e-10` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-| `weak_learner` | [`character`](#doc_character) | The type of weak learner to use: 'decision_stump', or 'perceptron'. | `"decision_stump"` |
-
-### Example
-
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- adaboost_train(training=X_train, labels=y_train)
-
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| train | Training AdaBoost model. |
-| predict | Class predictions from model. |
-| probabilities | Class probabilities from model. |
-
-### 1. train
-
-Training AdaBoost model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`integer vector`](#doc_integer_vector) | Labels for the training set. | 
-| `training` | [`numeric matrix`](#doc_numeric_matrix) | Dataset for training AdaBoost. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`AdaBoostModel`](#doc_model) | Output trained AdaBoost model. | 
-
-### 2. predict
-
-Class predictions from model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Test dataset. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`integer vector`](#doc_integer_vector) | Predicted labels for the test set. | 
-
-### 3. probabilities
-
-Class probabilities from model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Test dataset. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric matrix`](#doc_numeric_matrix) | Predicted class probabilities for each point in the test set. | 
-
-## class hoeffding_tree
-{: #hoeffding_tree }
-
-#### Hoeffding trees training
-{: #hoeffding_tree_descr }
-
-
-Implements Hoeffding trees, a form of streaming decision tree suited best for large (or streaming) datasets, supporting both categorical and numeric data.  Given an input dataset, it is able to train the tree with numerous training options, and return the model.
-
-The training file and associated labels are specified with the `training` and `labels` parameters, respectively. Optionally, if `labels` is not specified, the labels are assumed to be the last dimension of the training dataset.
-
-The training may be performed in batch mode (like a typical decision tree algorithm) by specifying the `batch_mode` option, but this may not be the best option for large datasets.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `batch_mode` | [`logical`](#doc_logical) | If true, samples will be considered in batch instead of as a stream.  This generally results in better trees but at the cost of memory usage and runtime. | `FALSE` |
-| `bins` | [`integer`](#doc_integer) | If the 'domingos' split strategy is used, this specifies the number of bins for each numeric split. | `10` |
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `confidence` | [`numeric`](#doc_numeric) | Confidence before splitting (between 0 and 1). | `0.95` |
-| `info_gain` | [`logical`](#doc_logical) | If set, information gain is used instead of Gini impurity for calculating Hoeffding bounds. | `FALSE` |
-| `max_samples` | [`integer`](#doc_integer) | Maximum number of samples before splitting. | `5000` |
-| `min_samples` | [`integer`](#doc_integer) | Minimum number of samples before splitting. | `100` |
-| `numeric_split_strategy` | [`character`](#doc_character) | The splitting strategy to use for numeric features: 'domingos' or 'binary'. | `"binary"` |
-| `observations_before_binning` | [`integer`](#doc_integer) | If the 'domingos' split strategy is used, this specifies the number of samples observed before binning is performed. | `100` |
-| `passes` | [`integer`](#doc_integer) | Number of passes to take over the dataset. | `1` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-
-### Example
-
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- hoeffding_tree_train(training=X_train, labels=y_train)
-
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| train | An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points. |
-| predict | Class predictions from Hoeffding trees model. |
-| probabilities | Class probabilities from Hoeffding trees model. |
-
-### 1. train
-
-An implementation of Hoeffding trees, a form of streaming decision tree for classification.  Given labeled data a Hoeffding tree can be trained for later use of predicting the classifications of new points.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`integer vector`](#doc_integer_vector) | Labels for training dataset. | 
-| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may be categorical). | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Labels of test data. | 
-| `training` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Training dataset (may be categorical). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`HoeffdingTreeModel`](#doc_model) | Output for trained Hoeffding tree model. | 
-
-### 2. predict
-
-Class predictions from Hoeffding trees model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may be categorical). | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Labels of test data. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`integer vector`](#doc_integer_vector) | Matrix to output label predictions for test data into. | 
-
-### 3. probabilities
-
-Class probabilities from Hoeffding trees model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`categorical matrix/data.frame`](#doc_categorical_matrix_data_frame) | Testing dataset (may be categorical). | 
-| `test_labels` | [`integer vector`](#doc_integer_vector) | Labels of test data. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric matrix`](#doc_numeric_matrix) | In addition to predicting labels, provide rediction probabilities in this matrix. | 
-
-## class nbc
-{: #nbc }
-
-#### Parametric Naive Bayes Classifier training
-{: #nbc_descr }
-
-
-Implements the Naive Bayes classifier on the given labeled training set for us of that trained model to classify the points in a given test set.
-
-The training set is specified with the `training` parameter.  Labels may be either the last row of the training set, or alternately the `labels` parameter may be specified to pass a separate matrix of labels.
-
-The `incremental_variance` parameter can be used to force the training to use an incremental algorithm for calculating variance.  This is slower, but can help avoid loss of precision in some cases.
-### Parameters
-
-| ***name*** | ***type*** | ***description*** | ***default*** |
-|------------|------------|-------------------|---------------|
-| `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `incremental_variance` | [`logical`](#doc_logical) | The variance of each class will be calculated incrementally. | `FALSE` |
-| `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
-
-### Example
-
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("http://datasets.mlpack.org/iris.csv", header=FALSE))
-y <- as.matrix(read.csv("http://datasets.mlpack.org/iris_labels.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- nbc_train(training=X_train, labels=y_train)
-
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
-```
-
-### Methods
-
-| **name** | **description** |
-|----------|-----------------|
-| train | An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data. |
-| predict | Class predictions from a Naive Bayes Classifier model. |
-| probabilities | Class probabilities from a Naive Bayes Classifier model. |
-
-### 1. train
-
-An implementation of the Naive Bayes Classifier, used for classification. Given labeled data, an NBC model is be trained for later use for classification on new data.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `labels` | [`integer vector`](#doc_integer_vector) | A vector containing labels for the training set. | 
-| `training` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the training set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`NBCModel`](#doc_model) | File to save trained Naive Bayes model to. | 
-
-### 2. predict
-
-Class predictions from a Naive Bayes Classifier model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the test set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`integer vector`](#doc_integer_vector) | The matrix in which the predicted labels for the test set will be written. | 
-
-### 3. probabilities
-
-Class probabilities from a Naive Bayes Classifier model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | A matrix containing the test set. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric matrix`](#doc_numeric_matrix) | The matrix in which the predicted probability of labels for the test set will be written. | 
+ - [knn()](#knn)
+ - [lsh()](#lsh)
+ - [Rank-approximate nearest neighbor search: Retaining meaning and speed in high dimensions (pdf)](https://proceedings.neurips.cc/paper_files/paper/2009/file/ddb30680a691d157187ee1cf9e896d03-Paper.pdf)
+ - [RASearch C++ class documentation](https://github.com/mlpack/mlpack/blob/master/src/mlpack/methods/rann/ra_search.hpp)
 
 ## class softmax_regression
 {: #softmax_regression }
@@ -3696,81 +3687,90 @@ An implementation of softmax regression for classification, which is a multiclas
 |----------|-----------------|
 | [`numeric matrix`](#doc_numeric_matrix) | Matrix to save class probabilities for test dataset into. | 
 
-## class linear_regression
-{: #linear_regression }
+## sparse_coding()
+{: #sparse_coding }
 
-#### Simple Linear Regression
-{: #linear_regression_descr }
+#### Sparse Coding
+{: #sparse_coding_descr }
+
+```R
+R> library(mlpack)
+R> d <- sparse_coding(atoms=15, initial_dictionary=matrix(numeric(), 0,
+        0), input_model=NA, lambda1=0, lambda2=0, max_iterations=0,
+        newton_tolerance=1e-06, normalize=FALSE, objective_tolerance=0.01,
+        seed=0, test=matrix(numeric(), 0, 0), training=matrix(numeric(), 0, 0),
+        verbose=getOption("mlpack.verbose", FALSE))
+R> codes <- d$codes
+R> dictionary <- d$dictionary
+R> output_model <- d$output_model
+```
+
+An implementation of Sparse Coding with Dictionary Learning.  Given a dataset, this will decompose the dataset into a sparse combination of a few dictionary elements, where the dictionary is learned during computation; a dictionary can be reused for future sparse coding of new points. [Detailed documentation](#sparse_coding_detailed-documentation).
 
 
-An implementation of simple linear regression and simple ridge regression using ordinary least squares. This solves the problem
 
-  y = X * b + e
-### Parameters
+### Input options
 
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
+| `atoms` | [`integer`](#doc_integer) | Number of atoms in the dictionary. | `15` |
 | `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `lambda` | [`numeric`](#doc_numeric) | Tikhonov regularization for ridge regression.  If 0, the method reduces to linear regression. | `0` |
+| `initial_dictionary` | [`numeric matrix`](#doc_numeric_matrix) | Optional initial dictionary matrix. | `matrix(numeric(), 0, 0)` |
+| `input_model` | [`SparseCoding`](#doc_model) | File containing input sparse coding model. | `NA` |
+| `lambda1` | [`numeric`](#doc_numeric) | Sparse coding l1-norm regularization parameter. | `0` |
+| `lambda2` | [`numeric`](#doc_numeric) | Sparse coding l2-norm regularization parameter. | `0` |
+| `max_iterations` | [`integer`](#doc_integer) | Maximum number of iterations for sparse coding (0 indicates no limit). | `0` |
+| `newton_tolerance` | [`numeric`](#doc_numeric) | Tolerance for convergence of Newton method. | `1e-06` |
+| `normalize` | [`logical`](#doc_logical) | If set, the input data matrix will be normalized before coding. | `FALSE` |
+| `objective_tolerance` | [`numeric`](#doc_numeric) | Tolerance for convergence of the objective function. | `0.01` |
+| `seed` | [`integer`](#doc_integer) | Random seed.  If 0, 'std::time(NULL)' is used. | `0` |
+| `test` | [`numeric matrix`](#doc_numeric_matrix) | Optional matrix to be encoded by trained model. | `matrix(numeric(), 0, 0)` |
+| `training` | [`numeric matrix`](#doc_numeric_matrix) | Matrix of training data (X). | `matrix(numeric(), 0, 0)` |
 | `verbose` | [`logical`](#doc_logical) | Display informational messages and the full list of parameters and timers at the end of execution. | `getOption("mlpack.verbose", FALSE)` |
 
+### Output options
+
+Results are returned in a R list.  The keys of the list are the names of the output parameters.
+
+| ***name*** | ***type*** | ***description*** |
+|------------|------------|-------------------|
+| `codes` | [`numeric matrix`](#doc_numeric_matrix) | Matrix to save the output sparse codes of the test matrix (--test_file) to. | 
+| `dictionary` | [`numeric matrix`](#doc_numeric_matrix) | Matrix to save the output dictionary to. | 
+| `output_model` | [`SparseCoding`](#doc_model) | File to save trained sparse coding model to. | 
+
+### Detailed documentation
+{: #sparse_coding_detailed-documentation }
+
+An implementation of Sparse Coding with Dictionary Learning, which achieves sparsity via an l1-norm regularizer on the codes (LASSO) or an (l1+l2)-norm regularizer on the codes (the Elastic Net).  Given a dense data matrix X with d dimensions and n points, sparse coding seeks to find a dense dictionary matrix D with k atoms in d dimensions, and a sparse coding matrix Z with n points in k dimensions.
+
+The original data matrix X can then be reconstructed as Z * D.  Therefore, this program finds a representation of each point in X as a sparse linear combination of atoms in the dictionary D.
+
+The sparse coding is found with an algorithm which alternates between a dictionary step, which updates the dictionary D, and a sparse coding step, which updates the sparse coding matrix.
+
+Once a dictionary D is found, the sparse coding model may be used to encode other matrices, and saved for future usage.
+
+To run this program, either an input matrix or an already-saved sparse coding model must be specified.  An input matrix may be specified with the `training` option, along with the number of atoms in the dictionary (specified with the `atoms` parameter).  It is also possible to specify an initial dictionary for the optimization, with the `initial_dictionary` parameter.  An input model may be specified with the `input_model` parameter.
+
 ### Example
+As an example, to build a sparse coding model on the dataset `"data"` using 200 atoms and an l1-regularization parameter of 0.1, saving the model into `"model"`, use 
 
-```r
-
-
-suppressMessages(library(mlpack)) # in case 'mlpack' is not yet loaded
-X <- as.matrix(read.csv("https://datasets.mlpack.org/admission_predict.csv", header=FALSE))
-y <- as.matrix(read.csv("https://datasets.mlpack.org/admission_predict.responses.csv", header=FALSE))
-pp <- preprocess_split(input=X, input_label=as.matrix(1:nrow(X)), test_ratio=0.2)
-X_train <- pp[["training"]]
-X_test <- pp[["test"]]
-# labels are indices to operate on both factors or numeric data
-y_train <- y[as.integer(pp[["training_labels"]]), 1]
-y_test <- y[as.integer(pp[["test_labels"]]), 1]
-
-model <- linear_regression_train(training=X_train, training_responses=y_train)
-  
-pred <- predict(model, newdata=X_test) 
+```R
+R> output <- sparse_coding(training=data, atoms=200, lambda1=0.1)
+R> model <- output$output_model
 ```
 
-### Methods
+Then, this model could be used to encode a new matrix, `"otherdata"`, and save the output codes to `"codes"`: 
 
-| **name** | **description** |
-|----------|-----------------|
-| train | Train a linear regression model. |
-| predict | Predictions from model. |
+```R
+R> output <- sparse_coding(input_model=model, test=otherdata)
+R> codes <- output$codes
+```
 
-### 1. train
+### See also
 
-Train a linear regression model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `training` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing training set X (regressors). | 
-| `training_responses` | [`numeric vector`](#doc_numeric_vector) | Optional vector containing y (responses). If not given, the responses are assumed to be the last row of the input file. | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`LinearRegression`](#doc_model) | Output LinearRegression model. | 
-
-### 2. predict
-
-Predictions from model.
-
-#### Input Parameters:
-
-| **name** | **type** | **description** |
-|----------|----------|-----------------|
-| `test` | [`numeric matrix`](#doc_numeric_matrix) | Matrix containing X' (test regressors). | 
-
-#### Returns: 
-
-| **type** | **description** |
-|----------|-----------------|
-| [`numeric vector`](#doc_numeric_vector) | Matrix containing predicted responses. | 
+ - [local_coordinate_coding()](#local_coordinate_coding)
+ - [Sparse dictionary learning on Wikipedia](https://en.wikipedia.org/wiki/Sparse_dictionary_learning)
+ - [Efficient sparse coding algorithms (pdf)](https://proceedings.neurips.cc/paper_files/paper/2006/file/2d71b2ae158c7c5912cc0bbde2bb9d95-Paper.pdf)
+ - [Regularization and variable selection via the elastic net (pdf)](https://sites.stat.washington.edu/courses/stat527/s13/readings/zouhastie05.pdf)
+ - [SparseCoding C++ class documentation](../../user/methods/sparse_coding.md)
 

--- a/doc/user/bindings/r.sidebar.html
+++ b/doc/user/bindings/r.sidebar.html
@@ -8,14 +8,14 @@
 <li><a href="LINKROOTuser/bindings/r.html#data-formats">Data Formats</a></li>
 <li><details><summary>Classification</summary>
 <ul>
-<li><a href="LINKROOTuser/bindings/r.html#logistic_regression">class logistic_regression</a></li>
-<li><a href="LINKROOTuser/bindings/r.html#random_forest">class random_forest</a></li>
-<li><a href="LINKROOTuser/bindings/r.html#decision_tree">class decision_tree</a></li>
-<li><a href="LINKROOTuser/bindings/r.html#perceptron">class perceptron</a></li>
-<li><a href="LINKROOTuser/bindings/r.html#linear_svm">class linear_svm</a></li>
 <li><a href="LINKROOTuser/bindings/r.html#adaboost">class adaboost</a></li>
+<li><a href="LINKROOTuser/bindings/r.html#decision_tree">class decision_tree</a></li>
 <li><a href="LINKROOTuser/bindings/r.html#hoeffding_tree">class hoeffding_tree</a></li>
+<li><a href="LINKROOTuser/bindings/r.html#linear_svm">class linear_svm</a></li>
+<li><a href="LINKROOTuser/bindings/r.html#logistic_regression">class logistic_regression</a></li>
 <li><a href="LINKROOTuser/bindings/r.html#nbc">class nbc</a></li>
+<li><a href="LINKROOTuser/bindings/r.html#perceptron">class perceptron</a></li>
+<li><a href="LINKROOTuser/bindings/r.html#random_forest">class random_forest</a></li>
 <li><a href="LINKROOTuser/bindings/r.html#softmax_regression">class softmax_regression</a></li>
 </ul>
 </details>

--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -14,27 +14,25 @@ macro(add_all_bindings directory name type)
   add_markdown_docs(${directory} ${name} "cli;python;julia;go;r" "")
 endmacro()
 
-# First, define all the "regular" bindings that exist for all languages.
+# Refactored classification and regression methods do not use the macro above.
+#
+# Commented lines below retained for spacing and visual seperation from other
+# methods using aggregation macro.
+#
+add_category(adaboost "Classification")
+group_bindings(adaboost adaboost "train;classify;probabilities")
+add_python_wrapper(adaboost adaboost)
+add_julia_class(adaboost adaboost)
+add_cli_executable(adaboost adaboost)
+add_go_binding(adaboost adaboost)
+add_r_binding(adaboost adaboost "include")
+add_r_binding(adaboost adaboost_train "skip")
+add_r_binding(adaboost adaboost_classify "skip")
+add_r_binding(adaboost adaboost_probabilities "skip")
+add_markdown_docs(adaboost adaboost "cli;python;julia;go;r" "python;r")
+#
 add_all_bindings(approx_kfn approx_kfn "Geometry")
-add_all_bindings(cf cf "Misc. / Other")
-add_all_bindings(dbscan dbscan "Clustering")
-#add_all_bindings(decision_tree decision_tree "Classification")
-add_all_bindings(det det "Misc. / Other")
-add_all_bindings(emst emst "Geometry")
-add_all_bindings(fastmks fastmks "Geometry")
-add_all_bindings(gmm gmm_train "Clustering")
-add_all_bindings(gmm gmm_generate "Clustering" "skip")
-add_all_bindings(gmm gmm_probability "Clustering" "skip")
-add_all_bindings(hmm hmm_train "Misc. / Other")
-add_all_bindings(hmm hmm_generate "Misc. / Other" "skip")
-add_all_bindings(hmm hmm_loglik "Misc. / Other" "skip")
-add_all_bindings(hmm hmm_viterbi "Misc. / Other" "skip")
-#add_all_bindings(hoeffding_trees hoeffding_tree "Classification")
-add_all_bindings(preprocess image_converter "Preprocessing")
-add_all_bindings(kde kde "Misc. / Other")
-add_all_bindings(kernel_pca kernel_pca "Transformations")
-add_all_bindings(kmeans kmeans "Clustering")
-
+#
 add_category(bayesian_linear_regression "Regression")
 group_bindings(bayesian_linear_regression bayesian_linear_regression
   "train;predict")
@@ -49,8 +47,50 @@ add_r_binding(bayesian_linear_regression bayesian_linear_regression_predict
   "skip")
 add_markdown_docs(bayesian_linear_regression bayesian_linear_regression
   "cli;python;julia;go;r" "python;r")
-
-#add_all_bindings(lars lars "Regression")
+#
+add_all_bindings(cf cf "Misc. / Other")
+add_all_bindings(dbscan dbscan "Clustering")
+#
+add_category(decision_tree "Classification")
+group_bindings(decision_tree decision_tree "train;classify;probabilities")
+add_python_wrapper(decision_tree decision_tree)
+add_julia_class(decision_tree decision_tree)
+add_cli_executable(decision_tree decision_tree)
+add_go_binding(decision_tree decision_tree)
+add_r_binding(decision_tree decision_tree "include")
+add_r_binding(decision_tree decision_tree_train "skip")
+add_r_binding(decision_tree decision_tree_classify "skip")
+add_r_binding(decision_tree decision_tree_probabilities "skip")
+add_markdown_docs(decision_tree decision_tree "cli;python;julia;go;r" "python;r")
+#
+add_all_bindings(det det "Misc. / Other")
+add_all_bindings(emst emst "Geometry")
+add_all_bindings(fastmks fastmks "Geometry")
+add_all_bindings(gmm gmm_train "Clustering")
+add_all_bindings(gmm gmm_generate "Clustering" "skip")
+add_all_bindings(gmm gmm_probability "Clustering" "skip")
+add_all_bindings(hmm hmm_train "Misc. / Other")
+add_all_bindings(hmm hmm_generate "Misc. / Other" "skip")
+add_all_bindings(hmm hmm_loglik "Misc. / Other" "skip")
+add_all_bindings(hmm hmm_viterbi "Misc. / Other" "skip")
+#
+add_category(hoeffding_tree "Classification")
+group_bindings(hoeffding_trees hoeffding_tree "train;classify;probabilities")
+add_python_wrapper(hoeffding_trees hoeffding_tree)
+add_julia_class(hoeffding_trees hoeffding_tree)
+add_cli_executable(hoeffding_trees hoeffding_tree)
+add_go_binding(hoeffding_trees hoeffding_tree)
+add_r_binding(hoeffding_trees hoeffding_tree "include")
+add_r_binding(hoeffding_trees hoeffding_tree_train "skip")
+add_r_binding(hoeffding_trees hoeffding_tree_classify "skip")
+add_r_binding(hoeffding_trees hoeffding_tree_probabilities "skip")
+add_markdown_docs(hoeffding_trees hoeffding_tree "cli;python;julia;go;r" "python;r")
+#
+add_all_bindings(preprocess image_converter "Preprocessing")
+add_all_bindings(kde kde "Misc. / Other")
+add_all_bindings(kernel_pca kernel_pca "Transformations")
+add_all_bindings(kmeans kmeans "Clustering")
+#
 add_category(lars "Regression")
 group_bindings(lars lars "train;predict")
 add_python_wrapper(lars lars)
@@ -61,12 +101,35 @@ add_r_binding(lars lars "include")
 add_r_binding(lars lars_train "skip")
 add_r_binding(lars lars_predict "skip")
 add_markdown_docs(lars lars "cli;python;julia;go;r" "python;r")
-
-#add_all_bindings(linear_svm linear_svm "Classification")
+#
+add_category(linear_regression "Regression")
+group_bindings(linear_regression linear_regression "train;predict")
+add_python_wrapper(linear_regression linear_regression)
+add_julia_class(linear_regression linear_regression)
+add_cli_executable(linear_regression linear_regression)
+add_go_binding(linear_regression linear_regression)
+add_r_binding(linear_regression linear_regression "include")
+add_r_binding(linear_regression linear_regression_train "skip")
+add_r_binding(linear_regression linear_regression_predict "skip")
+add_markdown_docs(linear_regression linear_regression "cli;python;julia;go;r"
+    "python;r")
+#
+add_category(linear_svm "Classification")
+group_bindings(linear_svm linear_svm "train;classify;scores")
+add_python_wrapper(linear_svm linear_svm)
+add_julia_class(linear_svm linear_svm)
+add_cli_executable(linear_svm linear_svm)
+add_go_binding(linear_svm linear_svm)
+add_r_binding(linear_svm linear_svm "include")
+add_r_binding(linear_svm linear_svm_train "skip")
+add_r_binding(linear_svm linear_svm_classify "skip")
+add_r_binding(linear_svm linear_svm_scores "skip")
+add_markdown_docs(linear_svm linear_svm "cli;python;julia;go;r" "python;r")
+#
 add_all_bindings(lmnn lmnn "Transformations")
 add_all_bindings(local_coordinate_coding local_coordinate_coding
     "Transformations")
-
+#
 add_category(logistic_regression "Classification")
 group_bindings(logistic_regression logistic_regression
   "train;classify;probabilities")
@@ -80,109 +143,10 @@ add_r_binding(logistic_regression logistic_regression_classify "skip")
 add_r_binding(logistic_regression logistic_regression_probabilities "skip")
 add_markdown_docs(logistic_regression logistic_regression
   "cli;python;julia;go;r" "python;r")
-
+#
 add_all_bindings(lsh lsh "Geometry")
 add_all_bindings(mean_shift mean_shift "Clustering")
-#add_all_bindings(naive_bayes nbc "Classification")
-add_all_bindings(nca nca "Transformations")
-add_all_bindings(neighbor_search knn "Geometry")
-add_all_bindings(neighbor_search kfn "Geometry")
-add_all_bindings(nmf nmf "Misc. / Other")
-add_all_bindings(pca pca "Transformations")
-#add_all_bindings(perceptron perceptron "Classification")
-add_all_bindings(preprocess preprocess_split "Preprocessing")
-add_all_bindings(preprocess preprocess_binarize "Preprocessing")
-add_all_bindings(preprocess preprocess_describe "Preprocessing")
-add_all_bindings(preprocess preprocess_scale "Preprocessing")
-add_all_bindings(preprocess preprocess_one_hot_encoding "Preprocessing")
-add_all_bindings(radical radical "Transformations")
-#add_all_bindings(random_forest random_forest "Classification")
-add_all_bindings(rann krann "Geometry")
-#add_all_bindings(softmax_regression softmax_regression "Classification")
-add_all_bindings(sparse_coding sparse_coding "Transformations")
-
-# Now, define the "special" bindings that are different somehow.
-
-# random forest
-add_category(random_forest "Classification")
-group_bindings(random_forest random_forest "train;classify;probabilities")
-add_python_wrapper(random_forest random_forest)
-add_julia_class(random_forest random_forest)
-add_cli_executable(random_forest random_forest)
-add_go_binding(random_forest random_forest)
-add_r_binding(random_forest random_forest "include")
-add_r_binding(random_forest random_forest_train "skip")
-add_r_binding(random_forest random_forest_classify "skip")
-add_r_binding(random_forest random_forest_probabilities "skip")
-add_markdown_docs(random_forest random_forest "cli;python;julia;go;r" "python;r")
-
-# decision tree
-add_category(decision_tree "Classification")
-group_bindings(decision_tree decision_tree "train;classify;probabilities")
-add_python_wrapper(decision_tree decision_tree)
-add_julia_class(decision_tree decision_tree)
-add_cli_executable(decision_tree decision_tree)
-add_go_binding(decision_tree decision_tree)
-add_r_binding(decision_tree decision_tree "include")
-add_r_binding(decision_tree decision_tree_train "skip")
-add_r_binding(decision_tree decision_tree_classify "skip")
-add_r_binding(decision_tree decision_tree_probabilities "skip")
-add_markdown_docs(decision_tree decision_tree "cli;python;julia;go;r" "python;r")
-
-# perceptron
-add_category(perceptron "Classification")
-group_bindings(perceptron perceptron "train;classify")
-add_python_wrapper(perceptron perceptron)
-add_julia_class(perceptron perceptron)
-add_cli_executable(perceptron perceptron)
-add_go_binding(perceptron perceptron)
-add_r_binding(perceptron perceptron "include")
-add_r_binding(perceptron perceptron_train "skip")
-add_r_binding(perceptron perceptron_classify "skip")
-add_markdown_docs(perceptron perceptron "cli;python;julia;go;r" "python;r")
-
-# linear svm
-add_category(linear_svm "Classification")
-group_bindings(linear_svm linear_svm "train;classify;scores")
-add_python_wrapper(linear_svm linear_svm)
-add_julia_class(linear_svm linear_svm)
-add_cli_executable(linear_svm linear_svm)
-add_go_binding(linear_svm linear_svm)
-add_r_binding(linear_svm linear_svm "include")
-add_r_binding(linear_svm linear_svm_train "skip")
-add_r_binding(linear_svm linear_svm_classify "skip")
-add_r_binding(linear_svm linear_svm_scores "skip")
-add_markdown_docs(linear_svm linear_svm "cli;python;julia;go;r" "python;r")
-
-# Adaboost has a Python wrapper class that encapsulates its functionality in a
-# few methods.
-add_category(adaboost "Classification")
-group_bindings(adaboost adaboost "train;classify;probabilities")
-add_python_wrapper(adaboost adaboost)
-add_julia_class(adaboost adaboost)
-
-add_cli_executable(adaboost adaboost)
-add_go_binding(adaboost adaboost)
-add_r_binding(adaboost adaboost "include")
-add_r_binding(adaboost adaboost_train "skip")
-add_r_binding(adaboost adaboost_classify "skip")
-add_r_binding(adaboost adaboost_probabilities "skip")
-add_markdown_docs(adaboost adaboost "cli;python;julia;go;r" "python;r")
-
-#add_all_bindings(hoeffding_trees hoeffding_tree "Classification")
-add_category(hoeffding_tree "Classification")
-group_bindings(hoeffding_trees hoeffding_tree "train;classify;probabilities")
-add_python_wrapper(hoeffding_trees hoeffding_tree)
-add_julia_class(hoeffding_trees hoeffding_tree)
-add_cli_executable(hoeffding_trees hoeffding_tree)
-add_go_binding(hoeffding_trees hoeffding_tree)
-add_r_binding(hoeffding_trees hoeffding_tree "include")
-add_r_binding(hoeffding_trees hoeffding_tree_train "skip")
-add_r_binding(hoeffding_trees hoeffding_tree_classify "skip")
-add_r_binding(hoeffding_trees hoeffding_tree_probabilities "skip")
-add_markdown_docs(hoeffding_trees hoeffding_tree "cli;python;julia;go;r" "python;r")
-
-#add_all_bindings(naive_bayes nbc "Classification")
+#
 add_category(nbc "Classification")
 group_bindings(naive_bayes nbc "train;classify;probabilities")
 add_python_wrapper(naive_bayes nbc)
@@ -194,7 +158,45 @@ add_r_binding(naive_bayes nbc_train "skip")
 add_r_binding(naive_bayes nbc_classify "skip")
 add_r_binding(naive_bayes nbc_probabilities "skip")
 add_markdown_docs(naive_bayes nbc "cli;python;julia;go;r" "python;r")
-
+#
+add_all_bindings(nca nca "Transformations")
+add_all_bindings(neighbor_search knn "Geometry")
+add_all_bindings(neighbor_search kfn "Geometry")
+add_all_bindings(nmf nmf "Misc. / Other")
+add_all_bindings(pca pca "Transformations")
+#
+add_category(perceptron "Classification")
+group_bindings(perceptron perceptron "train;classify")
+add_python_wrapper(perceptron perceptron)
+add_julia_class(perceptron perceptron)
+add_cli_executable(perceptron perceptron)
+add_go_binding(perceptron perceptron)
+add_r_binding(perceptron perceptron "include")
+add_r_binding(perceptron perceptron_train "skip")
+add_r_binding(perceptron perceptron_classify "skip")
+add_markdown_docs(perceptron perceptron "cli;python;julia;go;r" "python;r")
+#
+add_all_bindings(preprocess preprocess_split "Preprocessing")
+add_all_bindings(preprocess preprocess_binarize "Preprocessing")
+add_all_bindings(preprocess preprocess_describe "Preprocessing")
+add_all_bindings(preprocess preprocess_scale "Preprocessing")
+add_all_bindings(preprocess preprocess_one_hot_encoding "Preprocessing")
+add_all_bindings(radical radical "Transformations")
+#
+add_category(random_forest "Classification")
+group_bindings(random_forest random_forest "train;classify;probabilities")
+add_python_wrapper(random_forest random_forest)
+add_julia_class(random_forest random_forest)
+add_cli_executable(random_forest random_forest)
+add_go_binding(random_forest random_forest)
+add_r_binding(random_forest random_forest "include")
+add_r_binding(random_forest random_forest_train "skip")
+add_r_binding(random_forest random_forest_classify "skip")
+add_r_binding(random_forest random_forest_probabilities "skip")
+add_markdown_docs(random_forest random_forest "cli;python;julia;go;r" "python;r")
+#
+add_all_bindings(rann krann "Geometry")
+#
 #add_all_bindings(softmax_regression softmax_regression "Classification")
 add_category(softmax_regression "Classification")
 group_bindings(softmax_regression softmax_regression "train;classify;probabilities")
@@ -207,22 +209,10 @@ add_r_binding(softmax_regression softmax_regression_train "skip")
 add_r_binding(softmax_regression softmax_regression_classify "skip")
 add_r_binding(softmax_regression softmax_regression_probabilities "skip")
 add_markdown_docs(softmax_regression softmax_regression "cli;python;julia;go;r" "python;r")
+#
+add_all_bindings(sparse_coding sparse_coding "Transformations")
 
-
-
-# Linear Regression has a Python wrapper class that encapsulates its
-# functionality in a few methods.
-add_category(linear_regression "Regression")
-group_bindings(linear_regression linear_regression "train;predict")
-add_python_wrapper(linear_regression linear_regression)
-add_julia_class(linear_regression linear_regression)
-add_cli_executable(linear_regression linear_regression)
-add_go_binding(linear_regression linear_regression)
-add_r_binding(linear_regression linear_regression "include")
-add_r_binding(linear_regression linear_regression_train "skip")
-add_r_binding(linear_regression linear_regression_predict "skip")
-add_markdown_docs(linear_regression linear_regression "cli;python;julia;go;r"
-    "python;r")
+# Now, define the "special" bindings that are different somehow.
 
 # The imputer is only defined for CLI bindings right now.
 add_category(preprocess_imputer "Preprocessing")


### PR DESCRIPTION
This PR reorders the (generated) markdown documentation to be in alphabetical order.