### PR TITLE
[R] Turn feature libraries STB, DR_LIB, HTTPLIB off for R build but allow override (Closes #4224)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             runner: ubuntu-latest,
             os: 'Linux',
             name: 'R',
-            cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_R_BINDINGS=ON -DDISABLE_HTTPLIB=ON -DDISABLE_STB=ON -DDISABLE_DR_LIB=ON -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/',
+            cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_R_BINDINGS=ON -DDISABLE_HTTPLIB=OFF -DDISABLE_STB=OFF -DDISABLE_DR_LIB=OFF -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/',
             cores: 4
           },
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             runner: ubuntu-latest,
             os: 'Linux',
             name: 'R',
-            cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_R_BINDINGS=ON -DENABLE_HTTPLIB=ON -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/',
+            cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_R_BINDINGS=ON -DDISABLE_HTTPLIB=ON -DDISABLE_STB=ON -DDISABLE_DR_LIB=ON -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/',
             cores: 4
           },
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             runner: ubuntu-latest,
             os: 'Linux',
             name: 'R',
-            cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_R_BINDINGS=ON -DDISABLE_HTTPLIB=OFF -DDISABLE_STB=OFF -DDISABLE_DR_LIB=OFF -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/',
+            cmakeVars: '-DBUILD_CLI_EXECUTABLES=OFF -DBUILD_R_BINDINGS=ON -DCEREAL_INCLUDE_DIR=../cereal-1.3.2/include/',
             cores: 4
           },
           {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,8 +227,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR DEBUG)
       set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${LIBBFD_LIBRARIES}
           ${LIBDL_LIBRARIES})
       set(BFD_DL_AVAILABLE "YES")
-    else()
-      message(WARNING "No libBFD and/or libDL has been found!")
     endif()
   endif()
 endif()

--- a/src/mlpack/bindings/R/mlpack/R/package.R
+++ b/src/mlpack/bindings/R/mlpack/R/package.R
@@ -4,7 +4,14 @@
 #' aims to provide fast, extensible implementations of cutting-edge machine
 #' learning algorithms. mlpack provides these algorithms as simple command-line
 #' programs, C++ classes and bindings for Python, Julia, Go and R which can
-#' then be integrated into larger-scale machine learning solutions.
+#'
+#' @section Compile-time configuration:
+#' Three different \code{#define} variables can be used to turn on optional
+#' functionality that is off by default. These are \code{MLPACK_R_ENABLE_STB}
+#' and \code{MLPACK_R_ENABLE_DR_LIBS} to enable the \sQuote{STB} and
+#' \sQuote{DR_LIBS} libraries for image and audio processing, respectively, and
+#' \code{MLPACK_DISABLE_HTTPLIB} to enable \sQuote{HTTPLIB} to permit data-loading
+#' from remote URLs (which R has via \code{libcurl}).
 #'
 #' @name mlpack
 #' @aliases mlpack-package

--- a/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
+++ b/src/mlpack/bindings/R/mlpack/inst/include/mlpack.h.in
@@ -45,6 +45,21 @@
   #define MLPACK_DISABLE_HTTPLIB
 #endif
 
+#if !defined(MLPACK_R_ENABLE_STB)
+  #undef  MLPACK_DISABLE_STB
+  #define MLPACK_DISABLE_STB
+#endif
+
+#if !defined(MLPACK_R_ENABLE_DR_LIBS)
+  #undef  MLPACK_DISABLE_DR_LIBS
+  #define MLPACK_DISABLE_DR_LIBS
+#endif
+
+#if !defined(MLPACK_R_ENABLE_HTTPLIB)
+  #undef  MLPACK_DISABLE_HTTPLIB
+  #define MLPACK_DISABLE_HTTPLIB
+#endif
+
 @R_SRC@
 
 // Include the core library

--- a/src/mlpack/bindings/R/mlpack/src/r_util.cpp
+++ b/src/mlpack/bindings/R/mlpack/src/r_util.cpp
@@ -379,7 +379,8 @@ void SetPassed(SEXP params, const std::string& paramName)
   p.SetPassed(paramName);
 }
 
-// Show compile-time capabilities.
+// Show compile-time capabilities. These three libraries are 'opt-in' for
+// the R package build.
 // [[Rcpp::export]]
 Rcpp::LogicalVector capabilities() {
   Rcpp::LogicalVector v(3);     // default is all FALSE as FALSE == 0

--- a/src/mlpack/bindings/R/mlpack/src/r_util.cpp
+++ b/src/mlpack/bindings/R/mlpack/src/r_util.cpp
@@ -378,3 +378,25 @@ void SetPassed(SEXP params, const std::string& paramName)
   util::Params& p = *Rcpp::as<Rcpp::XPtr<util::Params>>(params);
   p.SetPassed(paramName);
 }
+
+// Show compile-time capabilities.
+// [[Rcpp::export]]
+Rcpp::LogicalVector capabilities() {
+  Rcpp::LogicalVector v(3);     // default is all FALSE as FALSE == 0
+
+#if !defined(MLPACK_DISABLE_STB)
+  v[0] = TRUE;
+#endif
+
+#if !defined(MLPACK_DISABLE_DR_LIBS)
+  v[1] = TRUE;
+#endif
+
+#if !defined(MLPACK_DISABLE_HTTPLIB)
+  v[2] = TRUE;
+#endif
+
+  v.names() = Rcpp::CharacterVector::create("STB", "DR_LIBS", "HTTPLIB");
+
+  return v;
+}

--- a/src/mlpack/bindings/R/mlpack/src/rcpp_mlpack.h
+++ b/src/mlpack/bindings/R/mlpack/src/rcpp_mlpack.h
@@ -13,11 +13,6 @@
 #ifndef MLPACK_BINDINGS_R_RCPP_MLPACK_H
 #define MLPACK_BINDINGS_R_RCPP_MLPACK_H
 
-// With RcppArmadillo 15.0.1-1 or later, prefer current Armadillo
-#if !defined(ARMA_USE_CURRENT)
-  #define ARMA_USE_CURRENT
-#endif
-
 // Armadillo does not provide an official support for unsigned / signed 8 bits
 // integers.
 // Since `char` might be represented differently on various hardware.
@@ -41,6 +36,25 @@
 #endif
 #if !defined(MLPACK_CERR_STREAM)
   #define MLPACK_CERR_STREAM Rcpp::Rcerr
+#endif
+
+// The R bindings default to not enabling STB, DR_LIBS or HTTPLIB.
+// This can be overriden via package compilerflags, i.e.
+//   PKG_CPPFLAGS=-DMLPACK_R_ENABLE_DR_LIBS R CMD INSTALL mlpack_*.tar.gz
+// on the command-line, or by editing src/Makevars or ~/.R/Makevars.
+#if !defined(MLPACK_R_ENABLE_STB)
+  #undef  MLPACK_DISABLE_STB
+  #define MLPACK_DISABLE_STB
+#endif
+
+#if !defined(MLPACK_R_ENABLE_DR_LIBS)
+  #undef  MLPACK_DISABLE_DR_LIBS
+  #define MLPACK_DISABLE_DR_LIBS
+#endif
+
+#if !defined(MLPACK_R_ENABLE_HTTPLIB)
+  #undef  MLPACK_DISABLE_HTTPLIB
+  #define MLPACK_DISABLE_HTTPLIB
 #endif
 
 #endif


### PR DESCRIPTION
This PR addresses #4224 and changes the R package build to skip STB, DR_LIB and HTTPLIB by default, unless an override variable (given for example via the per-package compiler flags) is set.  At present it also contains a simple helper debug/status function:

```sh
$ Rscript -e 'mlpack:::capabilities()'
    STB DR_LIBS HTTPLIB 
  FALSE   FALSE   FALSE 
$ 
```

This can be altered at package compilation:

```sh
$ PKG_CPPFLAGS=-DMLPACK_R_ENABLE_HTTPLIB R CMD INSTALL mlpack_4.8.1.tar.gz
[...]
$ Rscript -e 'mlpack:::capabilities()'
    STB DR_LIBS HTTPLIB 
  FALSE   FALSE    TRUE 
$ 
```

The PR should (at present) taken as a starting point for discussion and refinement.  We could flip one or more of the defaults (e.g. for HTTPLIB, maybe?) and decide to keep, or purge, the `capabilities()` helper.  Or keep it and add other compile-time state variables that may matter?  

