### PR TITLE
Document `DBSCAN`

### DIFF
--- a/doc/sidebar.html
+++ b/doc/sidebar.html
@@ -456,6 +456,11 @@ when the sidebar is built for each page.
                 </summary>
                 <ul>
                   <li>
+                    <a href="LINKROOTuser/methods/dbscan.html">
+                      <code>DBSCAN</code>
+                    </a>
+                  </li>
+                  <li>
                     <a href="LINKROOTuser/methods/mean_shift.html">
                       <code>MeanShift</code>
                     </a>

--- a/doc/user/bindings/cli.md
+++ b/doc/user/bindings/cli.md
@@ -427,9 +427,9 @@ $ mlpack_cf --input_model_file model.bin --query_file users.csv
 {: #dbscan_descr }
 
 ```bash
-$ mlpack_dbscan [--epsilon 1] [--help] [--info <string>] --input_file
-        <string> [--min_size 5] [--naive] [--selection_type 'ordered']
-        [--single_mode] [--tree_type 'kd'] [--verbose] [--version]
+$ mlpack_dbscan [--epsilon 0.5] [--help] [--info <string>] --input_file
+        <string> [--min_size 5] [--naive] [--radius 0.5] [--selection_type
+        'ordered'] [--single_mode] [--tree_type 'kd'] [--verbose] [--version]
         [--assignments_file <string>] [--centroids_file <string>]
 ```
 
@@ -442,12 +442,13 @@ An implementation of DBSCAN clustering.  Given a dataset, this can compute and r
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
 | `--check_input_matrices` | [`flag`](#doc_flag) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. |  |
-| `--epsilon (-e)` | [`double`](#doc_double) | Radius of each range search. | `1` |
+| `--epsilon (-e)` | [`double`](#doc_double) | Radius of each range search. (Deprecated: use 'radius' parameter instead!) | `0.5` |
 | `--help (-h)` | [`flag`](#doc_flag) | Default help info.  <span class="special">Only exists in CLI binding.</span> |  |
 | `--info` | [`string`](#doc_string) | Print help on a specific option.  <span class="special">Only exists in CLI binding.</span> | `''` |
 | `--input_file (-i)` | [`2-d matrix file`](#doc_a_2_d_matrix_file) | Input dataset to cluster. | `**--**` |
 | `--min_size (-m)` | [`int`](#doc_int) | Minimum number of points for a cluster. | `5` |
 | `--naive (-N)` | [`flag`](#doc_flag) | If set, brute-force range search (not tree-based) will be used. |  |
+| `--radius (-r)` | [`double`](#doc_double) | Radius of each range search. | `0.5` |
 | `--selection_type (-s)` | [`string`](#doc_string) | If using point selection policy, the type of selection to use ('ordered', 'random'). | `'ordered'` |
 | `--single_mode (-S)` | [`flag`](#doc_flag) | If set, single-tree range search (not dual-tree) will be used. |  |
 | `--tree_type (-t)` | [`string`](#doc_string) | If using single-tree or dual-tree search, the type of tree to use ('kd', 'r', 'r-star', 'x', 'hilbert-r', 'r-plus', 'r-plus-plus', 'cover', 'ball'). | `'kd'` |
@@ -467,7 +468,7 @@ An implementation of DBSCAN clustering.  Given a dataset, this can compute and r
 
 This program implements the DBSCAN algorithm for clustering using accelerated tree-based range search.  The type of tree that is used may be parameterized, or brute-force range search may also be used.
 
-The input dataset to be clustered may be specified with the `--input_file (-i)` parameter; the radius of each range search may be specified with the `--epsilon (-e)` parameters, and the minimum number of points in a cluster may be specified with the `--min_size (-m)` parameter.
+The input dataset to be clustered may be specified with the `--input_file (-i)` parameter; the radius of each range search may be specified with the `--radius (-r)` parameters, and the minimum number of points in a cluster may be specified with the `--min_size (-m)` parameter.
 
 The `--assignments_file (-a)` and `--centroids_file (-C)` output parameters may be used to save the output of the clustering. `--assignments_file (-a)` contains the cluster assignments of each point, and `--centroids_file (-C)` contains the centroids of each cluster.
 
@@ -477,7 +478,7 @@ The range search may be controlled with the `--tree_type (-t)`, `--single_mode (
 An example usage to run DBSCAN on the dataset in `'input.csv'` with a radius of 0.5 and a minimum cluster size of 5 is given below:
 
 ```bash
-$ mlpack_dbscan --input_file input.csv --epsilon 0.5 --min_size 5
+$ mlpack_dbscan --input_file input.csv --radius 0.5 --min_size 5
 ```
 
 ### See also

--- a/doc/user/bindings/go.md
+++ b/doc/user/bindings/go.md
@@ -527,9 +527,10 @@ import (
 
 // Initialize optional parameters for Dbscan().
 param := mlpack.DbscanOptions()
-param.Epsilon = 1
+param.Epsilon = 0.5
 param.MinSize = 5
 param.Naive = false
+param.Radius = 0.5
 param.SelectionType = "ordered"
 param.SingleMode = false
 param.TreeType = "kd"
@@ -548,10 +549,11 @@ There are two types of input options: required options, which are passed directl
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
 | `CheckInputMatrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `Epsilon` | [`float64`](#doc_float64) | Radius of each range search. | `1` |
+| `Epsilon` | [`float64`](#doc_float64) | Radius of each range search. (Deprecated: use 'radius' parameter instead!) | `0.5` |
 | `input` | [`*mat.Dense`](#doc_a__mat_Dense) | Input dataset to cluster. | `**--**` |
 | `MinSize` | [`int`](#doc_int) | Minimum number of points for a cluster. | `5` |
 | `Naive` | [`bool`](#doc_bool) | If set, brute-force range search (not tree-based) will be used. | `false` |
+| `Radius` | [`float64`](#doc_float64) | Radius of each range search. | `0.5` |
 | `SelectionType` | [`string`](#doc_string) | If using point selection policy, the type of selection to use ('ordered', 'random'). | `"ordered"` |
 | `SingleMode` | [`bool`](#doc_bool) | If set, single-tree range search (not dual-tree) will be used. | `false` |
 | `TreeType` | [`string`](#doc_string) | If using single-tree or dual-tree search, the type of tree to use ('kd', 'r', 'r-star', 'x', 'hilbert-r', 'r-plus', 'r-plus-plus', 'cover', 'ball'). | `"kd"` |
@@ -571,7 +573,7 @@ Output options are returned via Go's support for multiple return values, in the 
 
 This program implements the DBSCAN algorithm for clustering using accelerated tree-based range search.  The type of tree that is used may be parameterized, or brute-force range search may also be used.
 
-The input dataset to be clustered may be specified with the `Input` parameter; the radius of each range search may be specified with the `Epsilon` parameters, and the minimum number of points in a cluster may be specified with the `MinSize` parameter.
+The input dataset to be clustered may be specified with the `Input` parameter; the radius of each range search may be specified with the `Radius` parameters, and the minimum number of points in a cluster may be specified with the `MinSize` parameter.
 
 The `Assignments` and `Centroids` output parameters may be used to save the output of the clustering. `Assignments` contains the cluster assignments of each point, and `Centroids` contains the centroids of each cluster.
 
@@ -583,7 +585,7 @@ An example usage to run DBSCAN on the dataset in `input` with a radius of 0.5 an
 ```go
 // Initialize optional parameters for Dbscan().
 param := mlpack.DbscanOptions()
-param.Epsilon = 0.5
+param.Radius = 0.5
 param.MinSize = 5
 
 _, _ := mlpack.Dbscan(input, param)

--- a/doc/user/bindings/julia.md
+++ b/doc/user/bindings/julia.md
@@ -447,8 +447,8 @@ julia> recommendations, _ = cf(input_model=model, query=users,
 
 ```julia
 julia> using mlpack: dbscan
-julia> assignments, centroids = dbscan(input; epsilon=1.0, min_size=5,
-          naive=false, selection_type="ordered", single_mode=false,
+julia> assignments, centroids = dbscan(input; epsilon=0.5, min_size=5,
+          naive=false, radius=0.5, selection_type="ordered", single_mode=false,
           tree_type="kd", verbose=false)
 ```
 
@@ -461,10 +461,11 @@ An implementation of DBSCAN clustering.  Given a dataset, this can compute and r
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
 | `check_input_matrices` | [`Bool`](#doc_Bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `false` |
-| `epsilon` | [`Float64`](#doc_Float64) | Radius of each range search. | `1.0` |
+| `epsilon` | [`Float64`](#doc_Float64) | Radius of each range search. (Deprecated: use 'radius' parameter instead!) | `0.5` |
 | `input` | [`Float64 matrix-like`](#doc_Float64_matrix_like) | Input dataset to cluster. | `**--**` |
 | `min_size` | [`Int`](#doc_Int) | Minimum number of points for a cluster. | `5` |
 | `naive` | [`Bool`](#doc_Bool) | If set, brute-force range search (not tree-based) will be used. | `false` |
+| `radius` | [`Float64`](#doc_Float64) | Radius of each range search. | `0.5` |
 | `selection_type` | [`String`](#doc_String) | If using point selection policy, the type of selection to use ('ordered', 'random'). | `"ordered"` |
 | `single_mode` | [`Bool`](#doc_Bool) | If set, single-tree range search (not dual-tree) will be used. | `false` |
 | `tree_type` | [`String`](#doc_String) | If using single-tree or dual-tree search, the type of tree to use ('kd', 'r', 'r-star', 'x', 'hilbert-r', 'r-plus', 'r-plus-plus', 'cover', 'ball'). | `"kd"` |
@@ -484,7 +485,7 @@ Results are returned as a tuple, and can be unpacked directly into return values
 
 This program implements the DBSCAN algorithm for clustering using accelerated tree-based range search.  The type of tree that is used may be parameterized, or brute-force range search may also be used.
 
-The input dataset to be clustered may be specified with the `input` parameter; the radius of each range search may be specified with the `epsilon` parameters, and the minimum number of points in a cluster may be specified with the `min_size` parameter.
+The input dataset to be clustered may be specified with the `input` parameter; the radius of each range search may be specified with the `radius` parameters, and the minimum number of points in a cluster may be specified with the `min_size` parameter.
 
 The `assignments` and `centroids` output parameters may be used to save the output of the clustering. `assignments` contains the cluster assignments of each point, and `centroids` contains the centroids of each cluster.
 
@@ -496,7 +497,7 @@ An example usage to run DBSCAN on the dataset in ``input`` with a radius of 0.5 
 ```julia
 julia> using CSV
 julia> input = CSV.read("input.csv")
-julia> _, _ = dbscan(input; epsilon=0.5, min_size=5)
+julia> _, _ = dbscan(input; min_size=5, radius=0.5)
 ```
 
 ### See also

--- a/doc/user/bindings/python.md
+++ b/doc/user/bindings/python.md
@@ -453,8 +453,8 @@ Then, to use this model to generate recommendations for the list of users in the
 ```python
 >>> from mlpack import dbscan
 >>> d = dbscan(check_input_matrices=False, copy_all_inputs=False,
-        epsilon=1, input_=np.empty([0, 0]), min_size=5, naive=False,
-        selection_type='ordered', single_mode=False, tree_type='kd',
+        epsilon=0.5, input_=np.empty([0, 0]), min_size=5, naive=False,
+        radius=0.5, selection_type='ordered', single_mode=False, tree_type='kd',
         verbose=False)
 >>> assignments = d['assignments']
 >>> centroids = d['centroids']
@@ -470,10 +470,11 @@ An implementation of DBSCAN clustering.  Given a dataset, this can compute and r
 |------------|------------|-------------------|---------------|
 | `check_input_matrices` | [`bool`](#doc_bool) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `False` |
 | `copy_all_inputs` | [`bool`](#doc_bool) | If specified, all input parameters will be deep copied before the method is run.  This is useful for debugging problems where the input parameters are being modified by the algorithm, but can slow down the code.  <span class="special">Only exists in Python binding.</span> | `False` |
-| `epsilon` | [`float`](#doc_float) | Radius of each range search. | `1` |
+| `epsilon` | [`float`](#doc_float) | Radius of each range search. (Deprecated: use 'radius' parameter instead!) | `0.5` |
 | `input_` | [`matrix`](#doc_matrix) | Input dataset to cluster. | `**--**` |
 | `min_size` | [`int`](#doc_int) | Minimum number of points for a cluster. | `5` |
 | `naive` | [`bool`](#doc_bool) | If set, brute-force range search (not tree-based) will be used. | `False` |
+| `radius` | [`float`](#doc_float) | Radius of each range search. | `0.5` |
 | `selection_type` | [`str`](#doc_str) | If using point selection policy, the type of selection to use ('ordered', 'random'). | `'ordered'` |
 | `single_mode` | [`bool`](#doc_bool) | If set, single-tree range search (not dual-tree) will be used. | `False` |
 | `tree_type` | [`str`](#doc_str) | If using single-tree or dual-tree search, the type of tree to use ('kd', 'r', 'r-star', 'x', 'hilbert-r', 'r-plus', 'r-plus-plus', 'cover', 'ball'). | `'kd'` |
@@ -493,7 +494,7 @@ Results are returned in a Python dictionary.  The keys of the dictionary are the
 
 This program implements the DBSCAN algorithm for clustering using accelerated tree-based range search.  The type of tree that is used may be parameterized, or brute-force range search may also be used.
 
-The input dataset to be clustered may be specified with the `input_` parameter; the radius of each range search may be specified with the `epsilon` parameters, and the minimum number of points in a cluster may be specified with the `min_size` parameter.
+The input dataset to be clustered may be specified with the `input_` parameter; the radius of each range search may be specified with the `radius` parameters, and the minimum number of points in a cluster may be specified with the `min_size` parameter.
 
 The `assignments` and `centroids` output parameters may be used to save the output of the clustering. `assignments` contains the cluster assignments of each point, and `centroids` contains the centroids of each cluster.
 
@@ -503,7 +504,7 @@ The range search may be controlled with the `tree_type`, `single_mode`, and `nai
 An example usage to run DBSCAN on the dataset in `'input'` with a radius of 0.5 and a minimum cluster size of 5 is given below:
 
 ```python
->>> dbscan(input_=input, epsilon=0.5, min_size=5)
+>>> dbscan(input_=input, radius=0.5, min_size=5)
 ```
 
 ### See also

--- a/doc/user/bindings/r.md
+++ b/doc/user/bindings/r.md
@@ -450,8 +450,8 @@ R> recommendations <- output$output
 
 ```R
 R> library(mlpack)
-R> d <- dbscan(epsilon=1, input=matrix(numeric(), 0, 0), min_size=5,
-        naive=FALSE, selection_type="ordered", single_mode=FALSE,
+R> d <- dbscan(epsilon=0.5, input=matrix(numeric(), 0, 0), min_size=5,
+        naive=FALSE, radius=0.5, selection_type="ordered", single_mode=FALSE,
         tree_type="kd", verbose=getOption("mlpack.verbose", FALSE))
 R> assignments <- d$assignments
 R> centroids <- d$centroids
@@ -466,10 +466,11 @@ An implementation of DBSCAN clustering.  Given a dataset, this can compute and r
 | ***name*** | ***type*** | ***description*** | ***default*** |
 |------------|------------|-------------------|---------------|
 | `check_input_matrices` | [`logical`](#doc_logical) | If specified, the input matrix is checked for NaN and inf values; an exception is thrown if any are found. | `FALSE` |
-| `epsilon` | [`numeric`](#doc_numeric) | Radius of each range search. | `1` |
+| `epsilon` | [`numeric`](#doc_numeric) | Radius of each range search. (Deprecated: use 'radius' parameter instead!) | `0.5` |
 | `input` | [`numeric matrix`](#doc_numeric_matrix) | Input dataset to cluster. | `**--**` |
 | `min_size` | [`integer`](#doc_integer) | Minimum number of points for a cluster. | `5` |
 | `naive` | [`logical`](#doc_logical) | If set, brute-force range search (not tree-based) will be used. | `FALSE` |
+| `radius` | [`numeric`](#doc_numeric) | Radius of each range search. | `0.5` |
 | `selection_type` | [`character`](#doc_character) | If using point selection policy, the type of selection to use ('ordered', 'random'). | `"ordered"` |
 | `single_mode` | [`logical`](#doc_logical) | If set, single-tree range search (not dual-tree) will be used. | `FALSE` |
 | `tree_type` | [`character`](#doc_character) | If using single-tree or dual-tree search, the type of tree to use ('kd', 'r', 'r-star', 'x', 'hilbert-r', 'r-plus', 'r-plus-plus', 'cover', 'ball'). | `"kd"` |
@@ -489,7 +490,7 @@ Results are returned in a R list.  The keys of the list are the names of the out
 
 This program implements the DBSCAN algorithm for clustering using accelerated tree-based range search.  The type of tree that is used may be parameterized, or brute-force range search may also be used.
 
-The input dataset to be clustered may be specified with the `input` parameter; the radius of each range search may be specified with the `epsilon` parameters, and the minimum number of points in a cluster may be specified with the `min_size` parameter.
+The input dataset to be clustered may be specified with the `input` parameter; the radius of each range search may be specified with the `radius` parameters, and the minimum number of points in a cluster may be specified with the `min_size` parameter.
 
 The `assignments` and `centroids` output parameters may be used to save the output of the clustering. `assignments` contains the cluster assignments of each point, and `centroids` contains the centroids of each cluster.
 
@@ -499,7 +500,7 @@ The range search may be controlled with the `tree_type`, `single_mode`, and `nai
 An example usage to run DBSCAN on the dataset in `"input"` with a radius of 0.5 and a minimum cluster size of 5 is given below:
 
 ```R
-R> dbscan(input=input, epsilon=0.5, min_size=5)
+R> dbscan(input=input, radius=0.5, min_size=5)
 ```
 
 ### See also

--- a/doc/user/core/transforms/signal_processing.md
+++ b/doc/user/core/transforms/signal_processing.md
@@ -105,7 +105,7 @@ for (size_t k = 0; k < numToShow; ++k)
 #### See also:
 
  * [Empirical Mode Decomposition on Wikipedia](https://en.wikipedia.org/wiki/Hilbert%E2%80%93Huang_transform#Empirical_mode_decomposition)
- * [EMD for nonlinear and non-stationary time series analysis](https://ui.adsabs.harvard.edu/abs/1998RSPSA.454..903H/abstract) (original EMD paper)
+ * [EMD for nonlinear and non-stationary time series analysis](https://hal.science/hal-04014501/file/huang1998.pdf) (original EMD paper)
 
 
 ## EEMD
@@ -167,7 +167,7 @@ mlpack::EEMD(signal, imfs, residue, 100, 0.15, 10, 50, 1e-2);
 #### See also:
 
  * [Ensemble Empirical Mode Decomposition](https://perso.ens-lyon.fr/patrick.flandrin/EEMD.pdf) (original EEMD paper)
- * [EMD for nonlinear and non-stationary time series analysis](https://ui.adsabs.harvard.edu/abs/1998RSPSA.454..903H/abstract) (original EMD paper)
+ * [EMD for nonlinear and non-stationary time series analysis](https://hal.science/hal-04014501/file/huang1998.pdf) (original EMD paper)
 
 ## MFE
 

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -22,10 +22,13 @@ arma::mat dataset = arma::join_rows(
     arma::randn<arma::mat>(10, 1000) + 3.0,  // 1000 points from N( 3, 1).
     arma::randn<arma::mat>(10, 1) + 20.0);   // One outlier "noise" point.
 
-mlpack::DBSCAN dbscan(5.0, 10);                  // Step 1: create object.
+// Step 1: create object.
+mlpack::DBSCAN dbscan(5.0 /* radius */, 10 /* minPoints */);
+
+// Step 2: perform clustering.
 arma::Row<size_t> assignments;
 arma::mat centroids;
-dbscan.Cluster(dataset, assignments, centroids); // Step 2: perform clustering.
+dbscan.Cluster(dataset, assignments, centroids);
 
 // Print the number of clusters.
 std::cout << "Found " << centroids.n_cols << " centroids." << std::endl;
@@ -47,8 +50,8 @@ std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
 
  * [Constructors](#constructors): create `DBSCAN` objects.
  * [`Cluster()`](#clustering): perform clustering.
- * [Other functionality](#other-functionality) for loading, saving, inspecting,
-   and estimating the radius to use.
+ * [Other functionality](#other-functionality) for loading, saving and
+   inspecting.
  * [Examples](#simple-examples) of simple usage and links to detailed example
    projects.
  * [Template parameters](#advanced-functionality-template-parameters) for custom
@@ -62,42 +65,46 @@ std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
 
 ### Constructors
 
- * `dbscan = DBSCAN(epsilon=0.5, minPoints=5, batchMode=true)`
+ * `dbscan = DBSCAN(radius=0.5, minPoints=5, batchMode=true)`
    - Create a `DBSCAN` object with the specified parameters.
-   - Clustering results are highly sensitive to the values of `epsilon` and
+   - Clustering results are highly sensitive to the values of `radius` and
      `minPoints`; it is recommended to tune these parameters for your dataset!
      * See the notes below for more information on choosing these parameters.
    - mlpack's default [kd-tree](../core/trees/kdtree.md) dual-tree range search
-     functionality is used for range search operations.
+     functionality will be used during [clustering](#clustering) for range
+     search operations.
 
 ---
 
- * `dbscan = DBSCAN(epsilon, minPoints, batchMode, rangeSearch)`
- * `dbscan = DBSCAN(epsilon, minPoints, batchMode, rangeSearch, pointSelector)`
+ * `dbscan = DBSCAN(radius, minPoints, batchMode, rangeSearch)`
+ * `dbscan = DBSCAN(radius, minPoints, batchMode, rangeSearch, pointSelector)`
    - Create a `DBSCAN` object with the specified parameters, giving
-     pre-instantiated `RangeSearch` and `OrderedPointSelection` objects.
+     pre-instantiated
+     [`RangeSearch` and `OrderedPointSelection` objects](#advanced-functionality-template-parameters) that will be used during [clustering](#clustering).
    - This overload is generally only useful if you want to reuse a `RangeSearch`
      object from elsewhere.
 
 ---
 
- * `dbscan = DBSCAN<RangeSearchType>(epsilon=0.5, minPoints=5, batchMode=true)`
- * `dbscan = DBSCAN<RangeSearchType>(epsilon, minPoints, batchMode, rangeSearch)`
+ * `dbscan = DBSCAN<RangeSearchType>(radius=0.5, minPoints=5, batchMode=true)`
+ * `dbscan = DBSCAN<RangeSearchType>(radius, minPoints, batchMode, rangeSearch)`
    - Create a `DBSCAN` object with the specified parameters, giving a
-     pre-instantiated `RangeSearchType` object.
+     pre-instantiated `RangeSearchType` object that will be used during
+     [clustering](#clustering).
    - The `RangeSearchType` template parameter can be arbitrarily chosen and is
      described in the
      [advanced functionality section](#advanced-functionality-template-parameters).
 
 ---
 
- * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(epsilon=0.5, minPoints=5, batchMode=true)`
- * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(epsilon, minPoints, batchMode, rangeSearch)`
- * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(epsilon, minPoints, batchMode, rangeSearch, pointSelector)`
+ * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(radius=0.5, minPoints=5, batchMode=true)`
+ * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(radius, minPoints, batchMode, rangeSearch)`
+ * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(radius, minPoints, batchMode, rangeSearch, pointSelector)`
    - Create a `DBSCAN` object with the specified parameters, giving
-     pre-instantiated `RangeSearchType` and `PointSelectionPolicy` objects.
+     pre-instantiated `RangeSearchType` and `PointSelectionPolicy` objects that
+     will be used during [clustering](#clustering).
    - The `RangeSearchType` and `PointSelectionPolicy` template parameters can be
-     arbitrarily chosen and is described in the
+     arbitrarily chosen and are described in the
      [advanced functionality section](#advanced-functionality-template-parameters).
 
 ---
@@ -106,22 +113,25 @@ std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
 
 | **name** | **type** | **description** | **default** |
 |----------|----------|-----------------|-------------|
-| `epsilon` | `double` | Maximum distance between points that are a part of the same cluster. | `0.5` |
-| `minPoints` | `size_t` | Minimum number of points within distance `epsilon`
-for a point to be considered a 'core point'. | `5` |
+| `radius` | `double` | Maximum distance between points that are a part of the same cluster. | `0.5` |
+| `minPoints` | `size_t` | Minimum number of points within distance `radius` for a point to be considered a 'core point' (e.g. the root of a cluster). | `5` |
 | `batchMode` | `bool` | Whether to use batch-mode range search to find neighbors of points. | `true` |
 | `rangeSearch` | [`RangeSearchType`](#advanced-functionality-template-parameters) | Instantiated object to perform range searches with. | `RangeSearchType()` |
 | `pointSelector` | [`PointSelectionPolicy`](#advanced-functionality-template-parameters) | Instantiated object to select the next point to use as a candidate core point of a new cluster. | `PointSelectionPolicy()` |
 
 ***Notes:***
 
- - Clustering results are very sensitive to the settings of `epsilon` and
+ - Clustering results are ***very*** sensitive to the settings of `radius` and
    `minPoints`!  The defaults for both of those are likely not correct for any
-   dataset; *manual tuning and experimentation is generally necessary*.
+   dataset; ***manual tuning and experimentation is generally necessary***.
 
- - If `epsilon` is too small, then no points will be considered a part of the
-   same cluster and all points will be classified as noise.  If `epsilon` is too
+ - If `radius` is too small, then no points will be considered a part of the
+   same cluster and all points will be classified as noise.  If `radius` is too
    large, then all points will be classified as one cluster.
+   * One very simple way to find a starting point for the radius is to find the
+     nearest neighbor of a subset of points in `data` using [`KNN`](knn.md), and
+     then taking `2 * mean(distances)` as a starting point for `radius`.  (This
+     is just a heuristic to give a _starting point_ for tuning.)
 
  - `minPoints` specifies the minimum number of neighboring points that a point
    must have to be the root of a cluster (e.g. a 'core point').  As this
@@ -185,7 +195,7 @@ for a point to be considered a 'core point'. | `5` |
    [`Save()` and `Load()`](../load_save.md#mlpack-models-and-objects).
 
  * As an alternative to constructor parameters,
-   - epsilon can be set with `dbscan.Epsilon(newEpsilon)`,
+   - `radius` can be set with `dbscan.Radius(newRadius)`,
    - the minimum number of points for a core point can be set with
      `dbscan.MinPoints(newMinPoints)`, and
    - the batch mode setting can be set with `dbscan.BatchMode(newBatchMode)`.
@@ -200,9 +210,9 @@ for a point to be considered a 'core point'. | `5` |
 
 ### Simple Examples
 
-Perform DBSCAN clustering on the satellite dataset and print the average
-distance from each point to its assigned centroid, as well as the indices of any
-noise point.
+Perform DBSCAN clustering on the satellite dataset and print the indices of any
+noise point, as well as the average distance from each point to its assigned
+centroid.
 
 ```c++
 // See https://datasets.mlpack.org/satellite.train.csv.
@@ -211,7 +221,7 @@ mlpack::Load("satellite.train.csv", dataset, mlpack::Fatal);
 
 // Create DBSCAN object with parameters tuned to the satellite dataset and
 // perform clustering.
-mlpack::DBSCAN dbscan(25.0, 10);
+mlpack::DBSCAN dbscan(25.0 /* radius */, 10 /* minPoints */);
 arma::mat centroids;
 arma::Row<size_t> assignments;
 dbscan.Cluster(dataset, assignments, centroids);
@@ -228,6 +238,10 @@ for (size_t i = 0; i < dataset.n_cols; ++i)
   {
     sumDist += mlpack::EuclideanDistance::Evaluate(
         dataset.col(i), centroids.col(assignments[i]));
+  }
+  else
+  {
+    std::cout << " - Point " << i << " classified as noise." << std::endl;
   }
 }
 const double avgDist = sumDist / (double) dataset.n_cols;
@@ -247,7 +261,9 @@ arma::mat dataset;
 mlpack::Load("wave_energy_farm_100.csv", dataset, mlpack::Fatal);
 
 // Create DBSCAN object and set parameters.
-mlpack::DBSCAN dbscan(10000.0, 10);
+mlpack::DBSCAN dbscan(10000.0 /* radius */,
+                      10 /* minPoints */,
+                      false /* batchMode */);
 
 // Perform the clustering.
 arma::mat centroids;
@@ -278,7 +294,7 @@ mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
 // as the matrix type.
 using RangeSearchType = mlpack::RangeSearch<mlpack::EuclideanDistance,
                                             arma::fmat>;
-mlpack::DBSCAN<RangeSearchType> dbscan(40.0, 10);
+mlpack::DBSCAN<RangeSearchType> dbscan(40.0 /* radius */, 10 /* minPoints */);
 
 // Perform clustering.
 arma::fmat centroids;
@@ -299,8 +315,9 @@ std::cout << " - " << arma::accu(assignments == SIZE_MAX) << " points were "
 
 ---
 
-Perform DBSCAN clustering on the cloud dataset using the L1 (Manhattan)
-distance, using mlpack's `RangeSearch` class with the
+Perform DBSCAN clustering on the cloud dataset using the
+[L1 (Manhattan) distance](../core/distances.md#lmetric),
+using mlpack's `RangeSearch` class with the
 [`CoverTree`](../core/trees/cover_tree.md) for range search operations.
 
 ```c++
@@ -313,7 +330,7 @@ mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
 using RangeSearchType = mlpack::RangeSearch<mlpack::ManhattanDistance,
                                             arma::fmat,
                                             mlpack::StandardCoverTree>;
-mlpack::DBSCAN<RangeSearchType> dbscan(50.0, 10);
+mlpack::DBSCAN<RangeSearchType> dbscan(50.0 /* radius */, 10 /* minPoints */);
 
 // Perform clustering.
 arma::fmat centroids;
@@ -359,18 +376,20 @@ DBSCAN<RangeSearchType, PointSelectionPolicy>
 RangeSearch<DistanceType, MatType, TreeType>
 ```
 
-     * `DistanceType` should be a valid [distance metric](../core/distances.md);
-       the default is [`EuclideanDistance`](../core/distances.md#lmetric).
-     * `MatType` should be any matrix type implementing the Armadillo API; the
-       default is [`arma::mat`](../core/matrices.md).  Other options include,
-       e.g., `arma::fmat`, and `arma::hmat`.
-       - The `MatType` used here will be the same type that is accepted by
-         [`Cluster()`](#clustering).
-     * `TreeType` is the [tree type](../core/trees.md) used for tree-based
-       searching.  By default, [`KDTree`](../core/trees/kdtree.md) is used.
+ * When using mlpack's `RangeSearch` class as `RangeSearchType`, each of its
+   individual template parameters can be specified:
+   - `DistanceType` can be any valid [distance metric](../core/distances.md);
+     the default is [`EuclideanDistance`](../core/distances.md#lmetric).
+   - `MatType` should be any matrix type implementing the Armadillo API; the
+     default is [`arma::mat`](../matrices.md).  Other options include, e.g.,
+     `arma::fmat`, and `arma::hmat`.
+     * The `MatType` used here will be the same type that is accepted by
+       [`Cluster()`](#clustering).
+   - `TreeType` is the [tree type](../core/trees.md) used for tree-based
+     searching.  By default, [`KDTree`](../core/trees/kdtree.md) is used.
 
-   - An entirely custom `RangeSearchType` must implement two typedefs and three
-     member functions:
+ * An entirely custom `RangeSearchType` must implement two typedefs and three
+   member functions:
 
 ```c++
 class CustomRangeSearchType
@@ -433,7 +452,7 @@ Note that it is generally easier to use a variant of mlpack's existing
      sufficient for all DBSCAN clustering tasks.
 
    - DBSCAN point cluster assignment is greedy; a point is assigned to the first
-     cluster it is within a distance of `epsilon` of.  Therefore, to some
+     cluster it is within a distance of `radius` of.  Therefore, to some
      limited extent, clustering behavior can be controlled by
      `PointSelectionPolicy`.
 

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -1,11 +1,11 @@
 ## `DBSCAN`
 
-The `DBSCAN` class implements DBSCAN ("Density Based Spatial Clustering of
-Applications with Noise"), a clustering technique.  DBSCAN iteratively finds
-localized high-density data regions by using range searches.  Nearby points in
-connected high-density regions are grouped into clusters.  Clusters produced by
-DBSCAN may have arbitrary shapes, and points far away from any high-density
-region will be separately classified as noise.
+The `DBSCAN` class implements the clustering technique DBSCAN ("Density Based
+Spatial Clustering of Applications with Noise").  It iteratively finds localized
+high-density data regions by using range searches.  Nearby points in connected
+high-density regions are grouped into clusters.  Clusters produced by DBSCAN may
+have arbitrary shapes, and points far away from any high-density region will be
+separately classified as noise.
 
 DBSCAN does not require the user to guess the number of clusters, and
 does not make any assumptions on the shape of the data.

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -449,7 +449,11 @@ Note that it is generally easier to use a variant of mlpack's existing
  * `PointSelectionPolicy` specifies the order in which points are selected as
    candidate roots of clusters.
    - By default, the `OrderedPointSelection` class is used, and is generally
-     sufficient for all DBSCAN clustering tasks.
+     sufficient for all DBSCAN clustering tasks.  This selects the lowest-index
+     unvisited point.
+
+   - The `RandomPointSelection` class is also available; this selects randomly
+     from the set of unvisited points.
 
    - DBSCAN point cluster assignment is greedy; a point is assigned to the first
      cluster it is within a distance of `radius` of.  Therefore, to some

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -1,0 +1,290 @@
+## `DBSCAN`
+
+The `DBSCAN` class implements DBSCAN ("Density Based Spatial Clustering of
+Applications with Noise"), a clustering technique.  DBSCAN iteratively finds
+localized high-density data regions, and groups connected high-density regions
+into clusters.  Clusters produced by DBSCAN may have arbitrary shapes, and
+points far away from any high-density region will be separately classified as
+noise.
+
+DBSCAN does not require the user to guess the number of clusters, and
+does not make any assumptions on the shape of the data.
+
+#### Simple usage example:
+
+```c++
+// Use DBSCAN to cluster random data and print the number of points that
+// fall into each cluster.
+
+// Create random dataset with two separated 10-dimensional Gaussians.
+arma::mat dataset = arma::join_rows(
+    arma::randn<arma::mat>(10, 1000) + 3.0,  // 1000 points from N(-3, 1).
+    arma::randn<arma::mat>(10, 1000) - 3.0,  // 1000 points from N( 3, 1).
+    arma::randn<arma::mat>(10, 1) + 20.0);   // One outlier "noise" point.
+
+mlpack::DBSCAN dbscan(0.5, 10);                  // Step 1: create object.
+arma::Row<size_t> assignments;
+arma::mat centroids;
+dbscan.Cluster(dataset, assignments, centroids); // Step 2: perform clustering.
+
+// Print the number of clusters.
+std::cout << "Found " << centroids.n_cols << " centroids." << std::endl;
+
+// Print the number of points in each cluster.
+for (size_t c = 0; c < centroids.n_cols; ++c)
+{
+  std::cout << " * Cluster " << c << " has " << arma::accu(assignments == c)
+      << " points." << std::endl;
+}
+
+// Print the number of noise points.
+std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
+    << "classified as noise." << std::endl;
+```
+<p style="text-align: center; font-size: 85%"><a href="#simple-examples">More examples...</a></p>
+
+#### Quick links:
+
+ * [Constructors](#constructors): create `DBSCAN` objects.
+ * [`Cluster()`](#clustering): perform clustering.
+ * [Other functionality](#other-functionality) for loading, saving, inspecting,
+   and estimating the radius to use.
+ * [Examples](#simple-examples) of simple usage and links to detailed example
+   projects.
+ * [Template parameters](#advanced-functionality-template-parameters) for custom
+   behavior.
+
+#### See also:
+
+ * [mlpack clustering algorithms](../modeling.md#clustering)
+ * [DBSCAN on Wikipedia](https://en.wikipedia.org/wiki/DBSCAN)
+ * [A density-based algorithm for discovering clusters in large spatial databases with noise (pdf)](https://cdn.aaai.org/KDD/1996/KDD96-037.pdf)
+
+### Constructors
+
+ * `dbscan = DBSCAN(epsilon=0.5, minPoints=5, batchMode=true)`
+   - Create a `DBSCAN` object with the specified parameters.
+   - Clustering results are highly sensitive to the values of `epsilon` and
+     `minPoints`; it is recommended to tune these parameters for your dataset!
+     * See the notes below for more information on choosing these parameters.
+   - mlpack's default [kd-tree](../core/trees/kdtree.md) dual-tree range search
+     functionality is used for range search operations.
+
+---
+
+ * `dbscan = DBSCAN(epsilon, minPoints, batchMode, rangeSearch)`
+ * `dbscan = DBSCAN(epsilon, minPoints, batchMode, rangeSearch, pointSelector)`
+   - Create a `DBSCAN` object with the specified parameters, giving
+     pre-instantiated `RangeSearch` and `OrderedPointSelection` objects.
+
+---
+
+ * `dbscan = DBSCAN<RangeSearchType>(epsilon=0.5, minPoints=5, batchMode=true)`
+ * `dbscan = DBSCAN<RangeSearchType>(epsilon, minPoints, batchMode, rangeSearch)`
+   - Create a `DBSCAN` object with the specified parameters, giving a
+     pre-instantiated `RangeSearchType` object.
+   - The `RangeSearchType` template parameter can be arbitrarily chosen and is
+     described in the
+     [advanced functionality section](#advanced-functionality-template-parameters).
+
+---
+
+ * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(epsilon=0.5, minPoints=5, batchMode=true)`
+ * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(epsilon, minPoints, batchMode, rangeSearch)`
+ * `dbscan = DBSCAN<RangeSearchType, PointSelectionPolicy>(epsilon, minPoints, batchMode, rangeSearch, pointSelector)`
+   - Create a `DBSCAN` object with the specified parameters, giving
+     pre-instantiated `RangeSearchType` and `PointSelectionPolicy` objects.
+   - The `RangeSearchType` and `PointSelectionPolicy` template parameters can be
+     arbitrarily chosen and is described in the
+     [advanced functionality section](#advanced-functionality-template-parameters).
+
+---
+
+***Notes:***
+
+ - 
+
+---
+
+#### Constructor Parameters:
+
+| **name** | **type** | **description** | **default** |
+|----------|----------|-----------------|-------------|
+| `epsilon` | `double` |
+| `minPoints` | `size_t` |
+| `batchMode` | `bool` |
+| `rangeSearch` | [`RangeSearchType`](#advanced-functionality-template-parameters) |
+| `pointSelector` | [`PointSelectionPolicy`](#advanced-functionality-template-parameters) |
+
+***Notes:***
+
+ - A larger `radius` value will generally result in fewer clusters (e.g. a
+   coarser clustering); smaller `radius` values will generally result in more
+   clusters.
+
+ - When `MeanShift<false>` is used, `radius` is the hard distance threshold for
+   points to be considered in the recomputation of a centroid.
+
+### Clustering
+
+ * `dbscan.Cluster(data, centroids)`
+ * `dbscan.Cluster(data, assignments)`
+ * `dbscan.Cluster(data, assignments, centroids)`
+
+ * `ms.Cluster(data, centroids, forceConvergence=true, useSeeds=true)`
+   - Cluster the given data, storing the resulting cluster centroids in
+     `centroids`.
+   - `centroids` will be set to size `data.n_rows` x `numClusters`, where
+     `numClusters` is the number of clusters found by the mean shift algorithm.
+   - The `i`th cluster centroid can be obtained with `clusters.col(i)`.
+
+---
+
+#### Clustering Parameters:
+
+| **name** | **type** | **description** | **default** |
+|----------|----------|-----------------|-------------|
+| `data` | [`arma::mat`](../matrices.md) | [Column-major](../matrices.md#representing-data-in-mlpack) matrix holding the dataset to be clustered. | _(N/A)_ |
+| `centroids` | [`arma::mat`](../matrices.md) | [Column-major](../matrices.md#representing-data-in-mlpack) matrix that centroids will be stored into. | _(N/A)_ |
+| `assignments` | [`arma::Row<size_t>`](../matrices.md) | Vector to store cluster assignments for each point into. | _(N/A)_ |
+
+***Notes***:
+
+ * Different types can be used for `data` and `centroids` (e.g., `arma::fmat` or
+   any dense matrix type implementing the Armadillo API).  The types of `data`
+   and `centroids` must be the same.
+
+### Other Functionality
+
+ * A `DBSCAN` object can be serialized with
+   [`Save()` and `Load()`](../load_save.md#mlpack-models-and-objects).
+
+ * As an alternative to constructor parameters,
+   - epsilon can be set with `dbscan.Epsilon(newEpsilon)`,
+   - the minimum number of points for a core point can be set with
+     `dbscan.MinPoints(newMinPoints)`, and
+   - the batch mode setting can be set with `dbscan.BatchMode(newBatchMode)`.
+
+ * `dbscan.RangeSearch()` returns a reference to the instantiated
+    [`RangeSearchType`](#advanced-functionality-template-parameters) object used
+    for range searching.
+
+ * `dbscan.PointSelector()` returns a reference to the instantiated
+    [`PointSelectionPolicy`](#advanced-functionality-template-parameters) object
+    used to choose the first point of a new cluster.
+
+### Simple Examples
+
+Perform DBSCAN clustering on the satellite dataset and print the average
+distance from each point to its assigned centroid, as well as the indices of any
+noise point.
+
+```c++
+// See https://datasets.mlpack.org/satellite.train.csv.
+arma::mat dataset;
+mlpack::Load("satellite.train.csv", dataset, mlpack::Fatal);
+
+// Create DBSCAN object with default parameters and perform clustering.
+mlpack::DBSCAN dbscan;
+arma::mat centroids;
+arma::Row<size_t> assignments;
+ms.Cluster(dataset, assignments, centroids);
+
+// Print the number of clusters.
+std::cout << "MeanShift computed " << centroids.n_cols << " clusters."
+    << std::endl;
+
+// Compute the average distance from each point to its assigned centroid.
+double sumDist = 0.0;
+for (size_t i = 0; i < dataset.n_cols; ++i)
+{
+  sumDist += mlpack::EuclideanDistance::Evaluate(
+      dataset.col(i), centroids.col(assignments[i]));
+}
+const double avgDist = sumDist / (double) dataset.n_cols;
+
+std::cout << "Average distance from a point to its assigned centroid: "
+    << avgDist << "." << std::endl;
+```
+
+---
+
+Perform DBSCAN clustering on the wave energy farm dataset, setting `batchMode`
+to `false` to save RAM usage during range searching.
+
+```c++
+// See https://datasets.mlpack.org/wave_energy_farm_100.csv.
+arma::mat dataset;
+mlpack::Load("wave_energy_farm_100.csv", dataset, mlpack::Fatal);
+
+// Create DBSCAN object and set parameters.
+mlpack::DBSCAN dbscan;
+
+// Perform the clustering.
+arma::mat centroids;
+arma::Row<size_t> assignments;
+dbscan.Cluster(dataset, assignments, centroids);
+
+std::cout << "DBSCAN found " << centroids.n_cols << " clusters."
+    << std::endl;
+std::cout << arma::accu(assignments == SIZE_MAX) << " points were classified "
+    << "as noise." << std::endl;
+
+// Save the centroids to disk.
+mlpack::Save("wave_energy_centroids.csv", centroids);
+```
+
+---
+
+Perform DBSCAN clustering on the cloud dataset, using 32-bit floating point
+matrices to represent the data.
+
+```c++
+// See https://datasets.mlpack.org/cloud.csv.
+arma::fmat dataset;
+mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
+
+// Create the MeanShift object using a TriangularKernel.
+mlpack::DBSCAN dbscan();
+
+// Perform clustering.
+arma::fmat centroids;
+arma::Row<size_t> assignments;
+dbscan.Cluster(dataset, assignments, centroids);
+
+// Print the number of clusters and the number of points in each cluster.
+std::cout << "DBSCAN found " << centroids.n_cols << " clusters."
+    << std::endl;
+for (size_t i = 0; i < centroids.n_cols; ++i)
+{
+  std::cout << " - Cluster " << i << " has " << arma::accu(assignments == i)
+      << " points assigned to it." << std::endl;
+}
+std::cout << " - " << arma::accu(assignments == SIZE_MAX) << " points were "
+    << "classified as noise and not assigned to any cluster." << std::endl;
+```
+
+---
+
+Perform DBSCAN clustering on the cloud dataset, using mlpack's `RangeSearch`
+class with the [`CoverTree`](../core/trees/cover_tree.md_) for range search
+operations.
+
+```c++
+
+```
+
+### Advanced Functionality: Template Parameters
+
+The `DBSCAN` class has two template parameters that can be used for custom
+behavior.  The full signature of the class is:
+
+```
+MeanShift<RangeSearchType, PointSelectionPolicy>
+```
+
+ * `RangeSearchType` (default ) ...
+
+ * `PointSelectionPolicy` (default ) ...
+
+---

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -2,10 +2,10 @@
 
 The `DBSCAN` class implements DBSCAN ("Density Based Spatial Clustering of
 Applications with Noise"), a clustering technique.  DBSCAN iteratively finds
-localized high-density data regions, and groups connected high-density regions
-into clusters.  Clusters produced by DBSCAN may have arbitrary shapes, and
-points far away from any high-density region will be separately classified as
-noise.
+localized high-density data regions by using range searches.  Nearby points in
+connected high-density regions are grouped into clusters.  Clusters produced by
+DBSCAN may have arbitrary shapes, and points far away from any high-density
+region will be separately classified as noise.
 
 DBSCAN does not require the user to guess the number of clusters, and
 does not make any assumptions on the shape of the data.
@@ -76,6 +76,8 @@ std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
  * `dbscan = DBSCAN(epsilon, minPoints, batchMode, rangeSearch, pointSelector)`
    - Create a `DBSCAN` object with the specified parameters, giving
      pre-instantiated `RangeSearch` and `OrderedPointSelection` objects.
+   - This overload is generally only useful if you want to reuse a `RangeSearch`
+     object from elsewhere.
 
 ---
 
@@ -108,8 +110,8 @@ std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
 | `minPoints` | `size_t` | Minimum number of points within distance `epsilon`
 for a point to be considered a 'core point'. | `5` |
 | `batchMode` | `bool` | Whether to use batch-mode range search to find neighbors of points. | `true` |
-| `rangeSearch` | [`RangeSearchType`](#advanced-functionality-template-parameters) |
-| `pointSelector` | [`PointSelectionPolicy`](#advanced-functionality-template-parameters) |
+| `rangeSearch` | [`RangeSearchType`](#advanced-functionality-template-parameters) | Instantiated object to perform range searches with. | `RangeSearchType()` |
+| `pointSelector` | [`PointSelectionPolicy`](#advanced-functionality-template-parameters) | Instantiated object to select the next point to use as a candidate core point of a new cluster. | `PointSelectionPolicy()` |
 
 ***Notes:***
 
@@ -132,13 +134,34 @@ for a point to be considered a 'core point'. | `5` |
 ### Clustering
 
  * `dbscan.Cluster(data, centroids)`
- * `dbscan.Cluster(data, assignments)`
- * `dbscan.Cluster(data, assignments, centroids)`
    - Cluster the given data, storing the resulting cluster centroids in
      `centroids`.
    - `centroids` will be set to size `data.n_rows` x `numClusters`, where
-     `numClusters` is the number of clusters found by the mean shift algorithm.
+     `numClusters` is the number of clusters found by DBSCAN.
    - The `i`th cluster centroid can be obtained with `clusters.col(i)`.
+
+ * `dbscan.Cluster(data, assignments)`
+   - Cluster the given data, storing the resulting point assignments in
+     `assignments`.
+   - `assignments` will be set to size `data.n_cols`.
+   - The cluster assignment of the point `data.col(i)` can be obtained with
+     `assignments[i]`.
+   - If the point `data.col(i)` has been classified as noise, then
+     `assignments[i]` will be set to `SIZE_MAX`.  Otherwise, `assignments[i]`
+     will take values in the range `[0, numClusters - 1]`.
+
+ * `dbscan.Cluster(data, assignments, centroids)`
+   - Cluster the given data, storing the resulting cluster centroids in
+     `centroids` and the resulting point assignments in `assignments`.
+   - `centroids` will be set to size `data.n_rows` x `numClusters`, where
+     `numClusters` is the number of clusters found by DBSCAN.
+   - The `i`th cluster centroid can be obtained with `clusters.col(i)`.
+   - `assignments` will be set to size `data.n_cols`.
+   - The cluster assignment of the point `data.col(i)` can be obtained with
+     `assignments[i]`.
+   - If the point `data.col(i)` has been classified as noise, then
+     `assignments[i]` will be set to `SIZE_MAX`.  Otherwise, `assignments[i]`
+     will take values in the range `[0, numClusters - 1]`.
 
 ---
 
@@ -153,8 +176,8 @@ for a point to be considered a 'core point'. | `5` |
 ***Notes***:
 
  * Different types can be used for `data` and `centroids` (e.g., `arma::fmat` or
-   any dense matrix type implementing the Armadillo API).  The types of `data`
-   and `centroids` must be the same.
+   any dense matrix type implementing the Armadillo API) by specifying a custom
+   [`RangeSearchType`](#advanced-functionality-template-parameters).
 
 ### Other Functionality
 
@@ -190,18 +213,21 @@ mlpack::Load("satellite.train.csv", dataset, mlpack::Fatal);
 mlpack::DBSCAN dbscan;
 arma::mat centroids;
 arma::Row<size_t> assignments;
-ms.Cluster(dataset, assignments, centroids);
+dbscan.Cluster(dataset, assignments, centroids);
 
 // Print the number of clusters.
-std::cout << "MeanShift computed " << centroids.n_cols << " clusters."
+std::cout << "DBSCAN computed " << centroids.n_cols << " clusters."
     << std::endl;
 
 // Compute the average distance from each point to its assigned centroid.
 double sumDist = 0.0;
 for (size_t i = 0; i < dataset.n_cols; ++i)
 {
-  sumDist += mlpack::EuclideanDistance::Evaluate(
-      dataset.col(i), centroids.col(assignments[i]));
+  if (assigments[i] != SIZE_MAX) // Filter out noise points.
+  {
+    sumDist += mlpack::EuclideanDistance::Evaluate(
+        dataset.col(i), centroids.col(assignments[i]));
+  }
 }
 const double avgDist = sumDist / (double) dataset.n_cols;
 
@@ -239,15 +265,19 @@ mlpack::Save("wave_energy_centroids.csv", centroids);
 ---
 
 Perform DBSCAN clustering on the cloud dataset, using 32-bit floating point
-matrices to represent the data.
+matrices to represent the data via the
+[`RangeSearchType` template parameter](#advanced-functionality-template-parameters).
 
 ```c++
 // See https://datasets.mlpack.org/cloud.csv.
 arma::fmat dataset;
 mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
 
-// Create the MeanShift object using a TriangularKernel.
-mlpack::DBSCAN dbscan();
+// Create the DBSCAN object using a custom `RangeSearch` that uses `arma::fmat`
+// as the matrix type.
+using RangeSearchType = mlpack::RangeSearch<mlpack::EuclideanDistance,
+                                            arma::fmat>;
+mlpack::DBSCAN<RangeSearchType> dbscan;
 
 // Perform clustering.
 arma::fmat centroids;
@@ -269,11 +299,36 @@ std::cout << " - " << arma::accu(assignments == SIZE_MAX) << " points were "
 ---
 
 Perform DBSCAN clustering on the cloud dataset, using mlpack's `RangeSearch`
-class with the [`CoverTree`](../core/trees/cover_tree.md_) for range search
+class with the [`CoverTree`](../core/trees/cover_tree.md) for range search
 operations.
 
 ```c++
+// See https://datasets.mlpack.org/cloud.csv.
+arma::fmat dataset;
+mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
 
+// Create the DBSCAN object using a custom `RangeSearch` that uses `arma::fmat`
+// as the matrix type and `CoverTree` as the tree type.
+using RangeSearchType = mlpack::RangeSearch<mlpack::EuclideanDistance,
+                                            arma::fmat,
+                                            mlpack::StandardCoverTree>;
+mlpack::DBSCAN<RangeSearchType> dbscan;
+
+// Perform clustering.
+arma::fmat centroids;
+arma::Row<size_t> assignments;
+dbscan.Cluster(dataset, assignments, centroids);
+
+// Print the number of clusters and the number of points in each cluster.
+std::cout << "DBSCAN found " << centroids.n_cols << " clusters."
+    << std::endl;
+for (size_t i = 0; i < centroids.n_cols; ++i)
+{
+  std::cout << " - Cluster " << i << " has " << arma::accu(assignments == i)
+      << " points assigned to it." << std::endl;
+}
+std::cout << " - " << arma::accu(assignments == SIZE_MAX) << " points were "
+    << "classified as noise and not assigned to any cluster." << std::endl;
 ```
 
 ### Advanced Functionality: Template Parameters
@@ -282,11 +337,128 @@ The `DBSCAN` class has two template parameters that can be used for custom
 behavior.  The full signature of the class is:
 
 ```
-MeanShift<RangeSearchType, PointSelectionPolicy>
+DBSCAN<RangeSearchType, PointSelectionPolicy>
 ```
 
- * `RangeSearchType` (default ) ...
+---
 
- * `PointSelectionPolicy` (default ) ...
+<!-- TODO: elaborate here once RangeSearch is documented -->
+
+ * `RangeSearchType` specifies the algorithm to be used when performing range
+   searches.
+   - By default, the `RangeSearch` class is used, which uses an efficient
+     dual-tree [`KDTree`](../core/trees/kdtree.md)-based search.
+
+   - When `batchMode` is set to `false`, then single-tree search is used.
+
+   - The `RangeSearch` class is itself configurable with template parameters;
+     its full signature is:
+
+```
+RangeSearch<DistanceType, MatType, TreeType>
+```
+
+     * `DistanceType` should be a valid [distance metric](../core/distances.md);
+       the default is [`EuclideanDistance`](TODO).
+     * `MatType` should be any matrix type implementing the Armadillo API; the
+       default is [`arma::mat`](../core/matrices.md).  Other options include,
+       e.g., `arma::fmat`, and `arma::hmat`.
+       - The `MatType` used here will be the same type that is accepted by
+         [`Cluster()`](#clustering).
+     * `TreeType` is the [tree type](../core/trees.md) used for tree-based
+       searching.  By default, [`KDTree`](../core/trees/kdtree.md) is used.
+
+   - An entirely custom `RangeSearchType` must implement two typedefs and three
+     member functions:
+
+```c++
+class CustomRangeSearchType
+{
+  // This typedef is what DBSCAN uses as `MatType`.
+  using Mat = arma::mat; /* or any other Armadillo-compatible choice */
+  // This typedef defines the element type that the matrix holds.
+  using ElemType = typename Mat::elem_type;
+
+  /**
+   * Prepare for range search queries, using `referenceSet` as the set that is
+   * being searched in.
+   */
+  void Train(const Mat& referenceSet);
+
+  /**
+   * This will always be called after a call to `Train()`.
+   *
+   * For each point in `querySet`, find *all* points in `referenceSet` within a
+   * distance of `range.Lo()` and `range.Hi()`.  Store the indices of these
+   * points in `neighbors` and their distances in `distances`.
+   *
+   * After the function is done, `neighbors[i][j]` should contain the index of
+   * the `j`'th point in `referenceSet` that is within `range` of the point
+   * `querySet.col(i)`.
+   */
+  void Search(const Mat& querySet,
+              const RangeType<ElemType>& range,
+              std::vector<std::vector<size_t>>& neighbors,
+              std::vector<std::vector<ElemType>>& distances);
+
+  /**
+   * This will always be called after a call to `Train()`.
+   *
+   * For each point in `referenceSet` (which was passed to `Train()`), find all
+   * points within a distance of `range.Lo()` and `range.Hi()`.  Store the
+   * indices of these points in `neighbors` and their distances in `distances`.
+   *
+   * After the function is done, `neighbors[i][j]` should contain the index of
+   * the `j`'th point that is within `range` of the point `referenceSet.col(i)`.
+   *
+   * `neighbors[i]` should *not* contain `i`; that is, a point should not be
+   * returned in its own set of neighbors, even if `range.Lo() == 0`.
+   */
+  void Search(const Mat& querySet,
+              const RangeType<ElemType>& range,
+              std::vector<std::vector<size_t>>& neighbors,
+              std::vector<std::vector<ElemType>>& distances);
+};
+```
+
+   - Note that it is generally easier to use a variant of mlpack's existing
+     `RangeSearch` class instead of implementing an entirely new one from
+     scratch!
 
 ---
+
+ * `PointSelectionPolicy` specifies the order in which points are selected as
+   candidate roots of clusters.
+   - By default, the `OrderedPointSelection` class is used, and is generally
+     sufficient for all DBSCAN clustering tasks.
+
+   - DBSCAN point cluster assignment is greedy; a point is assigned to the first
+     cluster it is within a distance of `epsilon` of.  Therefore, to some
+     limited extent, clustering behavior can be controlled by
+     `PointSelectionPolicy`.
+
+   - A custom point selection strategy must implement one member function:
+
+```c++
+class CustomPointSelection
+{
+ public:
+  /**
+   * Select the next point to use as a candidate cluster root for DBSCAN.  This
+   * method should return the index of the point in `data` to use.
+   *
+   * MatType is the Armadillo-compatible matrix type used to store the data
+   * points.
+   *
+   * @param numVisited Number of points that have been visited so far.
+   * @param visited Bitset indicating which points have already been visited.
+   *      Note that more than `numVisited` points may have been visited, since
+   *      any point's neighbors are considered 'visited' at each iteration.
+   * @param data Matrix of data points.
+   */
+  template<typename MatType>
+  static size_t Select(const size_t numVisited,
+                       const std::vector<bool>& visited,
+                       const MatType& data);
+};
+```

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -421,9 +421,8 @@ class CustomRangeSearchType
 };
 ```
 
-   - Note that it is generally easier to use a variant of mlpack's existing
-     `RangeSearch` class instead of implementing an entirely new one from
-     scratch!
+Note that it is generally easier to use a variant of mlpack's existing
+`RangeSearch` class instead of implementing an entirely new one from scratch!
 
 ---
 

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -18,11 +18,11 @@ does not make any assumptions on the shape of the data.
 
 // Create random dataset with two separated 10-dimensional Gaussians.
 arma::mat dataset = arma::join_rows(
-    arma::randn<arma::mat>(10, 1000) + 3.0,  // 1000 points from N(-3, 1).
-    arma::randn<arma::mat>(10, 1000) - 3.0,  // 1000 points from N( 3, 1).
+    arma::randn<arma::mat>(10, 1000) - 3.0,  // 1000 points from N(-3, 1).
+    arma::randn<arma::mat>(10, 1000) + 3.0,  // 1000 points from N( 3, 1).
     arma::randn<arma::mat>(10, 1) + 20.0);   // One outlier "noise" point.
 
-mlpack::DBSCAN dbscan(0.5, 10);                  // Step 1: create object.
+mlpack::DBSCAN dbscan(5.0, 10);                  // Step 1: create object.
 arma::Row<size_t> assignments;
 arma::mat centroids;
 dbscan.Cluster(dataset, assignments, centroids); // Step 2: perform clustering.
@@ -209,8 +209,9 @@ noise point.
 arma::mat dataset;
 mlpack::Load("satellite.train.csv", dataset, mlpack::Fatal);
 
-// Create DBSCAN object with default parameters and perform clustering.
-mlpack::DBSCAN dbscan;
+// Create DBSCAN object with parameters tuned to the satellite dataset and
+// perform clustering.
+mlpack::DBSCAN dbscan(25.0, 10);
 arma::mat centroids;
 arma::Row<size_t> assignments;
 dbscan.Cluster(dataset, assignments, centroids);
@@ -223,7 +224,7 @@ std::cout << "DBSCAN computed " << centroids.n_cols << " clusters."
 double sumDist = 0.0;
 for (size_t i = 0; i < dataset.n_cols; ++i)
 {
-  if (assigments[i] != SIZE_MAX) // Filter out noise points.
+  if (assignments[i] != SIZE_MAX) // Filter out noise points.
   {
     sumDist += mlpack::EuclideanDistance::Evaluate(
         dataset.col(i), centroids.col(assignments[i]));
@@ -246,7 +247,7 @@ arma::mat dataset;
 mlpack::Load("wave_energy_farm_100.csv", dataset, mlpack::Fatal);
 
 // Create DBSCAN object and set parameters.
-mlpack::DBSCAN dbscan;
+mlpack::DBSCAN dbscan(10000.0, 10);
 
 // Perform the clustering.
 arma::mat centroids;
@@ -277,7 +278,7 @@ mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
 // as the matrix type.
 using RangeSearchType = mlpack::RangeSearch<mlpack::EuclideanDistance,
                                             arma::fmat>;
-mlpack::DBSCAN<RangeSearchType> dbscan;
+mlpack::DBSCAN<RangeSearchType> dbscan(40.0, 10);
 
 // Perform clustering.
 arma::fmat centroids;
@@ -298,9 +299,9 @@ std::cout << " - " << arma::accu(assignments == SIZE_MAX) << " points were "
 
 ---
 
-Perform DBSCAN clustering on the cloud dataset, using mlpack's `RangeSearch`
-class with the [`CoverTree`](../core/trees/cover_tree.md) for range search
-operations.
+Perform DBSCAN clustering on the cloud dataset using the L1 (Manhattan)
+distance, using mlpack's `RangeSearch` class with the
+[`CoverTree`](../core/trees/cover_tree.md) for range search operations.
 
 ```c++
 // See https://datasets.mlpack.org/cloud.csv.
@@ -309,10 +310,10 @@ mlpack::Load("cloud.csv", dataset, mlpack::Fatal);
 
 // Create the DBSCAN object using a custom `RangeSearch` that uses `arma::fmat`
 // as the matrix type and `CoverTree` as the tree type.
-using RangeSearchType = mlpack::RangeSearch<mlpack::EuclideanDistance,
+using RangeSearchType = mlpack::RangeSearch<mlpack::ManhattanDistance,
                                             arma::fmat,
                                             mlpack::StandardCoverTree>;
-mlpack::DBSCAN<RangeSearchType> dbscan;
+mlpack::DBSCAN<RangeSearchType> dbscan(50.0, 10);
 
 // Perform clustering.
 arma::fmat centroids;
@@ -359,7 +360,7 @@ RangeSearch<DistanceType, MatType, TreeType>
 ```
 
      * `DistanceType` should be a valid [distance metric](../core/distances.md);
-       the default is [`EuclideanDistance`](TODO).
+       the default is [`EuclideanDistance`](../core/distances.md#lmetric).
      * `MatType` should be any matrix type implementing the Armadillo API; the
        default is [`arma::mat`](../core/matrices.md).  Other options include,
        e.g., `arma::fmat`, and `arma::hmat`.

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -221,7 +221,7 @@ mlpack::Load("satellite.train.csv", dataset, mlpack::Fatal);
 
 // Create DBSCAN object with parameters tuned to the satellite dataset and
 // perform clustering.
-mlpack::DBSCAN dbscan(25.0 /* radius */, 10 /* minPoints */);
+mlpack::DBSCAN dbscan(55.0 /* radius */, 3 /* minPoints */);
 arma::mat centroids;
 arma::Row<size_t> assignments;
 dbscan.Cluster(dataset, assignments, centroids);

--- a/doc/user/methods/dbscan.md
+++ b/doc/user/methods/dbscan.md
@@ -100,38 +100,40 @@ std::cout << " * " << arma::accu(assignments == SIZE_MAX) << " points "
 
 ---
 
-***Notes:***
-
- - 
-
----
-
 #### Constructor Parameters:
 
 | **name** | **type** | **description** | **default** |
 |----------|----------|-----------------|-------------|
-| `epsilon` | `double` |
-| `minPoints` | `size_t` |
-| `batchMode` | `bool` |
+| `epsilon` | `double` | Maximum distance between points that are a part of the same cluster. | `0.5` |
+| `minPoints` | `size_t` | Minimum number of points within distance `epsilon`
+for a point to be considered a 'core point'. | `5` |
+| `batchMode` | `bool` | Whether to use batch-mode range search to find neighbors of points. | `true` |
 | `rangeSearch` | [`RangeSearchType`](#advanced-functionality-template-parameters) |
 | `pointSelector` | [`PointSelectionPolicy`](#advanced-functionality-template-parameters) |
 
 ***Notes:***
 
- - A larger `radius` value will generally result in fewer clusters (e.g. a
-   coarser clustering); smaller `radius` values will generally result in more
-   clusters.
+ - Clustering results are very sensitive to the settings of `epsilon` and
+   `minPoints`!  The defaults for both of those are likely not correct for any
+   dataset; *manual tuning and experimentation is generally necessary*.
 
- - When `MeanShift<false>` is used, `radius` is the hard distance threshold for
-   points to be considered in the recomputation of a centroid.
+ - If `epsilon` is too small, then no points will be considered a part of the
+   same cluster and all points will be classified as noise.  If `epsilon` is too
+   large, then all points will be classified as one cluster.
+
+ - `minPoints` specifies the minimum number of neighboring points that a point
+   must have to be the root of a cluster (e.g. a 'core point').  As this
+   increases, the minimum number of points in a cluster also increases, but
+   fewer points can be 'core points' that are the root of clusters.
+
+ - Setting `batchMode` to `false` can keep memory usage lower, but at the
+   potential cost of runtime slowdown.
 
 ### Clustering
 
  * `dbscan.Cluster(data, centroids)`
  * `dbscan.Cluster(data, assignments)`
  * `dbscan.Cluster(data, assignments, centroids)`
-
- * `ms.Cluster(data, centroids, forceConvergence=true, useSeeds=true)`
    - Cluster the given data, storing the resulting cluster centroids in
      `centroids`.
    - `centroids` will be set to size `data.n_rows` x `numClusters`, where

--- a/doc/user/methods/mean_shift.md
+++ b/doc/user/methods/mean_shift.md
@@ -333,6 +333,7 @@ one function (`Gradient()`):
 ```c++
 class CustomKernel
 {
+ public:
   // Evaluate the gradient of the kernel function given the distance between two
   // points.  Specifically, given that the kernel function is K(t) (where t is
   // the distance between the two points), this function should return K'(t).

--- a/doc/user/modeling.md
+++ b/doc/user/modeling.md
@@ -52,6 +52,8 @@ for a full list of algorithms.
 
 Group points into clusters.
 
+ * [`DBSCAN`](methods/dbscan.md): clustering with the density-based DBSCAN
+   algorithm; supports noisy data
  * [`MeanShift`](methods/mean_shift.md): clustering with the density-based mean
    shift algorithm
 

--- a/src/mlpack/bindings/cli/CMakeLists.txt
+++ b/src/mlpack/bindings/cli/CMakeLists.txt
@@ -20,7 +20,7 @@ if (BUILD_CLI_EXECUTABLES)
   # Make sure that we set BINDING_TYPE to cli so the command-line program is
   # compiled with the correct int main() call.
   set_target_properties(mlpack_${name} PROPERTIES COMPILE_FLAGS
-      -DBINDING_TYPE=BINDING_TYPE_CLI -DMLPACK_PRINT_INFO -DMLPACK_PRINT_WARN)
+      "-DBINDING_TYPE=BINDING_TYPE_CLI -DMLPACK_PRINT_INFO -DMLPACK_PRINT_WARN")
   install(TARGETS mlpack_${name} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
   # If man documentation is being generated, make sure this is a dependency.

--- a/src/mlpack/methods/dbscan/dbscan.hpp
+++ b/src/mlpack/methods/dbscan/dbscan.hpp
@@ -112,17 +112,17 @@ class DBSCAN
                  MatType& centroids);
 
   // Get the value of radius.
-  const ElemType Radius() const { return radius; }
+  ElemType Radius() const { return radius; }
   // Modify the value of radius.
   void Radius(const ElemType& radiusIn) { radius = radiusIn; }
 
   // Get the minimum number of points for a point to be a core-point.
-  const size_t MinPoints() const { return minPoints; }
+  size_t MinPoints() const { return minPoints; }
   // Modify the minimum number of points for a point to be a core-point.
   void MinPoints(const size_t minPointsIn) { minPoints = minPointsIn; }
 
   // Get whether to perform the search in batch mode.
-  const bool BatchMode() const { return batchMode; }
+  bool BatchMode() const { return batchMode; }
   // Modify whether the search is performed in batch mode.
   void BatchMode(const bool batchModeIn) { batchMode = batchModeIn; }
 

--- a/src/mlpack/methods/dbscan/dbscan.hpp
+++ b/src/mlpack/methods/dbscan/dbscan.hpp
@@ -68,8 +68,8 @@ class DBSCAN
    * @param rangeSearch Optional instantiated RangeSearch object.
    * @param pointSelector OptionL instantiated PointSelectionPolicy object.
    */
-  DBSCAN(const ElemType epsilon,
-         const size_t minPoints,
+  DBSCAN(const ElemType epsilon = 0.5,
+         const size_t minPoints = 5,
          const bool batchMode = true,
          RangeSearchType rangeSearch = RangeSearchType(),
          PointSelectionPolicy pointSelector = PointSelectionPolicy());

--- a/src/mlpack/methods/dbscan/dbscan.hpp
+++ b/src/mlpack/methods/dbscan/dbscan.hpp
@@ -58,17 +58,17 @@ class DBSCAN
   /**
    * Construct the DBSCAN object with the given parameters.  The batchMode
    * parameter should be set to false in the case where RAM issues will be
-   * encountered (i.e. if the dataset is very large or if epsilon is large).
+   * encountered (i.e. if the dataset is very large or if radius is large).
    * When batchMode is false, each point will be searched iteratively, which
    * could be slower but will use less memory.
    *
-   * @param epsilon Size of range query.
+   * @param radius Size of range query.
    * @param minPoints Minimum number of points for each cluster.
    * @param batchMode If true, all points are searched in batch.
    * @param rangeSearch Optional instantiated RangeSearch object.
    * @param pointSelector OptionL instantiated PointSelectionPolicy object.
    */
-  DBSCAN(const ElemType epsilon = 0.5,
+  DBSCAN(const ElemType radius = 0.5,
          const size_t minPoints = 5,
          const bool batchMode = true,
          RangeSearchType rangeSearch = RangeSearchType(),
@@ -111,10 +111,10 @@ class DBSCAN
                  arma::Row<size_t>& assignments,
                  MatType& centroids);
 
-  // Get the value of epsilon.
-  const ElemType Epsilon() const { return epsilon; }
-  // Modify the value of epsilon.
-  void Epsilon(const ElemType& epsilonIn) { epsilon = epsilonIn; }
+  // Get the value of radius.
+  const ElemType Radius() const { return radius; }
+  // Modify the value of radius.
+  void Radius(const ElemType& radiusIn) { radius = radiusIn; }
 
   // Get the minimum number of points for a point to be a core-point.
   const size_t MinPoints() const { return minPoints; }
@@ -142,9 +142,9 @@ class DBSCAN
 
  private:
   //! Maximum distance between two points to be part of same cluster.
-  ElemType epsilon;
+  ElemType radius;
 
-  //! Minimum number of points to be in the epsilon-neighborhood (including
+  //! Minimum number of points to be in the radius-neighborhood (including
   //! itself) for the point to be a core-point.
   size_t minPoints;
 

--- a/src/mlpack/methods/dbscan/dbscan.hpp
+++ b/src/mlpack/methods/dbscan/dbscan.hpp
@@ -111,6 +111,35 @@ class DBSCAN
                  arma::Row<size_t>& assignments,
                  MatType& centroids);
 
+  // Get the value of epsilon.
+  const ElemType Epsilon() const { return epsilon; }
+  // Modify the value of epsilon.
+  void Epsilon(const ElemType& epsilonIn) { epsilon = epsilonIn; }
+
+  // Get the minimum number of points for a point to be a core-point.
+  const size_t MinPoints() const { return minPoints; }
+  // Modify the minimum number of points for a point to be a core-point.
+  void MinPoints(const size_t minPointsIn) { minPoints = minPointsIn; }
+
+  // Get whether to perform the search in batch mode.
+  const bool BatchMode() const { return batchMode; }
+  // Modify whether the search is performed in batch mode.
+  void BatchMode(const bool batchModeIn) { batchMode = batchModeIn; }
+
+  // Get the object that will be used for range search.
+  const RangeSearchType& RangeSearch() const { return rangeSearch; }
+  // Modify the object that will be used for range search.
+  RangeSearchType& RangeSearch() { return rangeSearch; }
+
+  // Get the instantiated point selection policy.
+  const PointSelectionPolicy& PointSelector() const { return pointSelector; }
+  // Modify the instantiated point selection policy.
+  PointSelectionPolicy& PointSelector() { return pointSelector; }
+
+  // Serialize the DBSCAN object.
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */);
+
  private:
   //! Maximum distance between two points to be part of same cluster.
   ElemType epsilon;

--- a/src/mlpack/methods/dbscan/dbscan_impl.hpp
+++ b/src/mlpack/methods/dbscan/dbscan_impl.hpp
@@ -166,6 +166,7 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::PointwiseCluster(
 
   std::vector<bool> visited(data.n_cols, false);
   std::vector<bool> nonCorePoints(data.n_cols, false);
+  std::vector<bool> everVisited(data.n_cols, false);
 
   for (size_t i = 0; i < data.n_cols; ++i)
   {
@@ -173,8 +174,9 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::PointwiseCluster(
       Log::Info << "DBSCAN clustering on point " << i << "..." << std::endl;
 
     // Get the next index.
-    const size_t index = pointSelector.Select(i, data);
+    const size_t index = pointSelector.Select(i, everVisited, data);
     visited[index] = true;
+    everVisited[index] = true;
 
     // Do the range search for only this point.
     rangeSearch.Search(data.col(index),
@@ -188,6 +190,8 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::PointwiseCluster(
     {
       for (size_t j = 0; j < neighbors[0].size(); ++j)
       {
+        everVisited[neighbors[0][j]] = true;
+
         // Union to all neighbors that either do not have a label, or are core
         // points of other clusters.  (When we union to another core point, we
         // are merging clusters.)
@@ -239,19 +243,25 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::BatchCluster(
   // is the same here, but we have cached all range search results already.
   // That means we already have computed whether each point is or is not a core
   // point, just based on the size of its neighbors; so we don't need an
-  // auxiliary std::vector<bool> for that.
+  // auxiliary std::vector<bool> for that.  We do need a std::vector<bool> to
+  // track which points have ever been visited for the point selector, though.
+  std::vector<bool> visited(data.n_cols, false);
 
   // Now loop over all points.
   for (size_t i = 0; i < data.n_cols; ++i)
   {
     // Get the next index.
-    const size_t index = pointSelector.Select(i, data);
+    const size_t index = pointSelector.Select(i, visited, data);
+    visited[index] = true;
+
     // Monochromatic dual-tree range search does not return the point as its own
     // neighbor, so we are looking for `minPoints - 1` instead.
     if (neighbors[index].size() >= minPoints - 1)
     {
       for (size_t j = 0; j < neighbors[index].size(); ++j)
       {
+        visited[neighbors[index][j]] = true;
+
         if (uf.Find(neighbors[index][j]) == neighbors[index][j])
         {
           // This unions unlabeled points.

--- a/src/mlpack/methods/dbscan/dbscan_impl.hpp
+++ b/src/mlpack/methods/dbscan/dbscan_impl.hpp
@@ -21,12 +21,12 @@ namespace mlpack {
  */
 template<typename RangeSearchType, typename PointSelectionPolicy>
 DBSCAN<RangeSearchType, PointSelectionPolicy>::DBSCAN(
-    const ElemType epsilon,
+    const ElemType radius,
     const size_t minPoints,
     const bool batchMode,
     RangeSearchType rangeSearch,
     PointSelectionPolicy pointSelector) :
-    epsilon(epsilon),
+    radius(radius),
     minPoints(minPoints),
     batchMode(batchMode),
     rangeSearch(rangeSearch),
@@ -180,7 +180,7 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::PointwiseCluster(
 
     // Do the range search for only this point.
     rangeSearch.Search(data.col(index),
-        RangeType<ElemType>(ElemType(0.0), epsilon), neighbors, distances);
+        RangeType<ElemType>(ElemType(0.0), radius), neighbors, distances);
 
     // Union to all neighbors if the point is not noise.
     //
@@ -229,13 +229,13 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::BatchCluster(
     const MatType& data,
     UnionFind& uf)
 {
-  // For each point, find the points in epsilon-neighborhood and their
+  // For each point, find the points in radius-neighborhood and their
   // distances.
   std::vector<std::vector<size_t>> neighbors;
   std::vector<std::vector<ElemType>> distances;
   Log::Info << "Performing range search." << std::endl;
   rangeSearch.Train(data);
-  rangeSearch.Search(RangeType<ElemType>(ElemType(0.0), epsilon), neighbors,
+  rangeSearch.Search(RangeType<ElemType>(ElemType(0.0), radius), neighbors,
       distances);
   Log::Info << "Range search complete." << std::endl;
 
@@ -283,7 +283,7 @@ template<typename Archive>
 void DBSCAN<RangeSearchType, PointSelectionPolicy>::serialize(
     Archive& ar, const unsigned int /* version */)
 {
-  ar(CEREAL_NVP(epsilon));
+  ar(CEREAL_NVP(radius));
   ar(CEREAL_NVP(minPoints));
   ar(CEREAL_NVP(batchMode));
   ar(CEREAL_NVP(rangeSearch));

--- a/src/mlpack/methods/dbscan/dbscan_impl.hpp
+++ b/src/mlpack/methods/dbscan/dbscan_impl.hpp
@@ -267,6 +267,17 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::BatchCluster(
   }
 }
 
+// Serialize the DBSCAN object.
+template<typename Archive>
+void serialize(Archive& ar, const unsigned int /* version */)
+{
+  ar(CEREAL_NVP(epsilon));
+  ar(CEREAL_NVP(minPoints));
+  ar(CEREAL_NVP(batchMode));
+  ar(CEREAL_NVP(rangeSearch));
+  ar(CEREAL_NVP(pointSelector));
+}
+
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/dbscan/dbscan_impl.hpp
+++ b/src/mlpack/methods/dbscan/dbscan_impl.hpp
@@ -278,8 +278,10 @@ void DBSCAN<RangeSearchType, PointSelectionPolicy>::BatchCluster(
 }
 
 // Serialize the DBSCAN object.
+template<typename RangeSearchType, typename PointSelectionPolicy>
 template<typename Archive>
-void serialize(Archive& ar, const unsigned int /* version */)
+void DBSCAN<RangeSearchType, PointSelectionPolicy>::serialize(
+    Archive& ar, const unsigned int /* version */)
 {
   ar(CEREAL_NVP(epsilon));
   ar(CEREAL_NVP(minPoints));

--- a/src/mlpack/methods/dbscan/dbscan_main.cpp
+++ b/src/mlpack/methods/dbscan/dbscan_main.cpp
@@ -37,7 +37,7 @@ BINDING_LONG_DESC(
     "\n\n"
     "The input dataset to be clustered may be specified with the " +
     PRINT_PARAM_STRING("input") + " parameter; the radius of each range "
-    "search may be specified with the " + PRINT_PARAM_STRING("epsilon") +
+    "search may be specified with the " + PRINT_PARAM_STRING("radius") +
     " parameters, and the minimum number of points in a cluster may be "
     "specified with the " + PRINT_PARAM_STRING("min_size") + " parameter."
     "\n\n"
@@ -65,7 +65,7 @@ BINDING_EXAMPLE(
     PRINT_DATASET("input") + " with a radius of 0.5 and a minimum cluster size"
     " of 5 is given below:"
     "\n\n" +
-    PRINT_CALL("dbscan", "input", "input", "epsilon", 0.5, "min_size", 5));
+    PRINT_CALL("dbscan", "input", "input", "radius", 0.5, "min_size", 5));
 
 // See also...
 BINDING_SEE_ALSO("DBSCAN on Wikipedia", "https://en.wikipedia.org/wiki/DBSCAN");
@@ -80,7 +80,11 @@ PARAM_UROW_OUT("assignments", "Output matrix for assignments of each "
     "point.", "a");
 PARAM_MATRIX_OUT("centroids", "Matrix to save output centroids to.", "C");
 
-PARAM_DOUBLE_IN("epsilon", "Radius of each range search.", "e", 0.5);
+// This parameter is deprecated and will be removed for mlpack 5.0.0.
+PARAM_DOUBLE_IN("epsilon", "Radius of each range search. (Deprecated: use "
+    "'radius' parameter instead!)", "e", 0.5);
+
+PARAM_DOUBLE_IN("radius", "Radius of each range search.", "r", 0.5);
 PARAM_INT_IN("min_size", "Minimum number of points for a cluster.", "m", 5);
 
 PARAM_STRING_IN("tree_type", "If using single-tree or dual-tree search, the "
@@ -104,11 +108,14 @@ void RunDBSCAN(util::Params& params,
 
   // Load dataset.
   arma::mat dataset = std::move(params.Get<arma::mat>("input"));
-  const double epsilon = params.Get<double>("epsilon");
+  // Provide reverse-compatibility by checking for the deprecated 'epsilon'
+  // parameter first.  (This can be removed when mlpack 5.0.0 is released.)
+  const double radius = params.Has("epsilon") ? params.Get<double>("epsilon") :
+      params.Get<double>("radius");
   const size_t minSize = (size_t) params.Get<int>("min_size");
   arma::Row<size_t> assignments;
 
-  DBSCAN<RangeSearchType, PointSelectionPolicy> d(epsilon, minSize,
+  DBSCAN<RangeSearchType, PointSelectionPolicy> d(radius, minSize,
       !params.Has("single_mode"), rs, pointSelector);
 
   // If possible, avoid the overhead of calculating centroids.
@@ -147,15 +154,27 @@ void BINDING_FUNCTION(util::Params& params, util::Timers& /* timers */)
   RequireAtLeastOnePassed(params, { "assignments", "centroids" }, false,
       "no output will be saved");
 
+  RequireOnlyOnePassed(params, { "epsilon", "radius" }, true,
+      "cannot specify both 'epsilon' and 'radius'; use only one", true);
+  if (params.Has("epsilon"))
+  {
+    Log::Warn << PRINT_PARAM_STRING("epsilon") << " is deprecated and will be "
+        << "removed in mlpack 5.0.0.  Use " << PRINT_PARAM_STRING("radius")
+        << "instead." << std::endl;
+  }
+
   ReportIgnoredParam(params, {{ "naive", true }}, "single_mode");
 
   RequireParamInSet<string>(params, "tree_type", { "kd", "cover", "r", "r-star",
       "x", "hilbert-r", "r-plus", "r-plus-plus", "ball" }, true,
       "unknown tree type");
 
-  // Value of epsilon should be positive.
+  // Value of radius should be positive.
+  // (The epsilon check can be removed when mlpack 5.0.0 is released.)
   RequireParamValue<double>(params, "epsilon", [](double x) { return x > 0; },
       true, "invalid value of epsilon specified");
+  RequireParamValue<double>(params, "radius", [](double x) { return x > 0; },
+      true, "invalid value of radius specified");
 
   // Value of min_size should be positive.
   RequireParamValue<int>(params, "min_size", [](int y) { return y > 0; },

--- a/src/mlpack/methods/dbscan/dbscan_main.cpp
+++ b/src/mlpack/methods/dbscan/dbscan_main.cpp
@@ -80,7 +80,7 @@ PARAM_UROW_OUT("assignments", "Output matrix for assignments of each "
     "point.", "a");
 PARAM_MATRIX_OUT("centroids", "Matrix to save output centroids to.", "C");
 
-PARAM_DOUBLE_IN("epsilon", "Radius of each range search.", "e", 1.0);
+PARAM_DOUBLE_IN("epsilon", "Radius of each range search.", "e", 0.5);
 PARAM_INT_IN("min_size", "Minimum number of points for a cluster.", "m", 5);
 
 PARAM_STRING_IN("tree_type", "If using single-tree or dual-tree search, the "

--- a/src/mlpack/methods/dbscan/ordered_point_selection.hpp
+++ b/src/mlpack/methods/dbscan/ordered_point_selection.hpp
@@ -17,7 +17,8 @@
 namespace mlpack {
 
 /**
- * This class can be used to sequentially select the next point to use for DBSCAN.
+ * This class can be used to sequentially select the next point to use for
+ * DBSCAN.
  */
 class OrderedPointSelection
 {
@@ -25,11 +26,13 @@ class OrderedPointSelection
   /**
    * Select the next point to use, sequentially.
    *
-   * @param point unvisited Bitset indicating which points are unvisited.
+   * @param point Default index of point to use.
+   * @param visited Bitset indicating which points have already been visited.
    * @param * (data) Unused data.
    */
   template<typename MatType>
   static size_t Select(const size_t point,
+                       const std::vector<bool>& /* visited */,
                        const MatType& /* data */)
   {
     return point; // Just return point.

--- a/src/mlpack/methods/dbscan/random_point_selection.hpp
+++ b/src/mlpack/methods/dbscan/random_point_selection.hpp
@@ -30,36 +30,25 @@ class RandomPointSelection
    */
   template<typename MatType>
   size_t Select(const size_t /* point */,
+                const std::vector<bool>& visited,
                 const MatType& data)
   {
-    // Initialize the length of the unvisited bitset.
-    size_t size = data.n_cols; // Get the size of points.
-    if (unvisited.size() != size)
-      unvisited.resize(size, true); // Resize & Set bitset to one.
-
     // Count the unvisited points and generate nth index randomly.
-    const size_t max = std::count(unvisited.begin(), unvisited.end(), true);
+    const size_t max = std::count(visited.begin(), visited.end(), false);
     const size_t index = RandInt(max);
 
     // Select the index'th unvisited point.
     size_t found = 0;
-    for (size_t i = 0; i < unvisited.size(); ++i)
+    for (size_t i = 0; i < visited.size(); ++i)
     {
-      if (unvisited[i])
+      if (!visited[i])
         ++found;
 
       if (found > index)
-      {
-        unvisited[i].flip(); // Set unvisited point to visited point.
         return i;
-      }
     }
     return 0; // Not sure if it is possible to get here.
   }
-
- private:
-  // Bitset for unvisited points. If true, mean unvisited.
-  std::vector<bool> unvisited;
 };
 
 } // namespace mlpack

--- a/src/mlpack/methods/dbscan/random_point_selection.hpp
+++ b/src/mlpack/methods/dbscan/random_point_selection.hpp
@@ -31,7 +31,7 @@ class RandomPointSelection
   template<typename MatType>
   size_t Select(const size_t /* point */,
                 const std::vector<bool>& visited,
-                const MatType& data)
+                const MatType& /* data */)
   {
     // Count the unvisited points and generate nth index randomly.
     const size_t max = std::count(visited.begin(), visited.end(), false);

--- a/src/mlpack/methods/mean_shift/mean_shift.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift.hpp
@@ -111,20 +111,24 @@ class MeanShift
                bool forceConvergence = false,
                bool useSeeds = true);
 
-  //! Get the maximum number of iterations.
+  // Get the maximum number of iterations.
   size_t MaxIterations() const { return maxIterations; }
-  //! Set the maximum number of iterations.
+  // Set the maximum number of iterations.
   size_t& MaxIterations() { return maxIterations; }
 
-  //! Get the radius.
+  // Get the radius.
   double Radius() const { return radius; }
-  //! Set the radius.
+  // Set the radius.
   void Radius(double radius);
 
-  //! Get the kernel.
+  // Get the kernel.
   const KernelType& Kernel() const { return kernel; }
-  //! Modify the kernel.
+  // Modify the kernel.
   KernelType& Kernel() { return kernel; }
+
+  // Serialize the MeanShift object.
+  template<typename Archive>
+  void serialize(Archive& ar, const unsigned int /* version */);
 
  private:
   /**

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -321,6 +321,15 @@ inline void MeanShift<UseKernel, KernelType>::Cluster(
   }
 }
 
+// Serialize the MeanShift object.
+template<typename Archive>
+void MeanShift::serialize(Archive& ar, const unsigned int /* version */)
+{
+  ar(CEREAL_NVP(radius));
+  ar(CEREAL_NVP(maxIterations));
+  ar(CEREAL_NVP(kernel));
+}
+
 } // namespace mlpack
 
 #endif

--- a/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
+++ b/src/mlpack/methods/mean_shift/mean_shift_impl.hpp
@@ -322,8 +322,10 @@ inline void MeanShift<UseKernel, KernelType>::Cluster(
 }
 
 // Serialize the MeanShift object.
+template<bool UseKernel, typename KernelType>
 template<typename Archive>
-void MeanShift::serialize(Archive& ar, const unsigned int /* version */)
+void MeanShift<UseKernel, KernelType>::serialize(
+    Archive& ar, const unsigned int /* version */)
 {
   ar(CEREAL_NVP(radius));
   ar(CEREAL_NVP(maxIterations));


### PR DESCRIPTION
Unfortunately time has taken me away from the task of documenting mlpack's methods on our [main documentation page](https://www.mlpack.org/doc/).  So, I set aside some time to get back to this and picked the relatively easy `DBSCAN` clustering method.

There are a few changes I made to make the documentation clearer:

 * Changed the `epsilon` parameter name to `radius`, which is a little more descriptive.
 * Added helper functions to set `radius` and `minPoints`.
 * Added `serialize()` function, also to `MeanShift` because I noticed it was missing there.
 * Clarified the `PointSelectionPolicy` API... it really needs a list of what points have already been visited, so a little bit of modification to DBSCAN itself was needed (but it does not affect the results of `Cluster()`).

Once `RangeSearch` is documented, I'll be able to update some documentation here, but, that can come later.