### PR TITLE
Correct lars predict binding parameter for tranpose use

### DIFF
--- a/src/mlpack/methods/lars/lars_predict_main.cpp
+++ b/src/mlpack/methods/lars/lars_predict_main.cpp
@@ -48,8 +48,8 @@ BINDING_SEE_ALSO("Least angle regression (pdf)",
 BINDING_SEE_ALSO("LARS C++ class documentation", "@doc/user/methods/lars.md");
 
 PARAM_MODEL_IN_REQ(LARS<>, "input_model", "Trained LARS model to use.", "m");
-
-PARAM_MATRIX_IN_REQ("test", "Matrix containing points to regress on (test "
+// Note that lars uses internal transposition hence 'TMATRIX' as input.
+PARAM_TMATRIX_IN_REQ("test", "Matrix containing points to regress on (test "
     "points).", "t");
 
 PARAM_MATRIX_OUT("predictions", "Matrix containing predicted responses.", "o");

--- a/src/mlpack/methods/lars/lars_train_main.cpp
+++ b/src/mlpack/methods/lars/lars_train_main.cpp
@@ -97,6 +97,7 @@ BINDING_SEE_ALSO("Least angle regression (pdf)",
     "https://mlpack.org/papers/lars.pdf");
 BINDING_SEE_ALSO("LARS C++ class documentation", "@doc/user/methods/lars.md");
 
+// Note that lars uses internal transposition hence 'TMATRIX' as input.
 PARAM_TMATRIX_IN_REQ("input", "Matrix of covariates (X).", "i");
 PARAM_ROW_IN_REQ("responses", "Row vector of responses/observations (y).", "r");
 


### PR DESCRIPTION
The 'lars' methods differs in using a matrix transposition internally so the `predict` binding needs to reflect this (as the `train` binding already did).

Net change of the PR is adding one character, along with two comments stating why.

