### PR TITLE
Minor polish and update of doc/quickstart/r.md

### DIFF
--- a/doc/quickstart/cli.md
+++ b/doc/quickstart/cli.md
@@ -40,9 +40,9 @@ instructions in the
 
 As a really simple example of how to use mlpack from the command-line, let's do
 some simple classification on a subset of the standard machine learning
-`covertype` dataset.  We'll first split the dataset into a training set and a
-testing set, then we'll train an mlpack random forest on the training data, and
-finally we'll print the accuracy of the random forest on the test dataset.
+`covertype` dataset.  We will first split the dataset into a training set and a
+testing set, then we will train an mlpack random forest on the training data, and
+finally we will print the accuracy of the random forest on the test dataset.
 
 You can copy-paste this code directly into your shell to run it.
 
@@ -99,9 +99,9 @@ different mlpack learners, or to interface with other machine learning toolkits.
 
 ## Using mlpack for movie recommendations
 
-In this example, we'll train a collaborative filtering model using mlpack's
-`mlpack_cf` program.  We'll train this on the
-[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we'll
+In this example, we will train a collaborative filtering model using mlpack's
+`mlpack_cf` program.  We will train this on the
+[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we will
 use the model that we train to give recommendations.
 
 You can copy-paste this code directly into the command line to run it.

--- a/doc/quickstart/cpp.md
+++ b/doc/quickstart/cpp.md
@@ -27,7 +27,7 @@ and on Fedora or Red Hat:
 sudo dnf install mlpack-devel
 ```
 
-You can also use a Docker image from Dockerhub, 
+You can also use a Docker image from Dockerhub,
 which has mlpack headers already installed:
 
 ```sh
@@ -83,8 +83,8 @@ If the version is outdated or there is a new release version, please [create an 
 
 As a really simple example of how to use mlpack in C++, let's do some simple
 classification on a subset of the standard machine learning `covertype` dataset.
-We'll first split the dataset into a training set and a test set, then we'll
-train an mlpack random forest on the training data, and finally we'll print the
+We will first split the dataset into a training set and a test set, then we will
+train an mlpack random forest on the training data, and finally we will print the
 accuracy of the random forest on the test dataset.
 
 The first step is to download the covertype dataset onto your system so that it
@@ -181,9 +181,9 @@ different mlpack learners, or to interface with other machine learning toolkits.
 
 ## Using mlpack for movie recommendations
 
-In this example, we'll train a collaborative filtering model using mlpack's `CF`
-class.  We'll train this on this
-[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we'll
+In this example, we will train a collaborative filtering model using mlpack's `CF`
+class.  We will train this on this
+[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we will
 use the model that we train to give recommendations.
 
 First, download the MovieLens dataset:

--- a/doc/quickstart/go.md
+++ b/doc/quickstart/go.md
@@ -35,8 +35,8 @@ information on that, follow the instructions in the
 
 As a really simple example of how to use mlpack from Go, let's do some
 simple classification on a subset of the standard machine learning `covertype`
-dataset.  We'll first split the dataset into a training set and a testing set,
-then we'll train an mlpack random forest on the training data, and finally we'll
+dataset.  We will first split the dataset into a training set and a testing set,
+then we will train an mlpack random forest on the training data, and finally we will
 print the accuracy of the random forest on the test dataset.
 
 You can copy-paste this code directly into main.go to run it.
@@ -110,10 +110,10 @@ different mlpack learners, or to interface with other machine learning toolkits.
 
 ## Using mlpack for movie recommendations
 
-In this example, we'll train a collaborative filtering model using mlpack's
+In this example, we will train a collaborative filtering model using mlpack's
 [`cf()`](../user/bindings/go.md#cf) method.
-We'll train this on the
-[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we'll
+We will train this on the
+[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we will
 use the model that we train to give recommendations.
 
 You can copy-paste this code directly into main.go to run it.

--- a/doc/quickstart/julia.md
+++ b/doc/quickstart/julia.md
@@ -24,9 +24,9 @@ information on that, follow the instructions in the
 
 As a really simple example of how to use mlpack from Julia, let's do some
 simple classification on a subset of the standard machine learning `covertype`
-dataset.  We'll first split the dataset into a training set and a testing set,
-then we'll train an mlpack random forest on the training data, and finally we'll
-print the accuracy of the random forest on the test dataset.
+dataset.  We will first split the dataset into a training set and a testing set,
+then we will train an mlpack random forest on the training data, and finally we
+will print the accuracy of the random forest on the test dataset.
 
 You can copy-paste this code directly into Julia to run it.  You may need to add
 some extra packages with, e.g., `using Pkg; Pkg.add("CSV");
@@ -80,10 +80,10 @@ different mlpack learners, or to interface with other machine learning toolkits.
 
 ## Using mlpack for movie recommendations
 
-In this example, we'll train a collaborative filtering model using mlpack's
+In this example, we will train a collaborative filtering model using mlpack's
 [`cf()`](../user/bindings/julia.md#cf) method.
-We'll train this on the
-[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we'll
+We will train this on the
+[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we will
 use the model that we train to give recommendations.
 
 You can copy-paste this code directly into Julia to run it.

--- a/doc/quickstart/python.md
+++ b/doc/quickstart/python.md
@@ -34,8 +34,8 @@ For information on that, follow the instructions in the
 
 As a really simple example of how to use mlpack from Python, let's do some
 simple classification on a subset of the standard machine learning `covertype`
-dataset.  We'll first split the dataset into a training set and a testing set,
-then we'll train an mlpack random forest on the training data, and finally we'll
+dataset.  We will first split the dataset into a training set and a testing set,
+then we will train an mlpack random forest on the training data, and finally we will
 print the accuracy of the random forest on the test dataset.
 
 You can copy-paste this code directly into Python to run it.
@@ -54,7 +54,7 @@ labels = df['label']
 dataset = df.drop('label', axis = 1)
 
 # Split the dataset using mlpack.  The output comes back as a dictionary,
-# which we'll unpack for clarity of code.
+# which we will unpack for clarity of code.
 output = mlpack.preprocess_split(input_=dataset,
                                  input_labels=labels,
                                  test_ratio=0.3)
@@ -92,10 +92,10 @@ different mlpack learners, or to interface with other machine learning toolkits.
 
 ## Using mlpack for movie recommendations
 
-In this example, we'll train a collaborative filtering model using mlpack's
+In this example, we will train a collaborative filtering model using mlpack's
 [`cf()`](../user/bindings/python.md#cf) method.
-We'll train this on the
-[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we'll
+We will train this on the
+[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we will
 use the model that we train to give recommendations.
 
 You can copy-paste this code directly into Python to run it.

--- a/doc/quickstart/r.md
+++ b/doc/quickstart/r.md
@@ -1,14 +1,14 @@
 # mlpack in R quickstart guide
 
-This page describes how you can quickly get started using mlpack from R and
-gives a few examples of usage, and pointers to deeper documentation.
+This page describes how you can get started using mlpack from R, and
+gives a few examples of usage as well as pointers to additional documentation.
 
 This quickstart guide is also available for [C++](cpp.md), [Python](python.md),
 [Julia](julia.md), [the command line](cli.md), and [Go](go.md).
 
 ## Installing mlpack
 
-Installing the mlpack bindings for R is straightforward; you can just use
+Installing the mlpack bindings for R is straightforward as you can use
 CRAN:
 
 ```r
@@ -17,20 +17,23 @@ install.packages('mlpack')
 
 Building the R bindings from scratch is a little more in-depth, though.  For
 information on that, follow the instructions in the
-[installation guide](../user/install.md#compile-bindings-manually).
+[installation guide](../user/install.md#compile-bindings-manually). Note that
+the mlpack R binding turn off support for the STB, DR_LIBS, and HTTPLIB
+libraries which may be of lesser interst to R users. If desired, support at
+the C++ level can be enabled by setting per-library `#define` statements.
 
 ## Simple mlpack quickstart example
 
-As a really simple example of how to use mlpack from R, let's do some
+As a really simple example of how to use mlpack from R, let us do some
 simple classification on a subset of the standard machine learning `covertype`
-dataset.  We'll first split the dataset into a training set and a testing set,
-then we'll train an mlpack random forest on the training data, and finally we'll
-print the accuracy of the random forest on the test dataset.
+dataset.  We will first split the dataset into a training set and a testing set,
+then we will train an mlpack random forest on the training data, and finally
+we will print the accuracy of the random forest on the test dataset.
 
 You can copy-paste this code directly into R to run it.
 
 ```r
-if(!requireNamespace("data.table", quietly = TRUE)) { install.packages("data.table") }
+if (!requireNamespace("data.table", quietly = TRUE)) install.packages("data.table")
 suppressMessages({
     library("mlpack")
     library("data.table")
@@ -38,11 +41,12 @@ suppressMessages({
 
 # Load the dataset from an online URL.  Replace with 'covertype.csv.gz' if you
 # want to use on the full dataset.
-df <- fread("https://www.mlpack.org/datasets/covertype-small.csv.gz")
+url <- "https://www.mlpack.org/datasets/covertype-small.csv.gz"
+dataset <- fread(url, showProgress=FALSE)
 
 # Split the labels.
-labels <- df[, .(label)]
-dataset <- df[, label:=NULL]
+labels <- dataset[, label]  # extract column 'label' as a vector
+dataset[, label := NULL]    # remove column 'label'
 
 # Split the dataset using mlpack.
 prepdata <- preprocess_split(input = dataset,
@@ -51,22 +55,19 @@ prepdata <- preprocess_split(input = dataset,
                              verbose = TRUE)
 
 # Train a random forest.
-output <- random_forest(training = prepdata$training,
-                        labels = prepdata$training_labels,
-                        print_training_accuracy = TRUE,
-                        num_trees = 10,
-                        minimum_leaf_size = 3,
-                        verbose = TRUE)
-rf_model <- output$output_model
+rf_model <- random_forest_train(training = prepdata$training,
+                                labels = prepdata$training_labels,
+                                print_training_accuracy = TRUE,
+                                num_trees = 10,
+                                minimum_leaf_size = 3,
+                                verbose = TRUE)
 
 # Predict the labels of the test points.
-output <- random_forest(input_model = rf_model,
-                        test = prepdata$test,
-                        verbose = TRUE)
+output <- predict(rf_model, newdata = prepdata$test)
 
 # Now print the accuracy.  The third return value ('probabilities'), which we
 # ignored here, could also be used to generate an ROC curve.
-correct <- sum(output$predictions == prepdata$test_labels)
+correct <- sum(output == prepdata$test_labels)
 cat(correct, "out of", length(prepdata$test_labels), "test points correct",
     correct / length(prepdata$test_labels) * 100.0, "%\n")
 ```
@@ -75,21 +76,21 @@ We can see that we achieve reasonably good accuracy on the test dataset (80%+);
 if we use the full `covertype.csv.gz`, the accuracy should increase
 significantly (but training will take longer).
 
-It's easy to modify the code above to do more complex things, or to use
+It is easy to modify the code above to do more complex things, or to use
 different mlpack learners, or to interface with other machine learning toolkits.
 
 ## Using mlpack for movie recommendations
 
-In this example, we'll train a collaborative filtering model using mlpack's
+In this example, we will train a collaborative filtering model using mlpack's
 [`cf()`](../user/bindings/r.md#cf) method.
-We'll train this on the
-[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we'll
+We will train this on the
+[MovieLens dataset](https://grouplens.org/datasets/movielens/), and then we will
 use the model that we train to give recommendations.
 
 You can copy-paste this code directly into R to run it.
 
 ```r
-if(!requireNamespace("data.table", quietly = TRUE)) { install.packages("data.table") }
+if (!requireNamespace("data.table", quietly = TRUE)) install.packages("data.table")
 suppressMessages({
     library("mlpack")
     library("data.table")
@@ -97,8 +98,10 @@ suppressMessages({
 
 # First, load the MovieLens dataset.  This is taken from files.grouplens.org/
 # but reposted on mlpack.org as unpacked and slightly preprocessed data.
-ratings <- fread("http://www.mlpack.org/datasets/ml-20m/ratings-only.csv.gz")
-movies <- fread("http://www.mlpack.org/datasets/ml-20m/movies.csv.gz")
+ratings <- fread("http://www.mlpack.org/datasets/ml-20m/ratings-only.csv.gz",
+                 showProgress=FALSE)
+movies <- fread("http://www.mlpack.org/datasets/ml-20m/movies.csv.gz",
+                showProgress=FALSE)
 
 # Hold out 10% of the dataset into a test set so we can evaluate performance.
 predata <- preprocess_split(input = ratings,
@@ -124,7 +127,7 @@ output <- cf(input_model = cf_model,
 # Get the names of the movies for user 1.
 cat("Recommendations for user 1:\n")
 for (i in 1:10) {
-  cat("  ", i, ":", as.character(movies[output$output[i], 3]), "\n")
+  cat("  ", i, ":", movies[output$output[i], title], "\n")
 }
 ```
 
@@ -158,5 +161,5 @@ page:
 
 Also, mlpack is much more flexible from C++ and allows much greater
 functionality.  So, more complicated tasks are possible if you are willing to
-write C++ (or perhaps Rcpp).  To get started learning about mlpack in C++, a
-good starting point is the [C++ quickstart guide](cpp.md).
+write C++ (perhaps relying on Rcpp).  To get started learning about mlpack in
+C++, a good starting point is the [C++ quickstart guide](cpp.md).

--- a/doc/quickstart/r.md
+++ b/doc/quickstart/r.md
@@ -18,9 +18,10 @@ install.packages('mlpack')
 Building the R bindings from scratch is a little more in-depth, though.  For
 information on that, follow the instructions in the
 [installation guide](../user/install.md#compile-bindings-manually). Note that
-the mlpack R binding turn off support for the STB, DR_LIBS, and HTTPLIB
-libraries which may be of lesser interst to R users. If desired, support at
-the C++ level can be enabled by setting per-library `#define` statements.
+by default, mlpack's R bindings disable support for the STB, dr_libs, and httplib
+libraries, as they are not used in any of the R bindings. If desired, support at
+the C++ level can be enabled by setting per-library `#define` statements; see
+`inst/include/mlpack.h` in the generated package.
 
 ## Simple mlpack quickstart example
 


### PR DESCRIPTION
This PR update the 'quickstart' page for R a little.  It mentions that STB, DR_LIBS, HTTPLIB could be re-enabled at compile time without giving fuller details (and this can be extended, shortened, or be removed -- there is no one best approach here).  While at it, a little polish was applied to the R code, and a small amount of editorial rewrite has been applied.  