### PR TITLE
Add MLPACK_ENABLE_HTTPS to compile-time documentation

### DIFF
--- a/doc/embedded/crosscompile_example.md
+++ b/doc/embedded/crosscompile_example.md
@@ -1,4 +1,4 @@
-## Crosscompile mlpack example for an embedded hardware
+## Cross-compile mlpack example for an embedded hardware
 
 In this article, we explore how to add mlpack to a CMake project that cross-compiles
 code to embedded hardware.  See also these related other guides, which may be useful
@@ -30,6 +30,7 @@ Next, let's look at the `CMakeLists.txt` (e.g. the CMake configuration) in the
 The first part of the code, printed below or
 [available here](https://github.com/mlpack/examples/blob/master/embedded/crosscompile_random_forest/CMakeLists.txt),
 defines the project name and includes two useful CMake configuration files:
+
  * `mlpack.cmake`: finds mlpack's dependencies and download them if necessary.
  * `ConfigureCrossCompile.cmake`: set up CMake configuration for cross-compilation.
  * `crosscompile-toolchain.cmake`: invoke CMake crosscompilation infrastructure.

--- a/doc/img/pipeline-narrow.svg
+++ b/doc/img/pipeline-narrow.svg
@@ -113,17 +113,17 @@
       </a>
 
       <a xlink:href="../user/core/normalizing_labels.html" target="_top">
-        <text x="140" y="615" text-anchor="middle">Normalizing labels</text>
+        <text x="140" y="605" text-anchor="middle">Normalizing labels</text>
       </a>
       <a xlink:href="../user/core/split.html" target="_top">
-        <text x="140" y="630" text-anchor="middle">Dataset splitting</text>
+        <text x="140" y="620" text-anchor="middle">Dataset splitting</text>
       </a>
       <a xlink:href="../user/core/images.html" target="_top">
-        <text x="140" y="645" text-anchor="middle">Image preprocessing</text>
+        <text x="140" y="635" text-anchor="middle">Image preprocessing</text>
       </a>
 
       <a xlink:href="../user/core/imputation.html" target="_top">
-        <text x="140" y="660" text-anchor="middle">Imputing missing values</text>
+        <text x="140" y="650" text-anchor="middle">Imputing missing values</text>
       </a>
     </g>
 

--- a/doc/user/compile.md
+++ b/doc/user/compile.md
@@ -70,7 +70,8 @@ program (before including mlpack or Armadillo!).
 | `-DMLPACK_USE_SYSTEM_DR_LIBS` | `#define MLPACK_USE_SYSTEM_DR_LIBS` | Use the version of dr\_libs available on the system instead of the version bundled with mlpack.  If set, make sure `dr_mp3.h` and `dr_wav.h` are available. |
 | `-DMLPACK_DONT_USE_SYSTEM_DR_LIBS` | `#define MLPACK_DONT_USE_SYSTEM_DR_LIBS` | Force usage of the bundled version of dr\_libs.  Only necessary if mlpack was [configured](install.md#cmake-options) with `USE_SYSTEM_DR_LIBS=ON`. |
 | `-DMLPACK_DISABLE_DR_LIBS` | `#define MLPACK_DISABLE_DR_LIBS` | Disable dr_libs (audio) support within mlpack; use this if your system does not need audio processing (e.g., you are only using real time sensors data). |
-| `-DMLPACK_USE_SYSTEM_HTTPLIB` | `#define MLPACK_USE_SYSTEM_HTTPLIB`| Use the version of [cpp-httplib](https://github.com/yhirose/cpp-httplib) that is available on the system instead of the version bundled with mlpack. If set, make sure `httplib.h` is available. |
+| `-DMLPACK_ENABLE_HTTPS` | `#define MLPACK_ENABLE_HTTPS` | Enable HTTPS support for remote dataset loading with [`Load()`](load_save.md#loading-from-remote-urls); requires [linking with `-lssl -lcrypto`](compile.md#linking-against-optional-mlpack-dependencies). |
+| `-DMLPACK_USE_SYSTEM_HTTPLIB` | `#define MLPACK_USE_SYSTEM_HTTPLIB` | Use the version of [cpp-httplib](https://github.com/yhirose/cpp-httplib) that is available on the system instead of the version bundled with mlpack. If set, make sure `httplib.h` is available. |
 | `-DMLPACK_DONT_USE_SYSTEM_HTTPLIB` | `#define MLPACK_DONT_USE_SYSTEM_HTTPLIB` | Force usage of the bundled version of httplib.  Only necessary if mlpack was [configured](install.md#cmake-options) with `USE_SYSTEM_HTTPLIB=ON`. |
 | `-DMLPACK_DISABLE_HTTPLIB` | `#define MLPACK_DISABLE_HTTPLIB` | Disable httplib support within mlpack; use this if your system does not need httplib (e.g., embedded systems).|
 
@@ -78,6 +79,24 @@ program (before including mlpack or Armadillo!).
 `MLPACK_ENABLE_ANN_SERIALIZATION` option must be enabled.  This option is not
 enabled by default because it can cause compilation time to increase
 significantly, but it is necessary for any code that serializes neural networks.
+
+## Linking against optional mlpack dependencies
+
+The use of some optional mlpack dependencies necessitates linking against
+additional dependencies; add those to the example compilation command below
+after `-fopenmp`:
+
+```sh
+g++ -std=c++17 -O3 -o mlpack_program mlpack_program.cpp -larmadillo -fopenmp [extra libraries]
+```
+
+ * If HTTPS support is enabled with
+   [`MLPACK_ENABLE_HTTPS`](#configuring-mlpack-with-compile-time-definitions),
+   the SSL and libcrypto libraries must be linked against with `-lssl -lcrypto`.
+
+ * If the Armadillo runtime library is not available or linking against the underlying
+   BLAS/LAPACK libraries is desired, see the
+   [section below](#linking-without-the-armadillo-wrapper).
 
 ## Linking without the Armadillo wrapper
 
@@ -115,10 +134,11 @@ Some notes on the command above:
    reference LAPACK/BLAS, Intel MKL, and so forth.
 
  * In some programs, especially if sparse matrix support or HDF5 support is
-   used, it may be necessary to link against other libraries (e.g. `-lSuperLU
-   -lhdf5`, etc.).  The precise set of libraries to link against depends on the
-   code being used and the system configuration, but it should be easy enough to
-   use any linker errors to figure out what libraries need to be linked against.
+   used, it may be necessary to link against other libraries (e.g.
+   `-lSuperLU -lhdf5`, etc.).  The precise set of libraries to link against
+   depends on the code being used and the system configuration, but it should be
+   easy enough to use any linker errors to figure out what libraries need to be
+   linked against.
 
 ## Using mlpack in another CMake project
 

--- a/doc/user/deploy_docker.md
+++ b/doc/user/deploy_docker.md
@@ -83,10 +83,11 @@ g++ -O3 -o lstm_dga_detection_train lstm_dga_detection_train.cpp -fopenmp -larma
 
 Some modification of the command above may be necessary if mlpack is installed
 on your system in a nonstandard location, or if you are not using the Armadillo
-wrapper.  See [Configuring mlpack with compile-time
-definitions](compile.md#configuring-mlpack-with-compile-time-definitions) and
-[Linking without the Armadillo
-wrapper](compile.md#linking-without-the-armadillo-wrapper) for more details.
+wrapper.  See
+[Configuring mlpack with compile-time definitions](compile.md#configuring-mlpack-with-compile-time-definitions)
+and
+[Linking without the Armadillo wrapper](compile.md#linking-without-the-armadillo-wrapper)
+for more details.
 
 Once the program is compiled, we can train on a
 [dataset of domain names](https://datasets.mlpack.org/dga_domains.csv.gz).  The

--- a/doc/user/load_save.md
+++ b/doc/user/load_save.md
@@ -741,8 +741,8 @@ When a remote URL is given to `Load()`:
 
  * If the URL starts with `https://`, support must be enabled with
      [`#define MLPACK_USE_HTTPS`](compile.md#configuring-mlpack-with-compile-time-definitions) before
-     including mlpack, and the program must be additionally [linked with `-lssl
-     -lcrypto`](compile.md#linking-without-the-armadillo-wrapper).
+     including mlpack, and the program must be additionally
+     [linked with `-lssl -lcrypto`](compile.md#linking-against-optional-mlpack-dependencies).
 
  * The downloaded file will be saved to the system temporary directory (e.g. `/tmp/` on
     Linux systems).


### PR DESCRIPTION
@shrit and I noticed this morning that `MLPACK_ENABLE_HTTPS` isn't documented in the list of compile-time macros, and while fixing that I made a few other cleanups of things that I noticed weren't rendering right.  I also added a section about linking to optional dependencies, which we can use to add more optional dependencies (like libz and others) as they get implemented and documented.