### PR TITLE
Tune PendulumWithTD3 test

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/environment/acrobot.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/acrobot.hpp
@@ -225,8 +225,8 @@ class Acrobot
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;;
       return true;
     }
     else if (-std::cos(state.Theta1()) - std::cos(state.Theta1() +

--- a/src/mlpack/methods/reinforcement_learning/environment/cart_pole.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/cart_pole.hpp
@@ -219,14 +219,14 @@ class CartPole
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;
       return true;
     }
     else if (std::abs(state.Position()) > xThreshold ||
         std::abs(state.Angle()) > thetaThresholdRadians)
     {
-      Log::Info << "Episode terminated due to agent failing.";
+      Log::Info << "Episode terminated due to agent failing." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/cont_double_pole_cart.hpp
@@ -296,19 +296,20 @@ class ContinuousDoublePoleCart
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;
       return true;
     }
     if (std::abs(state.Position()) > xThreshold)
     {
-      Log::Info << "Episode terminated due to cart crossing threshold";
+      Log::Info << "Episode terminated due to cart crossing threshold."
+          << std::endl;
       return true;
     }
     if (std::abs(state.Angle(1)) > thetaThresholdRadians ||
         std::abs(state.Angle(2)) > thetaThresholdRadians)
     {
-      Log::Info << "Episode terminated due to pole falling";
+      Log::Info << "Episode terminated due to pole falling." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/methods/reinforcement_learning/environment/continuous_mountain_car.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/continuous_mountain_car.hpp
@@ -199,13 +199,13 @@ class ContinuousMountainCar
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;
       return true;
     }
     else if (state.Position() >= positionGoal)
     {
-      Log::Info << "Episode terminated due to agent succeeding.";
+      Log::Info << "Episode terminated due to agent succeeding." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/methods/reinforcement_learning/environment/double_pole_cart.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/double_pole_cart.hpp
@@ -301,19 +301,20 @@ class DoublePoleCart
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;
       return true;
     }
     if (std::abs(state.Position()) > xThreshold)
     {
-      Log::Info << "Episode terminated due to cart crossing threshold";
+      Log::Info << "Episode terminated due to cart crossing threshold."
+          << std::endl;
       return true;
     }
     if (std::abs(state.Angle(1)) > thetaThresholdRadians ||
         std::abs(state.Angle(2)) > thetaThresholdRadians)
     {
-      Log::Info << "Episode terminated due to pole falling";
+      Log::Info << "Episode terminated due to pole falling." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/methods/reinforcement_learning/environment/ftn.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/ftn.hpp
@@ -181,13 +181,13 @@ class FruitTreeNavigation
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          " being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          " being taken." << std::endl;
       return true;
     }
     else if (state.Row() == fruitTree.Depth())
     {
-      Log::Info << "Episode terminated due to reaching leaf node.";
+      Log::Info << "Episode terminated due to reaching leaf node." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/methods/reinforcement_learning/environment/mountain_car.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/mountain_car.hpp
@@ -201,13 +201,13 @@ class MountainCar
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;
       return true;
     }
     else if (state.Position() >= positionGoal)
     {
-      Log::Info << "Episode terminated due to agent succeeding.";
+      Log::Info << "Episode terminated due to agent succeeding." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
+++ b/src/mlpack/methods/reinforcement_learning/environment/pendulum.hpp
@@ -227,8 +227,8 @@ class Pendulum
   {
     if (maxSteps != 0 && stepsPerformed >= maxSteps)
     {
-      Log::Info << "Episode terminated due to the maximum number of steps"
-          "being taken.";
+      Log::Info << "Episode terminated due to the maximum number of steps "
+          "being taken." << std::endl;
       return true;
     }
     return false;

--- a/src/mlpack/tests/policy_gradient_test.cpp
+++ b/src/mlpack/tests/policy_gradient_test.cpp
@@ -226,7 +226,7 @@ TEST_CASE("GaussianNoiseTest", "[PolicyGradientTest]")
   REQUIRE(stdDevErr <= 1e-4);
 }
 
-//! Test TD3 on Pendulum task.
+// Test TD3 on Pendulum task.
 TEST_CASE("PendulumWithTD3", "[PolicyGradientTest][long]")
 {
   // It isn't guaranteed that the network will converge in the specified number
@@ -239,22 +239,22 @@ TEST_CASE("PendulumWithTD3", "[PolicyGradientTest][long]")
     RandomReplay<Pendulum> replayMethod(32, 10000);
 
     TrainingConfig config;
-    config.StepSize() = 0.001;
+    config.StepSize() = 0.0012;
     config.TargetNetworkSyncInterval() = 2;
     config.UpdateInterval() = 3;
 
     // Set up Actor network.
     FFN<EmptyLoss, GaussianInitialization>
-        policyNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
-    policyNetwork.Add<Linear>(128);
+        policyNetwork(EmptyLoss(), GaussianInitialization(0, 0.02));
+    policyNetwork.Add<Linear>(64);
     policyNetwork.Add<ReLU>();
     policyNetwork.Add<Linear>(1);
     policyNetwork.Add<TanH>();
 
     // Set up Critic network.
     FFN<EmptyLoss, GaussianInitialization>
-        qNetwork(EmptyLoss(), GaussianInitialization(0, 0.1));
-    qNetwork.Add<Linear>(128);
+        qNetwork(EmptyLoss(), GaussianInitialization(0, 0.02));
+    qNetwork.Add<Linear>(64);
     qNetwork.Add<ReLU>();
     qNetwork.Add<Linear>(1);
 

--- a/src/mlpack/tests/test_reinforcement_learning_agent.hpp
+++ b/src/mlpack/tests/test_reinforcement_learning_agent.hpp
@@ -48,7 +48,7 @@ bool testAgent(AgentType& agent,
 
     Log::Debug << "Average return in last " << returnList.size()
         << " consecutive episodes: " << averageReturn
-        << " Episode return: " << episodeReturn << std::endl;
+        << ".  Episode return: " << episodeReturn << std::endl;
 
     // For the speed of the test case, a high criterion should not be set
     // for the rewardThreshold.


### PR DESCRIPTION
I noticed this test failing on the Windows CI runner and have seen it fail elsewhere before, so I ran it locally with lots of different random seeds and found a failure about every 300 trials.

So, I tuned the step size and made the networks a little smaller (which leads to easier convergence in this case, it seems).  Then I was able to run the test 3000 times without observing any failures.

I also cleaned up a bunch of the Log::Info output that was missing newlines from inside the reinforcement learning code.