### PR TITLE
Added Focal Loss implementation and unit tests

### DIFF
--- a/src/mlpack/methods/ann/loss_functions/focal_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/focal_loss.hpp
@@ -9,7 +9,8 @@ namespace mlpack {
  * @code
  * @article{Lin2017
  *   title   = {Focal Loss for Dense Object Detection},
- *   author  = {Tsung-Yi Lin, Priya Goyal, Ross Girshick, Kaiming He, Piotr Dollár},
+ *   author  = {Tsung-Yi Lin, Priya Goyal, Ross Girshick, 
+ *              Kaiming He, Piotr Dollár},
  *   journal = {IEEE International Conference on Computer Vision (ICCV)},
  *   year    = {2017}
  * }

--- a/src/mlpack/methods/ann/loss_functions/focal_loss.hpp
+++ b/src/mlpack/methods/ann/loss_functions/focal_loss.hpp
@@ -1,0 +1,63 @@
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_FOCAL_LOSS_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_FOCAL_LOSS_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+
+/**
+ * @code
+ * @article{Lin2017
+ *   title   = {Focal Loss for Dense Object Detection},
+ *   author  = {Tsung-Yi Lin, Priya Goyal, Ross Girshick, Kaiming He, Piotr Dollár},
+ *   journal = {IEEE International Conference on Computer Vision (ICCV)},
+ *   year    = {2017}
+ * }
+ * @endcode
+ */
+
+template<typename MatType = arma::mat>
+class FocalLossType
+{
+ public:
+  FocalLossType(
+      const double gamma = 2.0,
+      const double alpha = 0.25,
+      const bool reduction = true);
+
+  inline typename MatType::elem_type Forward(
+      const MatType& prediction,
+      const MatType& target);
+
+  inline void Backward(
+      const MatType& prediction,
+      const MatType& target,
+      MatType& loss);
+
+  double Gamma() const { return gamma; }
+  double& Gamma() { return gamma; }
+
+  double Alpha() const { return alpha; }
+  double& Alpha() { return alpha; }
+
+  bool Reduction() const { return reduction; }
+  bool& Reduction() { return reduction; }
+
+  template<typename Archive>
+  void serialize(
+      Archive& ar,
+      const uint32_t /* version */);
+
+ private:
+  double gamma;
+  double alpha;
+  bool reduction;
+};
+
+using FocalLoss = FocalLossType<arma::mat>;
+
+} // namespace mlpack
+
+#include "focal_loss_impl.hpp"
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/focal_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/focal_loss_impl.hpp
@@ -1,0 +1,98 @@
+/**
+ * @file methods/ann/loss_functions/focal_loss_impl.hpp
+ *
+ * Implementation of the Focal Loss function with logits.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_FOCAL_LOSS_IMPL_HPP
+#define MLPACK_METHODS_ANN_LOSS_FUNCTION_FOCAL_LOSS_IMPL_HPP
+
+#include "focal_loss.hpp"
+
+namespace mlpack {
+
+template<typename MatType>
+FocalLossType<MatType>::FocalLossType(
+    const double gamma,
+    const double alpha,
+    const bool reduction) :
+    gamma(gamma),
+    alpha(alpha),
+    reduction(reduction)
+{
+  // Nothing to do.
+}
+
+template<typename MatType>
+typename MatType::elem_type FocalLossType<MatType>::Forward(
+    const MatType& prediction,
+    const MatType& target)
+{
+  // p = sigmoid(logits)
+  MatType p = 1.0 / (1.0 + arma::exp(-prediction));
+
+  // Clamp probabilities to prevent log(0)
+  const double eps = 1e-15;
+  MatType p_clamped = arma::clamp(p, eps, 1.0 - eps);
+
+  // p_t = p if target == 1 else 1 - p
+  MatType p_t = target % p_clamped + (1.0 - target) % (1.0 - p_clamped);
+
+  // alpha_t = alpha if target == 1 else 1 - alpha
+  MatType alpha_t = target * alpha + (1.0 - target) * (1.0 - alpha);
+
+  // FL = -alpha_t * (1 - p_t)^gamma * log(p_t)
+  MatType loss = -alpha_t % arma::pow(1.0 - p_t, gamma) % arma::log(p_t);
+
+  typename MatType::elem_type lossSum = arma::accu(loss);
+
+  if (!reduction)
+    return lossSum / prediction.n_elem;
+
+  return lossSum;
+}
+
+template<typename MatType>
+void FocalLossType<MatType>::Backward(
+    const MatType& prediction,
+    const MatType& target,
+    MatType& loss)
+{
+  MatType p = 1.0 / (1.0 + arma::exp(-prediction));
+
+  const double eps = 1e-15;
+  MatType p_clamped = arma::clamp(p, eps, 1.0 - eps);
+
+  MatType p_t = target % p_clamped + (1.0 - target) % (1.0 - p_clamped);
+  MatType alpha_t = target * alpha + (1.0 - target) * (1.0 - alpha);
+
+  // Gradient w.r.t logits (x):
+  // dFL/dx = alpha_t * (1 - p_t)^gamma * (gamma * p_t * log(p_t) + p_t - 1) * (2*y - 1)
+  MatType term1 = arma::pow(1.0 - p_t, gamma);
+  MatType term2 = gamma * p_t % arma::log(p_t) + p_t - 1.0;
+  MatType signFactor = 2.0 * target - 1.0;
+
+  loss = alpha_t % term1 % term2 % signFactor;
+
+  if (!reduction)
+    loss /= prediction.n_elem;
+}
+
+template<typename MatType>
+template<typename Archive>
+void FocalLossType<MatType>::serialize(
+    Archive& ar,
+    const uint32_t /* version */)
+{
+  ar(CEREAL_NVP(gamma));
+  ar(CEREAL_NVP(alpha));
+  ar(CEREAL_NVP(reduction));
+}
+
+} // namespace mlpack
+
+#endif

--- a/src/mlpack/methods/ann/loss_functions/focal_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/focal_loss_impl.hpp
@@ -3,9 +3,10 @@
  *
  * Implementation of the Focal Loss function with logits.
  *
- * mlpack is free software; you may redistribute it and/or modify it under the
- * terms of the 3-clause BSD license.  You should have received a copy of the
- * 3-clause BSD license along with mlpack.  If not, see
+ * mlpack is free software; you may redistribute it and/or modify it 
+ * under the terms of the 3-clause BSD license.  You should have 
+ * received a copy of the 3-clause BSD license along with mlpack.  
+ * If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 #ifndef MLPACK_METHODS_ANN_LOSS_FUNCTION_FOCAL_LOSS_IMPL_HPP
@@ -71,7 +72,8 @@ void FocalLossType<MatType>::Backward(
   MatType alpha_t = target * alpha + (1.0 - target) * (1.0 - alpha);
 
   // Gradient w.r.t logits (x):
-  // dFL/dx = alpha_t * (1 - p_t)^gamma * (gamma * p_t * log(p_t) + p_t - 1) * (2*y - 1)
+  // dFL/dx = alpha_t * (1 - p_t)^gamma * (gamma * p_t * log(p_t)
+  // + p_t - 1) * (2*y - 1)
   MatType term1 = arma::pow(1.0 - p_t, gamma);
   MatType term2 = gamma * p_t % arma::log(p_t) + p_t - 1.0;
   MatType signFactor = 2.0 * target - 1.0;

--- a/src/mlpack/methods/ann/loss_functions/loss_functions.hpp
+++ b/src/mlpack/methods/ann/loss_functions/loss_functions.hpp
@@ -37,5 +37,6 @@
 #include "soft_margin_loss.hpp"
 #include "triplet_margin_loss.hpp"
 #include "vr_class_reward.hpp"
+#include "focal_loss.hpp" // added
 
 #endif

--- a/src/mlpack/tests/ann/loss_functions_test.cpp
+++ b/src/mlpack/tests/ann/loss_functions_test.cpp
@@ -1261,3 +1261,46 @@ TEST_CASE("JacobianNegativeLogLikelihoodLayerTest", "[LossFunctionsTest][tiny]")
     REQUIRE(error <= 1e-5);
   }
 }
+
+/**
+ * Simple FocalLoss test. GEMINI GENERATED
+ */
+TEST_CASE("FocalLossTest", "[ANNLossTest]")
+{
+  arma::mat prediction = {{-0.5, 1.2, 2.0}, {-1.0, 0.0, 0.5}};
+  arma::mat target = {{0.0, 1.0, 1.0}, {0.0, 0.0, 1.0}};
+
+  // 1. Test Forward & Backward execution
+  FocalLoss loss(2.0, 0.25, true);
+  double lossValue = loss.Forward(prediction, target);
+  REQUIRE(lossValue > 0.0);
+
+  arma::mat outputGrad;
+  loss.Backward(prediction, target, outputGrad);
+  REQUIRE(outputGrad.n_rows == prediction.n_rows);
+  REQUIRE(outputGrad.n_cols == prediction.n_cols);
+
+  // 2. Numerical Gradient Check via Finite Differences
+  const double eps = 1e-5;
+  arma::mat numGrad(prediction.n_rows, prediction.n_cols);
+
+  for (size_t i = 0; i < prediction.n_elem; ++i)
+  {
+    arma::mat predPlus = prediction;
+    arma::mat predMinus = prediction;
+
+    predPlus(i) += eps;
+    predMinus(i) -= eps;
+
+    double lossPlus = loss.Forward(predPlus, target);
+    double lossMinus = loss.Forward(predMinus, target);
+
+    numGrad(i) = (lossPlus - lossMinus) / (2.0 * eps);
+  }
+
+  // Check that analytical gradient matches numerical gradient
+  for (size_t i = 0; i < prediction.n_elem; ++i)
+  {
+    REQUIRE(outputGrad(i) == Approx(numGrad(i)).margin(1e-4));
+  }
+}


### PR DESCRIPTION
This PR introduces an implementation of Focal Loss (`FocalLossType`) to mlpack's neural network loss functions.

`src/mlpack/methods/ann/loss_functions/focal_loss.hpp` & `focal_loss_impl.hpp`:
- Implemented `FocalLossType` template supporting customizable `gamma` (focusing parameter), `alpha` (balancing factor), and `reduction` ('sum' vs 'mean') settings.
- Implemented numerically stable `Forward()` and `Backward()` passes operating directly on raw input logits.
- Added cereal serialization support via `serialize()`.

`src/mlpack/methods/ann/loss_functions/loss_functions.hpp`:
- Included `focal_loss.hpp` in the main loss functions convenience header.

`src/mlpack/tests/ann/loss_functions_test.cpp`:
- Added `FocalLossTest` to verify `Forward()` output, output matrix dimensions, and analytical gradient accuracy against numerical finite-difference gradient checks.

### Testing
Ran the test suite locally:

```bash
./bin/mlpack_test "FocalLossTest"
```

NB: Gemini was used to generate the test.