### PR TITLE
Fix degenerate matrix that can sometimes happen for RADICAL

### DIFF
--- a/src/mlpack/tests/main_tests/radical_test.cpp
+++ b/src/mlpack/tests/main_tests/radical_test.cpp
@@ -29,19 +29,23 @@ BINDING_TEST_FIXTURE(RadicalTestFixture);
 TEST_CASE_METHOD(RadicalTestFixture, "RadicalOutputDimensionTest",
                 "[RadicalMainTest][BindingTests]")
 {
-  arma::mat input = arma::randu<arma::mat>(5, 3);
+  // The number of points must be less than the number of dimensions, so that
+  // the covariance of input.t() (which is computed by RADICAL) is full-rank.
+  arma::mat input = arma::randu<arma::mat>(3, 5);
 
   SetInputParam("input", std::move(input));
 
   RUN_BINDING();
 
   // Check dimension of Y matrix.
-  REQUIRE(params.Get<arma::mat>("output_ic").n_rows == 5);
-  REQUIRE(params.Get<arma::mat>("output_ic").n_cols == 3);
+  REQUIRE(params.Get<arma::mat>("output_ic").n_rows == 3);
+  REQUIRE(params.Get<arma::mat>("output_ic").n_cols == 5);
+  REQUIRE(params.Get<arma::mat>("output_ic").is_finite());
 
   // Check dimension of W matrix.
-  REQUIRE(params.Get<arma::mat>("output_unmixing").n_rows == 5);
-  REQUIRE(params.Get<arma::mat>("output_unmixing").n_cols == 5);
+  REQUIRE(params.Get<arma::mat>("output_unmixing").n_rows == 3);
+  REQUIRE(params.Get<arma::mat>("output_unmixing").n_cols == 3);
+  REQUIRE(params.Get<arma::mat>("output_unmixing").is_finite());
 }
 
 /**
@@ -51,7 +55,9 @@ TEST_CASE_METHOD(RadicalTestFixture, "RadicalOutputDimensionTest",
 TEST_CASE_METHOD(RadicalTestFixture, "RadicalBoundsTest",
                 "[RadicalMainTest][BindingTests]")
 {
-  arma::mat input = arma::randu<arma::mat>(5, 3);
+  // The number of points must be less than the number of dimensions, so that
+  // the covariance of input.t() (which is computed by RADICAL) is full-rank.
+  arma::mat input = arma::randu<arma::mat>(3, 5);
 
   // Test for replicates.
 


### PR DESCRIPTION
For a long time, there have been extremely occasional random failures with `RadicalOutputDimensionTest` that I have never been able to reproduce or track down.  This is the most recent failure I saw: https://github.com/mlpack/mlpack/actions/runs/32726907768/job/97430301953

Given my lack of time to actually look into this issue, I figured this might be a good place to use the "you are an open source developer" Claude subscription that Anthropic gave me.

Claude was able to pretty quickly reproduce the issue---in part because it happened to be working in an Ubuntu container instead of on Debian, where due to package versions the issue does not occur (hence my failure to reproduce).  After that it successfully identified that the issue is just that a random matrix of size 5x3 is being transposed and we take the SVD of its covariance (so, e.g., we take the SVD of a 5x5 matrix).  But that covariance can pretty easily be randomly low-rank if the three columns turn out to be close to linearly dependent.

Claude then burned some indeterminate amount of tokens going down unrelated rabbit holes.  But, it did find the bug, and once I understood what was going on, it's an easy fix: just change the size of the matrix to 3x5, so that the covariance matrix is 3x3 and not low rank (or: at least, the likelihood of it being low rank is so small as to be negligible).