### PR TITLE
Fix cross-compilation table rendering

### DIFF
--- a/doc/embedded/supported_boards.md
+++ b/doc/embedded/supported_boards.md
@@ -84,6 +84,7 @@ cmake \
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ULTRASPARC | [Bootlin toolchain link](https://toolchains.bootlin.com/releases_sparc64.html)   | [Sysroot and toolchain prefix](#ultrasparc) |[UltraSPARC on Wikipedia](https://en.wikipedia.org/wiki/UltraSPARC)        |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
 If you didn't see your architecture in the table above, use the closest
 architecture with a similar word size, or, adapt the parameters directly in
 `CMake/crosscompile-arch-config.cmake` and feel free to open a pull request so we can get


### PR DESCRIPTION
I noticed that the cross-compilation table does not render right on [mlpack.org](https://www.mlpack.org/doc/embedded/supported_boards.html):

<img width="1519" height="857" alt="image" src="https://github.com/user-attachments/assets/1177e309-c856-4f7b-80a2-44320848967a" />

It doesn't render right because the paragraph right after the table isn't separated, so kramdown doesn't see it as a table.  With the fix in this PR (literally just a newline), now it renders fine:

<img width="1311" height="572" alt="image" src="https://github.com/user-attachments/assets/34ea065b-caef-4293-adb6-00b867ef1982" />