### PR TITLE
[R] Create JUnit XML file in 'R CMD check' step (Closes #4205)

### DIFF
--- a/.github/actions/binding_run_tests/action.yml
+++ b/.github/actions/binding_run_tests/action.yml
@@ -63,16 +63,11 @@ runs:
       # and therein the standard directory 'mlpack.Rcheck/tests/'
       # TODO: revert to error_on = 'warning'
       run: |
+          ROOTDIR=`pwd`
           Rscript -e "rcmdcheck::rcmdcheck('build/src/mlpack/bindings/R/${{ env.MLPACK_R_PACKAGE }}', \
                          args = c('--no-manual', '--as-cran'), \
                          error_on = 'error', \
                          check_dir = 'check')"
-          pwd
-          ls -ld check
-          ls -ld check/mlpack.Rcheck
-          ls -ld check/mlpack.Rcheck/tests
-          ls -l check/mlpack.Rcheck/tests/
-          ls -ld $ROOTDIR/build/
           mv check/mlpack.Rcheck/tests/r_bindings.junit.xml $ROOTDIR/build/r_bindings.junit.xml
 
     # TODO: upload check results on failure

--- a/.github/actions/binding_run_tests/action.yml
+++ b/.github/actions/binding_run_tests/action.yml
@@ -41,16 +41,6 @@ runs:
     #
     # R bindings.
     #
-    - name: "Run R binding tests"
-      if: inputs.lang == 'R'
-      shell: bash
-      run: |
-          ROOTDIR=`pwd`;
-          cd build/src/mlpack/bindings/R/mlpack/
-          R CMD INSTALL .
-          Rscript -e 'res <- tinytest::run_test_dir("inst/tinytest"); tinytest2JUnit::writeJUnit(res, "r_bindings.junit.xml")'
-          mv r_bindings.junit.xml $ROOTDIR/build/r_bindings.junit.xml
-
     - name: "Upload R package artifact"
       if: inputs.lang == 'R' && runner.os == 'Linux' # Only upload one tarball.
       uses: actions/upload-artifact@v4.4.0
@@ -68,8 +58,16 @@ runs:
     - name: "Run R CMD check"
       if: inputs.lang == 'R'
       shell: bash
+      # This moves the JUnit-style XML file for later consumption in another task. The
+      # file will be create in a subdirectory of 'check' (an argument to `rcmdcheck()),
+      # and therein the standard directory 'mlpack.Rcheck/tests/'
       # TODO: revert to error_on = 'warning'
-      run: Rscript -e "rcmdcheck::rcmdcheck('build/src/mlpack/bindings/R/${{ env.MLPACK_R_PACKAGE }}', args = c('--no-manual', '--as-cran'), error_on = 'error', check_dir = 'check')"
+      run: |
+          Rscript -e "rcmdcheck::rcmdcheck('build/src/mlpack/bindings/R/${{env.MLPACK_R_PACKAGE }}', \
+                         args = c('--no-manual', '--as-cran'), \
+                         error_on = 'error', \
+                         check_dir = 'check')"
+          mv check/mlpack.Rcheck/tests/r_bindings.junit.xml $ROOTDIR/build/r_bindings.junit.xml
 
     # TODO: upload check results on failure
 

--- a/.github/actions/binding_run_tests/action.yml
+++ b/.github/actions/binding_run_tests/action.yml
@@ -61,14 +61,13 @@ runs:
       # This moves the JUnit-style XML file for later consumption in another task. The
       # file will be create in a subdirectory of 'check' (an argument to `rcmdcheck()),
       # and therein the standard directory 'mlpack.Rcheck/tests/'
-      # TODO: revert to error_on = 'warning'
+      # TODO: revert to error_on = 'warning' (but our dev versions often have warnings)
       run: |
-          ROOTDIR=`pwd`
           Rscript -e "rcmdcheck::rcmdcheck('build/src/mlpack/bindings/R/${{ env.MLPACK_R_PACKAGE }}', \
                          args = c('--no-manual', '--as-cran'), \
                          error_on = 'error', \
                          check_dir = 'check')"
-          mv check/mlpack.Rcheck/tests/r_bindings.junit.xml $ROOTDIR/build/r_bindings.junit.xml
+          mv check/mlpack.Rcheck/tests/r_bindings.junit.xml build/r_bindings.junit.xml
 
     # TODO: upload check results on failure
 

--- a/.github/actions/binding_run_tests/action.yml
+++ b/.github/actions/binding_run_tests/action.yml
@@ -63,10 +63,16 @@ runs:
       # and therein the standard directory 'mlpack.Rcheck/tests/'
       # TODO: revert to error_on = 'warning'
       run: |
-          Rscript -e "rcmdcheck::rcmdcheck('build/src/mlpack/bindings/R/${{env.MLPACK_R_PACKAGE }}', \
+          Rscript -e "rcmdcheck::rcmdcheck('build/src/mlpack/bindings/R/${{ env.MLPACK_R_PACKAGE }}', \
                          args = c('--no-manual', '--as-cran'), \
                          error_on = 'error', \
                          check_dir = 'check')"
+          pwd
+          ls -ld check
+          ls -ld check/mlpack.Rcheck
+          ls -ld check/mlpack.Rcheck/tests
+          ls -l check/mlpack.Rcheck/tests/
+          ls -ld $ROOTDIR/build/
           mv check/mlpack.Rcheck/tests/r_bindings.junit.xml $ROOTDIR/build/r_bindings.junit.xml
 
     # TODO: upload check results on failure

--- a/.github/actions/binding_setup/action.yml
+++ b/.github/actions/binding_setup/action.yml
@@ -100,7 +100,7 @@ runs:
       shell: bash
       run: |
           cp src/mlpack/bindings/R/mlpack/DESCRIPTION.in DESCRIPTION
-          Rscript -e 'install.packages(c("remotes", "roxygen2", "tinytest2JUnit"))'
+          Rscript -e 'install.packages(c("remotes", "roxygen2"))'
           Rscript -e 'remotes::install_deps(".", dependencies=TRUE)'
 
     - name: Install cereal manually for R

--- a/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
+++ b/src/mlpack/bindings/R/mlpack/DESCRIPTION.in
@@ -13,7 +13,7 @@ Imports: Rcpp (>= 0.12.12)
 LinkingTo: Rcpp,
            RcppArmadillo (>= @RcppArmadillo_Version@),
            RcppEnsmallen (>= @RcppEnsmallen_Version@)
-Suggests: tinytest
+Suggests: tinytest, tinytest2JUnit
 URL: https://www.mlpack.org/doc/user/bindings/r.html,
      https://github.com/mlpack/mlpack
 BugReports: https://github.com/mlpack/mlpack/issues

--- a/src/mlpack/bindings/R/mlpack/tests/tinytest.R
+++ b/src/mlpack/bindings/R/mlpack/tests/tinytest.R
@@ -1,3 +1,11 @@
-if (requireNamespace("tinytest", quietly=TRUE)) {
+if (requireNamespace("tinytest2JUnit", quietly=TRUE)
+    && requireNamespace("tinytest", quietly=TRUE)) {
+    ## When mlpack runs in CI, it picks up ${LANGUAGE}_bindings.junit.xml files so we
+    ## make sure we create one for it; in all other settings the file is ignored (but
+    ## also cheap to produce, and tinytest2Junit is lightweight and low dependency).
+    ## This also runs and escalates tests as usual via the invocation of tinytest.
+    tinytest2JUnit::writeJUnit(tinytest::test_package("mlpack"), "r_bindings.junit.xml")
+} else if (requireNamespace("tinytest", quietly=TRUE)) {
+    ## Run only tinytest as usual
     tinytest::test_package("mlpack")
 }


### PR DESCRIPTION
This PR addresses the in #4205 by having the JUnit XML file created when the `tinytest` tests are being run, and moving the file for subsequent use as before.  Net-net this save one step in the CI.
