### PR TITLE
YOLOv3 layer backward pass

### DIFF
--- a/src/mlpack/methods/ann/models/yolov3/yolov3_layer.hpp
+++ b/src/mlpack/methods/ann/models/yolov3/yolov3_layer.hpp
@@ -86,22 +86,22 @@ class YOLOv3Layer : public Layer<MatType>
   void ComputeOutputDimensions() override;
 
   /**
-   * NOTE: This will be changed when training is implemented.
+   * If training is true, returns raw model outputs.
    *
-   * Takes in 3d input and outputs bounding boxes, based on anchors,
-   * input image size and cell position, for each batch item.
+   * Otherwise, takes in input and outputs bounding boxes, based on anchors,
+   * original image size and cell position, for each batch item.
    *
    * Bounding boxes are outputted in the format: cx, cy, w, h.
    *
    * @param input Input data representing outputs of model.
-   * @param output Resulting bounding boxes after being normalized to image.
+   * @param output If training is true, returns raw model outputs. Otherwise,
+   *               resulting bounding boxes after being normalized to
+   *               the input image dimensions.
    */
   void Forward(const MatType& input, MatType& output) override;
 
   /**
-   * NOTE: This will be changed when training is implemented.
-   *
-   * Currently not implemented.
+   * Simply copies gradients to previous layer.
    */
   void Backward(const MatType& input,
                 const MatType& output,

--- a/src/mlpack/methods/ann/models/yolov3/yolov3_layer_impl.hpp
+++ b/src/mlpack/methods/ann/models/yolov3/yolov3_layer_impl.hpp
@@ -144,9 +144,16 @@ void YOLOv3Layer<MatType>::ComputeOutputDimensions()
 template <typename MatType>
 void YOLOv3Layer<MatType>::Forward(const MatType& input, MatType& output)
 {
-  ElemType stride = imgSize / (ElemType)(gridSize);
   size_t batchSize = input.n_cols;
   output.set_size(input.n_rows, batchSize);
+
+  if (this->training)
+  {
+    output = input;
+    return;
+  }
+
+  ElemType stride = imgSize / (ElemType)(gridSize);
 
   CubeType inputCube;
   MakeAlias(inputCube, input, grid * numAttributes, predictionsPerCell,
@@ -189,7 +196,6 @@ void YOLOv3Layer<MatType>::Forward(const MatType& input, MatType& output)
     1, predictionsPerCell, batchSize);
 #endif
 
-  // TODO: add if (this->training). Add check for different batchSize.
   const size_t cols = predictionsPerCell - 1;
 
   // x
@@ -229,10 +235,10 @@ template <typename MatType>
 void YOLOv3Layer<MatType>::Backward(
     const MatType& /* input */,
     const MatType& /* output */,
-    const MatType& /* gy */,
-    MatType& /* g */)
+    const MatType& gy,
+    MatType& g)
 {
-  throw std::runtime_error("YOLOv3Layer::Backward() not implemented.");
+  g = gy;
 }
 
 template <typename MatType>


### PR DESCRIPTION
### YOLOv3 layer backward pass

For training YOLOv3, instead of normalizing bounding boxes in the forward and backward passes, you simply do the inverse once on the input bounding boxes, and then calculate the loss. So for the `Backward` method, simply pass along the gradients, and for `Forward`, check if training is true, and if it is just copy the output forward.
