### PR TITLE
doc: move wiki developer section to doc/developer/ 

### DIFF
--- a/doc/developer/cmake.md
+++ b/doc/developer/cmake.md
@@ -1,0 +1,224 @@
+**Note: this wiki page is out of date, and probably isn't very useful for reference anymore.  It was written in 2010, and many things have changed since then.  So maybe it might be useful for you to read, but keep in mind that there are differences between what is written here and what is actually implemented in the CMake configuration now.  It may be more useful to refer to the current source code.**
+
+Using CMake with **mlpack**
+===========================
+
+In early 2010, the build system has changed from the homebuilt `fl-build` system to [CMake](http://cmake.org/).
+
+CMake is basically the equivalent to GNU Autotools.  With Autotools, you would type
+
+```
+$ ./configure
+$ make
+# make install
+```
+
+but with CMake it'll be just a little more complex, looking more like
+
+```
+$ mkdir build; cd build
+$ cmake ../
+$ make
+# make install
+```
+
+At this time, our CMake setup has only been extensively tested when producing GNU Makefiles.  In the future it needs to be tested with more systems, like Visual Studio and so on.
+
+In-Source / Out-Of-Source Builds
+--------------------------------
+
+I will reference this concept several times during this document, so if the words 'out-of-source build' are foreign to you, it may be helpful to read this section.
+
+Traditionally, most projects have used the "in-source build" model.  That is, all the compilation and building is done right from the source directory you extracted.  But this has a big drawback: this puts `.o`s, `.a`s, and executables all over that source tree you extracted, and you have to reconfigure it each time you want to build.
+
+If instead you make an entirely separate directory to build your project in, then you can keep all the build artifacts completely separate from the source code.  In addition, you can have multiple build directories, each with a different configuration.  For example, I personally keep `build_debug` and `build_nodebug` directories for convenience.
+
+All of the code samples I give will be for the example of an out-of-source build.
+
+Just Build It!
+--------------
+
+To build **mlpack** using the default options, first make your build directory:
+
+```
+$ mkdir build
+$ cd build
+```
+
+Now, configure CMake.  The option we pass to CMake (`../`) is to tell it where the root of the source tree is (that is, where `mlpack/trunk/` is).
+
+```
+$ cmake ../
+```
+
+Finally, we can build **mlpack**.
+
+```
+$ make
+```
+
+Configuring **mlpack**
+----------------------
+
+So, after checking out the source, the first thing to do before building **mlpack** is to pick the configuration options you want.  This is the analog of `./configure` for those of you who have used autotools.  Here are the current options you can pass to the **mlpack** configuration:
+
+* **`CMAKE_INSTALL_PREFIX`** - where the build artifacts will be installed if you type `make install`; default `/usr/local`
+* **`DEBUG`** - compile with debugging symbols and no optimization (GCC `-g`); **default ON** (for non-releases)
+* **`PROFILE`** - compile with profiling symbols (GCC `-pg`); **default ON** (for non-releases)
+
+Also, the following options can be used to explicitly tell CMake where to find necessary libraries.  If you don't specify these options, CMake will search in default locations to try and find them.
+
+* **`ARMADILLO_INCLUDE_DIR`** - directory where Armadillo headers are located (directory with `armadillo`)
+* **`ARMADILLO_LIBRARY`** - path to libarmadillo.so
+* **`PTHREADS_INCLUDE_DIR`** - include path of the Pthreads library
+* **`PTHREADS_LIBRARY`** - location of the Pthreads library
+* **`LAPACK_LIBRARIES`** - uncached list of libraries (using full path name) to link against to use LAPACK
+* **`BLAS_LIBRARIES`** - uncached list of libraries (using full path name) to link against to use BLAS
+* **`LIBXML2_INCLUDE_DIR`** - The LibXml2 include directory
+* **`LIBXML2_LIBRARIES`** - The location of the LibXml2 library
+
+These are not all the possible options; consult the [official CMake Documentation](http://cmake.org/cmake/help/documentation.html).
+
+To specify an option, pass `-D <option>=<value>` to CMake.  For example, to compile without debugging or profiling symbols and specify that Armadillo is installed in `/home/ryan/armadillo/`, write
+
+```
+$ mkdir build
+$ cd build
+$ cmake -D DEBUG=OFF -D PROFILE=OFF -D ARMADILLO_INCLUDE_DIR=/home/ryan/armadillo/include/ -D ARMADILLO_LIBRARY=/home/ryan/armadillo/lib/libarmadillo.so ../
+```
+
+Here is another example, where we only change one option.
+
+```
+$ cd build
+$ cmake -D CMAKE_INSTALL_PREFIX=/home/ryan/mlpack ../
+```
+
+So there, we have just changed the install prefix from the default of `/usr/local` to `/home/ryan/mlpack`.  This is useful for when you want to install **mlpack** locally (if you don't have root access on the system you are using).
+
+You can also use an interactive CMake configuration tool, like `ccmake` (ncurses GUI).  I am sure there are more tools but I personally find the CMake command line interface sufficient and efficient.
+
+It should also be noted that you can reconfigure a project at any time using the steps I just mentioned.  You can also have several existing configurations in different out-of-source build directories.  For instance, these commands would set up two build directories, one that would build without debugging or profiling symbols, and one with:
+
+```
+$ mkdir build_nodebug
+$ cd build_nodebug
+$ cmake -D DEBUG=OFF -D PROFILE=OFF ../
+...
+$ cd ..
+$ mkdir build_sparse
+$ cd build_sparse
+$ cmake ../
+...
+```
+
+Building **mlpack** (using GNU Makefiles)
+-----------------------------------------
+
+So far our tutorial here has assumed that you are using GNU Makefiles.  As noted earlier, more information will need to be added to explain how to do this with Visual Studio and other IDEs.
+
+Once your build directory has been configured with CMake (and assuming you are in that directory), all you have to do is type `make` to build everything.  Or, you could type `make <target>` to make a specific target.  All the dependencies of the target you make will be built, and remember, at any time you can reconfigure and rebuild without needing to erase your build directory or anything like that.
+
+Here are a couple examples of useful targets you might use:
+
+```
+$ make mlpack           # mlpack library (libmlpack.so)
+$ make allknn           # the allknn executable from mlpack
+$ make                  # mlpack library and all executables
+```
+
+You will also see that the directory hierarchy from the source tree is copied into the build tree.  If you just type `make` in the root build directory it will build everything, but it may take a while.
+
+Hacking on **mlpack** with CMake
+--------------------------------
+
+So now, say that you are working on your amazing new machine learning method, but it doesn't compile right because you forgot to give one of your variables a type for some reason (e.g. [5466]).  So you make your change to the code in the source tree.  But you don't have to change the build tree or reconfigure the project or anything like that.  Just type `make <target>` or whatever you had been doing in the build tree and CMake will detect the changes, rebuild anything that needs to be rebuilt, and hopefully it will compile just fine.
+
+Writing a CMakeLists.txt File
+-----------------------------
+
+You will notice that each directory has a `CMakeLists.txt` file; this is like a `build.py` file but for CMake, not for `fl-build`.  The easiest way to make one of these is probably to copy it from a nearby directory and then modify as necessary.  Here I will discuss the syntax for this file (and how it is actually very similar to `build.py`).  Below is the `CMakeLists.txt` file (as of [9802]) from `src/mlpack/methods/nca/`:
+
+```
+cmake_minimum_required(VERSION 2.8)
+
+# Define the files we need to compile.
+# Anything not in this list will not be compiled into mlpack.
+set(SOURCES
+  nca.h
+  nca_impl.h
+  nca_softmax_error_function.h
+  nca_softmax_error_function_impl.h
+)
+
+# Add directory name to sources.
+set(DIR_SRCS)
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+# Append sources (with directory name) to list of all MLPACK sources (used at
+# the parent scope).
+set(MLPACK_SRCS ${MLPACK_SRCS} ${DIR_SRCS} PARENT_SCOPE)
+
+add_executable(nca
+  nca_main.cc
+)
+target_link_libraries(nca
+  mlpack
+)
+
+add_executable(nca_test
+  nca_test.cc
+)
+target_link_libraries(nca_test
+  mlpack
+  boost_unit_test_framework
+)
+```
+
+The first thing we do is set the `SOURCES` variable to include all of the files that will be compiled into the library (**mlpack**).  This is a very important thing to do and is one of the two things you must do.  Like the comment says, don't include the main executable or the test here (or anything that defines ```int main()```) -- that will cause things to fail.
+
+The next stanza of lines is a bit of an ugly hack to add all of the files from `SOURCES` to a global variable called `MLPACK_SRCS` which is the full list of all **mlpack** sources.  This is used by the CMakeLists.txt at the top-level directory of the library in question.  This stanza will be the same in just about every project directory, so don't worry too much about it.
+
+The other thing you have to do is define the executables produced in that directory, in the following format:
+
+```
+add_executable(<executable_name>
+  executable_source_1.cc
+  executable_source_2.cc
+  ...
+)
+target_link_libraries(<executable_name>
+  dependency_1
+  dependency_2
+)
+```
+
+This is fairly self-explanatory.  You will notice that in the old `build.py` files you had to specify which parts of FASTLIB or **mlpack** you were linking against.  Here, if you are linking against _anything_ in MLPACK, specify `mlpack` as a dependency.  Note that our NCA example above links against MLPACK; this is because those other source files in `src/mlpack/methods/nca/` are part of MLPACK.
+
+A good process to make your own `CMakeLists.txt` is:
+
+1. Copy `CMakeLists.txt` from a nearby directory.
+1. Modify `SOURCES` to include all of the sources (the things you would put under `librule()` in `build.py`)
+1. Make `add_executable()` and `target_link_libraries()` stanzas for any executables (things that would go under `binrule()` in `build.py`)
+
+The last thing to do is to look in the `CMakeLists.txt` in the parent directory; it will have a list of directories that it recurses into.
+
+**Make sure to add your directory to this list, otherwise CMake won't even attempt to compile it!**
+
+Doing Complicated Things With CMake
+-----------------------------------
+
+If you don't have the time to learn CMake, you are likely best off just asking me (email: gth671b@mail.gatech.edu) what it is you want to do, because chances are, I've either done it before or can quickly point you in the right direction or just do it for you.
+
+If you _do_ have the time to learn CMake, it is a neat system, and the documentation on their website is extensive.  Just make sure you use the right documentation (currently we are using CMake 2.8) since their API changes now and then.
+
+Conclusion
+----------
+
+To wrap this all up, CMake is at least moderately cool.  It will help make **mlpack** more portable (since it supports generation of Visual Studio projects as output as well as other formats), and should keep development moving quickly.
+
+To encourage you to agree with this, here is a picture of a kitten using CMake:
+
+
+![http://existentialtype.net/wp-content/uploads/2007/05/im-in-ur-stackz-overflowing-ur-bufferz.jpg]

--- a/doc/developer/design_guidelines.md
+++ b/doc/developer/design_guidelines.md
@@ -17,7 +17,7 @@ In 2009 and 2010, a complete code overhaul was started after an in-depth survey 
 * Implement as large a collection as possible of machine learning methods
 * Provide cutting-edge machine learning algorithms that no other library does
 
-This last goal is somewhat in contrast to the scikit-learn project, which generally only implements stable, well-known algorithms.  mlpack can fill a niche by providing high-quality implementations of algorithms that just appeared in conferences or journals.  In those cases where mlpack is implementing well-known algorithms (i.e. SVMs or other standard techniques), we should strive to ensure that our implementation is faster than other implementations.  To ensure that, we may use the automatic benchmarking system; see https://www.github.com/zoq/benchmarks/.
+This last goal is somewhat in contrast to the scikit-learn project, which generally only implements stable, well-known algorithms.  mlpack can fill a niche by providing high-quality implementations of algorithms that just appeared in conferences or journals.  In those cases where mlpack is implementing well-known algorithms (i.e. SVMs or other standard techniques), we should strive to ensure that our implementation is faster than other implementations.  To ensure that, we may use the automatic benchmarking system; see <https://www.github.com/zoq/benchmarks/>.
 
 General Machine Learning Abstractions
 =====================================

--- a/doc/developer/design_guidelines.md
+++ b/doc/developer/design_guidelines.md
@@ -10,7 +10,7 @@ Goals of mlpack (plus a little history)
 
 The mlpack project was started around 2007 as "FASTLIB/MLPACK", a machine learning library for use by Alex Gray's FASTLab (http://www.fast-lab.org/) to implement their fast machine learning algorithms.  The types of problems considered were generally statistical tasks: nearest neighbor search, density estimation, range search, and so forth.  In addition to being a research delivery vehicle for the research of the FASTLab, the goal was to produce very high-speed implementations of these algorithms that could be used as building blocks for higher-level tasks.
 
-In 2009 and 2010, a complete code overhaul was started after an in-depth survey of the code.  This led to the design document "The Future of MLPACK": http://www.igglybob.com/mlpack_future.pdf.  That document, and the later papers (at the NIPS BigLearning workshop (http://www.ratml.org/pub/pdf/2011mlpack.pdf) and in JMLR (http://www.ratml.org/pub/pdf/2013mlpack.pdf)) formalizes four development goals of mlpack:
+In 2009 and 2010, a complete code overhaul was started after an in-depth survey of the code.  This led to the design document "The Future of MLPACK": http://www.igglybob.com/mlpack_future.pdf.  That document, and the later papers (at the NIPS BigLearning workshop (<http://www.ratml.org/pub/pdf/2011mlpack.pdf>) and in JMLR (<http://www.ratml.org/pub/pdf/2013mlpack.pdf>)) formalizes four development goals of mlpack:
 
 * Implement scalable, fast machine learning algorithms 
 * Design an intuitive, simple API for users who are not C++ experts

--- a/doc/developer/design_guidelines.md
+++ b/doc/developer/design_guidelines.md
@@ -8,9 +8,9 @@ It is worth remembering that this is a guide, not a rulebook: everything written
 Goals of mlpack (plus a little history)
 =======================================
 
-The mlpack project was started around 2007 as "FASTLIB/MLPACK", a machine learning library for use by Alex Gray's FASTLab (http://www.fast-lab.org/) to implement their fast machine learning algorithms.  The types of problems considered were generally statistical tasks: nearest neighbor search, density estimation, range search, and so forth.  In addition to being a research delivery vehicle for the research of the FASTLab, the goal was to produce very high-speed implementations of these algorithms that could be used as building blocks for higher-level tasks.
+The mlpack project was started around 2007 as "FASTLIB/MLPACK", a machine learning library for use by Alex Gray's FASTLab (<http://www.fast-lab.org/>) to implement their fast machine learning algorithms.  The types of problems considered were generally statistical tasks: nearest neighbor search, density estimation, range search, and so forth.  In addition to being a research delivery vehicle for the research of the FASTLab, the goal was to produce very high-speed implementations of these algorithms that could be used as building blocks for higher-level tasks.
 
-In 2009 and 2010, a complete code overhaul was started after an in-depth survey of the code.  This led to the design document "The Future of MLPACK": http://www.igglybob.com/mlpack_future.pdf.  That document, and the later papers (at the NIPS BigLearning workshop (<http://www.ratml.org/pub/pdf/2011mlpack.pdf>) and in JMLR (<http://www.ratml.org/pub/pdf/2013mlpack.pdf>)) formalizes four development goals of mlpack:
+In 2009 and 2010, a complete code overhaul was started after an in-depth survey of the code.  This led to the design document "The Future of MLPACK": <http://www.igglybob.com/mlpack_future.pdf>.  That document, and the later papers (at the NIPS BigLearning workshop (<http://www.ratml.org/pub/pdf/2011mlpack.pdf>) and in JMLR (<http://www.ratml.org/pub/pdf/2013mlpack.pdf>)) formalizes four development goals of mlpack:
 
 * Implement scalable, fast machine learning algorithms 
 * Design an intuitive, simple API for users who are not C++ experts

--- a/doc/developer/design_guidelines.md
+++ b/doc/developer/design_guidelines.md
@@ -1,0 +1,497 @@
+Introduction
+============
+
+C++ is a very complicated language (especially C++11 and C++14), and we have many free choices when designing a library.  Therefore, it is a good idea to write up a document that details the basic design decisions for mlpack, so that we as developers may use this as a guide to keep the library's code and functionality coherent.  This is also a good place to start for contributors who want to develop large patches to be added to mlpack.  Contributors who only have simple changes to implement are probably best served by looking at the style guidelines.
+
+It is worth remembering that this is a guide, not a rulebook: everything written here is open to some amount of interpretation and the guidelines may apply to some situations well and some situations not at all.  When in doubt, start a conversation.  When you disagree with something written here or think it can be improved, start a conversation.  This is meant to be a living document, so nothing is set in stone---just Markdown.
+
+Goals of mlpack (plus a little history)
+=======================================
+
+The mlpack project was started around 2007 as "FASTLIB/MLPACK", a machine learning library for use by Alex Gray's FASTLab (http://www.fast-lab.org/) to implement their fast machine learning algorithms.  The types of problems considered were generally statistical tasks: nearest neighbor search, density estimation, range search, and so forth.  In addition to being a research delivery vehicle for the research of the FASTLab, the goal was to produce very high-speed implementations of these algorithms that could be used as building blocks for higher-level tasks.
+
+In 2009 and 2010, a complete code overhaul was started after an in-depth survey of the code.  This led to the design document "The Future of MLPACK": http://www.igglybob.com/mlpack_future.pdf.  That document, and the later papers (at the NIPS BigLearning workshop (http://www.ratml.org/pub/pdf/2011mlpack.pdf) and in JMLR (http://www.ratml.org/pub/pdf/2013mlpack.pdf)) formalizes four development goals of mlpack:
+
+* Implement scalable, fast machine learning algorithms 
+* Design an intuitive, simple API for users who are not C++ experts
+* Implement as large a collection as possible of machine learning methods
+* Provide cutting-edge machine learning algorithms that no other library does
+
+This last goal is somewhat in contrast to the scikit-learn project, which generally only implements stable, well-known algorithms.  mlpack can fill a niche by providing high-quality implementations of algorithms that just appeared in conferences or journals.  In those cases where mlpack is implementing well-known algorithms (i.e. SVMs or other standard techniques), we should strive to ensure that our implementation is faster than other implementations.  To ensure that, we may use the automatic benchmarking system; see https://www.github.com/zoq/benchmarks/.
+
+General Machine Learning Abstractions
+=====================================
+
+Machine learning algorithms can operate on a wide variety of data, including numerical, textual, and categorical data.  Because our underlying matrix type is an Armadillo matrix, which does not support textual or categorical data, we assume that all of our data is numerical and can be represented by a matrix (specifically, as an Armadillo matrix, whether it be sparse or dense).
+
+Usually, machine learning algorithms perform some predictive task: they may cluster a set of points; they may perform classification; they may estimate a density; they may find a nearest neighbor.  These are only some of the possible tasks that algorithms in mlpack may accomplish.  Other core components in mlpack include things like probability distributions, metrics, and kernels.
+
+For each of these pieces in mlpack, some preprocessing may be required or useful to accelerate the core functionality of the component, be it classification, nearest neighbor searching, density estimation, regression, evaluating a metric, estimating a probability distribution, or whatever else.  One example is that a Gaussian distribution can do some preprocessing to store the inverse of the covariance matrix, which accelerates the later estimation of probability at a given point.
+
+We will aim to perform the preprocessing in the constructor, re-calculate any preprocessing with accessors and mutators, and then perform the actual processing with a specific method (or set of methods).  To elaborate on each of these points:
+
+* The constructor of an mlpack object *must* return a _valid_ object which is ready to be used (and/or trained).  For a machine learning method, any training should not take place in the constructor: instead, constructing the object should set parameters to train with (note that it is often useful to provide a constructor that calls a training function too).
+
+* mlpack objects should provide copy and move constructors and operators (if different behavior than the default versions are needed); these functions should have warnings in their documentation if the computational cost may be memory-intensive (i.e. if there is a big copy).
+
+* mlpack objects should be serializable via a `Serialize()` function (see the section on serialization).
+
+* Any preprocessing should be done in the constructor.  For example, the `GaussianDistribution` class calculates (1 / sigma^2) and stores that during preprocessing.
+
+* Members of the class should be modifiable through accessors and mutators; when necessary, a mutator should re-calculate any preprocessing that needs to be done.  Mutators should not incur re-training of a model (or re-estimation of parameters); the user should do that manually.
+
+* Machine learning algorithms that have a specific training step (for instance: logistic regression) should expose a `Train()` or `Estimate()` function.  Some machine learning algorithms will learn in batch while others will learn using a single point at a time.  Ideally, both interfaces (batch learning and single-instance learning) should be provided, and batch learning should re-train the model from scratch whereas single-instance learning should update the existing model.  The same applies for other components that need to be estimated (i.e. distributions).
+
+* Evaluation of a machine learning algorithm (functions like `Cluster()`, `Classify()`, `Regress()`, and `Predict()`) should have the same interface across all algorithms.  These should work on both a single point and many points at once, but in general this should be accomplishable via a single function that takes an Armadillo matrix; in the single-instance case, that matrix should have just one column.
+
+* Components of mlpack should be modular via templates, allowing the user to specify their own options.  In accordance with this, no constructor of an mlpack component should take parameters for a template member's constructor.  Instead, there should be a constructor which allows the user to pass in their own already-instantiated template member.
+
+C++ Features
+============
+
+Templates
+---------
+
+C++ templates are the means by which we achieve fast code.  The primary usage is via 'policy-based design', which allows us to write highly customizable code.  This is easiest to demonstrate with an example.  Consider the following code:
+
+```
+template<typename MetricType = EuclideanDistance>
+double CalculateAverageDistance(const arma::mat& data, MetricType& metric)
+{
+  // Calculate the average pairwise distance between points.
+  double result = 0.0;
+  for (size_t i = 0; i < data.n_cols; ++i)
+  {
+    for (size_t j = 0; j < data.n_cols; ++j)
+    {
+      if (i == j)
+        continue;
+      else
+        result += metric.Evaluate(data.col(i), data.col(j));
+    }
+  }
+}
+```
+
+This snippet allows the user to pass *any* `MetricType` class so long as it has an `Evaluate()` function which takes two Armadillo vector objects.  Therefore, a user can now use `CalculateAverageDistance()` with the default `EuclideanDistance`, any other metric provided by mlpack, or a metric that they have written themselves.
+
+Each time a template parameter is given with the intention of using policy-based design, it must be made clear in the documentation exactly what methods that template type should have and how they must work.  So, for instance, in the example above, the `MetricType` class should specify that an `Evaluate()` function is necessary, and also that `Evaluate()` between two points must return the evaluation of a valid metric (so, it must be nonnegative, symmetric, and satisfy the triangle inequality).
+
+Inheritance
+-----------
+
+In general, we should avoid inheritance (or, at least, virtual inheritance) in deference to templates (see above).  This is because virtual functions incur runtime overhead, and especially in critical inner loops where these functions are called many, many times, this overhead is non-negligible.
+
+Compelling cases for inheritance should be considered carefully.  In order to keep the code consistent, we should be careful with the use of various C++ features: if a user is used to mlpack using templates for static polymorphism, then it is not good if that user suddenly encounters inheritance used to solve the same type of design problem in a different context.
+
+Multiple inheritance isn't used inside the mlpack codebase, and given the previous two paragraphs, is probably not necessary in light of the use of templates.
+
+References and pointers
+-----------------------
+
+Where possible, references are preferred; const references are for input parameters (when possible), and non-const references are for output parameters.  Only primitive types should ever be passed by value in a method call, so as to avoid unnecessary object copies.
+
+The use of references allows us to skip checks for NULL because we are making the assumption that the user is passing in a valid object.  Below is an example:
+
+```
+template<typename MetricType = EuclideanDistance>
+double CalculateOffsetAverageDistance(const arma::mat& data, MetricType& metric, const double offset)
+{
+  // Calculate the average pairwise distance between points.
+  double result = 0.0;
+  for (size_t i = 0; i < data.n_cols; ++i)
+  {
+    for (size_t j = 0; j < data.n_cols; ++j)
+    {
+      if (i == j)
+        continue;
+      else
+        result += metric.Evaluate(data.col(i), data.col(j)) + offset;
+    }
+  }
+}
+```
+
+In this case, all three parameters to the method are input, but we cannot label `MetricType` as const, because a call to `MetricType::Evaluate()` may be non-const -- for instance, if the class is counting how many times `Evaluate()` has been called.
+
+One instance where references don't make sense are with structures like trees.  Consider a simplified binary tree, given below:
+
+```
+struct SimpleTree
+{
+  SimpleTree* left;
+  SimpleTree* right;
+};
+```
+
+In this case, it does not make sense to have `left` and `right` be of type `SimpleTree&`, because various operators on the `SimpleTree` structure may modify the left and right children (for instance, rebalancing of a tree may attach a child somewhere else in the tree).  References can't be re-seated, so rebalancing a reference-based tree would be a nightmare.
+
+So, the general rule of thumb is: always try to use references, but when this isn't reasonably possible (i.e. when you may need to reassign), use pointers.  Note that the use of references can make serialization difficult, so it is not always possible to cleanly use references.
+
+Template metaprogramming and SFINAE
+-----------------------------------
+
+SFINAE (substitution failure is not an error) is in wide use throughout the mlpack codebase, in order to perform partial specializations.  So, here is an example, using some structures from Boost:
+
+```
+// This overload catches the case where T is a class.
+template<typename T>
+void Print(T& t,
+           const typename std::enable_if<std::is_class<T>::value>::type* = 0)
+{
+  std::cout << "T is a class!" << std::endl;
+}
+
+// This overload catches the case where T is not a class (it is a pointer, reference, or primitive type).
+template<typename T>
+void Print(T& t,
+           const typename std::enable_if<!std::is_class<T>::value>::type* = 0)
+{
+  std::cout << "T is not a class!" << std::endl;
+}
+```
+
+Because template metaprogramming is confusing and hard to read, it is very important to be explicit in the documentation.  Here, each overload is documented for the cases that it catches.  If you are going to use template metaprogramming to solve a problem in mlpack, first make sure that the problem can't be solved in some easier way, and second make sure that all aspects of your solution are comprehensively documented.
+
+There do exist some useful utilities for template metaprogramming in `src/mlpack/core/util/`.
+
+Exceptions
+----------
+
+We can use the same approach to exceptions that was documented in "The Future of mlpack".  The use of exceptions does not generally incur any significant runtime overhead.  In the context of machine learning algorithms, an exception will generally mean malformed data or erroneous code.  In this situation it is reasonable to throw an exception, since in general it's not really possible to recover from this situation.
+
+Exceptions shouldn't be used as a substitute for a success indicator, though; if a method can easily return `true` or `false` to indicate its convergence, there is no need to throw an exception when convergence does not occur.
+
+Class members
+-------------
+
+Any mlpack class should hold no more members internally than are absolutely necessary.  So, because each machine learning algorithm that has a training process will have a `Train()` method that takes the training dataset as input, then it is likely that the class does not need to hold a reference to the training dataset internally, because the training dataset is only used at training time.  (There are exceptions where this is not the case.)
+
+There are some cases where members need to be held internally, but copying these members would be costly, and holding a reference internally is not necessarily the best idea.  Consider the following example:
+
+```
+template<typename OptimizerType>
+class LogisticRegression;
+```
+
+This is a logistic regression class, which uses the OptimizerType optimizer to train the model.  But, it is possible that the OptimizerType class is quite large, or holds matrices internally, so we want to avoid copies.  At the same time, we want to hold an instantiated OptimizerType internally, because we will be using it.  The user should also be able to pass in their own OptimizerType to use.  This can be accomplished in the following way:
+
+```
+template<typename OptimizerType>
+class LogisticRegression
+{
+ public:
+  LogisticRegression(...) : optimizer(new OptimizerType()), ownsOptimizer(true), ... { ... }
+  LogisticRegression(..., OptimizerType& opt) : optimizer(&opt), ownsOptimizer(false), ... { ... }
+  ~LogisticRegression()
+  {
+    if (ownsOptimizer)
+      delete optimizer;
+    ...
+  }
+
+  const OptimizerType& Optimizer() const { return *optimizer; }
+  OptimizerType& Optimizer() { return *optimizer; }
+
+ private:
+  OptimizerType* optimizer;
+  bool ownsOptimizer;
+};
+```
+
+In general, this type of pattern should be applied to prevent copies of constructor parameters, as well as allowing user flexibility: with this design, a user can create a default optimizer and modify its parameters via `Optimizer()`, or create their optimizer on their own and pass it in via the constructor.
+
+Requirements of each class
+--------------------------
+
+Each mlpack class should be serializable, via a `Serialize()` function with the signature:
+
+```
+template<typename Archive>
+void Serialize(Archive& ar, const unsigned int version);
+```
+
+The particular usage of this class follows the `boost::serialization` library guidelines, and functions equivalently to the `serialize()` method in regular `boost::serialization` classes.  For coherence with the method naming guidelines, mlpack implements a shim (in `src/mlpack/core/data/`) that allows a `Serialize()` method to be used in place of a `serialize()` method.
+
+In order to serialize properly, most objects will need to avoid the use of references entirely, because serialization generally means that all data members must have their values changed (during loading, at least).  In those situations where references *must* be used, or where a default constructor is not available, it is possible to have `boost::serialization` load into a pointer; see `src/mlpack/core/tree/binary_space_tree/binary_space_tree_impl.hpp`.
+
+This serializability allows easy loading and saving of models.
+
+Style Guidelines
+================
+
+Tabbing
+-------
+
+Tabs should be two spaces wide.  i.e.
+
+```
+void Class::Method(int num)
+{
+  DoSomething();
+
+  for (int i = 0; i < num; i++)
+    DoSomethingElse(i);
+}
+```
+
+Use spaces, not tab characters.  See [jwz's rant](http://www.jwz.org/doc/tabs-vs-spaces.html) for more information and reasoning.  If you're using vim, here is what should go in your .vimrc:
+
+```
+set softtabstop=2
+set expandtab
+set shiftwidth=2
+```
+
+One exception to this rule is the public: and private: keywords in classes, which should be indented just one space: 
+	 	 
+``` 
+class X 
+{ 
+ public: 
+  // Stuff. 
+ 
+ private: 
+  // Stuff. 
+}; 
+``` 
+
+Spacing for operators
+---------------------
+
+There should be a space between an operator and its argument.  For instance:
+
+```
+if (condition)
+```
+
+or in the case of a for loop,
+
+```
+for (i = 0; i < 10; ++i)
+```
+ 
+Line Length and Wrapping
+------------------------
+
+Lines should be no more than 80 characters wide.  This was chosen because it is a standard for other projects out there, and it is not too difficult to adhere to.  Also, it makes putting code samples in a paper possible and easy.
+
+When wrapping a line, the next line should be tabbed twice from where the previous line began.  An example is easier to understand:
+
+```
+void Class::Method(arma::mat& xx, const arma::mat& y)
+{
+  // We assume local variables arma::vec z and m.
+
+  xx = y * SomeReallyLongMethodName(z, m) + 
+      SomeOtherReallyLongMethodNameThatIsLong(z, m) +
+      AThirdReallyLongMethodNameThatIsAlsoVeryLong(z, m);
+}
+```
+
+As a side note, try to avoid method names that are that long if possible.
+
+Method Declarations
+-------------------
+
+Suppose you have a method with parameters that ends up being longer than 80 characters.  Wrap it such that each new line of parameters lines up with the previous line of parameters, like so:
+
+```
+AllNN::AllNN(arma::mat& referencesIn,
+             struct datanode* moduleIn,
+             bool alias_matrix,
+             bool naive)
+```
+
+If the method names are so long that you can't make that fit, you can do this:
+
+```
+AllNN::AllNN(
+    arma::mat& referencesIn,
+    struct datanode* moduleIn,
+    bool alias_matrix,
+    bool naive)
+```
+
+And if the method and class names are too long for that, you could do this:
+
+```
+void AReallyLongClassName::
+SomeReallySuperLongMethodNameWhichShouldBeShorter(
+    arguments)
+```
+
+If you add templates too, you can do this:
+
+```
+void KMeans<
+    DistanceMetric,
+    InitialPartitionPolicy,
+    EmptyClusterPolicy>::
+Cluster(const arma::mat& data,
+        const size_t clusters,
+        arma::Col<size_t>& assignments)
+```
+
+Constructor Initialization Lists
+--------------------------------
+
+We have already defined how parameters should be, but initialization lists should adhere to the line wrapping style with two tabs.  The same example is below:
+
+```
+AllNN::AllNN(arma::mat& referencesIn,
+             struct datanode* moduleIn,
+             bool aliasMatrix,
+             bool naive) :
+    module(moduleIn),
+    naive(naive),
+    references(referencesIn.memptr(), referencesIn.n_rows,
+        referencesIn.n_cols, !aliasMatrix),
+    queries(references.memptr(), references.n_rows, references.n_cols,
+        false)
+{
+  // Do some stuff inside of the constructor here that could not be done with
+  // initialization lists.
+}
+```
+
+Again, it may be easier to read each initialization list entry on separate lines if many things are being initialized.  That is left up to the developer to decide.
+
+Note that on very long initialization list lines, the wrapping rules are again used.
+
+Brace Placement
+---------------
+
+Avoid placing opening braces on the same line as a `loop/if/else/switch/function/class`.  The block is more readable with braces aligned.
+
+Use
+```
+if (n > 12)
+{
+  x += 2;
+  y -= 12.5;
+}
+```
+
+rather than
+```
+if (n > 12) {
+  x += 2;
+  y -= 12.5;
+}
+```
+
+To conserve lines, refrain from using braces if the `if`, `while`, or `for` statement applies to a single statement.
+
+Namespaces
+----------
+ 
+The exception to the rules of braces and tabbing is namespaces.  For simplicity, write this: 
+ 	 
+``` 
+namespace mlpack { 
+namespace mvu { 
+	 
+// stuff goes here 
+ 	 
+} // namespace mvu 
+} // namespace mlpack 
+```
+	 	 
+Don't indent anything inside namespaces---it's a waste of columns, especially when you are several namespaces deep. 
+ 
+Operator and Keyword Spacing Rules
+----------------------------------
+
+Use spaces between your operators for readability.  Below is an example:
+
+```
+for (int i = 0; i < 10; i++)
+{
+  if (i > 5)
+    someValue = (4 * i) + 5;
+  else
+    someValue = (someBool ? (3 * i) : 2);
+}
+```
+
+Things like `i=(4+5-i)` are not cool, and are not easy to read.  A space between parentheses and what is inside of them, like `i = ( 4 + 5 - i )` is technically superfluous but is still readable so is not a huge problem.  Also do note the spaces between the for and if operators and the opening parentheses.
+
+Naming Conventions
+------------------
+
+Use [camel casing](http://en.wikipedia.org/wiki/CamelCase) for all names.  Capitalize class and method names.  Variable, reference, and pointer names begin with a lower case letter.  Setters and getters share names with their respective data members, distinguished by the case of the first letter of each of their names. 
+
+```
+class Hilarious
+{
+  private:
+    int laugh;
+    char chuckle;
+    matrix& matr;
+  public:
+    Hilarious();
+    const int Laugh() { return laugh; }
+    void Laugh(int i) { laugh = i; }
+    const matrix& Matr() { return matr; }
+}
+```
+
+It is your choice whether you want to provide a setter that takes the input as an argument (like `void Laugh(int i)`) or if you want to provide a setter that allows direct access (like `int& Laugh()`).  Generally the latter is used when it is not necessary to validate what the user is setting the value to (or if no processing is necessary on the value), and the former is used when validation or processing is necessary.
+
+Pointers and reference placement
+--------------------------------
+
+Place the reference (`&`) or pointer (`*`) with the type, not with the variable:
+
+```
+const A& b; // not const A &b
+const C* d;
+```
+
+Casting
+-------
+
+When doing a C-style cast, use spaces:
+
+```
+double d = (double) integer;
+```
+
+and not
+
+```
+double d = (double)integer;
+```
+
+Comments
+--------
+
+**Everyone has their own individual style for comments.  This section doesn't intend to hinder your own personal style (unless your style is 'no comments').**
+
+Not everyone that uses mlpack is an English speaker, so it's helpful to always have comments that are complete sentences with proper grammar and punctuation; this should help any translation (whether done by human or machine).  So try to avoid ambiguous short phrases that are difficult to translate.
+
+Also, be aware that not everyone reading the code will be an expert on the technique, so be sure to insert high-level comments on what the algorithm is doing (at the same time, saying `Do an eigendecomposition of X` every time you write `X.eig()` is overly verbose).  Remember that sooner or later someone will come along to maintain your code (it might even be you) and have nothing more than a basic machine learning and C++ background.
+
+As always, more comments are better than fewer comments.
+
+Citations
+---------
+
+Following a lengthy discussion in [#195](https://github.com/mlpack/mlpack/issues/195), consensus was that there should be
+
+* no citations in the `-h` output of any mlpack program (that is, no citations in `PROGRAM_INFO()` macros).
+* citations in comments should be in BiBTeX format (keep it simple -- author, year, pages, title, journal/conference; no need for the DOI or URL or abstract or anything).  One exception for URLs is arXiv papers; for instance, ICLR does not have proceedings; all the papers are on arXiv.  So we can assume that arXiv URLs won't go out of date and therefore they should be ok to put in the code.
+
+
+Lambda Functions
+----------------
+
+Lambda functions can be used to encapsulate code that is passed to another method. The brace placement will follow the same guidelines as other functions i.e. The opening braces of lambda function will also be indented. An example of lambda function is shown below.
+```
+digits.erase(std::remove_if(digits.begin(), digits.end(), [&blacklist](int i)
+    {
+      return blacklist.find(i) != blacklist.end();
+    }),
+  digits.end());
+```

--- a/doc/developer/developers.md
+++ b/doc/developer/developers.md
@@ -4,26 +4,29 @@ If you want to contribute to mlpack, or if you already are a regular contributor
 to mlpack or a maintainer, the following pages may serve as useful documentation
 about internal development processes, guidelines, and systems:
 
- * [Community](community.md): details of how the mlpack community operates and
-   communicates, including *how to get involved*.
+* [Community](community.md): details of how the mlpack community operates and
+communicates, including *how to get involved*.
+* [Google Summer of Code](gsoc.md): advice on applying to mlpack for Google
+Summer of Code.
+* [CI/CD](ci.md): systems and servers involved in mlpack's continuous
+integration pipeline.
+* [Timers](timer.md): interface for timing bindings and other mlpack programs.
+* [Automatic binding system](bindings.md): design details and operation of
+mlpack's automatic binding generator, including how to add a new language.
+* [Writing a binding](iodoc.md): a tutorial on writing an mlpack binding that
+will automatically be compiled to any language mlpack has bindings for.
+* [Template policies](policies.md): documentation for standardized class
+interfaces used by mlpack algorithms.
 
- * [Google Summer of Code](gsoc.md): advice on applying to mlpack for Google
-   Summer of Code.
+  * [The ElemType policy](elemtype.md)
+  * [The DistanceType policy](distances.md)
+  * [The KernelType policy](kernels.md)
+  * [The TreeType policy](trees.md)
 
- * [CI/CD](ci.md): systems and servers involved in mlpack's continuous
-   integration pipeline.
+\## Additional Developer Resources
 
- * [Timers](timer.md): interface for timing bindings and other mlpack programs.
+* \- \[Design Guidelines](design\_guidelines.md)
+* \- \[CMake Configuration](cmake.md)
+* \- \[Testing Guidelines](testing\_guidelines.md)
+* \- \[Release Preparation Guide](release\_preparation.md)
 
- * [Automatic binding system](bindings.md): design details and operation of
-   mlpack's automatic binding generator, including how to add a new language.
-
- * [Writing a binding](iodoc.md): a tutorial on writing an mlpack binding that
-   will automatically be compiled to any language mlpack has bindings for.
-
- * [Template policies](policies.md): documentation for standardized class
-   interfaces used by mlpack algorithms.
-   - [The ElemType policy](elemtype.md)
-   - [The DistanceType policy](distances.md)
-   - [The KernelType policy](kernels.md)
-   - [The TreeType policy](trees.md)

--- a/doc/developer/release_preparation.md
+++ b/doc/developer/release_preparation.md
@@ -1,0 +1,102 @@
+**mlpack** Release Preparation Guide
+====================================
+
+There are some things to be done before a release which are easy to forget but shouldn't be forgotten.  A simple guide is here:
+
+1.  Run `release-mlpack.sh` with the new version number.
+  - _notes from 3.3.2 release_: updating Doxyfile needed a bit of changing
+  - _notes from 3.3.2 release_: needs to fail if there are any uncommitted changes
+  - _notes from 3.3.2 release_: needs to commit finished history block only to tag
+  - _notes from 3.3.2 release_: website did not update right; had to change versions in .md links with sed
+  - _notes from 3.3.2 release_: soversion for library wasn't right---need to manually update src/mlpack/CMakeLists.txt
+  - _notes from 3.3.2 release_: seems like src/mlpack/core/util/version.hpp did not get updated!
+  - _notes from 3.4.0 release_: now we check out the master branch
+  - _notes from 3.4.0 release_: all files now seem to be updating correctly
+1.  Send announcement to mlpack list.
+1.  Add release notes to Github page.
+
+Push to distributions
+---------------------
+
+###### Fedora
+
+1. Get git source: `fedpkg clone mlpack`.
+2. Get new mlpack version: `wget http://www.mlpack.org/files/mlpack-x.y.z.tar.gz`.
+3. Push tarball to lookaside cache: `fedpkg new-sources mlpack-x.y.z.tar.gz`.
+4. Update spec file; build locally (`rpmbuild -ba mlpack.spec`) and make sure everything seems okay.  It may be useful to mock build for EPEL (since that can be picky sometimes).
+5. Commit changes; `git commit -a`.
+6. For each release of Fedora/EPEL, `fedpkg switch-branch <release>; git merge master; git push; fedpkg build; fedpkg update`.
+7. When the waiting period is over for each update, push to stable (3-7 days for Fedora, 2 weeks for EPEL).
+
+ _notes from 3.4.0 release_: this isn't automated
+
+###### Python
+
+See https://github.com/mlpack/mlpack-wheels, and update `BUILD_COMMIT` in `travis.yml` and `appveyor.yml`.
+
+###### Julia
+
+See https://github.com/mlpack/mlpack.jl, specifically the file `rel/deployment.md`.
+
+###### R
+
+TODO (the process is not fully devised yet)
+
+###### Go
+
+See https://github.com/mlpack/mlpack-go/, specifically the file `rel/deployment.md`.
+
+###### Ubuntu/Debian
+
+This isn't automated; it's handled downstream.
+
+###### vcpkg
+
+This isn't automated; it's handled downstream.
+
+Push new benchmarks to website
+------------------------------
+
+We need to rebuild the benchmark reports so that the figure colors are right for the webpage.
+
+1. Check out the benchmarking system to some directory.
+2. Download massif.tar.gz and benchmark.db from the artifacts of the build server's [http://big.cc.gt.atl.ga.us:8080/job/benchmark%20-%20reports/ completed "benchmark - reports" job]
+3. Put benchmark.db in the reports/ folder, and unpack the .mout files from massif.tar.gz into reports/etc/
+4. Modify config.yaml; change chartColor to #000000, topChartColor to #000000, and textColor to #aaaaaa (the same color as the website text).
+5. Run 'make reports' from the base benchmark directory.
+6. Access the created file, reports/index.html, in a browser and take a look to make sure everything is okay.
+7. Save the old benchmark.html on www.mlpack.org to some different file (for reference).
+8. Copy index.html to www.mlpack.org:/var/www/www.mlpack.org/benchmark.html and all the support files too.
+9. Use vimdiff to copy changes from benchmark-old.html to benchmark.html.  This should include loading another css stylesheet, adding the header and navigation menu to the top of the page, and removing the top graph (because it might be confusing to users who aren't sure what it means).
+10. Change the version in the phrase "This page contains benchmarks for the various algorithms implemented in mlpack x.y.z."
+
+Other notes
+-----------
+
+You can check which files have a license like this:
+
+```
+for i in `find src/ -iname '*.[hc]pp'`; do echo -n $i": "; cat $i | grep 'mlpack is free software;' | wc -l; done | grep -v ': 1' | grep -v 'arma_extend' | grep -v 'boost_backport' | grep -v 'arma_config.hpp' | grep -v 'gitversion.hpp'
+```
+
+You can get a list of all commits to master (doesn't print merge histories) like this:
+
+```
+# The first commit is the first commit since the last release.
+git log --first-parent master --oneline ac73c69^..master
+```
+
+Then you can get the name of a branch to find its history:
+
+```
+# Get the name of the branch:
+git show-branch | grep -A 2 'term to search for'
+```
+
+Or you can get the list of commits on Github.  In either case, then you can get a list of what to cherry-pick with (assuming branch commit `master~136^2` or similar):
+
+```
+git log --reverse --first-parent master~136^2 --oneline master~136^2~10..master~136^2
+```
+
+(where only 10 commits are shown here; you need to get the exact number from the PR or by inspecting the history) and then it is easy to take this and pipe the commits to `git cherry-pick`.

--- a/doc/developer/release_preparation.md
+++ b/doc/developer/release_preparation.md
@@ -60,7 +60,7 @@ Push new benchmarks to website
 We need to rebuild the benchmark reports so that the figure colors are right for the webpage.
 
 1. Check out the benchmarking system to some directory.
-2. Download massif.tar.gz and benchmark.db from the artifacts of the build server's [http://big.cc.gt.atl.ga.us:8080/job/benchmark%20-%20reports/ completed "benchmark - reports" job]
+2. Download massif.tar.gz and benchmark.db from the artifacts of the build server's [completed "benchmark - reports" job](http://big.cc.gt.atl.ga.us:8080/job/benchmark%20-%20reports/)
 3. Put benchmark.db in the reports/ folder, and unpack the .mout files from massif.tar.gz into reports/etc/
 4. Modify config.yaml; change chartColor to #000000, topChartColor to #000000, and textColor to #aaaaaa (the same color as the website text).
 5. Run 'make reports' from the base benchmark directory.

--- a/doc/developer/testing_guidelines.md
+++ b/doc/developer/testing_guidelines.md
@@ -1,0 +1,113 @@
+# Introduction
+
+Software testing is an integral part of development workflow of every major piece of technology that you see around. Naturally, it is one of the core guidelines to write unit tests and `mlpack` follows the same ideology in our `tests` submodule. We all make mistakes, and introducing tests not only helps to realize those mistakes, it also makes the review process much faster. A proper test framework also ensures that one does not simply disturb the higher-level API correctness, while meddling with the lower level stuff, saving a huge amount of time.
+
+It is also worth noting, that while it is great to follow all of these mentioned guidelines, a number of them are open to interpretation depending upon unique situations. So we highly encourage people to start a conversation whenever in doubt. Shall we begin?
+
+## What to Test?
+
+While we appreciate your dedication to test each individual line of your code separately in a unit test, it is simply too redundant. However, this doesn't mean that you should leave areas of your code unchecked at all. Ultimately, we wish to get a working and correct implementation of a functionality out of your code. Ideally we strive to test out individual functions and the use of those functions in conjunction with previously available functionality.
+
+## Objective and Limits
+
+The end goal of software testing is to provide as much code coverage as possible for every line of code written. `mlpack` wouldn't be useful at all if simply the code you wrote is wrong; wrong code is subjectively much worse than no code at all. A good test suite would aim to test the logical (the implementation arrives at the correct solution) and semantic (the implementation arrives at the solution using the correct methodology) aspects of the code. Syntactical checking is provided by the compiler, so we do not worry about that. However, there are still hurdles to realizing this objective. With `mlpack`, we expect contributors to provide valid test-cases, which itself is an error prone task, especially in situations where manual calculation is hard. Furthermore, valid test-cases only test the logical correctness of the code, semantical issues can arise as well. Take the following piece of code from a previous case,
+
+### Logically Correct but Semantically Incorrect
+```
+Incorrect
+g.each_col() += arma::sum(norm.each_col() % -stdInv, 1)
+                + var % arma::mean(-2 * inputMean, 1) / input.n_cols;
+
+Correct
+g.each_col() += (arma::sum(norm.each_col() % -stdInv, 1)
+                 + (var % arma::mean(-2 * inputMean, 1))) / input.n_cols;
+```
+
+The above piece of code is used while computing the backward function of `Batch Normalization` layer. On a quick look, it doesn't seem to be radically different in the two cases, however, there is a subtle difference,
+
+```
+Assuming,
+a = arma::sum(norm.each_col() % -stdInv, 1); 
+b = var % arma::mean(-2 * inputMean, 1);
+c = input.n_cols;
+
+Incorrect
+g.each_col() += a + b / c; or more simply, g.each_col() += a + (b / c);
+
+Correct
+g.each_col() += (a + b) / c;
+```
+What's even scarier is that for the existing test case, the above two virtually provided the same output (logical correctness). Such implementations are quite hard to analyze and debug, and often go unnoticed by the developers who implement them. Hence, we also request our contributors to be patient with the review process, we just don't want to rush and end up shipping faulty code.
+
+## Good Test Sources
+
+Ideally, the best source of logical tests are values computed manually by defining the methodology implemented in code, and plugging in some random cases. However, these are error prone too, since the number of test cases one may implement are limited and might not cover all the corner cases. We may suggest you to implement some of the original test routines and architectures used by the authors of the said technique, since these tend to be the most scrutinized aspects of their work. Finally, in cases where none of the above are viable options, one can look up for the test cases implemented in other major libraries (`PyTorch`, `Tensorflow` and the rest), and replicate their results. This is the least preferred approach to writing test cases, but comes in handy in certain scenarios. For example, take the following cases:
+
+### Manual Computation
+```
+You implemented a recently published activation function module, however the
+publication doesn't mention any practical value based results, except for
+the formula. Here, manual computation is the most plausible approach for
+creating tests for your code.
+```
+
+### Authored Test Cases
+```
+You implemented the module for a new type of Generative Adversarial Network (GAN)
+from a peer reviewed publication and wish to test the same. However, testing is an
+abstract concept here, since GANs are used to primarily generate data. In such a
+scenario, it is advised to replicate the test models depicted in the paper, and
+comparing the output data (or imagery) directly with the standard results
+mentioned in the paper.
+```
+
+### External Libraries
+```
+You implemented the module for computing 2D convolutions on the given matrix.
+However, it is cumbersome to manually compute the different test cases with
+different parameters (stride, filter size, padding and so on). Also, since it
+is a general functionality, you couldn't find any authored publications with
+test cases for the same. As a last resort, you can head to
+tensorflow.nn.conv_2d() (https://www.tensorflow.org/api_docs/python/tf/nn/conv2d)
+and pass the input matrix and other parameters and record the result, later
+using it as a test case for the results generated from your implementation.
+```
+
+## Creating Tests
+
+We use `Catch2` as the unit test framework. For a detailed explanation of the usage, 
+please refer to the [documentation](https://github.com/catchorg/Catch2/blob/devel/docs/Readme.md).
+However, for a quick view, you can refer to the previously implemented test cases in 
+`src/mlpack/tests/` under the appropriate sub-directory as well as [README.md](https://github.com/mlpack/mlpack/blob/master/src/mlpack/tests/README.md) in `src/mlpack/tests/`.
+
+### Tests With Random Input
+For time and resource-based constraints, `Travis` only runs the test cases for a single time. This is however not the correct way to test out the code implementations which require a random input. It is possible that the code may pass on a single run, but while on multiple runs, it might lead to a failure (like the way it is done in `Jenkins`). For such a case, the right way to test the random input based tests is to set the random seed and run many times locally on your machine to be sure. Add `mlpack::math::RandomSeed(std::time(NULL))` to the top of your test case, compile and then run the following script in the terminal:
+```
+$ i=0; while(true); do echo $i; bin/mlpack_test --rng-seed $i "[testname]" 2>&1 | grep 'fatal error'; i=$(($i + 1)); sleep 1; done
+```
+
+It's useful to run that script for ~1000 iterations and make sure the test does not fail in that period.  If you don't do this, then you should not be surprised if a bug gets opened and you get tagged in it because the test you wrote that got merged was not stable. :)
+
+Note that if you are writing a test for a binding (i.e. something in `src/mlpack/tests/main_tests/`), then `BINDING_TYPE_TEST` is defined such that `math::RandomSeed()` doesn't do anything.  Therefore, in place of a call to `RandomSeed()`, use this code (which is just the implementation of `RandomSeed()`):
+
+```
+const size_t seed = std::time(NULL);
+mlpack::math::randGen.seed((uint32_t) seed);
+srand((unsigned int) seed);
+arma::arma_rng::set_seed(seed);
+```
+
+Then you can build and use the same loop as above.
+
+## Reporting and Analyzing Failures
+
+Okay, so we're through with the conception and the implementation of the test cases for your code. However, it may still happen that your code may fail to compile, raise a test-case exception, or a test failure. Here's what you can do to correct the implementation:
+
+### Code Compilation Failure
+Nothing much to say here, compilation failure means that your usage of language syntax is simply wrong. Fortunately, C++ enjoys the support of powerful compilers, which would point out the line of error, as well as the candidate fixtures, if applicable. Being able to make sense out of compilation errors is an art in itself, one that comes with practice and patience. So don't rush yourself through your errors.
+
+### Test Case Exception
+If for some reason your code compiles well, but raises an exception in one of the test cases whenever you run the test suite, it can broadly point to two issues. Either your implementation of the test case is semantically incorrect, or your implementation of your code is leading to a runtime error. Finding out the case out of these two should help you in clearing out your problem.
+
+### Test Failure
+Much like the previous case, test failures can emerge from two cases as well. Either your code is logically incorrect and leads to the wrong answer, or simply the test value your are trying to compare your output against is plain wrong. Re-checking your code and test value is the only way to go here. If that doesn't help, we're there to alleviate the pain.

--- a/doc/developer/testing_guidelines.md
+++ b/doc/developer/testing_guidelines.md
@@ -83,7 +83,7 @@ However, for a quick view, you can refer to the previously implemented test case
 ### Tests With Random Input
 For time and resource-based constraints, `Travis` only runs the test cases for a single time. This is however not the correct way to test out the code implementations which require a random input. It is possible that the code may pass on a single run, but while on multiple runs, it might lead to a failure (like the way it is done in `Jenkins`). For such a case, the right way to test the random input based tests is to set the random seed and run many times locally on your machine to be sure. Add `mlpack::math::RandomSeed(std::time(NULL))` to the top of your test case, compile and then run the following script in the terminal:
 ```
-$ i=0; while(true); do echo $i; bin/mlpack_test --rng-seed $i "[testname]" 2>&1 | grep 'fatal error'; i=$(($i + 1)); sleep 1; done
+$ i=0; while(true); do echo $i; bin/mlpack_test --rng-seed $i "\[testname\]" 2>&1 | grep 'fatal error'; i=$(($i + 1)); sleep 1; done
 ```
 
 It's useful to run that script for ~1000 iterations and make sure the test does not fail in that period.  If you don't do this, then you should not be surprised if a bug gets opened and you get tagged in it because the test you wrote that got merged was not stable. :)


### PR DESCRIPTION
I came across issue and wanted to help move things forward.

The mlpack wiki has several developer-focused pages that aren't 
version-controlled or reviewable via PRs. I cloned the wiki locally 
and ported the following pages into `doc/developer/`:

- `design_guidelines.md` — from [Design Guidelines](https://github.com/mlpack/mlpack/wiki/Design-Guidelines)
- `cmake.md` — from [Using CMake](https://github.com/mlpack/mlpack/wiki/Using-CMake)
- `testing_guidelines.md` — from [Testing Guidelines](https://github.com/mlpack/mlpack/wiki/Testing-Guidelines)
- `release_preparation.md` — from [Release Preparation Guide](https://github.com/mlpack/mlpack/wiki/Release-Preparation-Guide)

I also updated `developers.md` to add navigation links to each 
new page so they're discoverable from the developer index.

The content is migrated directly from the existing wiki pages — 
no LLM-generated content involved.

I have read [CONTRIBUTING.md] including the LLM policy.
Note: This PR addresses issue #3656 (not #3966 as previously referenced — 
apologies for the mix-up). Closes #3656

