### PR TITLE
[R] Adjust doc generation for two corner cases (Closes #4220)

### DIFF
--- a/doc/user/bindings/r.md
+++ b/doc/user/bindings/r.md
@@ -72,8 +72,8 @@ y_test <- pp[["test_labels"]]
 
 model <- adaboost_train(training=X_train, labels=y_train)
 
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods
@@ -274,7 +274,7 @@ y_test <- y[as.integer(pp[["test_labels"]]), 1]
 model <- bayesian_linear_regression_train(input=X_train, responses=y_train,
   center=1, scale=0)
   
-pred <- predict(model, newdata=X_test) 
+pred <- predict(model, newdata=X_test)
 ```
 
 ### Methods
@@ -548,8 +548,8 @@ y_test <- pp[["test_labels"]]
 model <- decision_tree_train(training=X_train, labels=y_train,
   minimum_leaf_size=20, minimum_gain_split=0.001)
   
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods
@@ -1280,8 +1280,8 @@ y_test <- pp[["test_labels"]]
 
 model <- hoeffding_tree_train(training=X_train, labels=y_train)
 
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods
@@ -1745,7 +1745,7 @@ y_test <- y[as.integer(pp[["test_labels"]]), 1]
 model <- lars_train(input=X_train, responses=y_train, lambda1=1e-05,
   lambda2=1e-06)
   
-pred <- predict(model, newdata=X_test) 
+pred <- predict(model, newdata=X_test)
 ```
 
 ### Methods
@@ -1823,7 +1823,7 @@ y_test <- y[as.integer(pp[["test_labels"]]), 1]
 
 model <- linear_regression_train(training=X_train, training_responses=y_train)
   
-pred <- predict(model, newdata=X_test) 
+pred <- predict(model, newdata=X_test)
 ```
 
 ### Methods
@@ -1917,8 +1917,8 @@ y_test <- pp[["test_labels"]]
 model <- linear_svm_train(training=X_train, labels=y_train, lambda=0.1,
   delta=1, num_classes=0)
   
-pred <- predict(model, newdata=X_test) 
-) 
+pred <- predict(model, newdata=X_test)
+pred <- predict(model, newdata=X_test)
 ```
 
 ### Methods
@@ -2222,8 +2222,8 @@ y_test <- pp[["test_labels"]]
 model <- logistic_regression_train(training=X_train, labels=y_train,
   lambda=0.1)
   
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods
@@ -2464,8 +2464,8 @@ y_test <- pp[["test_labels"]]
 
 model <- nbc_train(training=X_train, labels=y_train)
 
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods
@@ -2924,7 +2924,7 @@ y_test <- pp[["test_labels"]]
 model <- perceptron_train(training=X_train, labels=y_train,
   max_iterations=100)
   
-pred <- predict(model, newdata=X_test) 
+pred <- predict(model, newdata=X_test)
 ```
 
 ### Methods
@@ -3432,8 +3432,8 @@ y_test <- pp[["test_labels"]]
 model <- random_forest_train(training=X_train, labels=y_train,
   minimum_leaf_size=20, num_trees=10, print_training_accuracy=TRUE)
   
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods
@@ -3615,8 +3615,8 @@ y_test <- pp[["test_labels"]]
 model <- softmax_regression_train(training=X_train, labels=y_train,
   lambda=0.1)
   
-pred <- predict(model, newdata=X_test) 
-prob <- predict(model, newdata=X_test, type="probabilities") 
+pred <- predict(model, newdata=X_test)
+prob <- predict(model, newdata=X_test, type="probabilities")
 ```
 
 ### Methods

--- a/src/mlpack/bindings/R/print_R.cpp
+++ b/src/mlpack/bindings/R/print_R.cpp
@@ -111,7 +111,8 @@ void PrintR(util::Params& params,
   const bool isMainMethodCall =
     (functionName.find("_predict") == std::string::npos &&
      functionName.find("_classify") == std::string::npos &&
-     functionName.find("_probabilities") == std::string::npos);
+     functionName.find("_probabilities") == std::string::npos &&
+     functionName.find("_scores") == std::string::npos);
   // Next print the long description as @details. But only if
   // we are not a '_predict' or '_classify' or '_probabilities' function
   if (isMainMethodCall)

--- a/src/mlpack/bindings/R/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/R/print_doc_functions_impl.hpp
@@ -630,15 +630,13 @@ std::string CallMethod(const std::string& bindingName,
   util::Params params = IO::Parameters(bindingName);
   std::map<std::string, util::ParamData> parameters = params.Parameters();
   std::string callMethod = "";
-  bool nonFitMethod = methodName == "classify" || methodName == "predict" ||
-    methodName == "probabilities" || methodName == "scores";
 
   if (methodName == "train")
   {
     // If we are a 'train' method a possible \dontrun{} occurred earlier
     callMethod += objectName + " <- " + bindingName + "(";
   }
-  else if (nonFitMethod)
+  else
   {
     // Other methods consider 'dontrun', adjust method and binding name use.
     callMethod += (dontrun ? "\\dontrun{ " : "");
@@ -652,7 +650,7 @@ std::string CallMethod(const std::string& bindingName,
   {
     callMethod += PrintInputOptions(params, args...);
   }
-  else if (nonFitMethod)
+  else
   {
     // We need a special case to turn 'test=X_test' into
     // 'newdata=X_test' to satisfy the R generic
@@ -660,7 +658,9 @@ std::string CallMethod(const std::string& bindingName,
   }
 
   if (methodName == "probabilities")
+  {
     callMethod += ", type=\"probabilities\"";
+  }
   callMethod += ")";
   if (methodName == "train")
   {

--- a/src/mlpack/bindings/R/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/R/print_doc_functions_impl.hpp
@@ -631,7 +631,7 @@ std::string CallMethod(const std::string& bindingName,
   std::map<std::string, util::ParamData> parameters = params.Parameters();
   std::string callMethod = "";
   bool nonFitMethod = methodName == "classify" || methodName == "predict" ||
-    methodName == "probabilities";
+    methodName == "probabilities" || methodName == "scores";
 
   if (methodName == "train")
   {
@@ -662,8 +662,14 @@ std::string CallMethod(const std::string& bindingName,
   if (methodName == "probabilities")
     callMethod += ", type=\"probabilities\"";
   callMethod += ")";
-  callMethod += (methodName == "train" ? "\n" : " ");
-  callMethod += (dontrun ? "}" : "");
+  if (methodName == "train")
+  {
+    callMethod += "\n";
+  }
+  else
+  {
+    callMethod += (dontrun ? " }" : "");
+  }
   return util::HyphenateString(callMethod, 2);
 }
 


### PR DESCRIPTION
This PR addresses the documentation generation issue outlined in #4220 by adjusting placement of a closing curly bracket relative to use of `train`, and recognises `scores` as another valid method.
