### PR TITLE
DAGNetwork: set size of error matrix in `EvaluateWithGradient`

### DIFF
--- a/src/mlpack/methods/ann/dag_network.hpp
+++ b/src/mlpack/methods/ann/dag_network.hpp
@@ -39,7 +39,7 @@ namespace mlpack {
  * concatenation over the last axis of that layer.
  *
  * A DAGNetwork cannot have any cycles. Creating a network with a cycle will
- * result in an error. A DAGNetwork can only have one input layer and one 
+ * result in an error. A DAGNetwork can only have one input layer and one
  * output layer.
  *
  * Although the actual types passed as input will be matrix objects with one
@@ -332,7 +332,7 @@ class DAGNetwork
   typename MatType::elem_type Evaluate(const MatType& predictors,
                                        const MatType& responses);
 
-  //! Serialize the model.
+  // Serialize the model.
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */);
 
@@ -518,7 +518,7 @@ class DAGNetwork
    * This computes the dimensions of each layer held by the network, and the
    * output dimensions are set to the output dimensions of the last layer.
    *
-   * Input dimensions of nodes that have multiple parents are also 
+   * Input dimensions of nodes that have multiple parents are also
    * calculated here, based on their connection type.
    */
   void ComputeOutputDimensions();
@@ -656,19 +656,20 @@ class DAGNetwork
   // Dimensions of input data.
   std::vector<size_t> inputDimensions;
 
-  //! The matrix of data points (predictors).  This member is empty, except
-  //! during training---we must store a local copy of the training data since
-  //! the ensmallen optimizer will not provide training data.
+  // The matrix of data points (predictors).  This member is empty, except
+  // during training---we must store a local copy of the training data since
+  // the ensmallen optimizer will not provide training data.
   MatType predictors;
 
-  //! The matrix of responses to the input data points.  This member is empty,
-  //! except during training.
+  // The matrix of responses to the input data points.  This member is empty,
+  // except during training.
   MatType responses;
 
   // Locally-stored output of the network from a forward pass; used by the
   // backward pass.
   MatType networkOutput;
-  //! Locally-stored output of the backward pass; used by the gradient pass.
+  // Locally-stored output of the backward pass of the loss function.
+  // Used by the gradient pass.
   MatType error;
 
   // This matrix stores all of the outputs of each layer when `Forward()` is

--- a/src/mlpack/methods/ann/dag_network_impl.hpp
+++ b/src/mlpack/methods/ann/dag_network_impl.hpp
@@ -1445,6 +1445,7 @@ typename MatType::elem_type DAGNetwork<
   const size_t lastLayer = sortedNetwork.back();
   networkOutput.set_size(network[lastLayer]->OutputSize(),
     predictors.n_cols);
+  error.set_size(network[lastLayer]->OutputSize(), predictors.n_cols);
 
   MatType predictorsBatch, responsesBatch;
   MakeAlias(predictorsBatch, predictors, predictors.n_rows,

--- a/src/mlpack/methods/ann/ffn_impl.hpp
+++ b/src/mlpack/methods/ann/ffn_impl.hpp
@@ -332,6 +332,7 @@ typename MatType::elem_type FFN<
       ElemType(network.Loss());
 
   // Compute the error of the output layer.
+  error.set_size(networkOutput.n_rows, networkOutput.n_cols);
   outputLayer.Backward(networkOutput, targets, error);
 
   // Perform the backward pass.

--- a/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/cosine_embedding_loss_impl.hpp
@@ -77,7 +77,6 @@ void CosineEmbeddingLossType<MatType>::Backward(
 
   ColType inputTemp1 = vectorise(prediction);
   ColType inputTemp2 = vectorise(target);
-  loss.set_size(size(inputTemp1));
 
   ColType outputTemp;
   MakeAlias(outputTemp, loss, inputTemp1.n_elem, 0, false);

--- a/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/huber_loss_impl.hpp
@@ -55,7 +55,6 @@ void HuberLossType<MatType>::Backward(
 {
   using ElemType = typename MatType::elem_type;
 
-  loss.set_size(size(prediction));
   for (size_t i = 0; i < loss.n_elem; ++i)
   {
     const ElemType absError = std::abs(target[i] - prediction[i]);

--- a/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/mean_bias_error_impl.hpp
@@ -45,7 +45,6 @@ void MeanBiasErrorType<MatType>::Backward(
     const MatType& /* target */,
     MatType& loss)
 {
-  loss.set_size(size(prediction));
   loss.fill(-1.0);
 
   if (!reduction)

--- a/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/multilabel_softmargin_loss_impl.hpp
@@ -58,7 +58,6 @@ void MultiLabelSoftMarginLossType<MatType>::Backward(
     const MatType& target,
     MatType& output)
 {
-  output.set_size(size(input));
   MatType sigmoid = (1 / (1 + exp(-input)));
   output = -(target % (1 - sigmoid) - (1 - target) % sigmoid) %
         repmat(classWeights, target.n_rows, 1) / output.n_elem;

--- a/src/mlpack/methods/ann/loss_functions/poisson_nll_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/poisson_nll_loss_impl.hpp
@@ -70,8 +70,6 @@ void PoissonNLLLossType<MatType>::Backward(
     const MatType& target,
     MatType& loss)
 {
-  loss.set_size(size(prediction));
-
   if (logInput)
     loss = (exp(prediction) - target);
   else

--- a/src/mlpack/methods/ann/loss_functions/soft_margin_loss_impl.hpp
+++ b/src/mlpack/methods/ann/loss_functions/soft_margin_loss_impl.hpp
@@ -43,7 +43,6 @@ void SoftMarginLossType<MatType>::Backward(
     const MatType& target,
     MatType& loss)
 {
-  loss.set_size(size(prediction));
   MatType temp = exp(-target % prediction);
   MatType numerator = -target % temp;
   MatType denominator = 1 + temp;

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -718,7 +718,7 @@ typename MatType::elem_type RNN<
 
     // Now backpropagate through time, starting with the current time step and
     // moving backwards.
-    MatType error(output.n_rows, activeBatchSize);
+    MatType error(outputs.n_rows, activeBatchSize);
     for (size_t step = 0; step < std::min(t + 1, effectiveBPTTSteps); ++step)
     {
       SetCurrentStep(t - step, (step == 0), batchSize, activeBatchSize, true);

--- a/src/mlpack/methods/ann/rnn_impl.hpp
+++ b/src/mlpack/methods/ann/rnn_impl.hpp
@@ -718,7 +718,7 @@ typename MatType::elem_type RNN<
 
     // Now backpropagate through time, starting with the current time step and
     // moving backwards.
-    MatType error;
+    MatType error(output.n_rows, activeBatchSize);
     for (size_t step = 0; step < std::min(t + 1, effectiveBPTTSteps); ++step)
     {
       SetCurrentStep(t - step, (step == 0), batchSize, activeBatchSize, true);

--- a/src/mlpack/tests/ann/loss_functions_test.cpp
+++ b/src/mlpack/tests/ann/loss_functions_test.cpp
@@ -41,6 +41,7 @@ TEST_CASE("HuberLossTest", "[LossFunctionsTest]")
       "-1.0000 0.7748 0.2580 1.0000 0.0976 1.0000");
   input.reshape(4, 3);
   target.reshape(4, 3);
+  output.reshape(4, 3);
   expectedOutput.reshape(4, 3);
 
   // Test the Forward function. Loss should be 6.36364.
@@ -95,6 +96,11 @@ TEST_CASE("PoissonNLLLossTest", "[LossFunctionsTest]")
   input4 = arma::mat("0.658502 0.445627 0.667651 0.310549 "
                      "0.589540 0.052568 0.549769 0.381504 ");
   target4 = arma::mat("1.0 3.0 1.0 2.0 1.0 4.0 2.0 1.0");
+
+  output1.reshape(2, 4);
+  output2.reshape(2, 4);
+  output3.reshape(2, 4);
+  output4.reshape(2, 4);
 
   double loss1 = module1.Forward(input, target);
   double loss2 = module2.Forward(input, target);
@@ -602,6 +608,7 @@ TEST_CASE("SimpleMeanBiasErrorTest", "[LossFunctionsTest]")
 
   input.reshape(4, 3);
   target.reshape(4, 3);
+  output.reshape(4, 3);
 
   // Test the forward function.
   // Loss should  be 0.1081.
@@ -782,6 +789,8 @@ TEST_CASE("CosineEmbeddingLossTest", "[LossFunctionsTest]")
   input2.ones();
   y = arma::mat(1, 1);
   y.ones();
+  output.reshape(1, 10);
+
   loss = module.Forward(input1, input1);
   REQUIRE(loss == Approx(0.0).margin(1e-6));
 
@@ -806,6 +815,8 @@ TEST_CASE("CosineEmbeddingLossTest", "[LossFunctionsTest]")
   input2(0) = 2;
   input2(1) = 2;
   input2(2) = 2;
+  output.reshape(3, 2);
+
   loss = module.Forward(input1, input2);
   // Calculated using torch.nn.CosineEmbeddingLoss().
   REQUIRE(loss == Approx(2.897367).epsilon(1e-3));
@@ -878,6 +889,7 @@ TEST_CASE("SoftMarginLossTest", "[LossFunctionsTest]")
   target = arma::mat("1 1 -1 1 -1 1 -1 1 1");
   input.reshape(3, 3);
   target.reshape(3, 3);
+  output.reshape(3, 3);
 
   // Test for sum reduction.
 
@@ -1096,6 +1108,7 @@ TEST_CASE("MultiLabelSoftMarginLossTest", "[LossFunctionsTest]")
   target = arma::mat("0 1 0 1 0 0 0 0 1");
   input.reshape(3, 3);
   target.reshape(3, 3);
+  output.reshape(3, 3);
 
   // Test for sum reduction.
 

--- a/src/mlpack/tests/ann/loss_functions_test.cpp
+++ b/src/mlpack/tests/ann/loss_functions_test.cpp
@@ -1166,6 +1166,7 @@ TEST_CASE("MultiLabelSoftMarginLossWeightedTest", "[LossFunctionsTest]")
   target = arma::mat("0 1 0 1 1 0 0 0 0 0 1 0");
   input.reshape(4, 3);
   target.reshape(4, 3);
+  output.reshape(4, 3);
 
   // Test for sum reduction.
 


### PR DESCRIPTION
Small PR that sets the size of the `error` matrix that a loss function writes to.