### PR TITLE
Only run 'stale.yml' on mlpack/mlpack (closes #4216)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: ${{ github.repository == 'mlpack/mlpack' }}
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
This one-line PR adds the check for `mlpack/mlpack` that all the other top-level yaml files have over to `stale.yml`.