### PR TITLE
Tweak ccache setup

### DIFF
--- a/.github/etc/R_Makevars_Linux
+++ b/.github/etc/R_Makevars_Linux
@@ -1,5 +1,0 @@
-CC=ccache gcc
-CXX=ccache g++
-CXX17=ccache g++ -Wno-deprecated-declarations
-#CXX17=ccache g++ 
-SHLIB_CXXLD=ccache g++

--- a/.github/etc/R_Makevars_macOS
+++ b/.github/etc/R_Makevars_macOS
@@ -1,5 +1,0 @@
-CC=ccache clang
-CXX=ccache clang++
-CXX17=ccache clang++ -Wno-deprecated-declarations
-#CXX17=ccache clang++
-SHLIB_CXXLD=ccache clang++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,16 +111,14 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Set up ccache.
       - name: Get ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.name }}
-          append-timestamp: false
-          variant: ccache
-          max-size: 1G # Github has a 10GB repo cache limit, so we use 1GB/job.
+          max-size: 1.5G # Github has a 10GB repo cache limit, so we use 1.5GB/job.
 
       - name: Configure ccache
         shell: bash
@@ -220,16 +218,14 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Set up ccache.
       - name: Get ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}
-          append-timestamp: false
-          variant: ccache
-          max-size: 1G
+          max-size: 1.5G # Github has a 10GB repo cache limit, so we use 1.5GB/job.
 
       # Set up Visual Studio.
       - name: Set up Visual Studio


### PR DESCRIPTION
The `ccache` compiler front-end can help reduce build times.  While even small code changes (or changes in system headers) may lead to cache misses, many builds will still benefit from cache hits when the changes to code are small or even zero (when for example documentation or tests are being updated).  

The PR makes a number of small changes that should benefit the use of `ccache`:

1.  Appending of the timestamp to the cache key is no longer prevented.  As GitHub Actions artefacts are immutable, it ensures each build creates a fresh cache file. This is the behavior recommended in the documentation of the action we use here.
2.  The per-file limit is increased to 1.5gb.  GitHub Actions only gives 10gb per repo.  We (currently) run nine actions in each invocation.  While the average size per cache file tends to be (well) below 1gb, we have seen occassional size spikes this would accommodate.  
3.  The default setting of `variant: ccache` has been removed, its value is implicit.
4.  The action tag has been increaed to v1.2.23 to avoid the 'node20' nag.
5.  The checkout action tag was also increased to the current v7.
6.  Two old and no-longer-used config file snippets have been removed.