### PR TITLE
Templetize Scalar methods to allow using float types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 _????-??-??_
 
+ * Templetize Scalar methods to allow using float types (#4229).
+
  * Accelerated `LeakyReLU` ANN Layer (#4174).
 
  * Update `LinearSVM` documentation: `Classify()` returns class scores, not

--- a/src/mlpack/core/data/scaler_methods/max_abs_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/max_abs_scaler.hpp
@@ -46,7 +46,6 @@ template<typename MatType = arma::mat>
 class MaxAbsScaler
 {
  public:
-
   using VecType = typename GetColType<MatType>::type;
   using ElemType = typename MatType::elem_type;
 

--- a/src/mlpack/core/data/scaler_methods/max_abs_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/max_abs_scaler.hpp
@@ -42,22 +42,26 @@ namespace mlpack {
  * scale.InverseTransform(output, input);
  * @endcode
  */
+template<typename MatType = arma::mat>
 class MaxAbsScaler
 {
  public:
+
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+
   /**
    * Function to fit features, to find out the min max and scale.
    *
    * @param input Dataset to fit.
    */
-  template<typename MatType>
   void Fit(const MatType& input)
   {
     itemMin = min(input, 1);
     itemMax = arma::max(input, 1);
     scale = arma::max(arma::abs(itemMin), arma::abs(itemMax));
     // Handling zeros in scale vector.
-    scale.for_each([](arma::vec::elem_type& val) { val =
+    scale.for_each([](ElemType& val) { val =
         (val == 0) ? 1 : val; });
   }
 
@@ -67,7 +71,6 @@ class MaxAbsScaler
    * @param input Dataset to scale features.
    * @param output Output matrix with scaled features.
    */
-  template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
     if (scale.is_empty())
@@ -85,7 +88,6 @@ class MaxAbsScaler
    * @param input Scaled dataset.
    * @param output Output matrix with original Dataset.
    */
-  template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
     output.copy_size(input);
@@ -93,11 +95,11 @@ class MaxAbsScaler
   }
 
   //! Get the Min row vector.
-  const arma::vec& ItemMin() const { return itemMin; }
+  const VecType& ItemMin() const { return itemMin; }
   //! Get the Max row vector.
-  const arma::vec& ItemMax() const { return itemMax; }
+  const VecType& ItemMax() const { return itemMax; }
   //! Get the Scale row vector.
-  const arma::vec& Scale() const { return scale; }
+  const VecType& Scale() const { return scale; }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */)
@@ -108,11 +110,11 @@ class MaxAbsScaler
   }
  private:
   // Vector which holds minimum of each feature.
-  arma::vec itemMin;
+  VecType itemMin;
   // Vector which holds maximum of each feature.
-  arma::vec itemMax;
+  VecType itemMax;
   // Vector which is used to scale up each feature.
-  arma::vec scale;
+  VecType scale;
 }; // class MaxAbsScaler
 
 } // namespace mlpack

--- a/src/mlpack/core/data/scaler_methods/mean_normalization.hpp
+++ b/src/mlpack/core/data/scaler_methods/mean_normalization.hpp
@@ -42,15 +42,19 @@ namespace mlpack {
  * scale.InverseTransform(output, input);
  * @endcode
  */
+template<typename MatType = arma::mat>
 class MeanNormalization
 {
  public:
+
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+
   /**
    * Function to fit features, to find out the min max and scale.
    *
    * @param input Dataset to fit.
    */
-  template<typename MatType>
   void Fit(const MatType& input)
   {
     itemMean = mean(input, 1);
@@ -58,7 +62,7 @@ class MeanNormalization
     itemMax = max(input, 1);
     scale = itemMax - itemMin;
     // Handling zeros in scale vector.
-    scale.for_each([](arma::vec::elem_type& val) { val =
+    scale.for_each([](ElemType& val) { val =
         (val == 0) ? 1 : val; });
   }
 
@@ -68,7 +72,6 @@ class MeanNormalization
    * @param input Dataset to scale features.
    * @param output Output matrix with scaled features.
    */
-  template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
     if (itemMean.is_empty() || scale.is_empty())
@@ -86,7 +89,6 @@ class MeanNormalization
    * @param input Scaled dataset.
    * @param output Output matrix with original Dataset.
    */
-  template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
     output.copy_size(input);
@@ -94,13 +96,13 @@ class MeanNormalization
   }
 
   //! Get the Mean row vector.
-  const arma::vec& ItemMean() const { return itemMean; }
+  const VecType& ItemMean() const { return itemMean; }
   //! Get the Min row vector.
-  const arma::vec& ItemMin() const { return itemMin; }
+  const VecType& ItemMin() const { return itemMin; }
   //! Get the Max row vector.
-  const arma::vec& ItemMax() const { return itemMax; }
+  const VecType& ItemMax() const { return itemMax; }
   //! Get the Scale row vector.
-  const arma::vec& Scale() const { return scale; }
+  const VecType& Scale() const { return scale; }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */)
@@ -113,13 +115,13 @@ class MeanNormalization
 
  private:
   // Vector which holds mean of each feature.
-  arma::vec itemMean;
+  VecType itemMean;
   // Vector which holds minimum of each feature.
-  arma::vec itemMin;
+  VecType itemMin;
   // Vector which holds maximum of each feature.
-  arma::vec itemMax;
+  VecType itemMax;
   // Vector which is used to scale up each feature.
-  arma::vec scale;
+  VecType scale;
 }; // class MeanNormalization
 
 } // namespace mlpack

--- a/src/mlpack/core/data/scaler_methods/mean_normalization.hpp
+++ b/src/mlpack/core/data/scaler_methods/mean_normalization.hpp
@@ -46,7 +46,6 @@ template<typename MatType = arma::mat>
 class MeanNormalization
 {
  public:
-
   using VecType = typename GetColType<MatType>::type;
   using ElemType = typename MatType::elem_type;
 

--- a/src/mlpack/core/data/scaler_methods/min_max_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/min_max_scaler.hpp
@@ -44,9 +44,14 @@ namespace mlpack {
  * scale.InverseTransform(output, input);
  * @endcode
  */
+template<typename MatType = arma::mat>
 class MinMaxScaler
 {
  public:
+
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+
   /**
    * Default constructor
    *
@@ -69,14 +74,13 @@ class MinMaxScaler
    *
    * @param input Dataset to fit.
    */
-  template<typename MatType>
   void Fit(const MatType& input)
   {
     itemMin = min(input, 1);
     itemMax = arma::max(input, 1);
     scale = itemMax - itemMin;
     // Handle zeros in scale vector.
-    scale.for_each([](arma::vec::elem_type& val) { val =
+    scale.for_each([](ElemType& val) { val =
         (val == 0) ? 1 : val; });
     scale = (scaleMax - scaleMin) / scale;
     scalerowmin.copy_size(itemMin);
@@ -90,7 +94,6 @@ class MinMaxScaler
    * @param input Dataset to scale features.
    * @param output Output matrix with scaled features.
    */
-  template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
     if (scalerowmin.is_empty() || scale.is_empty())
@@ -108,7 +111,6 @@ class MinMaxScaler
    * @param input Scaled dataset.
    * @param output Output matrix with original Dataset.
    */
-  template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
     output.copy_size(input);
@@ -116,15 +118,15 @@ class MinMaxScaler
   }
 
   //! Get the Min row vector.
-  const arma::vec& ItemMin() const { return itemMin; }
+  const VecType& ItemMin() const { return itemMin; }
   //! Get the Max row vector.
-  const arma::vec& ItemMax() const { return itemMax; }
+  const VecType& ItemMax() const { return itemMax; }
   //! Get the Scale row vector.
-  const arma::vec& Scale() const { return scale; }
+  const VecType& Scale() const { return scale; }
   //! Get the upper range parameter.
-  double ScaleMax() const { return scaleMax; }
+  ElemType ScaleMax() const { return scaleMax; }
   //! Get the lower range parameter.
-  double ScaleMin() const { return scaleMin; }
+  ElemType ScaleMin() const { return scaleMin; }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */)
@@ -139,17 +141,17 @@ class MinMaxScaler
 
  private:
   // Vector which holds minimum of each feature.
-  arma::vec itemMin;
+  VecType itemMin;
   // Vector which holds maximum of each feature.
-  arma::vec itemMax;
+  VecType itemMax;
   // Scale vector which is used to scale up each feature.
-  arma::vec scale;
+  VecType scale;
   // Lower value for range.
-  double scaleMin;
+  ElemType scaleMin;
   // Upper value for range.
-  double scaleMax;
+  ElemType scaleMax;
   // Column vector of scalemin
-  arma::vec scalerowmin;
+  VecType scalerowmin;
 }; // class MinMaxScaler
 
 } // namespace mlpack

--- a/src/mlpack/core/data/scaler_methods/min_max_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/min_max_scaler.hpp
@@ -48,7 +48,6 @@ template<typename MatType = arma::mat>
 class MinMaxScaler
 {
  public:
-
   using VecType = typename GetColType<MatType>::type;
   using ElemType = typename MatType::elem_type;
 

--- a/src/mlpack/core/data/scaler_methods/pca_whitening.hpp
+++ b/src/mlpack/core/data/scaler_methods/pca_whitening.hpp
@@ -46,7 +46,6 @@ template<typename MatType = arma::mat>
 class PCAWhitening
 {
  public:
-
   using VecType = typename GetColType<MatType>::type;
   using ElemType = typename MatType::elem_type;
 

--- a/src/mlpack/core/data/scaler_methods/pca_whitening.hpp
+++ b/src/mlpack/core/data/scaler_methods/pca_whitening.hpp
@@ -42,9 +42,14 @@ namespace mlpack {
  * scale.InverseTransform(output, input);
  * @endcode
  */
+template<typename MatType = arma::mat>
 class PCAWhitening
 {
  public:
+
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+
   /**
    * A constructor to set the regularization parameter.
    *
@@ -65,7 +70,6 @@ class PCAWhitening
    *
    * @param input Dataset to fit.
    */
-  template<typename MatType>
   void Fit(const MatType& input)
   {
     itemMean = mean(input, 1);
@@ -81,7 +85,6 @@ class PCAWhitening
    * @param input Dataset to scale features.
    * @param output Output matrix with whitened features.
    */
-  template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
     if (eigenValues.is_empty() || eigenVectors.is_empty())
@@ -101,7 +104,6 @@ class PCAWhitening
    * @param input Scaled dataset.
    * @param output Output matrix with original Dataset.
    */
-  template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
     output = arma::diagmat(sqrt(eigenValues)) * inv(eigenVectors.t())
@@ -110,13 +112,13 @@ class PCAWhitening
   }
 
   //! Get the mean row vector.
-  const arma::vec& ItemMean() const { return itemMean; }
+  const VecType& ItemMean() const { return itemMean; }
   //! Get the eigenvalues vector.
-  const arma::vec& EigenValues() const { return eigenValues; }
+  const VecType& EigenValues() const { return eigenValues; }
   //! Get the eigenvector.
-  const arma::mat& EigenVectors() const { return eigenVectors; }
+  const MatType& EigenVectors() const { return eigenVectors; }
   //! Get the regularization parameter.
-  const double& Epsilon() const { return epsilon; }
+  const ElemType& Epsilon() const { return epsilon; }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */)
@@ -129,13 +131,13 @@ class PCAWhitening
 
  private:
   // Vector which holds mean of each feature.
-  arma::vec itemMean;
+  VecType itemMean;
   // Mat which hold the eigenvectors.
-  arma::mat eigenVectors;
+  MatType eigenVectors;
   // Regularization Paramter.
-  double epsilon;
+  ElemType epsilon;
   // Vector which hold the eigenvalues.
-  arma::vec eigenValues;
+  VecType eigenValues;
 }; // class PCAWhitening
 
 } // namespace mlpack

--- a/src/mlpack/core/data/scaler_methods/standard_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/standard_scaler.hpp
@@ -43,21 +43,25 @@ namespace mlpack {
  * scale.InverseTransform(output, input);
  * @endcode
  */
+template<typename MatType = arma::mat>
 class StandardScaler
 {
  public:
+
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+
   /**
    * Function to fit features, to find out the min max and scale.
    *
    * @param input Dataset to fit.
    */
-  template<typename MatType>
   void Fit(const MatType& input)
   {
     itemMean = mean(input, 1);
     itemStdDev = stddev(input, 1, 1);
     // Handle zeros in scale vector.
-    itemStdDev.for_each([](arma::vec::elem_type& val) { val =
+    itemStdDev.for_each([](ElemType& val) { val =
         (val == 0) ? 1 : val; });
   }
 
@@ -67,7 +71,6 @@ class StandardScaler
    * @param input Dataset to scale features.
    * @param output Output matrix with scaled features.
    */
-  template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
     if (itemMean.is_empty() || itemStdDev.is_empty())
@@ -85,7 +88,6 @@ class StandardScaler
    * @param input Scaled dataset.
    * @param output Output matrix with original Dataset.
    */
-  template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
     output.copy_size(input);
@@ -93,9 +95,9 @@ class StandardScaler
   }
 
   //! Get the mean row vector.
-  const arma::vec& ItemMean() const { return itemMean; }
+  const VecType& ItemMean() const { return itemMean; }
   //! Get the standard deviation row vector.
-  const arma::vec& ItemStdDev() const { return itemStdDev; }
+  const VecType& ItemStdDev() const { return itemStdDev; }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */)
@@ -106,9 +108,9 @@ class StandardScaler
 
  private:
   // Vector which holds mean of each feature.
-  arma::vec itemMean;
-  // Vector which holds standard devation of each feature.
-  arma::vec itemStdDev;
+  VecType itemMean;
+  // Vector which holds standard deviation of each feature.
+  VecType itemStdDev;
 }; // class StandardScaler
 
 } // namespace mlpack

--- a/src/mlpack/core/data/scaler_methods/standard_scaler.hpp
+++ b/src/mlpack/core/data/scaler_methods/standard_scaler.hpp
@@ -47,7 +47,6 @@ template<typename MatType = arma::mat>
 class StandardScaler
 {
  public:
-
   using VecType = typename GetColType<MatType>::type;
   using ElemType = typename MatType::elem_type;
 

--- a/src/mlpack/core/data/scaler_methods/zca_whitening.hpp
+++ b/src/mlpack/core/data/scaler_methods/zca_whitening.hpp
@@ -42,9 +42,14 @@ namespace mlpack {
  * scale.InverseTransform(output, input);
  * @endcode
  */
+template<typename MatType = arma::mat>
 class ZCAWhitening
 {
  public:
+
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+
   /**
    * A constructor to set the regularization parameter.
    *
@@ -57,7 +62,6 @@ class ZCAWhitening
    *
    * @param input Dataset to fit.
    */
-  template<typename MatType>
   void Fit(const MatType& input)
   {
     pca.Fit(input);
@@ -69,7 +73,6 @@ class ZCAWhitening
    * @param input Dataset to scale features.
    * @param output Output matrix with whitened features.
    */
-  template<typename MatType>
   void Transform(const MatType& input, MatType& output)
   {
     pca.Transform(input, output);
@@ -82,7 +85,6 @@ class ZCAWhitening
    * @param input Scaled dataset.
    * @param output Output matrix with original Dataset.
    */
-  template<typename MatType>
   void InverseTransform(const MatType& input, MatType& output)
   {
     output = inv(pca.EigenVectors()) * arma::diagmat(sqrt(
@@ -91,13 +93,13 @@ class ZCAWhitening
   }
 
   //! Get the mean row vector.
-  const arma::vec& ItemMean() const { return pca.ItemMean(); }
+  const VecType& ItemMean() const { return pca.ItemMean(); }
   //! Get the eigenvalues vector.
-  const arma::vec& EigenValues() const { return pca.EigenValues(); }
+  const VecType& EigenValues() const { return pca.EigenValues(); }
   //! Get the eigenvector.
-  const arma::mat& EigenVectors() const { return pca.EigenVectors(); }
+  const MatType& EigenVectors() const { return pca.EigenVectors(); }
   //! Get the regularization parameter.
-  double Epsilon() const { return pca.Epsilon(); }
+  ElemType Epsilon() const { return pca.Epsilon(); }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */)
@@ -107,7 +109,7 @@ class ZCAWhitening
 
  private:
   // A pointer to PcaWhitening Class.
-  PCAWhitening pca;
+  PCAWhitening<MatType> pca;
 }; // class ZCAWhitening
 
 } // namespace mlpack

--- a/src/mlpack/core/data/scaler_methods/zca_whitening.hpp
+++ b/src/mlpack/core/data/scaler_methods/zca_whitening.hpp
@@ -46,7 +46,6 @@ template<typename MatType = arma::mat>
 class ZCAWhitening
 {
  public:
-
   using VecType = typename GetColType<MatType>::type;
   using ElemType = typename MatType::elem_type;
 

--- a/src/mlpack/methods/preprocess/scaling_model.hpp
+++ b/src/mlpack/methods/preprocess/scaling_model.hpp
@@ -40,12 +40,12 @@ class ScalingModel
 
  private:
   size_t scalerType;
-  MinMaxScaler* minmaxscale;
-  MaxAbsScaler* maxabsscale;
-  MeanNormalization* meanscale;
-  StandardScaler* standardscale;
-  PCAWhitening* pcascale;
-  ZCAWhitening* zcascale;
+  MinMaxScaler<>* minmaxscale;
+  MaxAbsScaler<>* maxabsscale;
+  MeanNormalization<>* meanscale;
+  StandardScaler<>* standardscale;
+  PCAWhitening<>* pcascale;
+  ZCAWhitening<>* zcascale;
   int minValue;
   int maxValue;
   double epsilon;

--- a/src/mlpack/methods/preprocess/scaling_model_impl.hpp
+++ b/src/mlpack/methods/preprocess/scaling_model_impl.hpp
@@ -39,17 +39,17 @@ inline ScalingModel::ScalingModel(const int minvalue,
 inline ScalingModel::ScalingModel(const ScalingModel& other) :
     scalerType(other.scalerType),
     minmaxscale(other.minmaxscale == NULL ? NULL :
-        new MinMaxScaler(*other.minmaxscale)),
+        new MinMaxScaler<>(*other.minmaxscale)),
     maxabsscale(other.maxabsscale == NULL ? NULL :
-        new MaxAbsScaler(*other.maxabsscale)),
+        new MaxAbsScaler<>(*other.maxabsscale)),
     meanscale(other.meanscale == NULL ? NULL :
-        new MeanNormalization(*other.meanscale)),
+        new MeanNormalization<>(*other.meanscale)),
     standardscale(other.standardscale == NULL ? NULL :
-        new StandardScaler(*other.standardscale)),
+        new StandardScaler<>(*other.standardscale)),
     pcascale(other.pcascale == NULL ? NULL :
-        new PCAWhitening(*other.pcascale)),
+        new PCAWhitening<>(*other.pcascale)),
     zcascale(other.zcascale == NULL ? NULL :
-        new ZCAWhitening(*other.zcascale)),
+        new ZCAWhitening<>(*other.zcascale)),
     minValue(other.minValue),
     maxValue(other.maxValue),
     epsilon(other.epsilon)
@@ -93,27 +93,27 @@ inline ScalingModel& ScalingModel::operator=(const ScalingModel& other)
 
   delete minmaxscale;
   minmaxscale = (other.minmaxscale == NULL) ? NULL :
-      new MinMaxScaler(*other.minmaxscale);
+      new MinMaxScaler<>(*other.minmaxscale);
 
   delete maxabsscale;
   maxabsscale = (other.maxabsscale == NULL) ? NULL :
-      new MaxAbsScaler(*other.maxabsscale);
+      new MaxAbsScaler<>(*other.maxabsscale);
 
   delete standardscale;
   standardscale = (other.standardscale == NULL) ? NULL :
-      new StandardScaler(*other.standardscale);
+      new StandardScaler<>(*other.standardscale);
 
   delete meanscale;
   meanscale = (other.meanscale == NULL) ? NULL :
-      new MeanNormalization(*other.meanscale);
+      new MeanNormalization<>(*other.meanscale);
 
   delete pcascale;
   pcascale = (other.pcascale == NULL) ? NULL :
-      new PCAWhitening(*other.pcascale);
+      new PCAWhitening<>(*other.pcascale);
 
   delete zcascale;
   zcascale = (other.zcascale == NULL) ? NULL :
-      new ZCAWhitening(*other.zcascale);
+      new ZCAWhitening<>(*other.zcascale);
 
   minValue = other.minValue;
   maxValue = other.maxValue;
@@ -168,37 +168,37 @@ void ScalingModel::Fit(const MatType& input)
   if (scalerType == ScalerTypes::STANDARD_SCALER)
   {
     delete standardscale;
-    standardscale = new StandardScaler();
+    standardscale = new StandardScaler<>();
     standardscale->Fit(input);
   }
   else if (scalerType == ScalerTypes::MIN_MAX_SCALER)
   {
     delete minmaxscale;
-    minmaxscale = new MinMaxScaler(minValue, maxValue);
+    minmaxscale = new MinMaxScaler<>(minValue, maxValue);
     minmaxscale->Fit(input);
   }
   else if (scalerType == ScalerTypes::MEAN_NORMALIZATION)
   {
     delete meanscale;
-    meanscale = new MeanNormalization();
+    meanscale = new MeanNormalization<>();
     meanscale->Fit(input);
   }
   else if (scalerType == ScalerTypes::MAX_ABS_SCALER)
   {
     delete maxabsscale;
-    maxabsscale = new MaxAbsScaler();
+    maxabsscale = new MaxAbsScaler<>();
     maxabsscale->Fit(input);
   }
   else if (scalerType == ScalerTypes::PCA_WHITENING)
   {
     delete pcascale;
-    pcascale = new PCAWhitening(epsilon);
+    pcascale = new PCAWhitening<>(epsilon);
     pcascale->Fit(input);
   }
   else if (scalerType == ScalerTypes::ZCA_WHITENING)
   {
     delete zcascale;
-    zcascale = new ZCAWhitening(epsilon);
+    zcascale = new ZCAWhitening<>(epsilon);
     zcascale->Fit(input);
   }
 }

--- a/src/mlpack/tests/scaling_test.cpp
+++ b/src/mlpack/tests/scaling_test.cpp
@@ -16,152 +16,214 @@
 using namespace mlpack;
 using namespace std;
 
-arma::mat dataset = "-1 -0.5 0 1;"
-                    "2 6 10 18;";
-arma::mat scaleddataset;
-arma::mat temp;
-
 /**
  * Test For MinMax Scaler Class.
  */
-TEST_CASE("MinMaxScalerTest", "[ScalingTest][tiny]")
+TEMPLATE_TEST_CASE("MinMaxScalerTest", "[ScalingTest][tiny]",
+    arma::mat, arma::fmat)
 {
-  arma::mat scaled = "0 0.2500 0.5000 1.000;"
-                     "0 0.2500 0.5000 1.000;";
-  MinMaxScaler scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "-1 -0.5 0 1;"
+                    "2 6 10 18;";
+  MatType scaled = "0 0.2500 0.5000 1.000;"
+                   "0 0.2500 0.5000 1.000;";
+  MatType scaleddataset, temp;
+  MinMaxScaler<MatType> scale;
   scale.Fit(dataset);
   scale.Transform(dataset, scaleddataset);
   scale.InverseTransform(scaleddataset, temp);
-  CheckMatrices(scaleddataset, scaled);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(scaleddataset, scaled, tolerance);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test For MaxAbs Scaler Class.
  */
-TEST_CASE("MaxAbsScalerTest", "[ScalingTest][tiny]")
+TEMPLATE_TEST_CASE("MaxAbsScalerTest", "[ScalingTest][tiny]",
+    arma::mat, arma::fmat)
 {
-  arma::mat scaled = "-1 -0.5 0 1;"
-                     "0.1111111111 0.3333333333 0.55555556 1.0000;";
-  MaxAbsScaler scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "-1 -0.5 0 1;"
+                    "2 6 10 18;";
+  MatType scaled = "-1 -0.5 0 1;"
+                   "0.1111111111 0.3333333333 0.55555556 1.0000;";
+  MatType scaleddataset, temp;
+  MaxAbsScaler<MatType> scale;
   scale.Fit(dataset);
   scale.Transform(dataset, scaleddataset);
   scale.InverseTransform(scaleddataset, temp);
-  CheckMatrices(scaleddataset, scaled);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(scaleddataset, scaled, tolerance);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test For Standard Scaler Class.
  */
-TEST_CASE("StandardScalerTest", "[ScalingTest][tiny]")
+TEMPLATE_TEST_CASE("StandardScalerTest", "[ScalingTest][tiny]",
+    arma::mat, arma::fmat)
 {
-  arma::mat scaled = "-1.18321596 -0.50709255  0.16903085 1.52127766;"
-                     "-1.18321596 -0.50709255  0.16903085 1.52127766;";
-  StandardScaler scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "-1 -0.5 0 1;"
+                    "2 6 10 18;";
+  MatType scaled = "-1.18321596 -0.50709255  0.16903085 1.52127766;"
+                   "-1.18321596 -0.50709255  0.16903085 1.52127766;";
+  MatType scaleddataset, temp;
+  StandardScaler<MatType> scale;
   scale.Fit(dataset);
   scale.Transform(dataset, scaleddataset);
   scale.InverseTransform(scaleddataset, temp);
-  CheckMatrices(scaleddataset, scaled);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(scaleddataset, scaled, tolerance);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test For MeanNormalization Scaler Class.
  */
-TEST_CASE("MeanNormalizationTest", "[ScalingTest][tiny]")
+TEMPLATE_TEST_CASE("MeanNormalizationTest", "[ScalingTest][tiny]",
+    arma::mat, arma::fmat)
 {
-  arma::mat scaled = "-0.43750000000 -0.187500000 0.062500000 0.562500000;"
-                     "-0.43750000000 -0.187500000 0.062500000 0.562500000;";
-  MeanNormalization scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "-1 -0.5 0 1;"
+                    "2 6 10 18;";
+  MatType scaled = "-0.43750000000 -0.187500000 0.062500000 0.562500000;"
+                   "-0.43750000000 -0.187500000 0.062500000 0.562500000;";
+  MatType scaleddataset, temp;
+  MeanNormalization<MatType> scale;
   scale.Fit(dataset);
   scale.Transform(dataset, scaleddataset);
   scale.InverseTransform(scaleddataset, temp);
-  CheckMatrices(scaleddataset, scaled);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(scaleddataset, scaled, tolerance);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test to pass same matrix as input and output
  */
-TEST_CASE("SameInputOutputTest", "[ScalingTest]")
+TEMPLATE_TEST_CASE("SameInputOutputTest", "[ScalingTest]",
+    arma::mat, arma::fmat)
 {
-  temp = dataset;
-  arma::mat scaled = "-0.43750000000 -0.187500000 0.062500000 0.562500000;"
-                     "-0.43750000000 -0.187500000 0.062500000 0.562500000;";
-  MeanNormalization scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "-1 -0.5 0 1;"
+                    "2 6 10 18;";
+  MatType temp = dataset;
+  MatType scaled = "-0.43750000000 -0.187500000 0.062500000 0.562500000;"
+                   "-0.43750000000 -0.187500000 0.062500000 0.562500000;";
+  MeanNormalization<MatType> scale;
   scale.Fit(temp);
   scale.Transform(temp, temp);
-  CheckMatrices(scaled, temp);
+  CheckMatrices(scaled, temp, tolerance);
   scale.InverseTransform(temp, temp);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test for Zero Matrix.
  */
-TEST_CASE("ZeroMatrixTest", "[ScalingTest]")
+TEMPLATE_TEST_CASE("ZeroMatrixTest", "[ScalingTest]",
+    arma::mat, arma::fmat)
 {
-  arma::mat input(2, 4);
-  MeanNormalization scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType input(2, 4);
+  MatType temp;
+  MeanNormalization<MatType> scale;
   scale.Fit(input);
   scale.Transform(input, temp);
-  CheckMatrices(input, temp);
+  CheckMatrices(input, temp, tolerance);
   scale.InverseTransform(input, temp);
-  CheckMatrices(input, temp);
+  CheckMatrices(input, temp, tolerance);
 }
 
 /**
  * Test for Zero Scale.
  */
-TEST_CASE("ZeroScaleTest", "[ScalingTest]")
+TEMPLATE_TEST_CASE("ZeroScaleTest", "[ScalingTest]",
+    arma::mat, arma::fmat)
 {
-  dataset = "1 1 1 1;"
-            "2 6 10 18;";
-  arma::mat scaled = "0 0 0 0;"
-                     "0 0.2500 0.5000 1.000;";
-  MinMaxScaler scale;
+  using MatType = TestType;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "1 1 1 1;"
+                    "2 6 10 18;";
+  MatType scaled = "0 0 0 0;"
+                   "0 0.2500 0.5000 1.000;";
+  MatType scaleddataset, temp;
+  MinMaxScaler<MatType> scale;
   scale.Fit(dataset);
   scale.Transform(dataset, scaleddataset);
   scale.InverseTransform(scaleddataset, temp);
-  CheckMatrices(scaleddataset, scaled);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(scaleddataset, scaled, tolerance);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test for PCA whitening Scale.
  */
-TEST_CASE("PCAWhiteningTest", "[ScalingTest]")
+TEMPLATE_TEST_CASE("PCAWhiteningTest", "[ScalingTest]",
+    arma::mat, arma::fmat)
 {
-  PCAWhitening scale;
-  arma::mat output;
+  using MatType = TestType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "1 1 1 1;"
+                    "2 6 10 18;";
+  PCAWhitening<MatType> scale;
+  MatType output, temp;
   scale.Fit(dataset);
   scale.Transform(dataset, output);
-  arma::vec diagonals = (ColumnCovariance(output)).diag();
+  VecType diagonals = (ColumnCovariance(output)).diag();
   // Checking covarience is close to 1.0
-  double ccovsum = 0.0;
+  ElemType ccovsum = 0.0;
   for (size_t i = 0; i < diagonals.n_elem; ++i)
     ccovsum += diagonals(i);
-  REQUIRE(ccovsum == Approx(1.0).epsilon(1e-5));
+  REQUIRE(ccovsum == Approx(1.0).epsilon(tolerance));
   scale.InverseTransform(output, temp);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(dataset, temp, tolerance);
 }
 
 /**
  * Test for ZCA whitening Scale.
  */
-TEST_CASE("ZCAWhiteningTest", "[ScalingTest]")
+TEMPLATE_TEST_CASE("ZCAWhiteningTest", "[ScalingTest]",
+    arma::mat, arma::fmat)
 {
-  ZCAWhitening scale;
-  arma::mat output;
+  using MatType = TestType;
+  using VecType = typename GetColType<MatType>::type;
+  using ElemType = typename MatType::elem_type;
+  const double tolerance = std::is_same_v<ElemType, float> ? 1e-4 : 1e-5;
+
+  MatType dataset = "1 1 1 1;"
+                    "2 6 10 18;";
+  ZCAWhitening<MatType> scale;
+  MatType output, temp;
   scale.Fit(dataset);
   scale.Transform(dataset, output);
-  arma::vec diagonals = (ColumnCovariance(output)).diag();
+  VecType diagonals = (ColumnCovariance(output)).diag();
   // Check that the covariance is close to 1.0.
-  double ccovsum = 0.0;
+  ElemType ccovsum = 0.0;
   for (size_t i = 0; i < diagonals.n_elem; ++i)
     ccovsum += diagonals(i);
-  REQUIRE(ccovsum == Approx(1.0).epsilon(1e-5));
+  REQUIRE(ccovsum == Approx(1.0).epsilon(tolerance));
   scale.InverseTransform(output, temp);
-  CheckMatrices(dataset, temp);
+  CheckMatrices(dataset, temp, tolerance);
 }


### PR DESCRIPTION
During the work on the tutorial training code I have discovered that it is not possible to use scalar methods with float types, especially since the vector type in the class members is double. Therefore, this PR allows to have the class templetized allowing easier usage with different matrix types
