### PR TITLE
Fix MLPACK_DISABLE_HTTPLIB macro

### DIFF
--- a/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
+++ b/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
@@ -38,6 +38,12 @@
   #define MLPACK_CERR_STREAM Rcpp::Rcerr
 #endif
 
+// If we are on Windows 8 or older, simply disable httplib since it will fail to
+// compile on CRAN.
+#if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0A00
+  #define MLPACK_DISABLE_HTTPLIB
+#endif
+
 @R_SRC@
 
 // Include the core library

--- a/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
+++ b/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
@@ -41,6 +41,7 @@
 // If we are on Windows 8 or older, simply disable httplib since it will fail to
 // compile on CRAN.
 #if defined(_WIN32) && defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0A00
+  #undef  MLPACK_DISABLE_HTTPLIB
   #define MLPACK_DISABLE_HTTPLIB
 #endif
 

--- a/src/mlpack/config.hpp
+++ b/src/mlpack/config.hpp
@@ -126,4 +126,9 @@
   #undef MLPACK_HAS_BFD_DL
 #endif
 
+#ifdef MLPACK_DISABLE_HTTPLIB
+  #undef MLPACK_ENABLE_HTTPLIB
+  #undef MLPACK_USE_SYSTEM_HTTPLIB
+#endif
+
 #endif

--- a/src/mlpack/core/httplib/httplib.hpp
+++ b/src/mlpack/core/httplib/httplib.hpp
@@ -31,10 +31,8 @@
 #else
 
 #ifdef MLPACK_ENABLE_HTTPLIB
-  #ifndef MLPACK_DISABLE_HTTPLIB
-    // Now include httplib headers
-    #include "bundled/httplib.h"
-  #endif
+  // Now include httplib headers
+  #include "bundled/httplib.h"
 #endif
 
 #endif


### PR DESCRIPTION
I noticed while uploading mlpack 4.8.0 to CRAN that there are a bunch of warnings in httplib on Windows... so, I added `#define MLPACK_DISABLE_HTTPLIB` but noticed that actually did not work.

When I dug into it a little bit, I realized that all we needed to do was ensure (like the other macros) that if `MLPACK_DISABLE_HTTPLIB` was defined, that it overrode `MLPACK_ENABLE_HTTPLIB` and any other httplib-related macros.