### PR TITLE
[R] Ensure inline.R is installed (closes #4210)

### DIFF
--- a/src/mlpack/bindings/R/CMakeLists.txt
+++ b/src/mlpack/bindings/R/CMakeLists.txt
@@ -199,6 +199,7 @@ if (BUILD_R_BINDINGS)
     "${CMAKE_CURRENT_SOURCE_DIR}/mlpack/R/matrix_utils.R"
     "${CMAKE_CURRENT_SOURCE_DIR}/mlpack/R/package.R"
     "${CMAKE_CURRENT_SOURCE_DIR}/mlpack/R/generics.R"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mlpack/R/inline.R"
   )
 
   set(BINDINGS_SOURCES


### PR DESCRIPTION
This one-line PR addresses the issue identified in #4210.  Once merged we can use

```c++
#include <mlpack.h>   // note that this includes mlpack.h with added defines, not mlpack.hpp

// [[Rcpp::depends(mlpack)]]

// [[Rcpp::export]]
std::string foo() {
  std::string s = mlpack::util::GetVersion();
  return s;
}

/*** R
foo()
*/
```

via a quick call from R:

```r
> Rcpp::sourceCpp("/tmp/r/quick_mlpack_check.cpp")

> foo()
[1] "mlpack 4.8.1"
> 
```